### PR TITLE
fix(mix): unstick Deep Cuts + 5 related discovery-pipeline fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,8 +72,8 @@ android {
         applicationId = "com.stash.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 56
-        versionName = "0.9.18"
+        versionCode = 57
+        versionName = "0.9.19"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // AppAuth redirect scheme removed -- Spotify now uses sp_dc cookie auth
         // Last.fm API credentials exposed via BuildConfig for the app-level

--- a/app/src/main/kotlin/com/stash/app/StashApplication.kt
+++ b/app/src/main/kotlin/com/stash/app/StashApplication.kt
@@ -9,6 +9,7 @@ import androidx.work.WorkManager
 import coil3.SingletonImageLoader
 import android.util.Log
 import com.stash.core.data.db.dao.ArtistProfileCacheDao
+import com.stash.core.data.db.dao.DiscoveryQueueDao
 import com.stash.core.data.db.dao.PlaylistDao
 import com.stash.core.data.db.dao.StashMixRecipeDao
 import com.stash.core.data.db.dao.TrackDao
@@ -89,6 +90,9 @@ class StashApplication : Application(), Configuration.Provider {
 
     @Inject
     lateinit var stashMixRecipeDao: StashMixRecipeDao
+
+    @Inject
+    lateinit var discoveryQueueDao: DiscoveryQueueDao
 
     @Inject
     lateinit var trackDao: TrackDao
@@ -172,6 +176,7 @@ class StashApplication : Application(), Configuration.Provider {
             StashMixDefaults.seedIfNeeded(stashMixRecipeDao)
             maybeRetuneStashDiscover()
             maybeRetuneStashMixes()
+            maybeCleanupDiscoveryLibraryHits()
             // Fire a one-shot refresh on first launch so mixes populate
             // without waiting for the 24-hour periodic cycle. Subsequent
             // one-shots are safe (unique-work policy = REPLACE).
@@ -404,6 +409,35 @@ class StashApplication : Application(), Configuration.Provider {
     }
 
     /**
+     * PR 7 one-time cleanup: delete pre-PR-6 era "library-hit" discovery
+     * DONE rows from `discovery_queue`. Pre-PR-6 StashDiscoveryWorker.handle()
+     * canonical-deduped Last.fm candidates against the user's library and
+     * linked existing library tracks instead of creating discovery stubs —
+     * those rows then surfaced in mixes as "discovery survivors" despite
+     * being library content. PR 6's seed-stage pre-filter prevents new
+     * library-hits; this migration cleans up the backlog.
+     *
+     * Gated by [STASH_DISCOVERY_LIBRARY_HIT_CLEANUP_VERSION] so the
+     * migration runs exactly once per install. Fresh installs after PR 7
+     * have nothing to clean up — the query is a fast no-op.
+     */
+    private suspend fun maybeCleanupDiscoveryLibraryHits() {
+        val prefs = getSharedPreferences("stash_migrations", MODE_PRIVATE)
+        val stored = prefs.getInt("stash_discovery_library_hit_cleanup_version", 0)
+        if (stored >= STASH_DISCOVERY_LIBRARY_HIT_CLEANUP_VERSION) return
+
+        val deleted = discoveryQueueDao.deleteLibraryHitDoneRows()
+        Log.i(
+            "StashMigration",
+            "Cleaned up $deleted pre-PR-6 library-hit discovery rows " +
+                "(v$STASH_DISCOVERY_LIBRARY_HIT_CLEANUP_VERSION)",
+        )
+        prefs.edit()
+            .putInt("stash_discovery_library_hit_cleanup_version", STASH_DISCOVERY_LIBRARY_HIT_CLEANUP_VERSION)
+            .apply()
+    }
+
+    /**
      * Retroactively enables `sync_enabled = 1` on every YouTube playlist in
      * the local DB exactly once. Fixes the parity gap where YouTube
      * playlists discovered before the Sync-preferences UI was extended to
@@ -550,6 +584,18 @@ class StashApplication : Application(), Configuration.Provider {
          *    strategy from NONE to TRACK_SIMILAR.
          */
         private const val STASH_MIX_RECIPE_TUNING_VERSION = 1
+
+        /**
+         * Bump when [maybeCleanupDiscoveryLibraryHits] should run again.
+         *  - v1 = PR 7 one-time cleanup: removes pre-PR-6 era discovery_queue
+         *    DONE rows whose linked track has source != YOUTUBE. Pre-PR-6
+         *    StashDiscoveryWorker.handle() canonical-deduped Last.fm
+         *    candidates against the library and linked existing library
+         *    tracks instead of creating stubs; those rows surfaced in mixes
+         *    as "discovery survivors" despite being library content. PR 6's
+         *    seed-stage pre-filter prevents new ones from being created.
+         */
+        private const val STASH_DISCOVERY_LIBRARY_HIT_CLEANUP_VERSION = 1
 
         /**
          * v0.9.13: bump when [maybeBackfillCodecsFromExtension] should run

--- a/app/src/main/kotlin/com/stash/app/StashApplication.kt
+++ b/app/src/main/kotlin/com/stash/app/StashApplication.kt
@@ -341,6 +341,8 @@ class StashApplication : Application(), Configuration.Provider {
                 discoveryRatio = 1.0f,
                 freshnessWindowDays = 14,
                 targetLength = 50,
+                affinityBias = 0.0f,
+                seedStrategy = "TAG_GRAPH",
             )
             if (updated > 0) {
                 Log.i(

--- a/app/src/main/kotlin/com/stash/app/StashApplication.kt
+++ b/app/src/main/kotlin/com/stash/app/StashApplication.kt
@@ -169,6 +169,7 @@ class StashApplication : Application(), Configuration.Provider {
             maybeReseedStashMixes()
             StashMixDefaults.seedIfNeeded(stashMixRecipeDao)
             maybeRetuneStashDiscover()
+            maybeRetuneStashMixes()
             // Fire a one-shot refresh on first launch so mixes populate
             // without waiting for the 24-hour periodic cycle. Subsequent
             // one-shots are safe (unique-work policy = REPLACE).
@@ -357,6 +358,40 @@ class StashApplication : Application(), Configuration.Provider {
     }
 
     /**
+     * v0.9.20 pivot: Daily Discover + Deep Cuts move from library-substrate
+     * to recommendation-substrate (85% discovery, 15% library). Deep Cuts
+     * switches seed strategy from NONE to TRACK_SIMILAR. Gated by
+     * [STASH_MIX_RECIPE_TUNING_VERSION] so the migration runs exactly once
+     * per install. Fresh installs skip this because [StashMixDefaults]
+     * already seeds with the new values.
+     */
+    private suspend fun maybeRetuneStashMixes() {
+        val prefs = getSharedPreferences("stash_migrations", MODE_PRIVATE)
+        val stored = prefs.getInt("stash_mix_recipe_tuning_version", 0)
+        if (stored >= STASH_MIX_RECIPE_TUNING_VERSION) return
+
+        var totalUpdated = 0
+        for (recipe in StashMixDefaults.ALL.filter { it.isBuiltin }) {
+            val updated = stashMixRecipeDao.retuneBuiltin(
+                name = recipe.name,
+                discoveryRatio = recipe.discoveryRatio,
+                freshnessWindowDays = recipe.freshnessWindowDays,
+                targetLength = recipe.targetLength,
+                affinityBias = recipe.affinityBias,
+                seedStrategy = recipe.seedStrategy,
+            )
+            totalUpdated += updated
+        }
+        Log.i(
+            "StashMigration",
+            "Retuned $totalUpdated builtin mix recipe(s) to v$STASH_MIX_RECIPE_TUNING_VERSION",
+        )
+        prefs.edit()
+            .putInt("stash_mix_recipe_tuning_version", STASH_MIX_RECIPE_TUNING_VERSION)
+            .apply()
+    }
+
+    /**
      * Retroactively enables `sync_enabled = 1` on every YouTube playlist in
      * the local DB exactly once. Fixes the parity gap where YouTube
      * playlists discovered before the Sync-preferences UI was extended to
@@ -493,6 +528,16 @@ class StashApplication : Application(), Configuration.Provider {
          *    used to fill the non-discovery slots drop on next refresh.
          */
         private const val STASH_DISCOVER_TUNING_VERSION = 2
+
+        /**
+         * Bump when the built-in Stash Mix recipes' tunables change and
+         * existing installs should adopt them.
+         *  - v1 = 2026-05-11 v0.9.20 pivot: Daily Discover + Deep Cuts
+         *    move from library-substrate to recommendation-substrate
+         *    (85% discovery, 15% library). Deep Cuts switches seed
+         *    strategy from NONE to TRACK_SIMILAR.
+         */
+        private const val STASH_MIX_RECIPE_TUNING_VERSION = 1
 
         /**
          * v0.9.13: bump when [maybeBackfillCodecsFromExtension] should run

--- a/app/src/main/kotlin/com/stash/app/StashApplication.kt
+++ b/app/src/main/kotlin/com/stash/app/StashApplication.kt
@@ -22,12 +22,14 @@ import com.stash.core.data.sync.SyncNotificationManager
 import com.stash.data.download.ytdlp.YtDlpManager
 import com.stash.core.data.sync.workers.ArtBackfillWorker
 import com.stash.core.data.sync.workers.AutoSaveScrobbler
+import com.stash.core.data.sync.workers.DiscoveryDownloadWorker
 import com.stash.core.data.sync.workers.QualityInfoBackfillWorker
 import com.stash.core.data.sync.workers.StashDiscoveryWorker
 import com.stash.core.data.sync.workers.StashMixRefreshWorker
 import com.stash.core.data.sync.workers.TagEnrichmentWorker
 import com.stash.core.data.sync.workers.TrackInfoEnrichmentWorker
 import com.stash.core.data.sync.workers.UpdateCheckWorker
+import com.stash.core.data.sync.workers.constraintsForManualTrigger
 import com.stash.core.media.preview.LosslessUrlPrefetcher
 import com.stash.data.download.lossless.LosslessRetryScheduler
 import com.stash.data.download.ytdlp.YtDlpUpdateWorker
@@ -174,6 +176,16 @@ class StashApplication : Application(), Configuration.Provider {
             // without waiting for the 24-hour periodic cycle. Subsequent
             // one-shots are safe (unique-work policy = REPLACE).
             StashMixRefreshWorker.enqueueOneTime(this@StashApplication)
+            // v0.9.20: drain orphan discovery download rows from prior version
+            // installs (stubs that StashDiscoveryWorker created in PR 3 era but
+            // were never downloaded because the sync-chain TrackDownloadWorker
+            // was always sync-gated). Respects user's network preference; runs
+            // when constraints are satisfied.
+            val mode = downloadNetworkPreference.current()
+            DiscoveryDownloadWorker.enqueueOneTime(
+                this@StashApplication,
+                constraintsForManualTrigger(mode),
+            )
         }
         StashMixRefreshWorker.schedulePeriodic(this)
         // Tag enrichment + discovery worker constraints come from the

--- a/core/auth/src/main/kotlin/com/stash/core/auth/store/EncryptedTokenStore.kt
+++ b/core/auth/src/main/kotlin/com/stash/core/auth/store/EncryptedTokenStore.kt
@@ -2,7 +2,9 @@ package com.stash.core.auth.store
 
 import android.content.Context
 import android.util.Base64
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.stash.core.auth.crypto.TinkEncryptionManager
@@ -17,7 +19,10 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /** Single DataStore instance scoped to the application process. */
-private val Context.authDataStore by preferencesDataStore(name = "auth_tokens")
+private val Context.authDataStore by preferencesDataStore(
+    name = "auth_tokens",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+)
 
 /**
  * Internal serializable representation that combines token data and basic user profile

--- a/core/auth/src/main/kotlin/com/stash/core/auth/youtube/YouTubeCredentialsStore.kt
+++ b/core/auth/src/main/kotlin/com/stash/core/auth/youtube/YouTubeCredentialsStore.kt
@@ -1,7 +1,9 @@
 package com.stash.core.auth.youtube
 
 import android.content.Context
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -85,4 +87,7 @@ class YouTubeCredentialsStore @Inject constructor(
 }
 
 /** Singleton DataStore instance for YouTube credentials. */
-private val Context.youTubeCredentials by preferencesDataStore(name = "youtube_credentials")
+private val Context.youTubeCredentials by preferencesDataStore(
+    name = "youtube_credentials",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+)

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
@@ -177,4 +177,30 @@ interface DiscoveryQueueDao {
         """
     )
     suspend fun deleteStalePending(cutoffMillis: Long): Int
+
+    /**
+     * One-time PR 7 cleanup: delete discovery_queue DONE rows whose linked
+     * track has `source != 'YOUTUBE'`. Such rows were created pre-PR-6 by
+     * StashDiscoveryWorker.handle()'s canonical-dedup branch — Last.fm
+     * candidates that matched an existing library track got linked to that
+     * track instead of producing a real discovery stub. They surface in
+     * mixes as "discovery survivors" despite being library content.
+     *
+     * Heuristic: real discovery stubs have `source = MusicSource.YOUTUBE`
+     * (set by StashDiscoveryWorker.handle's stub-creation branch). Library
+     * tracks have other sources (`SPOTIFY`, `LOCAL`, `BOTH`).
+     *
+     * PR 6's seed-stage pre-filter prevents new library-hit rows from being
+     * created; this query cleans up the accumulated backlog.
+     *
+     * @return number of rows deleted.
+     */
+    @Query(
+        """
+        DELETE FROM discovery_queue
+        WHERE status = 'DONE'
+          AND track_id IN (SELECT id FROM tracks WHERE source != 'YOUTUBE')
+        """
+    )
+    suspend fun deleteLibraryHitDoneRows(): Int
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
@@ -29,6 +29,52 @@ interface DiscoveryQueueDao {
     suspend fun getPending(limit: Int): List<DiscoveryQueueEntity>
 
     /**
+     * Pending entries that aren't in the supplied at-cap recipe set.
+     * Without this fairness filter, a single recipe's deferred-at-cap
+     * backlog (rows that keep getting skipped because their recipe is
+     * over its weekly download budget) sits at the head of the queue and
+     * starves out fresher candidates from under-cap recipes. See
+     * conversation 2026-05-12: First Listen had 100+ deferred PENDING
+     * blocking Deep Cuts' freshly-queued candidates from ever being
+     * processed.
+     *
+     * Pass an empty list to behave like [getPending] — Room rejects
+     * empty `IN ()` SQL so the worker special-cases the empty case
+     * before calling.
+     */
+    @Query(
+        """
+        SELECT * FROM discovery_queue
+        WHERE status = 'PENDING'
+          AND recipe_id NOT IN (:cappedRecipeIds)
+        ORDER BY queued_at ASC
+        LIMIT :limit
+        """
+    )
+    suspend fun getPendingExcludingRecipes(
+        cappedRecipeIds: List<Long>,
+        limit: Int,
+    ): List<DiscoveryQueueEntity>
+
+    /**
+     * Recipe ids currently over the weekly download cap. Mirrors
+     * [countRecentCompletedForRecipe]'s join + filter exactly so the
+     * pre-fetch and per-row checks agree.
+     */
+    @Query(
+        """
+        SELECT dq.recipe_id FROM discovery_queue dq
+        INNER JOIN tracks t ON t.id = dq.track_id
+        WHERE dq.status = 'DONE'
+          AND dq.completed_at >= :sinceMillis
+          AND t.is_downloaded = 1
+        GROUP BY dq.recipe_id
+        HAVING COUNT(*) >= :cap
+        """
+    )
+    suspend fun findRecipesAtWeeklyCap(sinceMillis: Long, cap: Int): List<Long>
+
+    /**
      * Count of discovery entries completed within [sinceMillis] for a
      * specific recipe — enforces the per-recipe weekly cap so discovery
      * doesn't spiral.

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
@@ -76,17 +76,30 @@ interface DiscoveryQueueDao {
      * playlist — without this step, a Discovery download that completed
      * between refreshes gets wiped from the mix and then garbage-
      * collected by the orphan sweeper.
+     *
+     * v0.9.19 follow-up: capped at [limit] rows ordered by
+     * `completed_at DESC`, so newest-DONE survivors win when
+     * `materializeMix` trims to the recipe's discovery slot count
+     * (`targetLength * discoveryRatio`). Without the cap, every DONE row
+     * accumulated for the recipe got re-linked, growing the playlist
+     * unboundedly across release transitions (Daily Discover went
+     * 50 -> 100 between v0.9.18 and v0.9.19 because ~50 survivors had
+     * accumulated). SQLite treats NULL as "smaller than any value" under
+     * `DESC`, so any pathological NULL `completed_at` rows fall to the
+     * end naturally, but they're already excluded by the status filter
+     * since worker DONE transitions stamp the timestamp.
      */
     @Query(
         """
-        SELECT dq.track_id FROM discovery_queue dq
-        INNER JOIN tracks t ON t.id = dq.track_id
-        WHERE dq.recipe_id = :recipeId
-          AND dq.status = 'DONE'
-          AND dq.track_id IS NOT NULL
+        SELECT track_id FROM discovery_queue
+        WHERE recipe_id = :recipeId
+          AND status = 'DONE'
+          AND track_id IS NOT NULL
+        ORDER BY completed_at DESC
+        LIMIT :limit
         """
     )
-    suspend fun getDoneTrackIdsForRecipe(recipeId: Long): List<Long>
+    suspend fun getDoneTrackIdsForRecipe(recipeId: Long, limit: Int): List<Long>
 
     /**
      * Track ids referenced by any non-terminal discovery row (PENDING /

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
@@ -32,13 +32,22 @@ interface DiscoveryQueueDao {
      * Count of discovery entries completed within [sinceMillis] for a
      * specific recipe — enforces the per-recipe weekly cap so discovery
      * doesn't spiral.
+     *
+     * v0.9.21: Aligned with [getDoneTrackIdsForRecipe] — only count DONE
+     * rows whose track actually landed on disk (`is_downloaded = 1`). The
+     * cap exists to bound real disk usage; counting unmaterialized stubs
+     * trapped recipes in a "100 intended but 0 downloaded" loop where
+     * fresh PENDING candidates could never drain. See conversation
+     * 2026-05-12: Deep Cuts had ~100 DONE rows but 0 in the mix.
      */
     @Query(
         """
-        SELECT COUNT(*) FROM discovery_queue
-        WHERE recipe_id = :recipeId
-          AND status = 'DONE'
-          AND completed_at >= :sinceMillis
+        SELECT COUNT(*) FROM discovery_queue dq
+        INNER JOIN tracks t ON t.id = dq.track_id
+        WHERE dq.recipe_id = :recipeId
+          AND dq.status = 'DONE'
+          AND dq.completed_at >= :sinceMillis
+          AND t.is_downloaded = 1
         """
     )
     suspend fun countRecentCompletedForRecipe(recipeId: Long, sinceMillis: Long): Int

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
@@ -94,6 +94,14 @@ interface DiscoveryQueueDao {
      * orphan sweeper, user delete, or stale state from migrations). Without
      * this JOIN, materializeMix's insertCrossRef into playlist_tracks throws
      * SQLITE_CONSTRAINT_FOREIGNKEY because the FK on tracks(id) is enforced.
+     *
+     * v0.9.20 follow-up: AND t.is_downloaded = 1 ensures the mix never
+     * surfaces a stub TrackEntity (a discovery row that was marked DONE
+     * by StashDiscoveryWorker but whose file hasn't landed on disk yet).
+     * Without this filter, a transient window between StashDiscoveryWorker
+     * completion and DiscoveryDownloadWorker completion would put unplayable
+     * tracks in the playlist. DiscoveryDownloadWorker fixes the underlying
+     * issue (downloads run promptly); this filter is defense-in-depth.
      */
     @Query(
         """
@@ -102,6 +110,7 @@ interface DiscoveryQueueDao {
         WHERE dq.recipe_id = :recipeId
           AND dq.status = 'DONE'
           AND dq.track_id IS NOT NULL
+          AND t.is_downloaded = 1
         ORDER BY dq.completed_at DESC
         LIMIT :limit
         """

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
@@ -88,14 +88,21 @@ interface DiscoveryQueueDao {
      * `DESC`, so any pathological NULL `completed_at` rows fall to the
      * end naturally, but they're already excluded by the status filter
      * since worker DONE transitions stamp the timestamp.
+     *
+     * v0.9.20 follow-up: INNER JOIN tracks filters out orphan rows whose
+     * track_id no longer points at a live row in `tracks` (deleted by the
+     * orphan sweeper, user delete, or stale state from migrations). Without
+     * this JOIN, materializeMix's insertCrossRef into playlist_tracks throws
+     * SQLITE_CONSTRAINT_FOREIGNKEY because the FK on tracks(id) is enforced.
      */
     @Query(
         """
-        SELECT track_id FROM discovery_queue
-        WHERE recipe_id = :recipeId
-          AND status = 'DONE'
-          AND track_id IS NOT NULL
-        ORDER BY completed_at DESC
+        SELECT dq.track_id FROM discovery_queue dq
+        INNER JOIN tracks t ON t.id = dq.track_id
+        WHERE dq.recipe_id = :recipeId
+          AND dq.status = 'DONE'
+          AND dq.track_id IS NOT NULL
+        ORDER BY dq.completed_at DESC
         LIMIT :limit
         """
     )

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt
@@ -81,6 +81,7 @@ interface DownloadQueueDao {
             OR (bl.spotify_uri IS NOT NULL AND bl.spotify_uri = t.spotify_uri)
             OR (bl.youtube_id  IS NOT NULL AND bl.youtube_id  = t.youtube_id)
         WHERE dq.status = 'PENDING'
+          AND dq.sync_id IS NOT NULL
           AND t.source IN (:sources)
           AND bl.canonical_key IS NULL
           AND EXISTS (
@@ -110,6 +111,7 @@ interface DownloadQueueDao {
             OR (bl.spotify_uri IS NOT NULL AND bl.spotify_uri = t.spotify_uri)
             OR (bl.youtube_id  IS NOT NULL AND bl.youtube_id  = t.youtube_id)
         WHERE dq.status = 'FAILED' AND dq.retry_count < 3
+          AND dq.sync_id IS NOT NULL
           AND t.source IN (:sources)
           AND bl.canonical_key IS NULL
           AND EXISTS (
@@ -122,6 +124,29 @@ interface DownloadQueueDao {
         ORDER BY (CASE WHEN dq.youtube_url IS NULL THEN 0 ELSE 1 END) ASC, dq.created_at ASC
     """)
     suspend fun getRetryableBySources(sources: List<String>): List<DownloadQueueEntity>
+
+    /**
+     * Discovery rows queued for download — `sync_id IS NULL` partitions
+     * them away from sync-chain [com.stash.core.data.sync.workers.TrackDownloadWorker]
+     * (which after the v0.9.20 predicate update only touches rows with
+     * non-null sync_id).
+     *
+     * Includes FAILED rows with retry_count < 3 so a transient network
+     * blip doesn't permanently sideline a discovery candidate — matches
+     * the retry posture of [getRetryableBySources].
+     *
+     * Filtered to exclude WAITING_FOR_LOSSLESS (owned by LosslessRetryWorker)
+     * and IN_PROGRESS / COMPLETED (already running or done).
+     */
+    @Query(
+        """
+        SELECT * FROM download_queue
+        WHERE sync_id IS NULL
+          AND (status = 'PENDING' OR (status = 'FAILED' AND retry_count < 3))
+        ORDER BY created_at ASC
+        """
+    )
+    suspend fun pendingDiscoveryDownloads(): List<DownloadQueueEntity>
 
     // ── Updates ─────────────────────────────────────────────────────────
 

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/ListeningEventDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/ListeningEventDao.kt
@@ -235,4 +235,24 @@ interface ListeningEventDao {
     suspend fun getTopArtistsSince(sinceEpochMs: Long, limit: Int = 20): List<ArtistPlayCount>
 
     data class ArtistPlayCount(val artist: String, val plays: Int)
+
+    /**
+     * Top tracks by in-app play count within the time window, returned as
+     * (artist, title) pairs ready for [com.stash.core.data.mix.MixSeedGenerator]'s
+     * TRACK_SIMILAR seed source. Used as the second tier of the seedTracks
+     * fallback chain (Last.fm persona top tracks → local listening events →
+     * library top by LFM playcount).
+     */
+    @Query(
+        """
+        SELECT t.artist AS artist, t.title AS title
+        FROM listening_events e
+        INNER JOIN tracks t ON t.id = e.track_id
+        WHERE e.started_at >= :sinceEpochMs
+        GROUP BY e.track_id
+        ORDER BY COUNT(*) DESC
+        LIMIT :limit
+        """
+    )
+    suspend fun getTopTracksByLocalPlays(sinceEpochMs: Long, limit: Int): List<TrackArtistTitle>
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
@@ -400,4 +400,16 @@ interface PlaylistDao {
     /** Soft-delete a single track from a playlist. */
     @Query("UPDATE playlist_tracks SET removed_at = CURRENT_TIMESTAMP WHERE playlist_id = :playlistId AND track_id = :trackId AND removed_at IS NULL")
     suspend fun softDeleteTrackFromPlaylist(playlistId: Long, trackId: Long)
+
+    /**
+     * Returns DISTINCT track ids that appear in any of the given playlists.
+     * Used by [com.stash.core.data.sync.workers.StashMixRefreshWorker]'s
+     * single-recipe refresh path to seed `excludeIds` from the user's
+     * currently-materialized OTHER mixes — without this, a manual refresh
+     * of one mix sees an empty exclude set and naturally produces overlap
+     * with the others (the very symptom PR 3's batch-mode dedup was meant
+     * to fix).
+     */
+    @Query("SELECT DISTINCT track_id FROM playlist_tracks WHERE playlist_id IN (:playlistIds)")
+    suspend fun getTrackIdsForPlaylists(playlistIds: List<Long>): List<Long>
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/StashMixRecipeDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/StashMixRecipeDao.kt
@@ -82,13 +82,19 @@ interface StashMixRecipeDao {
      * cascading its discovery_queue. Used when we ship a new default
      * (e.g. bumping discovery_ratio) and want existing installs to pick
      * it up without wiping the user's accumulated discovery state.
+     *
+     * v0.9.20: extended from 4 to 6 fields. The recipe-pivot migration
+     * needs to change affinityBias + seedStrategy alongside the original
+     * three knobs in a single atomic UPDATE.
      */
     @Query(
         """
         UPDATE stash_mix_recipes
         SET discovery_ratio = :discoveryRatio,
             freshness_window_days = :freshnessWindowDays,
-            target_length = :targetLength
+            target_length = :targetLength,
+            affinity_bias = :affinityBias,
+            seed_strategy = :seedStrategy
         WHERE is_builtin = 1 AND name = :name
         """
     )
@@ -97,5 +103,7 @@ interface StashMixRecipeDao {
         discoveryRatio: Float,
         freshnessWindowDays: Int,
         targetLength: Int,
+        affinityBias: Float,
+        seedStrategy: String,
     ): Int
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackArtistTitle.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackArtistTitle.kt
@@ -1,0 +1,13 @@
+package com.stash.core.data.db.dao
+
+/**
+ * Minimal projection for seed-track lookups — returns just the
+ * artist+title pair without the rest of TrackEntity. Used by
+ * [ListeningEventDao.getTopTracksByLocalPlays] and
+ * [TrackDao.getTopTracksByLfmPlaycount] which feed the seedTracks
+ * fallback chain in StashMixRefreshWorker.queueDiscoveryForRecipe.
+ */
+data class TrackArtistTitle(
+    val artist: String,
+    val title: String,
+)

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -1083,6 +1083,27 @@ interface TrackDao {
     """)
     suspend fun findDownloadedByCanonical(canonicalTitle: String, canonicalArtist: String): TrackEntity?
 
+    /**
+     * Returns the canonical-key set ("$canonicalArtist|$canonicalTitle")
+     * for every downloaded track. Used by [com.stash.core.data.sync.workers.StashMixRefreshWorker]'s
+     * discovery pre-filter to drop Last.fm candidates that would dedup
+     * to library content downstream — keeping discovery_queue PENDING
+     * rows representative of genuinely-new music instead of "rediscovery"
+     * hits.
+     *
+     * `is_downloaded = 1` restricts to playable content. Stub TrackEntities
+     * (created by StashDiscoveryWorker before their files land) are excluded
+     * so we don't double-filter against in-flight discoveries.
+     */
+    @Query(
+        """
+        SELECT DISTINCT (canonical_artist || '|' || canonical_title) AS k
+        FROM tracks
+        WHERE is_downloaded = 1
+        """
+    )
+    suspend fun getLibraryCanonicalKeys(): List<String>
+
     // ── Wrong-match flagging (user-initiated) ───────────────────────────
 
     /**

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -176,6 +176,31 @@ interface TrackDao {
     )
     suspend fun getTopArtistsByTrackCount(limit: Int): List<String>
 
+    /**
+     * Top downloaded tracks by Last.fm scrobble count, returned as
+     * (artist, title) pairs ready for [com.stash.core.data.mix.MixSeedGenerator]'s
+     * TRACK_SIMILAR seed source. Used as the third tier (final fallback)
+     * of the seedTracks fallback chain — for users with no recent listening
+     * events but who have been scrobbling to Last.fm for a while, the LFM
+     * playcount carries meaningful taste signal.
+     *
+     * Filters to is_downloaded = 1 because the seed needs to actually be a
+     * library track (not a stub); and lastfm_user_playcount > 0 to ensure
+     * meaningful signal (NULL or 0 means "never scrobbled / no LFM data").
+     */
+    @Query(
+        """
+        SELECT artist AS artist, title AS title
+        FROM tracks
+        WHERE is_downloaded = 1
+          AND lastfm_user_playcount IS NOT NULL
+          AND lastfm_user_playcount > 0
+        ORDER BY lastfm_user_playcount DESC
+        LIMIT :limit
+        """
+    )
+    suspend fun getTopTracksByLfmPlaycount(limit: Int): List<TrackArtistTitle>
+
     // ── List queries (all reactive) ─────────────────────────────────────
 
     /** All tracks ordered by most-recently-added first. v0.9.15: filters blocked. */

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -118,6 +118,18 @@ data class DurationBackfillRow(
 )
 
 /**
+ * Minimal projection for the startup file-integrity sweep — only needs id
+ * and the stored path so we can verify the file actually exists on disk.
+ * `file_path` is nullable in the schema; rows with `is_downloaded=1` and
+ * `file_path IS NULL` are themselves a corrupt state we want to repair.
+ */
+data class DownloadedFileRef(
+    val id: Long,
+    @androidx.room.ColumnInfo(name = "file_path")
+    val filePath: String?,
+)
+
+/**
  * Data-access object for [TrackEntity].
  *
  * Provides CRUD operations, various sorted/filtered queries, full-text
@@ -969,6 +981,40 @@ interface TrackDao {
         """
     )
     suspend fun resetForReDownload(trackId: Long)
+
+    /**
+     * All `is_downloaded=1` rows with their stored `file_path`. Drives the
+     * startup file-integrity sweep that verifies every "downloaded" track
+     * actually has a readable file on disk. A track whose file vanished
+     * (user file-manager delete, SAF grant revoked, external storage
+     * unmounted at the wrong moment) keeps `is_downloaded=1` until something
+     * notices the file is gone — this query produces the candidate set.
+     */
+    @Query(
+        """
+        SELECT id, file_path FROM tracks
+        WHERE is_downloaded = 1
+        """
+    )
+    suspend fun getDownloadedFileRefs(): List<DownloadedFileRef>
+
+    /**
+     * Bulk-reset rows to undownloaded state. Companion to
+     * [resetForReDownload] but takes a list — used by the startup integrity
+     * sweep which collects all missing-file ids and resets them in one
+     * statement. `quality_kbps`/`file_format` deliberately untouched: the
+     * row may still hold useful metadata for a future re-download attempt.
+     */
+    @Query(
+        """
+        UPDATE tracks
+        SET is_downloaded = 0,
+            file_path = NULL,
+            file_size_bytes = 0
+        WHERE id IN (:trackIds)
+        """
+    )
+    suspend fun bulkResetForReDownload(trackIds: List<Long>)
 
     /**
      * YT-source tracks the Quick-scan backfill should verify. Two routes

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackSkipEventDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackSkipEventDao.kt
@@ -39,4 +39,37 @@ interface TrackSkipEventDao {
         """
     )
     suspend fun getSkipStatsSince(trackIds: List<Long>, sinceMs: Long): List<TrackSkipStats>
+
+    /**
+     * Returns canonical-key set ("$canonicalArtist|$canonicalTitle") for
+     * tracks that have been "early-skipped" at least [minSkips] times since
+     * [sinceMs], where "early" means within the first [maxPositionMs]
+     * milliseconds of playback. Used by [com.stash.core.data.sync.workers.StashMixRefreshWorker]'s
+     * discovery pre-filter to ban candidates the user has repeatedly
+     * rejected.
+     *
+     * Position-aware: a skip 90% of the way through a song is "finished
+     * listening, moving on," not a verdict. Only skips in the first
+     * [maxPositionMs] count.
+     *
+     * Joins to `tracks` to look up the canonical key. Tracks deleted from
+     * the library are naturally excluded (INNER JOIN) — acceptable; if a
+     * track is gone we don't need to ban it from future re-discovery.
+     */
+    @Query(
+        """
+        SELECT (t.canonical_artist || '|' || t.canonical_title) AS k
+        FROM track_skip_events s
+        INNER JOIN tracks t ON t.id = s.track_id
+        WHERE s.skipped_at >= :sinceMs
+          AND s.position_ms <= :maxPositionMs
+        GROUP BY k
+        HAVING COUNT(*) >= :minSkips
+        """
+    )
+    suspend fun getEarlySkipBannedCanonicalKeys(
+        minSkips: Int,
+        sinceMs: Long,
+        maxPositionMs: Long,
+    ): List<String>
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmSessionPreference.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmSessionPreference.kt
@@ -2,9 +2,11 @@ package com.stash.core.data.lastfm
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -22,6 +24,7 @@ data class LastFmSession(
 /** Dedicated DataStore for Last.fm session — independent of other prefs. */
 private val Context.lastFmDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "lastfm_session",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
 )
 
 /**

--- a/core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt
@@ -193,13 +193,14 @@ class MixGenerator @Inject constructor(
         )
 
         // Step 8: shortfall backfill from the remaining library pool.
-        // Gated on discoveryRatio < 1.0 — pure-discovery recipes like
-        // "Stash Discover" (ratio = 1.0) must NEVER fall back to library
-        // tracks, even at the cost of a sparser mix until Discovery
-        // downloads more candidates. The user has explicitly asked for
-        // zero familiarity; respecting that beats the old "better to
-        // repeat a little than look broken" heuristic.
-        if (recipe.discoveryRatio < 1.0f) {
+        // v0.9.20: gate raised from `< 1.0f` to `< 0.5f`. Recipes that should
+        // be substantially discovery-driven (>= 50% by ratio) must not silently
+        // degrade to library when discovery is sparse — that's exactly what
+        // produced the "library-heavy mixes" symptom on existing installs.
+        // A sparser-but-honest mix is better than a deceptively library-filled
+        // one. Library-only recipes (ratio == 0) and lightly-discovery recipes
+        // (< 0.5) still get the original full-fill behavior.
+        if (recipe.discoveryRatio < 0.5f) {
             val shortfall = recipe.targetLength - picked.size
             if (shortfall > 0 && picked.size < pool.size) {
                 val extra = ordered.filter { it !in picked }.take(shortfall)

--- a/core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt
@@ -109,14 +109,24 @@ class MixGenerator @Inject constructor(
      * Produces the finalized track list for [recipe]. The worker calling
      * this replaces the playlist_tracks rows for [recipe.playlistId] with
      * this ordering.
+     *
+     * v0.9.20: [excludeIds] is the cross-mix dedup primitive — when the
+     * refresh worker iterates multiple recipes back-to-back, it accumulates
+     * track ids already claimed by earlier recipes and passes them here so
+     * the current recipe can't re-pick them.
      */
-    suspend fun generate(recipe: StashMixRecipeEntity): List<TrackEntity> {
+    suspend fun generate(
+        recipe: StashMixRecipeEntity,
+        excludeIds: Set<Long> = emptySet(),
+    ): List<TrackEntity> {
         // Step 1: candidate pool — start from every downloaded,
-        // non-blacklisted track in the library.
+        // non-blacklisted track in the library. v0.9.20: filter through
+        // excludeIds first (cheap O(n) set lookup, before any other filtering).
         val rawPool = trackDao.getAllDownloaded()
+        val pool0 = if (excludeIds.isEmpty()) rawPool else rawPool.filter { it.id !in excludeIds }
 
         // Step 2: era filter (cheap, done in-memory).
-        var pool = filterByEra(rawPool, recipe)
+        var pool = filterByEra(pool0, recipe)
 
         // Step 3: include-tag filter (one DAO hit if recipe has tags).
         val includeTags = recipe.includeTagsCsv.splitTrim()

--- a/core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt
@@ -302,15 +302,32 @@ class MixGenerator @Inject constructor(
     /**
      * v0.9.16: Top-N user tags ordered by tag-affinity weight. Used by
      * [com.stash.core.data.sync.workers.StashMixRefreshWorker] to drive
-     * the TAG_GRAPH seed strategy. Returns empty list when the user has
-     * no listening history yet.
+     * the TAG_GRAPH seed strategy.
+     *
+     * v0.9.19: when the listening-affinity vector is empty (fresh install,
+     * recently played tracks not yet enriched, etc.) falls back to the
+     * library-wide tag histogram. The histogram represents "what kind of
+     * music this user collects" — the right anchor for First Listen's
+     * "wider net" semantics when there's no per-play signal yet. Returns
+     * an empty list ONLY when the user has zero tags anywhere in
+     * `track_tags` (truly fresh install, enrichment hasn't run a single
+     * batch yet) — at which point TAG_GRAPH-driven recipes correctly
+     * stay empty until the user's library has any tag data.
      */
     suspend fun computeUserTopTags(limit: Int = 10): List<String> {
         val vector = buildUserTagAffinityVector()
-        return vector.entries
-            .sortedByDescending { it.value }
+        if (vector.isNotEmpty()) {
+            return vector.entries
+                .sortedByDescending { it.value }
+                .take(limit)
+                .map { it.key }
+        }
+        return trackTagDao.getTagHistogram()
+            .asSequence()
+            .filter { it.tag != "__untaggable__" }
             .take(limit)
-            .map { it.key }
+            .map { it.tag }
+            .toList()
     }
 
     /**

--- a/core/data/src/main/kotlin/com/stash/core/data/mix/StashMixDefaults.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/mix/StashMixDefaults.kt
@@ -4,23 +4,24 @@ import com.stash.core.data.db.dao.StashMixRecipeDao
 import com.stash.core.data.db.entity.StashMixRecipeEntity
 
 /**
- * Ships Stash's built-in mix recipes. v0.9.16 expands the surface from
- * the single "Stash Discover" flagship to a three-recipe set that exercises
- * each [com.stash.core.data.mix.MixSeedStrategy]:
+ * Ships Stash's built-in mix recipes. As of v0.9.20, all three builtins
+ * are recommendation-substrate-with-library-seasoning — Daily Discover
+ * and Deep Cuts at 85% discovery, First Listen at 100% discovery. Each
+ * uses a distinct [com.stash.core.data.mix.MixSeedStrategy] so their
+ * discovery-survivor pools are naturally differentiated:
  *
- *  - **Daily Discover** — affinity-biased blend of library + new finds
- *    seeded from `artist.getSimilar`.
- *  - **Deep Cuts** — pure-library rediscovery, library-only (no
- *    discovery), surfaces tracks the user used to love but hasn't heard
- *    in a while.
- *  - **First Listen** — pure-discovery, seeded from the user's top tags
- *    via the tag-graph generator. Wider net than Daily Discover.
+ *  - **Daily Discover** — ARTIST_SIMILAR; recommendations from artists
+ *    similar to your top artists.
+ *  - **Deep Cuts** — TRACK_SIMILAR; recommendations from tracks similar
+ *    to your top tracks (deeper-dive flavor).
+ *  - **First Listen** — TAG_GRAPH; top tracks across your taste tags
+ *    (widest net).
  *
  * Only seeds when [StashMixRecipeDao.countBuiltins] is zero, so users
- * don't get defaults re-inserted every launch. Upgrades from pre-0.9.16
- * installs that already have the old single-recipe builtin go through
- * `StashApplication.maybeReseedStashMixes` which clears the old set
- * first and then runs this seed.
+ * don't get defaults re-inserted every launch. Upgrades from earlier
+ * installs that already have the previous builtin set go through
+ * `StashApplication.maybeRetuneStashMixes` which non-destructively
+ * updates the rows in place via [StashMixRecipeDao.retuneBuiltin].
  */
 object StashMixDefaults {
 
@@ -32,22 +33,22 @@ object StashMixDefaults {
     val ALL: List<StashMixRecipeEntity> = listOf(
         StashMixRecipeEntity(
             name = "Daily Discover",
-            description = "Personalized blend of your library + fresh finds.",
-            affinityBias = 0.3f,
+            description = "Mostly fresh finds via similar-artists. A pinch of your library.",
+            affinityBias = 0.0f,
             freshnessWindowDays = 7,
-            discoveryRatio = 0.4f,
-            targetLength = 50,
+            discoveryRatio = 0.85f,
+            targetLength = 40,
             seedStrategy = "ARTIST_SIMILAR",
             isBuiltin = true,
         ),
         StashMixRecipeEntity(
             name = "Deep Cuts",
-            description = "Tracks you used to love that haven't been on rotation.",
-            affinityBias = 0.6f,
+            description = "Mostly fresh finds via similar-tracks. A pinch of your library.",
+            affinityBias = 0.0f,
             freshnessWindowDays = 90,
-            discoveryRatio = 0f,
-            targetLength = 50,
-            seedStrategy = "NONE",
+            discoveryRatio = 0.85f,
+            targetLength = 40,
+            seedStrategy = "TRACK_SIMILAR",
             isBuiltin = true,
         ),
         StashMixRecipeEntity(

--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/DownloadNetworkPreference.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/DownloadNetworkPreference.kt
@@ -2,8 +2,10 @@ package com.stash.core.data.prefs
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.stash.core.model.DownloadNetworkMode
@@ -17,6 +19,7 @@ import javax.inject.Singleton
 /** Extension property providing a singleton DataStore for download network preference. */
 private val Context.downloadNetworkDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "download_network_preference",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
 )
 
 /**

--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/LikePreferences.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/LikePreferences.kt
@@ -2,9 +2,11 @@ package com.stash.core.data.prefs
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -17,6 +19,7 @@ import kotlinx.coroutines.flow.map
 // Top-level Context extension — mirrors LosslessSourcePreferences.kt:18-20.
 private val Context.likeDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "like_preferences",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
 )
 
 /**

--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/StoragePreferencesManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/StoragePreferencesManager.kt
@@ -3,8 +3,10 @@ package com.stash.core.data.prefs
 import android.content.Context
 import android.net.Uri
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -16,6 +18,7 @@ import javax.inject.Singleton
 /** Dedicated DataStore for storage preferences — independent of theme/quality. */
 private val Context.storageDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "storage_preferences",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
 )
 
 /**

--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/ThemePreferencesManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/ThemePreferencesManager.kt
@@ -2,8 +2,10 @@ package com.stash.core.data.prefs
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.stash.core.model.ThemeMode
@@ -16,6 +18,7 @@ import javax.inject.Singleton
 /** Singleton DataStore for theme preferences, separate from other preference stores. */
 private val Context.themeDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "theme_preferences",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
 )
 
 /**

--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/YouTubeHistoryPreference.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/YouTubeHistoryPreference.kt
@@ -2,9 +2,11 @@ package com.stash.core.data.prefs
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -16,6 +18,7 @@ import javax.inject.Singleton
 /** Dedicated DataStore for YT history sync opt-in. */
 private val Context.youtubeHistoryDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "youtube_history_preference",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
 )
 
 /**

--- a/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
@@ -121,11 +121,70 @@ class MusicRepositoryImpl @Inject constructor(
         // overwrote all Spotify tracks' date_added with the same timestamp, making
         // "Recently Added" show arbitrary tracks instead of actual recent downloads.
 
+        // v0.9.21: file integrity sweep — finds tracks marked is_downloaded=1
+        // whose file has vanished from disk and resets them to undownloaded.
+        // Without this, getDoneTrackIdsForRecipe surfaces them as mix
+        // survivors (they pass the is_downloaded=1 filter) but playback fails
+        // because the file is gone. Run BEFORE cleanOrphanedMixTracks so the
+        // sweep itself doesn't choke on stale paths. See conversation
+        // 2026-05-12: tracks with FLAC quality + album art + no audible
+        // playback because the file was missing.
+        reconcileMissingDownloadedFiles()
+
         // Clean up orphaned mix tracks — downloaded tracks whose playlist was
         // refreshed and that no longer belong to any playlist. Deletes their
         // audio files and DB rows to free storage. Safe to run every startup;
         // becomes a no-op when there are no orphans.
         cleanOrphanedMixTracks()
+    }
+
+    /**
+     * Verifies every `is_downloaded=1` row's file is actually readable.
+     * Handles both regular filesystem paths and SAF `content://` URIs.
+     * Rows with missing files have `is_downloaded`, `file_path`, and
+     * `file_size_bytes` cleared so the rest of the system stops treating
+     * them as playable.
+     *
+     * Skipped: rows whose path is already null (they're a separate kind
+     * of corrupt state that bulkResetForReDownload will also clean —
+     * captured in `nullPath`).
+     */
+    private suspend fun reconcileMissingDownloadedFiles() {
+        val refs = trackDao.getDownloadedFileRefs()
+        if (refs.isEmpty()) return
+
+        val missing = mutableListOf<Long>()
+        var nullPath = 0
+        for (ref in refs) {
+            val path = ref.filePath
+            if (path.isNullOrBlank()) {
+                missing += ref.id
+                nullPath++
+                continue
+            }
+            val exists = runCatching {
+                if (path.startsWith("content://")) {
+                    DocumentFile.fromSingleUri(context, Uri.parse(path))?.exists() == true
+                } else {
+                    java.io.File(path).exists()
+                }
+            }.getOrDefault(false)
+            if (!exists) missing += ref.id
+        }
+
+        if (missing.isEmpty()) {
+            android.util.Log.d("StashMigrations", "file integrity: all ${refs.size} downloaded files present")
+            return
+        }
+        // Bulk update in chunks to stay under SQLite's parameter ceiling.
+        missing.chunked(500).forEach { chunk ->
+            trackDao.bulkResetForReDownload(chunk)
+        }
+        android.util.Log.i(
+            "StashMigrations",
+            "file integrity: scanned ${refs.size} downloaded rows, " +
+                "reset ${missing.size} with missing files (nullPath=$nullPath)",
+        )
     }
 
     // ── Track queries ───────────────────────────────────────────────────

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/SyncPreferencesManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/SyncPreferencesManager.kt
@@ -1,8 +1,10 @@
 package com.stash.core.data.sync
 
 import android.content.Context
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -14,7 +16,10 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private val Context.syncPrefsDataStore by preferencesDataStore(name = "sync_preferences")
+private val Context.syncPrefsDataStore by preferencesDataStore(
+    name = "sync_preferences",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+)
 
 /**
  * User-configurable sync scheduling preferences backed by DataStore.

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorker.kt
@@ -196,6 +196,16 @@ class DiscoveryDownloadWorker @AssistedInject constructor(
             }
         }
 
+        // v0.9.21: Discovery downloads start as stubs with duration_ms=0
+        // (no Spotify metadata to seed from). Without this fill, every
+        // discovery track shows 0:00 in playlist UI and contributes 0 to
+        // the header's total-length sum. The sync path's TrackDownloadWorker
+        // has its own duration update; this is the discovery equivalent.
+        if (meta != null && meta.durationMs > 0) {
+            runCatching { trackDao.fillMissingDuration(trackEntity.id, meta.durationMs) }
+                .onFailure { Log.w(TAG, "fillMissingDuration failed for ${trackEntity.id}", it) }
+        }
+
         downloadQueueDao.updateStatus(
             id = queueItem.id,
             status = DownloadStatus.COMPLETED,

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorker.kt
@@ -1,4 +1,4 @@
-package com.stash.data.download
+package com.stash.core.data.sync.workers
 
 import android.content.Context
 import android.content.pm.ServiceInfo

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DownloadConstraints.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DownloadConstraints.kt
@@ -34,21 +34,29 @@ fun constraintsFor(mode: DownloadNetworkMode): Constraints = Constraints.Builder
 }.build()
 
 /**
- * Constraints for **manual triggers** — when the user explicitly taps
- * "Refresh this mix" or the app boots and we want to drain orphan
- * discovery downloads. Same network discipline as [constraintsFor]
- * (we still respect the user's [DownloadNetworkMode] pref for cellular)
- * but DROPS the charging requirement: the user is actively asking for
- * content; honoring that beats waiting for them to plug in.
+ * Constraints for **manual user-initiated triggers** — the user explicitly
+ * tapped "Refresh this mix" or the app booted with orphan downloads to
+ * drain. They're asking for content right now; the system honors that on
+ * whatever network is available.
+ *
+ * Differs from [constraintsFor]:
+ *  - Charging requirement DROPPED (user is actively using the app).
+ *  - Network requirement RELAXED from UNMETERED to CONNECTED — manual
+ *    triggers don't gate on cellular preference. The user's
+ *    DownloadNetworkMode pref still governs the periodic background
+ *    cycle (via [constraintsFor]); it doesn't govern foreground intent.
  *
  * `setRequiresBatteryNotLow(true)` stays on — a 5% battery + manual
  * refresh is still a bad combination.
+ *
+ * v0.9.20 history: shipped in PR 5 respecting DownloadNetworkMode for
+ * cellular gating. After a corruption-induced pref reset left the user
+ * stuck (default mode = WIFI_AND_CHARGING → manual triggers required
+ * unmetered → no firing on cellular), we relaxed to CONNECTED to match
+ * how every major music app handles user-initiated downloads.
  */
-fun constraintsForManualTrigger(mode: DownloadNetworkMode): Constraints = Constraints.Builder().apply {
-    setRequiresBatteryNotLow(true)
-    when (mode) {
-        DownloadNetworkMode.WIFI_AND_CHARGING -> setRequiredNetworkType(NetworkType.UNMETERED)
-        DownloadNetworkMode.WIFI_ANY -> setRequiredNetworkType(NetworkType.UNMETERED)
-        DownloadNetworkMode.ANY_NETWORK -> setRequiredNetworkType(NetworkType.CONNECTED)
-    }
-}.build()
+@Suppress("UNUSED_PARAMETER")
+fun constraintsForManualTrigger(mode: DownloadNetworkMode): Constraints = Constraints.Builder()
+    .setRequiresBatteryNotLow(true)
+    .setRequiredNetworkType(NetworkType.CONNECTED)
+    .build()

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DownloadConstraints.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DownloadConstraints.kt
@@ -32,3 +32,23 @@ fun constraintsFor(mode: DownloadNetworkMode): Constraints = Constraints.Builder
         }
     }
 }.build()
+
+/**
+ * Constraints for **manual triggers** — when the user explicitly taps
+ * "Refresh this mix" or the app boots and we want to drain orphan
+ * discovery downloads. Same network discipline as [constraintsFor]
+ * (we still respect the user's [DownloadNetworkMode] pref for cellular)
+ * but DROPS the charging requirement: the user is actively asking for
+ * content; honoring that beats waiting for them to plug in.
+ *
+ * `setRequiresBatteryNotLow(true)` stays on — a 5% battery + manual
+ * refresh is still a bad combination.
+ */
+fun constraintsForManualTrigger(mode: DownloadNetworkMode): Constraints = Constraints.Builder().apply {
+    setRequiresBatteryNotLow(true)
+    when (mode) {
+        DownloadNetworkMode.WIFI_AND_CHARGING -> setRequiredNetworkType(NetworkType.UNMETERED)
+        DownloadNetworkMode.WIFI_ANY -> setRequiredNetworkType(NetworkType.UNMETERED)
+        DownloadNetworkMode.ANY_NETWORK -> setRequiredNetworkType(NetworkType.CONNECTED)
+    }
+}.build()

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
@@ -6,7 +6,9 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
@@ -65,6 +67,7 @@ class StashDiscoveryWorker @AssistedInject constructor(
     companion object {
         private const val TAG = "StashDiscovery"
         private const val WORK_NAME = "stash_discovery"
+        private const val ONE_SHOT_WORK_NAME = "stash_discovery_oneshot"
         private const val BATCH_SIZE = 60
         // Raised from 30 → 100 on 2026-04-22. With Stash Discover at 100%
         // discovery ratio + targetLength=50, a 30/week drain couldn't
@@ -94,6 +97,26 @@ class StashDiscoveryWorker @AssistedInject constructor(
             WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                 WORK_NAME,
                 ExistingPeriodicWorkPolicy.UPDATE,
+                work,
+            )
+        }
+
+        /**
+         * Fire a one-shot discovery sweep — manual user trigger, no charging
+         * requirement. Respects [DownloadNetworkMode] for cellular gating via
+         * [constraintsForManualTrigger]. Unique work name + REPLACE policy so a
+         * rapid double-tap coalesces. At the end of [doWork], the existing
+         * v0.9.20 chain to [DiscoveryDownloadWorker] fires, completing the
+         * pipeline: discovery_queue PENDING → stubs + download_queue PENDING →
+         * actual downloads.
+         */
+        fun enqueueOneTime(context: Context, mode: DownloadNetworkMode) {
+            val work = OneTimeWorkRequestBuilder<StashDiscoveryWorker>()
+                .setConstraints(constraintsForManualTrigger(mode))
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                ONE_SHOT_WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
                 work,
             )
         }

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
@@ -134,7 +134,22 @@ class StashDiscoveryWorker @AssistedInject constructor(
             Log.i(TAG, "aged out $aged stale PENDING row(s) older than 30 days")
         }
 
-        val pending = discoveryQueueDao.getPending(BATCH_SIZE)
+        // v0.9.21: pre-filter the PENDING fetch by under-cap recipes so a
+        // single recipe's deferred-at-cap backlog doesn't starve other
+        // recipes' fresh candidates out of the BATCH_SIZE window. See
+        // conversation 2026-05-12: First Listen had 100+ deferred-at-cap
+        // PENDING rows clogging the head of the queue so Deep Cuts'
+        // freshly-queued candidates never reached the worker.
+        val cappedRecipeIds = discoveryQueueDao.findRecipesAtWeeklyCap(
+            sinceMillis = System.currentTimeMillis() - WEEK_MS,
+            cap = PER_RECIPE_WEEKLY_CAP,
+        )
+        val pending = if (cappedRecipeIds.isEmpty()) {
+            discoveryQueueDao.getPending(BATCH_SIZE)
+        } else {
+            Log.i(TAG, "recipes at cap (excluded from fetch): $cappedRecipeIds")
+            discoveryQueueDao.getPendingExcludingRecipes(cappedRecipeIds, BATCH_SIZE)
+        }
         if (pending.isEmpty()) {
             Log.d(TAG, "no pending discoveries")
             // Don't return early — fall through to the chain. download_queue
@@ -148,6 +163,9 @@ class StashDiscoveryWorker @AssistedInject constructor(
 
             // Per-recipe caps — counted lazily to avoid a DAO hit per candidate.
             val recipeBudget = HashMap<Long, Int>()
+            // Per-recipe one-shot "cap fired" log so a recipe with dozens of
+            // pending rows doesn't spam logcat with the same deferral line.
+            val cappedRecipesLogged = HashSet<Long>()
 
             for (entry in pending) {
                 val used = recipeBudget.getOrPut(entry.recipeId) {
@@ -155,7 +173,13 @@ class StashDiscoveryWorker @AssistedInject constructor(
                 }
                 if (used >= PER_RECIPE_WEEKLY_CAP) {
                     // Leave as PENDING so next week's cycle can pick it up.
-                    Log.d(TAG, "recipe ${entry.recipeId} hit weekly cap — deferring")
+                    if (cappedRecipesLogged.add(entry.recipeId)) {
+                        Log.i(
+                            TAG,
+                            "recipe ${entry.recipeId} at cap " +
+                                "($used downloaded in last 7d, limit $PER_RECIPE_WEEKLY_CAP) — deferring pending",
+                        )
+                    }
                     continue
                 }
 

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
@@ -14,18 +14,15 @@ import com.stash.core.data.db.dao.DiscoveryQueueDao
 import com.stash.core.model.DownloadNetworkMode
 import com.stash.core.data.prefs.DownloadNetworkPreference
 import com.stash.core.data.db.dao.DownloadQueueDao
-import com.stash.core.data.db.dao.PlaylistDao
 import com.stash.core.data.db.dao.StashMixRecipeDao
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.db.entity.DiscoveryQueueEntity
 import com.stash.core.data.db.entity.DownloadQueueEntity
-import com.stash.core.data.db.entity.PlaylistTrackCrossRef
 import com.stash.core.data.db.entity.TrackEntity
 import com.stash.core.data.sync.TrackMatcher
 import com.stash.core.model.MusicSource
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 /**
@@ -57,7 +54,6 @@ class StashDiscoveryWorker @AssistedInject constructor(
     private val discoveryQueueDao: DiscoveryQueueDao,
     private val downloadQueueDao: DownloadQueueDao,
     private val trackDao: TrackDao,
-    private val playlistDao: PlaylistDao,
     private val recipeDao: StashMixRecipeDao,
     private val trackMatcher: TrackMatcher,
     private val blocklistGuard: com.stash.core.data.blocklist.BlocklistGuard,
@@ -299,20 +295,15 @@ class StashDiscoveryWorker @AssistedInject constructor(
             newId
         }
 
-        // Link to the mix's playlist at the end of the current ordering.
-        // The Home card surfaces these as they become playable; until
-        // download completes they're present-but-unplayable.
-        val currentCount = playlistDao.getById(playlistId)?.trackCount ?: 0
-        playlistDao.insertCrossRef(
-            PlaylistTrackCrossRef(
-                playlistId = playlistId,
-                trackId = trackId,
-                position = currentCount,
-                addedAt = Instant.ofEpochMilli(now),
-            )
-        )
-        playlistDao.updateTrackCount(playlistId, currentCount + 1)
-
+        // v0.9.21: Do NOT insert into playlist_tracks here. Earlier versions
+        // inserted a cross-ref at this point so the mix would "show" stubs
+        // before downloads completed, but the UI hides non-downloaded
+        // tracks anyway AND a concurrent StashMixRefreshWorker's
+        // clearPlaylistTracks would race-wipe these inserts (user-visible
+        // 5 → 13 → 5 flash, conversation 2026-05-12). Linking is owned
+        // solely by materializeMix() via getDoneTrackIdsForRecipe(), which
+        // only sees is_downloaded=1 tracks — eliminates the race and the
+        // phantom-stub flash.
         return HandledResult(
             status = DiscoveryQueueEntity.STATUS_DONE,
             trackId = trackId,

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
@@ -3,8 +3,10 @@ package com.stash.core.data.sync.workers
 import android.content.Context
 import android.util.Log
 import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
@@ -144,6 +146,18 @@ class StashDiscoveryWorker @AssistedInject constructor(
                 errorMessage = result.error,
             )
         }
+
+        // v0.9.20: after queueing/processing discoveries, kick the downloader
+        // so the new tracks become playable in this charging+WiFi window.
+        // Mirror this worker's own constraints (charging + batteryNotLow +
+        // NetworkType.UNMETERED) — discovery downloads should respect the same
+        // posture that gated the discovery itself.
+        val downloadConstraints = Constraints.Builder()
+            .setRequiresCharging(true)
+            .setRequiresBatteryNotLow(true)
+            .setRequiredNetworkType(NetworkType.UNMETERED)
+            .build()
+        DiscoveryDownloadWorker.enqueueOneTime(applicationContext, downloadConstraints)
         return Result.success()
     }
 

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
@@ -114,37 +114,40 @@ class StashDiscoveryWorker @AssistedInject constructor(
         val pending = discoveryQueueDao.getPending(BATCH_SIZE)
         if (pending.isEmpty()) {
             Log.d(TAG, "no pending discoveries")
-            return Result.success()
-        }
-        Log.i(TAG, "draining ${pending.size} discovery candidates")
+            // Don't return early — fall through to the chain. download_queue
+            // is a separate table and may hold orphan PENDING or retry-
+            // eligible FAILED rows from prior runs that still need draining.
+        } else {
+            Log.i(TAG, "draining ${pending.size} discovery candidates")
 
-        val now = System.currentTimeMillis()
-        val weekAgo = now - WEEK_MS
+            val now = System.currentTimeMillis()
+            val weekAgo = now - WEEK_MS
 
-        // Per-recipe caps — counted lazily to avoid a DAO hit per candidate.
-        val recipeBudget = HashMap<Long, Int>()
+            // Per-recipe caps — counted lazily to avoid a DAO hit per candidate.
+            val recipeBudget = HashMap<Long, Int>()
 
-        for (entry in pending) {
-            val used = recipeBudget.getOrPut(entry.recipeId) {
-                discoveryQueueDao.countRecentCompletedForRecipe(entry.recipeId, weekAgo)
+            for (entry in pending) {
+                val used = recipeBudget.getOrPut(entry.recipeId) {
+                    discoveryQueueDao.countRecentCompletedForRecipe(entry.recipeId, weekAgo)
+                }
+                if (used >= PER_RECIPE_WEEKLY_CAP) {
+                    // Leave as PENDING so next week's cycle can pick it up.
+                    Log.d(TAG, "recipe ${entry.recipeId} hit weekly cap — deferring")
+                    continue
+                }
+
+                val result = handle(entry, now)
+                if (result.trackId != null) {
+                    recipeBudget[entry.recipeId] = used + 1
+                }
+                discoveryQueueDao.updateStatus(
+                    id = entry.id,
+                    status = result.status,
+                    trackId = result.trackId,
+                    completedAt = now,
+                    errorMessage = result.error,
+                )
             }
-            if (used >= PER_RECIPE_WEEKLY_CAP) {
-                // Leave as PENDING so next week's cycle can pick it up.
-                Log.d(TAG, "recipe ${entry.recipeId} hit weekly cap — deferring")
-                continue
-            }
-
-            val result = handle(entry, now)
-            if (result.trackId != null) {
-                recipeBudget[entry.recipeId] = used + 1
-            }
-            discoveryQueueDao.updateStatus(
-                id = entry.id,
-                status = result.status,
-                trackId = result.trackId,
-                completedAt = now,
-                errorMessage = result.error,
-            )
         }
 
         // v0.9.20: after queueing/processing discoveries, kick the downloader
@@ -152,6 +155,10 @@ class StashDiscoveryWorker @AssistedInject constructor(
         // Mirror this worker's own constraints (charging + batteryNotLow +
         // NetworkType.UNMETERED) — discovery downloads should respect the same
         // posture that gated the discovery itself.
+        //
+        // Always chain — even when discovery_queue was empty this run. Prior
+        // runs may have queued download_queue rows that haven't been drained
+        // yet (FAILED-with-retry, leftover PENDING, app crash mid-drain).
         val downloadConstraints = Constraints.Builder()
             .setRequiresCharging(true)
             .setRequiresBatteryNotLow(true)

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
@@ -3,17 +3,16 @@ package com.stash.core.data.sync.workers
 import android.content.Context
 import android.util.Log
 import androidx.hilt.work.HiltWorker
-import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
-import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.stash.core.data.db.dao.DiscoveryQueueDao
 import com.stash.core.model.DownloadNetworkMode
+import com.stash.core.data.prefs.DownloadNetworkPreference
 import com.stash.core.data.db.dao.DownloadQueueDao
 import com.stash.core.data.db.dao.PlaylistDao
 import com.stash.core.data.db.dao.StashMixRecipeDao
@@ -62,6 +61,7 @@ class StashDiscoveryWorker @AssistedInject constructor(
     private val recipeDao: StashMixRecipeDao,
     private val trackMatcher: TrackMatcher,
     private val blocklistGuard: com.stash.core.data.blocklist.BlocklistGuard,
+    private val downloadNetworkPreference: DownloadNetworkPreference,
 ) : CoroutineWorker(appContext, params) {
 
     companion object {
@@ -174,20 +174,24 @@ class StashDiscoveryWorker @AssistedInject constructor(
         }
 
         // v0.9.20: after queueing/processing discoveries, kick the downloader
-        // so the new tracks become playable in this charging+WiFi window.
-        // Mirror this worker's own constraints (charging + batteryNotLow +
-        // NetworkType.UNMETERED) — discovery downloads should respect the same
-        // posture that gated the discovery itself.
+        // so the new tracks become playable.
         //
         // Always chain — even when discovery_queue was empty this run. Prior
         // runs may have queued download_queue rows that haven't been drained
         // yet (FAILED-with-retry, leftover PENDING, app crash mid-drain).
-        val downloadConstraints = Constraints.Builder()
-            .setRequiresCharging(true)
-            .setRequiresBatteryNotLow(true)
-            .setRequiredNetworkType(NetworkType.UNMETERED)
-            .build()
-        DiscoveryDownloadWorker.enqueueOneTime(applicationContext, downloadConstraints)
+        //
+        // Use manual-trigger constraints (drop charging, respect user network
+        // pref) regardless of whether THIS worker invocation was periodic or
+        // manual. For the periodic path, the parent's own charging requirement
+        // already gated this worker from running — by the time we chain, we
+        // know the device is charging + on WiFi, so dropping the charging req
+        // on the chain is a no-op. For the manual path, dropping charging is
+        // the whole point: the user is actively asking for content; honor that.
+        val mode = downloadNetworkPreference.current()
+        DiscoveryDownloadWorker.enqueueOneTime(
+            applicationContext,
+            constraintsForManualTrigger(mode),
+        )
         return Result.success()
     }
 

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
 import java.time.Instant
 import java.util.concurrent.TimeUnit
+import kotlin.math.roundToInt
 
 /**
  * Periodic worker that regenerates every active Stash Mix. For each
@@ -307,8 +308,17 @@ class StashMixRefreshWorker @AssistedInject constructor(
         // DONE row is keyed by track id, not identity. `filter` doesn't
         // accept suspend lambdas, so the blocklist check is a manual
         // loop that calls the suspend guard sequentially.
+        // v0.9.19 follow-up: cap discovery survivors at the recipe's stated
+        // slot count (targetLength * discoveryRatio). DAO query orders by
+        // completed_at DESC so newest-DONE survivors win when we have to cut.
+        // Library shortfall-fill in MixGenerator is intentionally untouched —
+        // total playlist size for Daily Discover settles at up-to-50 (library)
+        // + up-to-20 (discovery) = <=70, replacing the previous unbounded growth.
+        val discoveryCap = (recipe.targetLength * recipe.discoveryRatio)
+            .roundToInt()
+            .coerceAtLeast(0)
         val candidateIds = discoveryQueueDao
-            .getDoneTrackIdsForRecipe(recipe.id)
+            .getDoneTrackIdsForRecipe(recipe.id, limit = discoveryCap)
             .filter { it !in librarySet }
         val discoveryTrackIds = buildList {
             for (trackId in candidateIds) {

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -86,7 +86,7 @@ class StashMixRefreshWorker @AssistedInject constructor(
     companion object {
         private const val TAG = "StashMixRefresh"
         private const val WORK_NAME = "stash_mix_refresh"
-        private const val ONE_SHOT_WORK_NAME = "stash_mix_refresh_oneshot"
+        const val ONE_SHOT_WORK_NAME = "stash_mix_refresh_oneshot"
         private const val TOP_ARTISTS_LIMIT = 8
         private const val SIMILAR_REQUEST_INTERVAL_MS = 220L
         private const val AFFINITY_LOOKBACK_DAYS = 180L

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -228,6 +228,22 @@ class StashMixRefreshWorker @AssistedInject constructor(
         // playlists in a single refresh run.
         val orderedRecipes = active.sortedBy { recipeDedupPriority(it) }
         val excludeIds = mutableSetOf<Long>()
+
+        // v0.9.20 follow-up: single-recipe path needs explicit seeding from the
+        // OTHER mixes' current playlist contents. The batch-mode loop accumulates
+        // excludeIds naturally as it iterates; the single-element loop has nothing
+        // to accumulate, so we seed it manually from the materialized state of the
+        // other builtin mixes. Effect: manual refresh of one mix no longer overlaps
+        // with whatever is currently in the others.
+        if (targetId > 0L) {
+            val otherPlaylistIds = recipeDao.getActive()
+                .filter { it.id != targetId && it.playlistId != null }
+                .mapNotNull { it.playlistId }
+            if (otherPlaylistIds.isNotEmpty()) {
+                excludeIds += playlistDao.getTrackIdsForPlaylists(otherPlaylistIds)
+            }
+        }
+
         for (recipe in orderedRecipes) {
             // Snapshot to an immutable Set per iteration so callees can't
             // observe (or accidentally mutate) the accumulator, and so

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -233,6 +233,17 @@ class StashMixRefreshWorker @AssistedInject constructor(
             "refreshing ${active.size} Stash Mix(es)" +
                 if (targetId > 0L) " (single: ${active.first().name})" else "",
         )
+        // v0.9.21: diagnostic snapshot of every active recipe so we can rule
+        // out duplicate-recipe / mismatched-id pathologies when a mix
+        // mysteriously fails to link survivors.
+        recipeDao.getActive().forEach { r ->
+            Log.i(
+                TAG,
+                "  active recipe: id=${r.id} name='${r.name}' " +
+                    "playlistId=${r.playlistId} ratio=${r.discoveryRatio} " +
+                    "target=${r.targetLength} seed=${r.seedStrategy}",
+            )
+        }
 
         val now = System.currentTimeMillis()
         val lastFmConfigured = lastFmCredentials.isConfigured
@@ -432,16 +443,50 @@ class StashMixRefreshWorker @AssistedInject constructor(
         val discoveryCap = (recipe.targetLength * recipe.discoveryRatio)
             .roundToInt()
             .coerceAtLeast(0)
+        // Generous over-fetch: in pathological pool-overlap cases (e.g. Deep
+        // Cuts' TRACK_SIMILAR pool ~95% overlapping First Listen's TAG_GRAPH
+        // pool because a user's top-tracks naturally share tags with the
+        // wider taste graph) the older limit could exhaust before we found
+        // discoveryCap survivors. Headroom is bounded by the total recipe
+        // backlog — DAO query has its own LIMIT clause.
         val rawCandidateIds = discoveryQueueDao
-            .getDoneTrackIdsForRecipe(recipe.id, limit = discoveryCap + excludeIds.size)
-        val filteredCandidateIds = rawCandidateIds
-            .filter { it !in librarySet && it !in excludeIds }
-            .take(discoveryCap)
+            .getDoneTrackIdsForRecipe(recipe.id, limit = discoveryCap * 2 + excludeIds.size)
+        val nonLibraryCandidates = rawCandidateIds.filter { it !in librarySet }
+        // v0.9.21: soft cross-mix dedup. Prefer survivors not already claimed
+        // by an earlier-ordered mix; if dedup leaves us below the cap, backfill
+        // from the shared pool rather than ship an empty discovery section.
+        // Without this, recipes that draw from overlapping Last.fm pools
+        // (TRACK_SIMILAR ∩ TAG_GRAPH ≈ everywhere) silently collapsed to
+        // library-only when refreshed after their peers had already grabbed
+        // the shared candidates. See conversation 2026-05-12: Deep Cuts had
+        // 102 recipe-4 downloaded tracks but 0 discovery survivors.
+        val (preferredIds, sharedIds) = nonLibraryCandidates
+            .partition { it !in excludeIds }
+        val survivorCandidates = if (preferredIds.size >= discoveryCap) {
+            preferredIds.take(discoveryCap)
+        } else {
+            val backfill = sharedIds.take(discoveryCap - preferredIds.size)
+            if (backfill.isNotEmpty()) {
+                Log.i(
+                    TAG,
+                    "'${recipe.name}': dedup left ${preferredIds.size}/$discoveryCap unique survivors; " +
+                        "backfilled ${backfill.size} from cross-mix pool",
+                )
+            }
+            preferredIds + backfill
+        }
         val discoveryTrackIds = buildList {
-            for (trackId in filteredCandidateIds) {
+            for (trackId in survivorCandidates) {
                 if (!blocklistGuard.isBlockedByTrackId(trackId)) add(trackId)
             }
         }
+        Log.i(
+            TAG,
+            "'${recipe.name}' (id=${recipe.id}) link: raw=${rawCandidateIds.size} " +
+                "nonLib=${nonLibraryCandidates.size} preferred=${preferredIds.size} " +
+                "shared=${sharedIds.size} cap=$discoveryCap linked=${discoveryTrackIds.size} " +
+                "excludeIds.size=${excludeIds.size}",
+        )
         discoveryTrackIds.forEachIndexed { offset, trackId ->
             playlistDao.insertCrossRef(
                 PlaylistTrackCrossRef(

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -116,9 +116,13 @@ class StashMixRefreshWorker @AssistedInject constructor(
             )
                 .setConstraints(constraints)
                 .build()
+            // v0.9.20: UPDATE (not KEEP) so existing installs reschedule against
+            // the current worker spec on the next cold start. KEEP previously meant
+            // constraint changes / class changes were ignored across upgrades —
+            // a credible cause of "periodic refresh hasn't fired in 3 days" reports.
             WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                 WORK_NAME,
-                ExistingPeriodicWorkPolicy.KEEP,
+                ExistingPeriodicWorkPolicy.UPDATE,
                 work,
             )
         }

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -496,9 +496,21 @@ class StashMixRefreshWorker @AssistedInject constructor(
                 .map { it.artist }
                 .ifEmpty { trackDao.getTopArtistsByTrackCount(TOP_ARTISTS_LIMIT) }
 
-        val seedTracks = personas.topTracksByPeriod[LastFmPeriod.ONE_MONTH]
+        // v0.9.20 PR 8: seedTracks gets the same three-tier fallback chain as
+        // seedArtists. When Last.fm persona top-tracks is empty (sparse
+        // scrobbles, persona fetch race, or 1-month window without enough
+        // data), fall back to local in-app listening events, then to library
+        // top-by-LFM-playcount. Prevents the silent zero-candidate failure
+        // that left Deep Cuts stuck on its library slice in PR 3+.
+        val seedTracks: List<Pair<String, String>> = personas.topTracksByPeriod[LastFmPeriod.ONE_MONTH]
+            ?.takeIf { it.isNotEmpty() }
             ?.take(20)?.map { it.artist to it.title }
-            ?: emptyList()
+            ?: listeningEventDao.getTopTracksByLocalPlays(since, 20)
+                .map { it.artist to it.title }
+                .ifEmpty {
+                    trackDao.getTopTracksByLfmPlaycount(20)
+                        .map { it.artist to it.title }
+                }
 
         val topTags = mixGenerator.computeUserTopTags(limit = 10)
 

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -220,8 +220,22 @@ class StashMixRefreshWorker @AssistedInject constructor(
             }
         } else LastFmPersonas.EMPTY
 
-        for (recipe in active) {
-            val tracks = mixGenerator.generate(recipe)
+        // v0.9.20: pre-sort by dedup priority so the most-restrictive
+        // recipes claim their natural picks before more-permissive ones
+        // see them. excludeIds accumulates library + discovery ids
+        // across iterations and is threaded into both generate() and
+        // materializeMix() — guarantees no track appears in two
+        // playlists in a single refresh run.
+        val orderedRecipes = active.sortedBy { recipeDedupPriority(it) }
+        val excludeIds = mutableSetOf<Long>()
+        for (recipe in orderedRecipes) {
+            // Snapshot to an immutable Set per iteration so callees can't
+            // observe (or accidentally mutate) the accumulator, and so
+            // tests / future tracing can see exactly what was excluded
+            // at the moment of the call.
+            val excludeSnapshot = excludeIds.toSet()
+            val tracks = mixGenerator.generate(recipe, excludeSnapshot)
+
             // Empty-tracks skip is only safe for library-only recipes
             // (discoveryRatio == 0). Pure-discovery recipes like "Stash
             // Discover" (ratio = 1.0) produce an empty generator result
@@ -234,9 +248,13 @@ class StashMixRefreshWorker @AssistedInject constructor(
                 continue
             }
 
-            val playlistId = materializeMix(recipe, tracks, now)
-            recipeDao.setPlaylistId(recipe.id, playlistId)
+            val result = materializeMix(recipe, tracks, now, excludeSnapshot)
+            recipeDao.setPlaylistId(recipe.id, result.playlistId)
             recipeDao.setLastRefreshedAt(recipe.id, now)
+
+            // v0.9.20: accumulate so the next recipe in the ordering doesn't re-pick these.
+            excludeIds += tracks.map { it.id }
+            excludeIds += result.discoveryIds
 
             // Discovery — opportunistic. Don't block refresh success on it.
             if (recipe.discoveryRatio > 0f && lastFmConfigured) {
@@ -248,14 +266,52 @@ class StashMixRefreshWorker @AssistedInject constructor(
     }
 
     /**
+     * Output of [materializeMix]. Carries the just-created/updated
+     * playlist id (existing return) AND the discovery-survivor track ids
+     * the materialization inserted, so [doWork]'s outer cross-mix dedup
+     * loop can add them to its accumulating excludeIds set.
+     */
+    private data class MaterializeResult(
+        val playlistId: Long,
+        val discoveryIds: List<Long>,
+    )
+
+    /**
+     * Cross-mix track-dedup priority. Most-restrictive recipes go first
+     * so they claim their natural picks; most-permissive last so it
+     * picks up the leftovers.
+     *
+     *  - First Listen (1.0 discovery, library-blind) — has no opinion on
+     *    the library pool; claims TAG_GRAPH survivors first.
+     *  - Deep Cuts (0.85 discovery) — claims TRACK_SIMILAR survivors and
+     *    a sparse library slice next.
+     *  - Daily Discover (0.85 discovery) — most permissive on the
+     *    library slice; claims ARTIST_SIMILAR survivors last.
+     *  - Non-builtins / unknown — last (99).
+     *
+     * Keyed by name rather than id because builtin id values aren't
+     * stable across reseeds.
+     */
+    private fun recipeDedupPriority(recipe: StashMixRecipeEntity): Int = when (recipe.name) {
+        "First Listen" -> 1
+        "Deep Cuts" -> 2
+        "Daily Discover" -> 3
+        else -> 99
+    }
+
+    /**
      * Find-or-create a playlist row for this recipe, then replace its
-     * tracklist with [tracks] in correct order. Returns the playlist_id.
+     * tracklist with [tracks] in correct order. Returns a
+     * [MaterializeResult] with the playlist_id and the discovery-survivor
+     * track ids actually inserted, so the caller can fold those into the
+     * cross-mix excludeIds accumulator for subsequent recipes.
      */
     private suspend fun materializeMix(
         recipe: StashMixRecipeEntity,
         tracks: List<TrackEntity>,
         now: Long,
-    ): Long {
+        excludeIds: Set<Long>,
+    ): MaterializeResult {
         // Existing playlist: verify it's still there (could have been
         // deleted by the user). If gone, fall through to re-create.
         val existing = recipe.playlistId?.let { playlistDao.getById(it) }
@@ -318,14 +374,22 @@ class StashMixRefreshWorker @AssistedInject constructor(
         // Library shortfall-fill in MixGenerator is intentionally untouched —
         // total playlist size for Daily Discover settles at up-to-50 (library)
         // + up-to-20 (discovery) = <=70, replacing the previous unbounded growth.
+        //
+        // v0.9.20: filter via excludeIds; over-fetch so post-filter still
+        // fills the cap. Worst case: every excluded id was a survivor — we
+        // still come back with `discoveryCap` distinct ids. Bounded — the
+        // DAO's ORDER BY completed_at DESC + LIMIT means we just slide the
+        // window further down the survivor list.
         val discoveryCap = (recipe.targetLength * recipe.discoveryRatio)
             .roundToInt()
             .coerceAtLeast(0)
-        val candidateIds = discoveryQueueDao
-            .getDoneTrackIdsForRecipe(recipe.id, limit = discoveryCap)
-            .filter { it !in librarySet }
+        val rawCandidateIds = discoveryQueueDao
+            .getDoneTrackIdsForRecipe(recipe.id, limit = discoveryCap + excludeIds.size)
+        val filteredCandidateIds = rawCandidateIds
+            .filter { it !in librarySet && it !in excludeIds }
+            .take(discoveryCap)
         val discoveryTrackIds = buildList {
-            for (trackId in candidateIds) {
+            for (trackId in filteredCandidateIds) {
                 if (!blocklistGuard.isBlockedByTrackId(trackId)) add(trackId)
             }
         }
@@ -349,7 +413,7 @@ class StashMixRefreshWorker @AssistedInject constructor(
             playlistDao.updateArtUrl(playlistId, coverUrl)
         }
         playlistDao.updateTrackCount(playlistId, totalCount)
-        return playlistId
+        return MaterializeResult(playlistId, discoveryTrackIds)
     }
 
     /**

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -116,7 +116,7 @@ class StashMixRefreshWorker @AssistedInject constructor(
             )
                 .setConstraints(constraints)
                 .build()
-            // v0.9.20: UPDATE (not KEEP) so existing installs reschedule against
+            // 2026-05-11: UPDATE (not KEEP) so existing installs reschedule against
             // the current worker spec on the next cold start. KEEP previously meant
             // constraint changes / class changes were ignored across upgrades —
             // a credible cause of "periodic refresh hasn't fired in 3 days" reports.

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -16,6 +16,7 @@ import com.stash.core.data.db.dao.ListeningEventDao
 import com.stash.core.data.db.dao.PlaylistDao
 import com.stash.core.data.db.dao.StashMixRecipeDao
 import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.dao.TrackSkipEventDao
 import com.stash.core.data.db.entity.PlaylistEntity
 import com.stash.core.data.db.entity.PlaylistTrackCrossRef
 import com.stash.core.data.db.entity.StashMixRecipeEntity
@@ -31,6 +32,7 @@ import com.stash.core.data.mix.MixGenerator
 import com.stash.core.data.mix.MixSeedGenerator
 import com.stash.core.data.mix.MixSeedStrategy
 import com.stash.core.data.mix.StashMixDefaults
+import com.stash.core.data.sync.TrackMatcher
 import com.stash.core.model.MusicSource
 import com.stash.core.model.PlaylistType
 import dagger.assisted.Assisted
@@ -81,6 +83,8 @@ class StashMixRefreshWorker @AssistedInject constructor(
     private val lastFmCredentials: LastFmCredentials,
     private val sessionPreference: LastFmSessionPreference,
     private val blocklistGuard: com.stash.core.data.blocklist.BlocklistGuard,
+    private val trackSkipEventDao: TrackSkipEventDao,
+    private val trackMatcher: TrackMatcher,
 ) : CoroutineWorker(appContext, params) {
 
     companion object {
@@ -90,6 +94,35 @@ class StashMixRefreshWorker @AssistedInject constructor(
         private const val TOP_ARTISTS_LIMIT = 8
         private const val SIMILAR_REQUEST_INTERVAL_MS = 220L
         private const val AFFINITY_LOOKBACK_DAYS = 180L
+
+        /**
+         * Floor for the filtered discovery pool. Below this, the TAG_GRAPH
+         * fallback fires.
+         *
+         * Why 20 and not the recipe's discoveryCap (e.g. 34 for an 85%-discovery
+         * recipe with targetLength 40)? Downstream attrition: not every queued
+         * candidate becomes a viable survivor. StashDiscoveryWorker.handle()
+         * applies an additional blocklist check; some candidates fail at the
+         * download stage (yt-dlp can't match, no audio available, etc.); and
+         * some get canonical-deduped against tracks added to the library AFTER
+         * the seed-gen filter ran. Twenty pre-filter survivors typically yields
+         * ~10-15 actually-downloaded DONE rows — enough to fill a 6-slot mix
+         * slot AND leave a queue buffer for tomorrow's refresh. The fallback
+         * is a viability gate, not a precise capacity match.
+         */
+        private const val MIN_DISCOVERY_POOL_AFTER_FILTER = 20
+
+        /** Skip-event ban threshold: this many "early" skips in the time window → ban. */
+        private const val DISCOVERY_SKIP_BAN_MIN_COUNT = 3
+
+        /** Skip-event ban time window in milliseconds. */
+        private val DISCOVERY_SKIP_BAN_WINDOW_MS = TimeUnit.DAYS.toMillis(90)
+
+        /** Skip-position cutoff: skips in the first this-many ms count as rejection. */
+        private const val DISCOVERY_SKIP_BAN_MAX_POSITION_MS = 30_000L
+
+        /** Timeout for the TAG_GRAPH fallback Last.fm call. */
+        private const val SEED_FALLBACK_TIMEOUT_MS = 30_000L
 
         /**
          * Input-data key for [enqueueOneTime] (single-recipe overload).
@@ -477,9 +510,80 @@ class StashMixRefreshWorker @AssistedInject constructor(
             personas = personas,
         )
         if (candidates.isEmpty()) return
-        Log.i(TAG, "'${recipe.name}': ${candidates.size} candidates via $strategy")
-        mixGenerator.queueDiscoveryCandidates(recipe, candidates)
+
+        // v0.9.20: pre-filter against library + skip-ban so discovery_queue
+        // PENDING rows represent genuinely-new music, not "rediscovery" hits.
+        val libraryKeys = trackDao.getLibraryCanonicalKeys().toHashSet()
+        val skipBannedKeys = trackSkipEventDao
+            .getEarlySkipBannedCanonicalKeys(
+                minSkips = DISCOVERY_SKIP_BAN_MIN_COUNT,
+                sinceMs = System.currentTimeMillis() - DISCOVERY_SKIP_BAN_WINDOW_MS,
+                maxPositionMs = DISCOVERY_SKIP_BAN_MAX_POSITION_MS,
+            )
+            .toHashSet()
+
+        val filtered = candidates.filter { candidate ->
+            val key = canonicalKey(candidate.artist, candidate.title)
+            key !in libraryKeys && key !in skipBannedKeys
+        }
+
+        val final = if (filtered.size >= MIN_DISCOVERY_POOL_AFTER_FILTER) {
+            filtered
+        } else {
+            // Fallback: top off with TAG_GRAPH candidates (different strategy
+            // typically yields different artists, so library overlap is lower).
+            // Same filters applied. withTimeout protects WorkManager's 10-minute
+            // budget — mirrors the existing 30s persona-fetch timeout.
+            val tagFallback = runCatching {
+                withTimeout(SEED_FALLBACK_TIMEOUT_MS) {
+                    seedGenerator.generate(
+                        strategy = MixSeedStrategy.TAG_GRAPH,
+                        seedArtists = emptyList(),
+                        topTags = topTags,
+                        seedTracks = emptyList(),
+                        personas = personas,
+                    )
+                }
+            }.getOrElse {
+                Log.w(TAG, "'${recipe.name}': TAG_GRAPH fallback timed out / failed", it)
+                emptyList()
+            }.filter { candidate ->
+                val key = canonicalKey(candidate.artist, candidate.title)
+                key !in libraryKeys && key !in skipBannedKeys
+            }
+            Log.i(
+                TAG,
+                "'${recipe.name}': filtered pool (${filtered.size}) below floor; " +
+                    "appending ${tagFallback.size} TAG_GRAPH fallback candidates",
+            )
+            filtered + tagFallback
+        }
+
+        if (final.isEmpty()) {
+            Log.w(TAG, "'${recipe.name}': all candidates filtered out (library + skips); skipping queue")
+            return
+        }
+
+        Log.i(
+            TAG,
+            "'${recipe.name}': ${final.size} candidates via $strategy " +
+                "(${candidates.size - filtered.size} filtered as library/banned)",
+        )
+        mixGenerator.queueDiscoveryCandidates(recipe, final)
     }
+
+    /**
+     * Canonical key used by the discovery pre-filter — must match the
+     * format the DAOs store and return: TrackMatcher's normalization
+     * applied to artist and title, joined with "|".
+     *
+     * The sync writer uses this same TrackMatcher instance to populate
+     * tracks.canonical_artist / canonical_title, so the keys produced
+     * here match the keys returned by getLibraryCanonicalKeys() and
+     * getEarlySkipBannedCanonicalKeys().
+     */
+    private fun canonicalKey(artist: String, title: String): String =
+        "${trackMatcher.canonicalArtist(artist)}|${trackMatcher.canonicalTitle(title)}"
 
     /**
      * v0.9.16: Snapshot the user's period-sliced top tracks/artists once

--- a/core/data/src/main/kotlin/com/stash/core/data/tipjar/TipJarRepository.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/tipjar/TipJarRepository.kt
@@ -3,8 +3,10 @@ package com.stash.core.data.tipjar
 import android.content.Context
 import android.util.Log
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -47,6 +49,7 @@ import okhttp3.Request
  */
 private val Context.tipJarDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "tip_jar_cache",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
 )
 
 @Singleton

--- a/core/data/src/main/kotlin/com/stash/core/data/youtube/YouTubeScrobblerState.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/youtube/YouTubeScrobblerState.kt
@@ -2,8 +2,10 @@ package com.stash.core.data.youtube
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -17,6 +19,7 @@ import javax.inject.Singleton
 /** Dedicated DataStore for YT scrobbler kill-switch + failure-counter state. */
 private val Context.youtubeScrobblerStateDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "youtube_scrobbler_state",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
 )
 
 /**

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt
@@ -1,0 +1,125 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.DiscoveryQueueEntity
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [DiscoveryQueueDao.getDoneTrackIdsForRecipe] — specifically the
+ * v0.9.19 follow-up cap fix that bounds the result at `:limit` ordered by
+ * `completed_at DESC` so newest-DONE survivors win when materializeMix
+ * trims to the recipe's discovery slot count.
+ *
+ * Note: [DiscoveryQueueEntity] has a foreign key to
+ * [StashMixRecipeEntity], so each test seeds a recipe row up front. There
+ * is no FK from `discovery_queue.track_id` to `tracks.id`, so the tests
+ * insert arbitrary track ids without seeding parent track rows.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DiscoveryQueueDaoCapTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: DiscoveryQueueDao
+    private var recipeId: Long = 0L
+
+    @Before fun setUp() = runTest {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.discoveryQueueDao()
+        // FK: discovery_queue.recipe_id -> stash_mix_recipes.id (CASCADE).
+        // Seed a single recipe row that all tests share.
+        recipeId = db.stashMixRecipeDao().insert(
+            StashMixRecipeEntity(name = "Test Recipe", isBuiltin = false)
+        )
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `respects limit when DONE rows exceed it`() = runTest {
+        // Insert 5 DONE rows with distinct track_ids and increasing completedAt.
+        for (i in 1..5) {
+            dao.insertIfNew(doneRow(recipeId, trackId = i.toLong(), completedAt = 1000L * i))
+        }
+
+        val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 3)
+
+        assertEquals(3, result.size)
+    }
+
+    @Test fun `orders by completed_at DESC (newest-DONE first)`() = runTest {
+        dao.insertIfNew(doneRow(recipeId, trackId = 1L, completedAt = 1000L))   // older
+        dao.insertIfNew(doneRow(recipeId, trackId = 2L, completedAt = 5000L))   // newer
+
+        val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 99)
+
+        assertEquals(listOf(2L, 1L), result)
+    }
+
+    @Test fun `filters status to DONE only`() = runTest {
+        dao.insertIfNew(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
+        dao.insertIfNew(pendingRow(recipeId, trackId = 2L))   // PENDING — must NOT appear
+
+        val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 99)
+
+        assertEquals(listOf(1L), result)
+    }
+
+    @Test fun `excludes rows with null track_id even when status is DONE`() = runTest {
+        // Transient state: a worker may set status=DONE just before linking the
+        // canonical track_id. Such a row must NOT consume a cap slot.
+        dao.insertIfNew(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
+        dao.insertIfNew(doneRow(recipeId, trackId = null, completedAt = 2000L))
+
+        val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 99)
+
+        assertEquals(listOf(1L), result)
+    }
+
+    @Test fun `limit zero returns empty list`() = runTest {
+        dao.insertIfNew(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
+
+        val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 0)
+
+        assertTrue("expected empty, got $result", result.isEmpty())
+    }
+
+    private fun doneRow(recipeId: Long, trackId: Long?, completedAt: Long?) = DiscoveryQueueEntity(
+        recipeId = recipeId,
+        artist = "Artist",
+        title = "Title $trackId",
+        seedArtist = "Seed",
+        status = DiscoveryQueueEntity.STATUS_DONE,
+        trackId = trackId,
+        queuedAt = 0L,
+        completedAt = completedAt,
+        errorMessage = null,
+    )
+
+    private fun pendingRow(recipeId: Long, trackId: Long?) = DiscoveryQueueEntity(
+        recipeId = recipeId,
+        artist = "Artist",
+        title = "Title $trackId",
+        seedArtist = "Seed",
+        status = DiscoveryQueueEntity.STATUS_PENDING,
+        trackId = trackId,
+        queuedAt = 0L,
+        completedAt = null,
+        errorMessage = null,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.stash.core.data.db.StashDatabase
 import com.stash.core.data.db.entity.DiscoveryQueueEntity
 import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.db.entity.TrackEntity
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -23,8 +24,11 @@ import org.robolectric.annotation.Config
  *
  * Note: [DiscoveryQueueEntity] has a foreign key to
  * [StashMixRecipeEntity], so each test seeds a recipe row up front. There
- * is no FK from `discovery_queue.track_id` to `tracks.id`, so the tests
- * insert arbitrary track ids without seeding parent track rows.
+ * is no FK from `discovery_queue.track_id` to `tracks.id` — orphan rows
+ * are physically possible — but the DAO query INNER JOINs `tracks` so
+ * that only track_ids with a live parent row are returned. Each test
+ * therefore seeds the corresponding [TrackEntity] rows it expects to see
+ * surface back through the DAO.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [33])
@@ -54,6 +58,7 @@ class DiscoveryQueueDaoCapTest {
     @Test fun `respects limit when DONE rows exceed it`() = runTest {
         // Insert 5 DONE rows with distinct track_ids and increasing completedAt.
         for (i in 1..5) {
+            db.trackDao().insert(trackEntity(id = i.toLong()))
             dao.insertIfNew(doneRow(recipeId, trackId = i.toLong(), completedAt = 1000L * i))
         }
 
@@ -63,6 +68,8 @@ class DiscoveryQueueDaoCapTest {
     }
 
     @Test fun `orders by completed_at DESC (newest-DONE first)`() = runTest {
+        db.trackDao().insert(trackEntity(id = 1L))
+        db.trackDao().insert(trackEntity(id = 2L))
         dao.insertIfNew(doneRow(recipeId, trackId = 1L, completedAt = 1000L))   // older
         dao.insertIfNew(doneRow(recipeId, trackId = 2L, completedAt = 5000L))   // newer
 
@@ -72,6 +79,7 @@ class DiscoveryQueueDaoCapTest {
     }
 
     @Test fun `filters status to DONE only`() = runTest {
+        db.trackDao().insert(trackEntity(id = 1L))
         dao.insertIfNew(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
         dao.insertIfNew(pendingRow(recipeId, trackId = 2L))   // PENDING — must NOT appear
 
@@ -83,6 +91,7 @@ class DiscoveryQueueDaoCapTest {
     @Test fun `excludes rows with null track_id even when status is DONE`() = runTest {
         // Transient state: a worker may set status=DONE just before linking the
         // canonical track_id. Such a row must NOT consume a cap slot.
+        db.trackDao().insert(trackEntity(id = 1L))
         dao.insertIfNew(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
         dao.insertIfNew(doneRow(recipeId, trackId = null, completedAt = 2000L))
 
@@ -92,12 +101,34 @@ class DiscoveryQueueDaoCapTest {
     }
 
     @Test fun `limit zero returns empty list`() = runTest {
+        db.trackDao().insert(trackEntity(id = 1L))
         dao.insertIfNew(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
 
         val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 0)
 
         assertTrue("expected empty, got $result", result.isEmpty())
     }
+
+    @Test fun `excludes rows whose track_id points to a deleted track`() = runTest {
+        // trackId=1 exists in tracks; trackId=999 is orphan (no parent row).
+        // Pre-fix: the DAO returned both, then materializeMix's
+        // insertCrossRef threw a FOREIGN KEY constraint failure on trackId=999.
+        db.trackDao().insert(trackEntity(id = 1L))
+        dao.insertIfNew(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
+        dao.insertIfNew(doneRow(recipeId, trackId = 999L, completedAt = 2000L))
+
+        val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 99)
+
+        assertEquals(listOf(1L), result)
+    }
+
+    private fun trackEntity(id: Long) = TrackEntity(
+        id = id,
+        title = "Track $id",
+        artist = "Artist $id",
+        canonicalTitle = "track $id",
+        canonicalArtist = "artist $id",
+    )
 
     private fun doneRow(recipeId: Long, trackId: Long?, completedAt: Long?) = DiscoveryQueueEntity(
         recipeId = recipeId,

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt
@@ -122,12 +122,24 @@ class DiscoveryQueueDaoCapTest {
         assertEquals(listOf(1L), result)
     }
 
-    private fun trackEntity(id: Long) = TrackEntity(
+    @Test fun `excludes rows whose track is not yet downloaded`() = runTest {
+        db.trackDao().insert(trackEntity(id = 1L, isDownloaded = true))
+        db.trackDao().insert(trackEntity(id = 2L, isDownloaded = false))  // stub
+        dao.insertIfNew(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
+        dao.insertIfNew(doneRow(recipeId, trackId = 2L, completedAt = 2000L))
+
+        val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 99)
+
+        assertEquals(listOf(1L), result)
+    }
+
+    private fun trackEntity(id: Long, isDownloaded: Boolean = true) = TrackEntity(
         id = id,
         title = "Track $id",
         artist = "Artist $id",
         canonicalTitle = "track $id",
         canonicalArtist = "artist $id",
+        isDownloaded = isDownloaded,
     )
 
     private fun doneRow(recipeId: Long, trackId: Long?, completedAt: Long?) = DiscoveryQueueEntity(

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoLibraryHitCleanupTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoLibraryHitCleanupTest.kt
@@ -1,0 +1,146 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.DiscoveryQueueEntity
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.model.MusicSource
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [DiscoveryQueueDao.deleteLibraryHitDoneRows] — the one-time
+ * PR 7 cleanup that removes pre-PR-6 era "library-hit" discovery DONE
+ * rows from `discovery_queue`. Pre-PR-6, StashDiscoveryWorker.handle()
+ * canonical-deduped Last.fm candidates against the library and linked
+ * existing library tracks instead of creating stubs — those rows now
+ * surface as "discovery survivors" in mixes despite being library
+ * content.
+ *
+ * Heuristic: discovery stubs have track.source = YOUTUBE; library
+ * tracks have other sources (SPOTIFY, LOCAL, BOTH).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DiscoveryQueueDaoLibraryHitCleanupTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: DiscoveryQueueDao
+    private lateinit var trackDao: TrackDao
+    private var recipeId: Long = 0L
+
+    @Before fun setUp() = runTest {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.discoveryQueueDao()
+        trackDao = db.trackDao()
+        recipeId = db.stashMixRecipeDao().insert(
+            StashMixRecipeEntity(name = "Test Recipe", isBuiltin = false)
+        )
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `deletes DONE rows whose track has non-YOUTUBE source`() = runTest {
+        // Library-sourced tracks
+        trackDao.insert(track(id = 1L, source = MusicSource.SPOTIFY))
+        trackDao.insert(track(id = 2L, source = MusicSource.LOCAL))
+        trackDao.insert(track(id = 3L, source = MusicSource.BOTH))
+        // Discovery stub
+        trackDao.insert(track(id = 4L, source = MusicSource.YOUTUBE))
+
+        dao.insertIfNew(doneRow(trackId = 1L))
+        dao.insertIfNew(doneRow(trackId = 2L))
+        dao.insertIfNew(doneRow(trackId = 3L))
+        dao.insertIfNew(doneRow(trackId = 4L))
+
+        val deleted = dao.deleteLibraryHitDoneRows()
+
+        assertEquals(3, deleted)
+        val remaining = dao.getDoneTrackIdsForRecipe(recipeId, limit = 99)
+        assertEquals(listOf(4L), remaining)
+    }
+
+    @Test fun `does not delete PENDING or FAILED rows even if track is library-sourced`() = runTest {
+        trackDao.insert(track(id = 1L, source = MusicSource.SPOTIFY))
+
+        dao.insertIfNew(pendingRow(trackId = 1L))
+
+        val deleted = dao.deleteLibraryHitDoneRows()
+
+        assertEquals(0, deleted)
+    }
+
+    @Test fun `is idempotent — second call deletes nothing`() = runTest {
+        trackDao.insert(track(id = 1L, source = MusicSource.SPOTIFY))
+        dao.insertIfNew(doneRow(trackId = 1L))
+
+        assertEquals(1, dao.deleteLibraryHitDoneRows())
+        assertEquals(0, dao.deleteLibraryHitDoneRows())
+    }
+
+    @Test fun `preserves YOUTUBE-sourced DONE rows`() = runTest {
+        trackDao.insert(track(id = 1L, source = MusicSource.YOUTUBE))
+        trackDao.insert(track(id = 2L, source = MusicSource.YOUTUBE))
+        dao.insertIfNew(doneRow(trackId = 1L))
+        dao.insertIfNew(doneRow(trackId = 2L))
+
+        val deleted = dao.deleteLibraryHitDoneRows()
+
+        assertEquals(0, deleted)
+        val remaining = dao.getDoneTrackIdsForRecipe(recipeId, limit = 99).toSet()
+        assertEquals(setOf(1L, 2L), remaining)
+    }
+
+    @Test fun `empty discovery_queue returns 0`() = runTest {
+        val deleted = dao.deleteLibraryHitDoneRows()
+        assertTrue("expected 0, got $deleted", deleted == 0)
+    }
+
+    private fun track(id: Long, source: MusicSource) = TrackEntity(
+        id = id,
+        title = "Title $id",
+        artist = "Artist $id",
+        canonicalTitle = "title $id",
+        canonicalArtist = "artist $id",
+        isDownloaded = true,
+        source = source,
+    )
+
+    private fun doneRow(trackId: Long) = DiscoveryQueueEntity(
+        recipeId = recipeId,
+        artist = "Artist",
+        title = "Title $trackId",
+        seedArtist = "Seed",
+        status = DiscoveryQueueEntity.STATUS_DONE,
+        trackId = trackId,
+        queuedAt = 0L,
+        completedAt = 1000L,
+        errorMessage = null,
+    )
+
+    private fun pendingRow(trackId: Long) = DiscoveryQueueEntity(
+        recipeId = recipeId,
+        artist = "Artist",
+        title = "Title $trackId",
+        seedArtist = "Seed",
+        status = DiscoveryQueueEntity.STATUS_PENDING,
+        trackId = trackId,
+        queuedAt = 0L,
+        completedAt = null,
+        errorMessage = null,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoPartitionTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoPartitionTest.kt
@@ -1,0 +1,188 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.DownloadQueueEntity
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.PlaylistTrackCrossRef
+import com.stash.core.data.db.entity.SyncHistoryEntity
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.model.DownloadStatus
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DownloadQueueDaoPartitionTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: DownloadQueueDao
+    private lateinit var trackDao: TrackDao
+    private lateinit var playlistDao: PlaylistDao
+    private lateinit var syncHistoryDao: SyncHistoryDao
+
+    @Before fun setUp() = runTest {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.downloadQueueDao()
+        trackDao = db.trackDao()
+        playlistDao = db.playlistDao()
+        syncHistoryDao = db.syncHistoryDao()
+
+        // DownloadQueueEntity has FK sync_id → sync_history.id (Room enables
+        // FK enforcement by default). Seed a single sync_history row so the
+        // sync-side test fixtures can reference syncId = 5L without crashing.
+        syncHistoryDao.insert(SyncHistoryEntity(id = 5L))
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `getAllPendingBySources excludes rows with sync_id IS NULL`() = runTest {
+        seedTrackInSyncEnabledPlaylist(trackId = 1L, source = MusicSource.YOUTUBE)
+        seedTrackInSyncEnabledPlaylist(trackId = 2L, source = MusicSource.YOUTUBE)
+
+        dao.insert(pendingRow(id = 100L, trackId = 1L, syncId = 5L))
+        dao.insert(pendingRow(id = 101L, trackId = 2L, syncId = null))
+
+        val result = dao.getAllPendingBySources(listOf("YOUTUBE"))
+
+        assertEquals("expected only sync row", listOf(100L), result.map { it.id })
+    }
+
+    @Test fun `getRetryableBySources excludes rows with sync_id IS NULL`() = runTest {
+        seedTrackInSyncEnabledPlaylist(trackId = 1L, source = MusicSource.YOUTUBE)
+        seedTrackInSyncEnabledPlaylist(trackId = 2L, source = MusicSource.YOUTUBE)
+
+        dao.insert(failedRow(id = 100L, trackId = 1L, syncId = 5L, retryCount = 1))
+        dao.insert(failedRow(id = 101L, trackId = 2L, syncId = null, retryCount = 1))
+
+        val result = dao.getRetryableBySources(listOf("YOUTUBE"))
+
+        assertEquals("expected only sync row", listOf(100L), result.map { it.id })
+    }
+
+    @Test fun `pendingDiscoveryDownloads returns only sync_id IS NULL rows in PENDING or retryable FAILED`() = runTest {
+        seedTrack(trackId = 1L)
+        seedTrack(trackId = 2L)
+        seedTrack(trackId = 3L)
+        seedTrack(trackId = 4L)
+
+        dao.insert(pendingRow(id = 100L, trackId = 1L, syncId = 5L))
+        dao.insert(pendingRow(id = 101L, trackId = 2L, syncId = null))
+        dao.insert(failedRow(id = 102L, trackId = 3L, syncId = null, retryCount = 1))
+        dao.insert(failedRow(id = 103L, trackId = 4L, syncId = null, retryCount = 3))
+
+        val result = dao.pendingDiscoveryDownloads()
+
+        assertEquals(setOf(101L, 102L), result.map { it.id }.toSet())
+    }
+
+    @Test fun `pendingDiscoveryDownloads excludes WAITING_FOR_LOSSLESS and IN_PROGRESS`() = runTest {
+        seedTrack(trackId = 1L)
+        seedTrack(trackId = 2L)
+
+        dao.insert(
+            DownloadQueueEntity(
+                id = 100L,
+                trackId = 1L,
+                status = DownloadStatus.WAITING_FOR_LOSSLESS,
+                syncId = null,
+                searchQuery = "q",
+            )
+        )
+        dao.insert(
+            DownloadQueueEntity(
+                id = 101L,
+                trackId = 2L,
+                status = DownloadStatus.IN_PROGRESS,
+                syncId = null,
+                searchQuery = "q",
+            )
+        )
+
+        val result = dao.pendingDiscoveryDownloads()
+
+        assertTrue("expected empty, got $result", result.isEmpty())
+    }
+
+    // ---- helpers ----
+
+    private suspend fun seedTrack(trackId: Long) {
+        trackDao.insert(
+            TrackEntity(
+                id = trackId,
+                title = "Track $trackId",
+                artist = "Artist $trackId",
+                canonicalTitle = "track $trackId",
+                canonicalArtist = "artist $trackId",
+                source = MusicSource.YOUTUBE,
+                isDownloaded = false,
+            )
+        )
+    }
+
+    private suspend fun seedTrackInSyncEnabledPlaylist(trackId: Long, source: MusicSource) {
+        trackDao.insert(
+            TrackEntity(
+                id = trackId,
+                title = "Track $trackId",
+                artist = "Artist $trackId",
+                canonicalTitle = "track $trackId",
+                canonicalArtist = "artist $trackId",
+                source = source,
+                isDownloaded = false,
+            )
+        )
+        val playlistId = playlistDao.insert(
+            PlaylistEntity(
+                name = "Test playlist",
+                source = MusicSource.BOTH,
+                sourceId = "test_playlist_$trackId",
+                type = PlaylistType.STASH_MIX,
+                trackCount = 0,
+                syncEnabled = true,
+                isActive = true,
+            )
+        )
+        playlistDao.insertCrossRef(
+            PlaylistTrackCrossRef(
+                playlistId = playlistId,
+                trackId = trackId,
+                position = 0,
+                addedAt = Instant.EPOCH,
+            )
+        )
+    }
+
+    private fun pendingRow(id: Long, trackId: Long, syncId: Long?) = DownloadQueueEntity(
+        id = id,
+        trackId = trackId,
+        status = DownloadStatus.PENDING,
+        syncId = syncId,
+        searchQuery = "artist - title",
+    )
+
+    private fun failedRow(id: Long, trackId: Long, syncId: Long?, retryCount: Int) = DownloadQueueEntity(
+        id = id,
+        trackId = trackId,
+        status = DownloadStatus.FAILED,
+        syncId = syncId,
+        searchQuery = "artist - title",
+        retryCount = retryCount,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/ListeningEventDaoTopTracksTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/ListeningEventDaoTopTracksTest.kt
@@ -1,0 +1,108 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.ListeningEventEntity
+import com.stash.core.data.db.entity.TrackEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ListeningEventDaoTopTracksTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: ListeningEventDao
+    private lateinit var trackDao: TrackDao
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.listeningEventDao()
+        trackDao = db.trackDao()
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `returns top tracks by play count descending within window`() = runTest {
+        trackDao.insert(track(id = 1L, artist = "Tame Impala", title = "Borderline"))
+        trackDao.insert(track(id = 2L, artist = "Tame Impala", title = "The Less I Know"))
+        trackDao.insert(track(id = 3L, artist = "Kanye West", title = "Runaway"))
+
+        val now = System.currentTimeMillis()
+        // Track 1: 5 plays
+        repeat(5) { dao.insert(listeningEvent(trackId = 1L, startedAt = now - it * 1000L)) }
+        // Track 2: 2 plays
+        repeat(2) { dao.insert(listeningEvent(trackId = 2L, startedAt = now - it * 1000L)) }
+        // Track 3: 1 play
+        dao.insert(listeningEvent(trackId = 3L, startedAt = now))
+
+        val result = dao.getTopTracksByLocalPlays(sinceEpochMs = 0L, limit = 10)
+
+        assertEquals(
+            listOf(
+                TrackArtistTitle("Tame Impala", "Borderline"),
+                TrackArtistTitle("Tame Impala", "The Less I Know"),
+                TrackArtistTitle("Kanye West", "Runaway"),
+            ),
+            result,
+        )
+    }
+
+    @Test fun `excludes plays outside the time window`() = runTest {
+        trackDao.insert(track(id = 1L, artist = "Old Artist", title = "Old Song"))
+
+        val now = System.currentTimeMillis()
+        val tooOld = now - 365L * 24 * 60 * 60 * 1000
+        repeat(10) { dao.insert(listeningEvent(trackId = 1L, startedAt = tooOld)) }
+
+        val result = dao.getTopTracksByLocalPlays(
+            sinceEpochMs = now - 30L * 24 * 60 * 60 * 1000,  // last 30 days
+            limit = 10,
+        )
+
+        assertTrue("expected empty, got $result", result.isEmpty())
+    }
+
+    @Test fun `respects limit`() = runTest {
+        for (i in 1..5) {
+            trackDao.insert(track(id = i.toLong(), artist = "Artist $i", title = "Title $i"))
+            dao.insert(listeningEvent(trackId = i.toLong(), startedAt = System.currentTimeMillis()))
+        }
+
+        val result = dao.getTopTracksByLocalPlays(sinceEpochMs = 0L, limit = 3)
+
+        assertEquals(3, result.size)
+    }
+
+    @Test fun `empty listening events returns empty`() = runTest {
+        val result = dao.getTopTracksByLocalPlays(sinceEpochMs = 0L, limit = 10)
+        assertTrue(result.isEmpty())
+    }
+
+    private fun track(id: Long, artist: String, title: String) = TrackEntity(
+        id = id,
+        title = title,
+        artist = artist,
+        canonicalTitle = title.lowercase(),
+        canonicalArtist = artist.lowercase(),
+        isDownloaded = true,
+    )
+
+    private fun listeningEvent(trackId: Long, startedAt: Long) = ListeningEventEntity(
+        trackId = trackId,
+        startedAt = startedAt,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoOtherMixTracksTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoOtherMixTracksTest.kt
@@ -1,0 +1,106 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.PlaylistTrackCrossRef
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PlaylistDaoOtherMixTracksTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var playlistDao: PlaylistDao
+    private lateinit var trackDao: TrackDao
+
+    @Before fun setUp() = runTest {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        playlistDao = db.playlistDao()
+        trackDao = db.trackDao()
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `returns DISTINCT track ids across multiple playlists`() = runTest {
+        trackDao.insert(track(1L))
+        trackDao.insert(track(2L))
+        trackDao.insert(track(3L))
+
+        val playlistA = playlistDao.insert(stashMixPlaylist(name = "Mix A"))
+        val playlistB = playlistDao.insert(stashMixPlaylist(name = "Mix B"))
+        playlistDao.insertCrossRef(crossRef(playlistA, trackId = 1L, position = 0))
+        playlistDao.insertCrossRef(crossRef(playlistA, trackId = 2L, position = 1))
+        playlistDao.insertCrossRef(crossRef(playlistB, trackId = 2L, position = 0))
+        playlistDao.insertCrossRef(crossRef(playlistB, trackId = 3L, position = 1))
+
+        val result = playlistDao.getTrackIdsForPlaylists(listOf(playlistA, playlistB))
+
+        assertEquals(setOf(1L, 2L, 3L), result.toSet())
+        assertEquals("expected DISTINCT — track 2 once", 3, result.size)
+    }
+
+    @Test fun `empty input returns empty list`() = runTest {
+        val result = playlistDao.getTrackIdsForPlaylists(emptyList())
+        assertTrue("expected empty, got $result", result.isEmpty())
+    }
+
+    @Test fun `filters by the given playlist ids — tracks in OTHER playlists are not returned`() = runTest {
+        trackDao.insert(track(1L))
+        trackDao.insert(track(2L))
+
+        val included = playlistDao.insert(stashMixPlaylist(name = "Included"))
+        val excluded = playlistDao.insert(stashMixPlaylist(name = "Excluded"))
+        playlistDao.insertCrossRef(crossRef(included, trackId = 1L, position = 0))
+        playlistDao.insertCrossRef(crossRef(excluded, trackId = 2L, position = 0))
+
+        val result = playlistDao.getTrackIdsForPlaylists(listOf(included))
+
+        assertEquals(listOf(1L), result)
+    }
+
+    private fun track(id: Long) = TrackEntity(
+        id = id,
+        title = "Track $id",
+        artist = "Artist $id",
+        canonicalTitle = "track $id",
+        canonicalArtist = "artist $id",
+        isDownloaded = true,
+    )
+
+    private fun stashMixPlaylist(name: String) = PlaylistEntity(
+        name = name,
+        source = MusicSource.BOTH,
+        sourceId = "stash_mix_$name",
+        type = PlaylistType.STASH_MIX,
+        trackCount = 0,
+        syncEnabled = true,
+        isActive = true,
+    )
+
+    private fun crossRef(playlistId: Long, trackId: Long, position: Int) =
+        PlaylistTrackCrossRef(
+            playlistId = playlistId,
+            trackId = trackId,
+            position = position,
+            addedAt = Instant.EPOCH,
+        )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/StashMixRecipeDaoRetuneTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/StashMixRecipeDaoRetuneTest.kt
@@ -1,0 +1,112 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [StashMixRecipeDao.retuneBuiltin] — specifically the v0.9.20
+ * expansion that adds affinityBias and seedStrategy to the SET clause so
+ * the recipe-pivot migration can update all five tunable fields in one
+ * UPDATE.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class StashMixRecipeDaoRetuneTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: StashMixRecipeDao
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.stashMixRecipeDao()
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `retuneBuiltin updates all 5 tunable fields including affinityBias and seedStrategy`() = runTest {
+        dao.insert(
+            StashMixRecipeEntity(
+                name = "Daily Discover",
+                discoveryRatio = 0.4f,
+                freshnessWindowDays = 7,
+                targetLength = 50,
+                affinityBias = 0.3f,
+                seedStrategy = "ARTIST_SIMILAR",
+                isBuiltin = true,
+            )
+        )
+
+        val updated = dao.retuneBuiltin(
+            name = "Daily Discover",
+            discoveryRatio = 0.85f,
+            freshnessWindowDays = 7,
+            targetLength = 40,
+            affinityBias = 0.0f,
+            seedStrategy = "ARTIST_SIMILAR",
+        )
+
+        assertEquals(1, updated)
+        val after = dao.getActive().single()
+        assertEquals(0.85f, after.discoveryRatio)
+        assertEquals(40, after.targetLength)
+        assertEquals(0.0f, after.affinityBias)
+        assertEquals("ARTIST_SIMILAR", after.seedStrategy)
+        assertEquals(7, after.freshnessWindowDays)
+    }
+
+    @Test fun `retuneBuiltin is idempotent — second call with same values returns 1 with no state change`() = runTest {
+        dao.insert(
+            StashMixRecipeEntity(
+                name = "Deep Cuts",
+                discoveryRatio = 0.85f,
+                freshnessWindowDays = 90,
+                targetLength = 40,
+                affinityBias = 0.0f,
+                seedStrategy = "TRACK_SIMILAR",
+                isBuiltin = true,
+            )
+        )
+
+        val first = dao.retuneBuiltin("Deep Cuts", 0.85f, 90, 40, 0.0f, "TRACK_SIMILAR")
+        val second = dao.retuneBuiltin("Deep Cuts", 0.85f, 90, 40, 0.0f, "TRACK_SIMILAR")
+
+        assertEquals(1, first)
+        assertEquals(1, second) // SQLite UPDATE rowcount is rows-matched, not rows-changed
+        val after = dao.getActive().single()
+        assertEquals("TRACK_SIMILAR", after.seedStrategy)
+    }
+
+    @Test fun `retuneBuiltin does not touch non-builtin recipes with the same name`() = runTest {
+        dao.insert(
+            StashMixRecipeEntity(
+                name = "Daily Discover",
+                discoveryRatio = 0.4f,
+                affinityBias = 0.3f,
+                seedStrategy = "ARTIST_SIMILAR",
+                isBuiltin = false, // user-created with same name
+            )
+        )
+
+        val updated = dao.retuneBuiltin("Daily Discover", 0.85f, 7, 40, 0.0f, "ARTIST_SIMILAR")
+
+        assertEquals(0, updated)
+        val after = dao.getActive().single()
+        assertEquals(0.4f, after.discoveryRatio) // untouched
+        assertEquals(0.3f, after.affinityBias)
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackDaoCanonicalKeysTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackDaoCanonicalKeysTest.kt
@@ -1,0 +1,79 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.TrackEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [TrackDao.getLibraryCanonicalKeys] — the v0.9.20 method
+ * used by [StashMixRefreshWorker]'s discovery pre-filter to drop
+ * Last.fm candidates that would dedup to library content.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class TrackDaoCanonicalKeysTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: TrackDao
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.trackDao()
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `returns canonical keys only for downloaded tracks`() = runTest {
+        dao.insert(trackEntity(id = 1L, canonicalArtist = "tame impala", canonicalTitle = "borderline", isDownloaded = true))
+        dao.insert(trackEntity(id = 2L, canonicalArtist = "tame impala", canonicalTitle = "the less i know the better", isDownloaded = true))
+        dao.insert(trackEntity(id = 3L, canonicalArtist = "stub artist", canonicalTitle = "stub title", isDownloaded = false))
+
+        val result = dao.getLibraryCanonicalKeys()
+
+        assertEquals(setOf("tame impala|borderline", "tame impala|the less i know the better"), result.toSet())
+        assertFalse("stub track must be excluded", "stub artist|stub title" in result)
+    }
+
+    @Test fun `returns DISTINCT keys — duplicate canonical-pairs collapse to one row`() = runTest {
+        dao.insert(trackEntity(id = 1L, canonicalArtist = "kanye west", canonicalTitle = "runaway", isDownloaded = true))
+        dao.insert(trackEntity(id = 2L, canonicalArtist = "kanye west", canonicalTitle = "runaway", isDownloaded = true))
+
+        val result = dao.getLibraryCanonicalKeys()
+
+        assertEquals(listOf("kanye west|runaway"), result)
+    }
+
+    @Test fun `empty library returns empty list`() = runTest {
+        val result = dao.getLibraryCanonicalKeys()
+        assertEquals(emptyList<String>(), result)
+    }
+
+    private fun trackEntity(
+        id: Long,
+        canonicalArtist: String,
+        canonicalTitle: String,
+        isDownloaded: Boolean,
+    ) = TrackEntity(
+        id = id,
+        title = "Title $id",
+        artist = "Artist $id",
+        canonicalTitle = canonicalTitle,
+        canonicalArtist = canonicalArtist,
+        isDownloaded = isDownloaded,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackDaoTopByLfmPlaycountTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackDaoTopByLfmPlaycountTest.kt
@@ -1,0 +1,102 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.TrackEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class TrackDaoTopByLfmPlaycountTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: TrackDao
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.trackDao()
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `returns top downloaded tracks by lastfm playcount descending`() = runTest {
+        dao.insert(track(id = 1L, artist = "A", title = "Top", lfmCount = 1000))
+        dao.insert(track(id = 2L, artist = "B", title = "Mid", lfmCount = 100))
+        dao.insert(track(id = 3L, artist = "C", title = "Low", lfmCount = 10))
+
+        val result = dao.getTopTracksByLfmPlaycount(limit = 10)
+
+        assertEquals(
+            listOf(
+                TrackArtistTitle("A", "Top"),
+                TrackArtistTitle("B", "Mid"),
+                TrackArtistTitle("C", "Low"),
+            ),
+            result,
+        )
+    }
+
+    @Test fun `excludes tracks with null or zero lastfm playcount`() = runTest {
+        dao.insert(track(id = 1L, artist = "A", title = "Counted", lfmCount = 5))
+        dao.insert(track(id = 2L, artist = "B", title = "Zero", lfmCount = 0))
+        dao.insert(track(id = 3L, artist = "C", title = "Null", lfmCount = null))
+
+        val result = dao.getTopTracksByLfmPlaycount(limit = 10)
+
+        assertEquals(listOf(TrackArtistTitle("A", "Counted")), result)
+    }
+
+    @Test fun `excludes non-downloaded tracks`() = runTest {
+        dao.insert(track(id = 1L, artist = "A", title = "Downloaded", lfmCount = 100, isDownloaded = true))
+        dao.insert(track(id = 2L, artist = "B", title = "Stub", lfmCount = 200, isDownloaded = false))
+
+        val result = dao.getTopTracksByLfmPlaycount(limit = 10)
+
+        assertEquals(listOf(TrackArtistTitle("A", "Downloaded")), result)
+    }
+
+    @Test fun `respects limit`() = runTest {
+        for (i in 1..5) dao.insert(track(id = i.toLong(), artist = "A$i", title = "T$i", lfmCount = i * 10))
+
+        val result = dao.getTopTracksByLfmPlaycount(limit = 3)
+
+        assertEquals(3, result.size)
+        // Highest 3 (lfmCount 50, 40, 30) — order desc
+        assertEquals(listOf("A5", "A4", "A3"), result.map { it.artist })
+    }
+
+    @Test fun `empty library returns empty`() = runTest {
+        val result = dao.getTopTracksByLfmPlaycount(limit = 10)
+        assertTrue(result.isEmpty())
+    }
+
+    private fun track(
+        id: Long,
+        artist: String,
+        title: String,
+        lfmCount: Int?,
+        isDownloaded: Boolean = true,
+    ) = TrackEntity(
+        id = id,
+        title = title,
+        artist = artist,
+        canonicalTitle = title.lowercase(),
+        canonicalArtist = artist.lowercase(),
+        isDownloaded = isDownloaded,
+        lastfmUserPlaycount = lfmCount,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackSkipEventDaoBanListTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackSkipEventDaoBanListTest.kt
@@ -1,0 +1,132 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.db.entity.TrackSkipEventEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class TrackSkipEventDaoBanListTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: TrackSkipEventDao
+    private lateinit var trackDao: TrackDao
+
+    @Before fun setUp() = runTest {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.trackSkipEventDao()
+        trackDao = db.trackDao()
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `bans canonical key with 3+ early skips inside time window`() = runTest {
+        trackDao.insert(track(id = 1L, canonicalArtist = "the strokes", canonicalTitle = "last nite"))
+
+        val now = System.currentTimeMillis()
+        repeat(4) { i -> dao.insert(skip(trackId = 1L, positionMs = 1000L, skippedAt = now - i * 1000L)) }
+
+        val result = dao.getEarlySkipBannedCanonicalKeys(
+            minSkips = 3,
+            sinceMs = now - TimeUnit.DAYS.toMillis(90),
+            maxPositionMs = 30_000L,
+        )
+
+        assertEquals(listOf("the strokes|last nite"), result)
+    }
+
+    @Test fun `excludes canonical keys with skips beyond position cutoff`() = runTest {
+        trackDao.insert(track(id = 1L, canonicalArtist = "arctic monkeys", canonicalTitle = "do i wanna know"))
+
+        val now = System.currentTimeMillis()
+        repeat(4) { dao.insert(skip(trackId = 1L, positionMs = 90_000L, skippedAt = now)) }
+
+        val result = dao.getEarlySkipBannedCanonicalKeys(
+            minSkips = 3,
+            sinceMs = now - TimeUnit.DAYS.toMillis(90),
+            maxPositionMs = 30_000L,
+        )
+
+        assertTrue("expected empty, got $result", result.isEmpty())
+    }
+
+    @Test fun `excludes canonical keys below skip count threshold`() = runTest {
+        trackDao.insert(track(id = 1L, canonicalArtist = "radiohead", canonicalTitle = "creep"))
+
+        val now = System.currentTimeMillis()
+        repeat(2) { dao.insert(skip(trackId = 1L, positionMs = 1000L, skippedAt = now)) }
+
+        val result = dao.getEarlySkipBannedCanonicalKeys(
+            minSkips = 3,
+            sinceMs = now - TimeUnit.DAYS.toMillis(90),
+            maxPositionMs = 30_000L,
+        )
+
+        assertTrue("expected empty, got $result", result.isEmpty())
+    }
+
+    @Test fun `excludes skips outside time window`() = runTest {
+        trackDao.insert(track(id = 1L, canonicalArtist = "blur", canonicalTitle = "song 2"))
+
+        val now = System.currentTimeMillis()
+        val veryOld = now - TimeUnit.DAYS.toMillis(100)
+        repeat(4) { dao.insert(skip(trackId = 1L, positionMs = 1000L, skippedAt = veryOld)) }
+
+        val result = dao.getEarlySkipBannedCanonicalKeys(
+            minSkips = 3,
+            sinceMs = now - TimeUnit.DAYS.toMillis(90),
+            maxPositionMs = 30_000L,
+        )
+
+        assertTrue("expected empty (events outside window), got $result", result.isEmpty())
+    }
+
+    @Test fun `bans multiple distinct canonical keys when each has 3+ qualifying skips`() = runTest {
+        trackDao.insert(track(id = 1L, canonicalArtist = "a", canonicalTitle = "x"))
+        trackDao.insert(track(id = 2L, canonicalArtist = "b", canonicalTitle = "y"))
+
+        val now = System.currentTimeMillis()
+        repeat(3) { dao.insert(skip(trackId = 1L, positionMs = 5000L, skippedAt = now)) }
+        repeat(3) { dao.insert(skip(trackId = 2L, positionMs = 5000L, skippedAt = now)) }
+
+        val result = dao.getEarlySkipBannedCanonicalKeys(
+            minSkips = 3,
+            sinceMs = now - TimeUnit.DAYS.toMillis(90),
+            maxPositionMs = 30_000L,
+        )
+
+        assertEquals(setOf("a|x", "b|y"), result.toSet())
+    }
+
+    private fun track(id: Long, canonicalArtist: String, canonicalTitle: String) = TrackEntity(
+        id = id,
+        title = "Title $id",
+        artist = "Artist $id",
+        canonicalTitle = canonicalTitle,
+        canonicalArtist = canonicalArtist,
+        isDownloaded = true,
+    )
+
+    private fun skip(trackId: Long, positionMs: Long, skippedAt: Long) = TrackSkipEventEntity(
+        trackId = trackId,
+        positionMs = positionMs,
+        skippedAt = skippedAt,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorComputeUserTopTagsTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorComputeUserTopTagsTest.kt
@@ -1,0 +1,155 @@
+package com.stash.core.data.mix
+
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.ListeningEventDao
+import com.stash.core.data.db.dao.ListeningEventDao.TrackPlayCountWithLatest
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.dao.TrackSkipEventDao
+import com.stash.core.data.db.dao.TrackTagDao
+import com.stash.core.data.db.dao.TrackTagDao.TagCount
+import com.stash.core.data.db.entity.TrackTagEntity
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [MixGenerator.computeUserTopTags] — specifically the v0.9.19
+ * library-histogram fallback path that fires when the user's
+ * listening-affinity vector is empty.
+ */
+class MixGeneratorComputeUserTopTagsTest {
+
+    private val trackDao: TrackDao = mockk(relaxed = true)
+    private val trackTagDao: TrackTagDao = mockk()
+    private val listeningEventDao: ListeningEventDao = mockk()
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val blocklistGuard: BlocklistGuard = mockk(relaxed = true)
+    private val trackSkipEventDao: TrackSkipEventDao = mockk(relaxed = true)
+
+    private val subject = MixGenerator(
+        trackDao,
+        trackTagDao,
+        listeningEventDao,
+        discoveryQueueDao,
+        blocklistGuard,
+        trackSkipEventDao,
+    )
+
+    // Helper: set up affinity-vector inputs to produce a non-empty vector.
+    // One play row with one real tag is enough for compute() to yield a
+    // non-empty L2-normalized result.
+    private fun stubAffinityVectorNonEmpty(now: Long = System.currentTimeMillis()) {
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns listOf(
+            TrackPlayCountWithLatest(trackId = 1L, plays = 5, latestPlayedAt = now),
+        )
+        coEvery { trackTagDao.getByTrack(1L) } returns listOf(
+            TrackTagEntity(trackId = 1L, tag = "indie", weight = 80f, source = "ARTIST", fetchedAt = now),
+            TrackTagEntity(trackId = 1L, tag = "dream pop", weight = 50f, source = "ARTIST", fetchedAt = now),
+        )
+    }
+
+    // Helper: set up affinity-vector inputs to produce an empty vector
+    // (plays exist but every track is untagged or only __untaggable__).
+    private fun stubAffinityVectorEmpty(now: Long = System.currentTimeMillis()) {
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns listOf(
+            TrackPlayCountWithLatest(trackId = 1L, plays = 5, latestPlayedAt = now),
+        )
+        coEvery { trackTagDao.getByTrack(1L) } returns listOf(
+            TrackTagEntity(trackId = 1L, tag = "__untaggable__", weight = 0f, source = "ARTIST", fetchedAt = now),
+        )
+    }
+
+    @Test fun `returns affinity-vector tags when vector is non-empty (histogram NOT consulted)`() = runTest {
+        stubAffinityVectorNonEmpty()
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertTrue("expected non-empty result, got $result", result.isNotEmpty())
+        assertTrue("indie should be in top tags, got $result", result.contains("indie"))
+        coVerify(exactly = 0) { trackTagDao.getTagHistogram() }
+    }
+
+    @Test fun `falls back to histogram when affinity vector is empty (no listening events)`() = runTest {
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { trackTagDao.getTagHistogram() } returns listOf(
+            TagCount(tag = "rock", trackCount = 100),
+            TagCount(tag = "indie", trackCount = 80),
+            TagCount(tag = "pop", trackCount = 60),
+        )
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertEquals(listOf("rock", "indie", "pop"), result)
+    }
+
+    @Test fun `falls back to histogram when plays exist but all tracks are untagged`() = runTest {
+        stubAffinityVectorEmpty()
+        coEvery { trackTagDao.getTagHistogram() } returns listOf(
+            TagCount(tag = "rock", trackCount = 100),
+            TagCount(tag = "indie", trackCount = 80),
+        )
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertEquals(listOf("rock", "indie"), result)
+    }
+
+    @Test fun `fallback filters out __untaggable__ sentinel`() = runTest {
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { trackTagDao.getTagHistogram() } returns listOf(
+            TagCount(tag = "__untaggable__", trackCount = 200),  // top of histogram
+            TagCount(tag = "rock", trackCount = 100),
+            TagCount(tag = "indie", trackCount = 80),
+        )
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertTrue("__untaggable__ must not appear, got $result", "__untaggable__" !in result)
+        assertEquals(listOf("rock", "indie"), result)
+    }
+
+    @Test fun `returns empty when both affinity vector and histogram are empty`() = runTest {
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { trackTagDao.getTagHistogram() } returns emptyList()
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertEquals(emptyList<String>(), result)
+    }
+
+    @Test fun `respects the limit on the fallback path`() = runTest {
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { trackTagDao.getTagHistogram() } returns (1..15).map {
+            TagCount(tag = "tag$it", trackCount = 100 - it)
+        }
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertEquals(10, result.size)
+        assertEquals("tag1", result.first())
+        assertEquals("tag10", result.last())
+    }
+
+    @Test fun `fallback yields limit real tags even when __untaggable__ tops the histogram`() = runTest {
+        // Combined-case regression guard. If the implementation ever
+        // accidentally swaps to take().filter() (instead of
+        // filter().take()), the sentinel consumes a result slot and
+        // we'd return 9 real tags + a hole. Pin the order.
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { trackTagDao.getTagHistogram() } returns listOf(
+            TagCount(tag = "__untaggable__", trackCount = 999),
+        ) + (1..11).map { TagCount(tag = "tag$it", trackCount = 100 - it) }
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertEquals(10, result.size)
+        assertTrue("sentinel must not appear, got $result", "__untaggable__" !in result)
+        assertEquals("tag1", result.first())
+        assertEquals("tag10", result.last())
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorExcludeIdsTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorExcludeIdsTest.kt
@@ -1,0 +1,92 @@
+package com.stash.core.data.mix
+
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.ListeningEventDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.dao.TrackSkipEventDao
+import com.stash.core.data.db.dao.TrackTagDao
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.db.entity.TrackEntity
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [MixGenerator.generate]'s v0.9.20 `excludeIds` parameter — the
+ * cross-mix dedup primitive. excludeIds filters the library pool BEFORE
+ * scoring + slot allocation, so excluded tracks can never appear in the
+ * result.
+ */
+class MixGeneratorExcludeIdsTest {
+
+    private val trackDao: TrackDao = mockk()
+    private val trackTagDao: TrackTagDao = mockk(relaxed = true)
+    private val listeningEventDao: ListeningEventDao = mockk(relaxed = true)
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val blocklistGuard: BlocklistGuard = mockk(relaxed = true)
+    private val trackSkipEventDao: TrackSkipEventDao = mockk(relaxed = true)
+    private lateinit var generator: MixGenerator
+
+    @Before fun setUp() {
+        generator = MixGenerator(
+            trackDao,
+            trackTagDao,
+            listeningEventDao,
+            discoveryQueueDao,
+            blocklistGuard,
+            trackSkipEventDao,
+        )
+    }
+
+    @Test fun `excludeIds removes matching tracks from the pool before scoring`() = runTest {
+        val tracks = (1L..5L).map { stubTrack(it) }
+        coEvery { trackDao.getAllDownloaded() } returns tracks
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { listeningEventDao.getTrackIdsPlayedSince(any()) } returns emptyList()
+        coEvery { trackTagDao.getByTrack(any()) } returns emptyList()
+
+        val result = generator.generate(
+            recipe = stubRecipe(discoveryRatio = 0.0f, targetLength = 10),
+            excludeIds = setOf(2L, 4L),
+        )
+
+        val ids = result.map { it.id }.toSet()
+        assertEquals(setOf(1L, 3L, 5L), ids)
+        assertTrue("expected 2L excluded", 2L !in ids)
+        assertTrue("expected 4L excluded", 4L !in ids)
+    }
+
+    @Test fun `empty excludeIds preserves the full library pool`() = runTest {
+        val tracks = (1L..5L).map { stubTrack(it) }
+        coEvery { trackDao.getAllDownloaded() } returns tracks
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { listeningEventDao.getTrackIdsPlayedSince(any()) } returns emptyList()
+        coEvery { trackTagDao.getByTrack(any()) } returns emptyList()
+
+        val result = generator.generate(stubRecipe(discoveryRatio = 0.0f, targetLength = 10))
+
+        assertEquals(5, result.size)
+    }
+
+    private fun stubRecipe(discoveryRatio: Float, targetLength: Int) = StashMixRecipeEntity(
+        id = 1L,
+        name = "Test",
+        discoveryRatio = discoveryRatio,
+        targetLength = targetLength,
+        freshnessWindowDays = 0,
+    )
+
+    private fun stubTrack(id: Long) = TrackEntity(
+        id = id,
+        title = "Track $id",
+        artist = "Artist $id",
+        canonicalTitle = "track $id",
+        canonicalArtist = "artist $id",
+        isDownloaded = true,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorShortfallFillTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorShortfallFillTest.kt
@@ -1,0 +1,112 @@
+package com.stash.core.data.mix
+
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.ListeningEventDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.dao.TrackSkipEventDao
+import com.stash.core.data.db.dao.TrackTagDao
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.db.entity.TrackEntity
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [MixGenerator.generate]'s v0.9.20 shortfall-fill threshold.
+ * The old gate was `discoveryRatio < 1.0f`; the new gate is
+ * `discoveryRatio < 0.5f` — high-discovery recipes return a sparser
+ * library slice rather than backfilling from the rest of the library.
+ */
+class MixGeneratorShortfallFillTest {
+
+    private val trackDao: TrackDao = mockk()
+    private val trackTagDao: TrackTagDao = mockk(relaxed = true)
+    private val listeningEventDao: ListeningEventDao = mockk(relaxed = true)
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val blocklistGuard: BlocklistGuard = mockk(relaxed = true)
+    private val trackSkipEventDao: TrackSkipEventDao = mockk(relaxed = true)
+    private lateinit var generator: MixGenerator
+
+    @Before fun setUp() {
+        generator = MixGenerator(
+            trackDao,
+            trackTagDao,
+            listeningEventDao,
+            discoveryQueueDao,
+            blocklistGuard,
+            trackSkipEventDao,
+        )
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { listeningEventDao.getTrackIdsPlayedSince(any()) } returns emptyList()
+        coEvery { trackTagDao.getByTrack(any()) } returns emptyList()
+    }
+
+    @Test fun `shortfall fill triggers at discoveryRatio = 0_4`() = runTest {
+        coEvery { trackDao.getAllDownloaded() } returns (1L..50L).map { stubTrack(it) }
+
+        val result = generator.generate(
+            stubRecipe(discoveryRatio = 0.4f, targetLength = 50),
+        )
+
+        // librarySlots = 50 * (1 - 0.4) = 30; pool = 50; shortfall fills to 50.
+        assertEquals(50, result.size)
+    }
+
+    @Test fun `shortfall fill does NOT trigger at discoveryRatio = 0_5`() = runTest {
+        coEvery { trackDao.getAllDownloaded() } returns (1L..50L).map { stubTrack(it) }
+
+        val result = generator.generate(
+            stubRecipe(discoveryRatio = 0.5f, targetLength = 50),
+        )
+
+        // librarySlots = 50 * (1 - 0.5) = 25; no shortfall fill.
+        assertEquals(25, result.size)
+    }
+
+    @Test fun `shortfall fill does NOT trigger at discoveryRatio = 0_85`() = runTest {
+        coEvery { trackDao.getAllDownloaded() } returns (1L..50L).map { stubTrack(it) }
+
+        val result = generator.generate(
+            stubRecipe(discoveryRatio = 0.85f, targetLength = 40),
+        )
+
+        // librarySlots = (40 * (1f - 0.85f)).toInt() = 5 (float precision:
+        // 1f - 0.85f = 0.14999998, * 40 = 5.9999..., truncated). The key
+        // assertion is that this is far below targetLength = 40 — i.e. no
+        // shortfall fill triggered.
+        assertEquals(5, result.size)
+    }
+
+    @Test fun `pure discovery recipe at ratio = 1_0 returns empty library slice`() = runTest {
+        coEvery { trackDao.getAllDownloaded() } returns (1L..50L).map { stubTrack(it) }
+
+        val result = generator.generate(
+            stubRecipe(discoveryRatio = 1.0f, targetLength = 50),
+        )
+
+        // librarySlots = 0; no shortfall fill (already gated by < 0.5).
+        assertTrue("expected empty, got ${result.size}", result.isEmpty())
+    }
+
+    private fun stubRecipe(discoveryRatio: Float, targetLength: Int) = StashMixRecipeEntity(
+        id = 1L,
+        name = "Test",
+        discoveryRatio = discoveryRatio,
+        targetLength = targetLength,
+        freshnessWindowDays = 0,
+    )
+
+    private fun stubTrack(id: Long) = TrackEntity(
+        id = id,
+        title = "Track $id",
+        artist = "Artist $id",
+        canonicalTitle = "track $id",
+        canonicalArtist = "artist $id",
+        isDownloaded = true,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorkerTest.kt
@@ -1,4 +1,4 @@
-package com.stash.data.download
+package com.stash.core.data.sync.workers
 
 import android.content.Context
 import androidx.work.WorkerParameters

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DownloadConstraintsTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DownloadConstraintsTest.kt
@@ -14,27 +14,12 @@ import org.junit.Test
  */
 class DownloadConstraintsTest {
 
-    @Test fun `constraintsForManualTrigger WIFI_AND_CHARGING requires WiFi but NOT charging`() {
-        val constraints = constraintsForManualTrigger(DownloadNetworkMode.WIFI_AND_CHARGING)
-
-        assertEquals(NetworkType.UNMETERED, constraints.requiredNetworkType)
-        assertFalse("manual trigger drops charging requirement", constraints.requiresCharging())
-        assertTrue("battery-not-low always required", constraints.requiresBatteryNotLow())
-    }
-
-    @Test fun `constraintsForManualTrigger WIFI_ANY requires WiFi but NOT charging`() {
-        val constraints = constraintsForManualTrigger(DownloadNetworkMode.WIFI_ANY)
-
-        assertEquals(NetworkType.UNMETERED, constraints.requiredNetworkType)
-        assertFalse(constraints.requiresCharging())
-        assertTrue(constraints.requiresBatteryNotLow())
-    }
-
-    @Test fun `constraintsForManualTrigger ANY_NETWORK requires any network and NOT charging`() {
-        val constraints = constraintsForManualTrigger(DownloadNetworkMode.ANY_NETWORK)
-
-        assertEquals(NetworkType.CONNECTED, constraints.requiredNetworkType)
-        assertFalse(constraints.requiresCharging())
-        assertTrue(constraints.requiresBatteryNotLow())
+    @Test fun `constraintsForManualTrigger ignores mode — always CONNECTED + battery-not-low + no charging`() {
+        for (mode in DownloadNetworkMode.values()) {
+            val constraints = constraintsForManualTrigger(mode)
+            assertEquals("mode=$mode", NetworkType.CONNECTED, constraints.requiredNetworkType)
+            assertFalse("mode=$mode", constraints.requiresCharging())
+            assertTrue("mode=$mode", constraints.requiresBatteryNotLow())
+        }
     }
 }

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DownloadConstraintsTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DownloadConstraintsTest.kt
@@ -1,0 +1,40 @@
+package com.stash.core.data.sync.workers
+
+import androidx.work.NetworkType
+import com.stash.core.model.DownloadNetworkMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for the [constraintsForManualTrigger] helper — drops charging
+ * requirement compared to [constraintsFor], otherwise honors the user's
+ * [DownloadNetworkMode] preference for cellular gating.
+ */
+class DownloadConstraintsTest {
+
+    @Test fun `constraintsForManualTrigger WIFI_AND_CHARGING requires WiFi but NOT charging`() {
+        val constraints = constraintsForManualTrigger(DownloadNetworkMode.WIFI_AND_CHARGING)
+
+        assertEquals(NetworkType.UNMETERED, constraints.requiredNetworkType)
+        assertFalse("manual trigger drops charging requirement", constraints.requiresCharging())
+        assertTrue("battery-not-low always required", constraints.requiresBatteryNotLow())
+    }
+
+    @Test fun `constraintsForManualTrigger WIFI_ANY requires WiFi but NOT charging`() {
+        val constraints = constraintsForManualTrigger(DownloadNetworkMode.WIFI_ANY)
+
+        assertEquals(NetworkType.UNMETERED, constraints.requiredNetworkType)
+        assertFalse(constraints.requiresCharging())
+        assertTrue(constraints.requiresBatteryNotLow())
+    }
+
+    @Test fun `constraintsForManualTrigger ANY_NETWORK requires any network and NOT charging`() {
+        val constraints = constraintsForManualTrigger(DownloadNetworkMode.ANY_NETWORK)
+
+        assertEquals(NetworkType.CONNECTED, constraints.requiredNetworkType)
+        assertFalse(constraints.requiresCharging())
+        assertTrue(constraints.requiresBatteryNotLow())
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt
@@ -8,6 +8,7 @@ import com.stash.core.data.db.dao.ListeningEventDao
 import com.stash.core.data.db.dao.PlaylistDao
 import com.stash.core.data.db.dao.StashMixRecipeDao
 import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.dao.TrackSkipEventDao
 import com.stash.core.data.db.entity.StashMixRecipeEntity
 import com.stash.core.data.db.entity.TrackEntity
 import com.stash.core.data.lastfm.LastFmApiClient
@@ -15,6 +16,7 @@ import com.stash.core.data.lastfm.LastFmCredentials
 import com.stash.core.data.lastfm.LastFmSessionPreference
 import com.stash.core.data.mix.MixGenerator
 import com.stash.core.data.mix.MixSeedGenerator
+import com.stash.core.data.sync.TrackMatcher
 import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.slot
@@ -50,12 +52,15 @@ class StashMixRefreshWorkerDedupTest {
     private val blocklistGuard: BlocklistGuard = mockk {
         coEvery { isBlockedByTrackId(any()) } returns false
     }
+    private val trackSkipEventDao: TrackSkipEventDao = mockk(relaxed = true)
+    private val trackMatcher: TrackMatcher = mockk(relaxed = true)
 
     private fun newWorker() = StashMixRefreshWorker(
         appContext, workerParams,
         recipeDao, playlistDao, discoveryQueueDao, listeningEventDao,
         trackDao, mixGenerator, seedGenerator, lastFmApiClient,
         lastFmCredentials, sessionPreference, blocklistGuard,
+        trackSkipEventDao, trackMatcher,
     )
 
     @Test fun `excludeIds accumulates across recipes — no track appears in two playlists`() = runTest {

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt
@@ -1,0 +1,107 @@
+package com.stash.core.data.sync.workers
+
+import android.content.Context
+import androidx.work.WorkerParameters
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.ListeningEventDao
+import com.stash.core.data.db.dao.PlaylistDao
+import com.stash.core.data.db.dao.StashMixRecipeDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.lastfm.LastFmApiClient
+import com.stash.core.data.lastfm.LastFmCredentials
+import com.stash.core.data.lastfm.LastFmSessionPreference
+import com.stash.core.data.mix.MixGenerator
+import com.stash.core.data.mix.MixSeedGenerator
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * End-to-end MockK test for [StashMixRefreshWorker]'s cross-mix dedup
+ * orchestration. Verifies that when multiple builtin recipes run in
+ * priority order, no track id appears in two playlists.
+ */
+class StashMixRefreshWorkerDedupTest {
+
+    private val appContext: Context = mockk(relaxed = true)
+    private val workerParams: WorkerParameters = mockk(relaxed = true)
+    private val recipeDao: StashMixRecipeDao = mockk(relaxed = true)
+    private val playlistDao: PlaylistDao = mockk(relaxed = true)
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val listeningEventDao: ListeningEventDao = mockk(relaxed = true)
+    private val trackDao: TrackDao = mockk(relaxed = true)
+    private val mixGenerator: MixGenerator = mockk()
+    private val seedGenerator: MixSeedGenerator = mockk(relaxed = true)
+    private val lastFmApiClient: LastFmApiClient = mockk(relaxed = true)
+    private val lastFmCredentials: LastFmCredentials = mockk {
+        coEvery { isConfigured } returns false  // skip persona fetch + discovery seeding
+    }
+    private val sessionPreference: LastFmSessionPreference = mockk {
+        coEvery { session } returns flowOf(null)
+    }
+    private val blocklistGuard: BlocklistGuard = mockk {
+        coEvery { isBlockedByTrackId(any()) } returns false
+    }
+
+    private fun newWorker() = StashMixRefreshWorker(
+        appContext, workerParams,
+        recipeDao, playlistDao, discoveryQueueDao, listeningEventDao,
+        trackDao, mixGenerator, seedGenerator, lastFmApiClient,
+        lastFmCredentials, sessionPreference, blocklistGuard,
+    )
+
+    @Test fun `excludeIds accumulates across recipes — no track appears in two playlists`() = runTest {
+        // Three active recipes in priority order: First Listen, Deep Cuts, Daily Discover.
+        val firstListen = recipe(id = 1L, name = "First Listen", ratio = 1.0f)
+        val deepCuts = recipe(id = 2L, name = "Deep Cuts", ratio = 0.85f)
+        val dailyDiscover = recipe(id = 3L, name = "Daily Discover", ratio = 0.85f)
+        coEvery { recipeDao.getActive() } returns listOf(dailyDiscover, deepCuts, firstListen) // unsorted
+
+        // Capture excludeIds passed to each generate() call.
+        val excludeCaptureFirstListen = slot<Set<Long>>()
+        val excludeCaptureDeepCuts = slot<Set<Long>>()
+        val excludeCaptureDailyDiscover = slot<Set<Long>>()
+        coEvery { mixGenerator.generate(firstListen, capture(excludeCaptureFirstListen)) } returns emptyList()
+        coEvery { mixGenerator.generate(deepCuts, capture(excludeCaptureDeepCuts)) } returns listOf(track(10L), track(11L))
+        coEvery { mixGenerator.generate(dailyDiscover, capture(excludeCaptureDailyDiscover)) } returns listOf(track(20L), track(21L))
+
+        // First Listen brings 5 discovery survivors; Deep Cuts brings 6 (10, 11 are also library); Daily Discover 7 (1 is in First Listen).
+        coEvery { discoveryQueueDao.getDoneTrackIdsForRecipe(firstListen.id, any()) } returns listOf(1L, 2L, 3L, 4L, 5L)
+        coEvery { discoveryQueueDao.getDoneTrackIdsForRecipe(deepCuts.id, any()) } returns listOf(6L, 7L, 8L, 9L, 10L, 11L)
+        coEvery { discoveryQueueDao.getDoneTrackIdsForRecipe(dailyDiscover.id, any()) } returns listOf(1L, 12L, 13L, 14L, 15L, 16L, 17L)
+
+        coEvery { playlistDao.getById(any()) } returns null
+        coEvery { playlistDao.insert(any()) } returnsMany listOf(100L, 200L, 300L)
+
+        newWorker().doWork()
+
+        // First Listen runs first (priority 1) — exclude set is empty.
+        assertTrue("first listen excludeIds should start empty", excludeCaptureFirstListen.captured.isEmpty())
+
+        // Deep Cuts runs second — exclude set has First Listen's 5 discovery ids.
+        assertEquals(setOf(1L, 2L, 3L, 4L, 5L), excludeCaptureDeepCuts.captured)
+
+        // Daily Discover runs third — exclude set has First Listen's {1..5} + Deep Cuts's library {10, 11} + Deep Cuts's NEW survivors {6, 7, 8, 9} (10/11 are in librarySet so filtered there, not by excludeIds).
+        assertEquals(setOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L), excludeCaptureDailyDiscover.captured)
+    }
+
+    private fun recipe(id: Long, name: String, ratio: Float) = StashMixRecipeEntity(
+        id = id, name = name,
+        discoveryRatio = ratio, targetLength = 40,
+        isBuiltin = true, isActive = true,
+    )
+
+    private fun track(id: Long) = TrackEntity(
+        id = id, title = "Track $id", artist = "Artist $id",
+        canonicalTitle = "track $id", canonicalArtist = "artist $id",
+        isDownloaded = true,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerPerRecipeDedupTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerPerRecipeDedupTest.kt
@@ -1,0 +1,128 @@
+package com.stash.core.data.sync.workers
+
+import android.content.Context
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.ListeningEventDao
+import com.stash.core.data.db.dao.PlaylistDao
+import com.stash.core.data.db.dao.StashMixRecipeDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.lastfm.LastFmApiClient
+import com.stash.core.data.lastfm.LastFmCredentials
+import com.stash.core.data.lastfm.LastFmSessionPreference
+import com.stash.core.data.mix.MixGenerator
+import com.stash.core.data.mix.MixSeedGenerator
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * MockK end-to-end test for [StashMixRefreshWorker]'s v0.9.20 single-
+ * recipe dedup. When `KEY_RECIPE_ID` is set, the worker pre-populates
+ * `excludeIds` from the OTHER builtin mixes' current playlist contents
+ * so a manual long-press refresh doesn't produce overlap with the
+ * other mixes.
+ */
+class StashMixRefreshWorkerPerRecipeDedupTest {
+
+    private val appContext: Context = mockk(relaxed = true)
+    private val recipeDao: StashMixRecipeDao = mockk(relaxed = true)
+    private val playlistDao: PlaylistDao = mockk(relaxed = true)
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val listeningEventDao: ListeningEventDao = mockk(relaxed = true)
+    private val trackDao: TrackDao = mockk(relaxed = true)
+    private val mixGenerator: MixGenerator = mockk()
+    private val seedGenerator: MixSeedGenerator = mockk(relaxed = true)
+    private val lastFmApiClient: LastFmApiClient = mockk(relaxed = true)
+    private val lastFmCredentials: LastFmCredentials = mockk {
+        coEvery { isConfigured } returns false
+    }
+    private val sessionPreference: LastFmSessionPreference = mockk {
+        coEvery { session } returns flowOf(null)
+    }
+    private val blocklistGuard: BlocklistGuard = mockk {
+        coEvery { isBlockedByTrackId(any()) } returns false
+    }
+
+    private fun newWorker(recipeId: Long): StashMixRefreshWorker {
+        val params: WorkerParameters = mockk(relaxed = true) {
+            coEvery { inputData } returns workDataOf(
+                StashMixRefreshWorker.KEY_RECIPE_ID to recipeId,
+            )
+        }
+        return StashMixRefreshWorker(
+            appContext, params,
+            recipeDao, playlistDao, discoveryQueueDao, listeningEventDao,
+            trackDao, mixGenerator, seedGenerator, lastFmApiClient,
+            lastFmCredentials, sessionPreference, blocklistGuard,
+        )
+    }
+
+    @Test fun `single-recipe path pre-populates excludeIds from other mixes' playlist contents`() = runTest {
+        val targetRecipe = recipe(id = 1L, name = "Daily Discover", playlistId = 100L)
+        val otherRecipe1 = recipe(id = 2L, name = "Deep Cuts", playlistId = 200L)
+        val otherRecipe2 = recipe(id = 3L, name = "First Listen", playlistId = 300L)
+
+        coEvery { recipeDao.getById(1L) } returns targetRecipe
+        coEvery { recipeDao.getActive() } returns listOf(targetRecipe, otherRecipe1, otherRecipe2)
+        coEvery {
+            playlistDao.getTrackIdsForPlaylists(match { it.toSet() == setOf(200L, 300L) })
+        } returns listOf(50L, 51L, 52L)
+        coEvery { playlistDao.getById(any()) } returns null
+        coEvery { playlistDao.insert(any()) } returns 999L
+
+        val excludeCapture = slot<Set<Long>>()
+        coEvery { mixGenerator.generate(targetRecipe, capture(excludeCapture)) } returns emptyList()
+        coEvery {
+            discoveryQueueDao.getDoneTrackIdsForRecipe(any(), any())
+        } returns emptyList()
+
+        newWorker(recipeId = 1L).doWork()
+
+        assertEquals(
+            "single-recipe path must pre-populate excludeIds from other mixes",
+            setOf(50L, 51L, 52L),
+            excludeCapture.captured,
+        )
+    }
+
+    @Test fun `single-recipe path skips lookup when no other mixes have playlist ids`() = runTest {
+        val targetRecipe = recipe(id = 1L, name = "Daily Discover", playlistId = 100L)
+        val otherRecipe = recipe(id = 2L, name = "Deep Cuts", playlistId = null)
+
+        coEvery { recipeDao.getById(1L) } returns targetRecipe
+        coEvery { recipeDao.getActive() } returns listOf(targetRecipe, otherRecipe)
+        coEvery { playlistDao.getById(any()) } returns null
+        coEvery { playlistDao.insert(any()) } returns 999L
+
+        val excludeCapture = slot<Set<Long>>()
+        coEvery { mixGenerator.generate(targetRecipe, capture(excludeCapture)) } returns emptyList()
+        coEvery {
+            discoveryQueueDao.getDoneTrackIdsForRecipe(any(), any())
+        } returns emptyList()
+
+        newWorker(recipeId = 1L).doWork()
+
+        assertTrue("expected empty excludeIds when no other mixes have playlists", excludeCapture.captured.isEmpty())
+        coVerify(exactly = 0) { playlistDao.getTrackIdsForPlaylists(any()) }
+    }
+
+    private fun recipe(id: Long, name: String, playlistId: Long?) = StashMixRecipeEntity(
+        id = id,
+        name = name,
+        discoveryRatio = 0.85f,
+        targetLength = 40,
+        playlistId = playlistId,
+        isBuiltin = true,
+        isActive = true,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerPerRecipeDedupTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerPerRecipeDedupTest.kt
@@ -9,12 +9,14 @@ import com.stash.core.data.db.dao.ListeningEventDao
 import com.stash.core.data.db.dao.PlaylistDao
 import com.stash.core.data.db.dao.StashMixRecipeDao
 import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.dao.TrackSkipEventDao
 import com.stash.core.data.db.entity.StashMixRecipeEntity
 import com.stash.core.data.lastfm.LastFmApiClient
 import com.stash.core.data.lastfm.LastFmCredentials
 import com.stash.core.data.lastfm.LastFmSessionPreference
 import com.stash.core.data.mix.MixGenerator
 import com.stash.core.data.mix.MixSeedGenerator
+import com.stash.core.data.sync.TrackMatcher
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -52,6 +54,8 @@ class StashMixRefreshWorkerPerRecipeDedupTest {
     private val blocklistGuard: BlocklistGuard = mockk {
         coEvery { isBlockedByTrackId(any()) } returns false
     }
+    private val trackSkipEventDao: TrackSkipEventDao = mockk(relaxed = true)
+    private val trackMatcher: TrackMatcher = mockk(relaxed = true)
 
     private fun newWorker(recipeId: Long): StashMixRefreshWorker {
         val params: WorkerParameters = mockk(relaxed = true) {
@@ -64,6 +68,7 @@ class StashMixRefreshWorkerPerRecipeDedupTest {
             recipeDao, playlistDao, discoveryQueueDao, listeningEventDao,
             trackDao, mixGenerator, seedGenerator, lastFmApiClient,
             lastFmCredentials, sessionPreference, blocklistGuard,
+            trackSkipEventDao, trackMatcher,
         )
     }
 

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerSeedFilterTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerSeedFilterTest.kt
@@ -1,0 +1,164 @@
+package com.stash.core.data.sync.workers
+
+import android.content.Context
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.ListeningEventDao
+import com.stash.core.data.db.dao.PlaylistDao
+import com.stash.core.data.db.dao.StashMixRecipeDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.dao.TrackSkipEventDao
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.lastfm.LastFmApiClient
+import com.stash.core.data.lastfm.LastFmCredentials
+import com.stash.core.data.lastfm.LastFmSessionPreference
+import com.stash.core.data.mix.MixGenerator
+import com.stash.core.data.mix.MixSeedGenerator
+import com.stash.core.data.mix.MixSeedStrategy
+import com.stash.core.data.sync.TrackMatcher
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StashMixRefreshWorkerSeedFilterTest {
+
+    private val appContext: Context = mockk(relaxed = true)
+    private val recipeDao: StashMixRecipeDao = mockk(relaxed = true)
+    private val playlistDao: PlaylistDao = mockk(relaxed = true)
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val listeningEventDao: ListeningEventDao = mockk(relaxed = true)
+    private val trackDao: TrackDao = mockk(relaxed = true)
+    private val mixGenerator: MixGenerator = mockk(relaxed = true)
+    private val seedGenerator: MixSeedGenerator = mockk()
+    private val lastFmApiClient: LastFmApiClient = mockk(relaxed = true)
+    private val lastFmCredentials: LastFmCredentials = mockk {
+        coEvery { isConfigured } returns true
+    }
+    private val sessionPreference: LastFmSessionPreference = mockk {
+        coEvery { session } returns flowOf(null)
+    }
+    private val blocklistGuard: BlocklistGuard = mockk(relaxed = true)
+    private val trackSkipEventDao: TrackSkipEventDao = mockk(relaxed = true)
+    private val trackMatcher: TrackMatcher = mockk()
+
+    private fun newWorker(recipeId: Long): StashMixRefreshWorker {
+        val params: WorkerParameters = mockk(relaxed = true) {
+            coEvery { inputData } returns workDataOf(
+                StashMixRefreshWorker.KEY_RECIPE_ID to recipeId,
+            )
+        }
+        return StashMixRefreshWorker(
+            appContext, params,
+            recipeDao, playlistDao, discoveryQueueDao, listeningEventDao,
+            trackDao, mixGenerator, seedGenerator, lastFmApiClient,
+            lastFmCredentials, sessionPreference, blocklistGuard,
+            trackSkipEventDao, trackMatcher,
+        )
+    }
+
+    @Test fun `filters library-canonical-keys + skip-banned-keys before queueing`() = runTest {
+        val recipe = recipe(id = 1L, name = "Daily Discover", seedStrategy = "ARTIST_SIMILAR")
+        coEvery { recipeDao.getById(1L) } returns recipe
+        coEvery { recipeDao.getActive() } returns listOf(recipe)
+        // Deliberate simplification — real TrackMatcher splits on ,;&/ then sorts;
+        // the test exercises FILTER LOGIC, not canonicalization.
+        coEvery { trackMatcher.canonicalArtist(any()) } answers { firstArg<String>().lowercase() }
+        coEvery { trackMatcher.canonicalTitle(any()) } answers { firstArg<String>().lowercase() }
+
+        val candidates = listOf(
+            candidate("In Library 1", "Track A"),
+            candidate("In Library 2", "Track B"),
+            candidate("Banned Artist", "Banned Song"),
+            candidate("New Artist 1", "New Track 1"),
+            candidate("New Artist 2", "New Track 2"),
+        )
+        coEvery {
+            seedGenerator.generate(MixSeedStrategy.ARTIST_SIMILAR, any(), any(), any(), any())
+        } returns candidates
+
+        coEvery { trackDao.getLibraryCanonicalKeys() } returns listOf(
+            "in library 1|track a",
+            "in library 2|track b",
+        )
+        coEvery {
+            trackSkipEventDao.getEarlySkipBannedCanonicalKeys(any(), any(), any())
+        } returns listOf("banned artist|banned song")
+
+        coEvery {
+            seedGenerator.generate(MixSeedStrategy.TAG_GRAPH, any(), any(), any(), any())
+        } returns emptyList()
+
+        val queuedSlot = slot<List<MixGenerator.DiscoveryCandidate>>()
+        coEvery { mixGenerator.queueDiscoveryCandidates(recipe, capture(queuedSlot)) } returns Unit
+
+        newWorker(recipeId = 1L).doWork()
+
+        val keys = queuedSlot.captured.map { "${it.artist.lowercase()}|${it.title.lowercase()}" }.toSet()
+        assertEquals(setOf("new artist 1|new track 1", "new artist 2|new track 2"), keys)
+    }
+
+    @Test fun `falls back to TAG_GRAPH when filtered pool is below floor`() = runTest {
+        val recipe = recipe(id = 1L, name = "Daily Discover", seedStrategy = "ARTIST_SIMILAR")
+        coEvery { recipeDao.getById(1L) } returns recipe
+        coEvery { recipeDao.getActive() } returns listOf(recipe)
+        coEvery { trackMatcher.canonicalArtist(any()) } answers { firstArg<String>().lowercase() }
+        coEvery { trackMatcher.canonicalTitle(any()) } answers { firstArg<String>().lowercase() }
+
+        val primary = listOf(
+            candidate("LibA", "TA"),
+            candidate("LibB", "TB"),
+            candidate("LibC", "TC"),
+        )
+        coEvery { seedGenerator.generate(MixSeedStrategy.ARTIST_SIMILAR, any(), any(), any(), any()) } returns primary
+        coEvery { trackDao.getLibraryCanonicalKeys() } returns listOf("liba|ta", "libb|tb", "libc|tc")
+        coEvery { trackSkipEventDao.getEarlySkipBannedCanonicalKeys(any(), any(), any()) } returns emptyList()
+
+        val fallback = (1..25).map { candidate("Fallback Artist $it", "Fallback Title $it") }
+        coEvery { seedGenerator.generate(MixSeedStrategy.TAG_GRAPH, any(), any(), any(), any()) } returns fallback
+
+        val queuedSlot = slot<List<MixGenerator.DiscoveryCandidate>>()
+        coEvery { mixGenerator.queueDiscoveryCandidates(recipe, capture(queuedSlot)) } returns Unit
+
+        newWorker(recipeId = 1L).doWork()
+
+        assertEquals(25, queuedSlot.captured.size)
+        coVerify { seedGenerator.generate(MixSeedStrategy.TAG_GRAPH, any(), any(), any(), any()) }
+    }
+
+    @Test fun `does NOT queue when all candidates filter out and fallback also empty`() = runTest {
+        val recipe = recipe(id = 1L, name = "Daily Discover", seedStrategy = "ARTIST_SIMILAR")
+        coEvery { recipeDao.getById(1L) } returns recipe
+        coEvery { recipeDao.getActive() } returns listOf(recipe)
+        coEvery { trackMatcher.canonicalArtist(any()) } answers { firstArg<String>().lowercase() }
+        coEvery { trackMatcher.canonicalTitle(any()) } answers { firstArg<String>().lowercase() }
+
+        coEvery {
+            seedGenerator.generate(MixSeedStrategy.ARTIST_SIMILAR, any(), any(), any(), any())
+        } returns listOf(candidate("Only", "Match"))
+        coEvery { trackDao.getLibraryCanonicalKeys() } returns listOf("only|match")
+        coEvery { trackSkipEventDao.getEarlySkipBannedCanonicalKeys(any(), any(), any()) } returns emptyList()
+        coEvery { seedGenerator.generate(MixSeedStrategy.TAG_GRAPH, any(), any(), any(), any()) } returns emptyList()
+
+        newWorker(recipeId = 1L).doWork()
+
+        coVerify(exactly = 0) { mixGenerator.queueDiscoveryCandidates(any(), any()) }
+    }
+
+    private fun recipe(id: Long, name: String, seedStrategy: String) = StashMixRecipeEntity(
+        id = id, name = name,
+        discoveryRatio = 0.85f, targetLength = 40,
+        seedStrategy = seedStrategy,
+        isBuiltin = true, isActive = true,
+    )
+
+    private fun candidate(artist: String, title: String) = MixGenerator.DiscoveryCandidate(
+        artist = artist, title = title, seedArtist = "test",
+    )
+}

--- a/core/media/src/main/kotlin/com/stash/core/media/PlaybackStateStore.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlaybackStateStore.kt
@@ -2,8 +2,10 @@ package com.stash.core.media
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -12,7 +14,10 @@ import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private val Context.playbackDataStore: DataStore<Preferences> by preferencesDataStore(name = "playback_state")
+private val Context.playbackDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "playback_state",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+)
 
 data class SavedPlaybackState(
     val trackId: Long,

--- a/core/media/src/main/kotlin/com/stash/core/media/di/MediaModule.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/di/MediaModule.kt
@@ -1,6 +1,8 @@
 package com.stash.core.media.di
 
 import android.content.Context
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStore
 import com.stash.core.media.PlayerRepository
 import com.stash.core.media.PlayerRepositoryImpl
@@ -17,7 +19,10 @@ import javax.inject.Singleton
 
 // File-scope extension for the new EqStore DataStore (name differs from the
 // legacy "equalizer_prefs" store so the two DataStore instances never collide).
-private val Context.eqDataStore by preferencesDataStore(name = "eq_state_v1")
+private val Context.eqDataStore by preferencesDataStore(
+    name = "eq_state_v1",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+)
 
 /**
  * Hilt module that provides the [PlayerRepository] binding for the app.

--- a/core/media/src/main/kotlin/com/stash/core/media/equalizer/LegacyEqualizerStoreImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/equalizer/LegacyEqualizerStoreImpl.kt
@@ -2,8 +2,10 @@
 package com.stash.core.media.equalizer
 
 import android.content.Context
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -15,7 +17,10 @@ import org.json.JSONArray
 
 // Uses the same DataStore name as the legacy EqualizerStore so it reads
 // the real on-device data written by the old code.
-private val Context.legacyEqDataStore by preferencesDataStore("equalizer_prefs")
+private val Context.legacyEqDataStore by preferencesDataStore(
+  name = "equalizer_prefs",
+  corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+)
 
 @Singleton
 class LegacyEqualizerStoreImpl @Inject constructor(

--- a/data/download/src/main/kotlin/com/stash/data/download/DiscoveryDownloadWorker.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/DiscoveryDownloadWorker.kt
@@ -90,6 +90,7 @@ class DiscoveryDownloadWorker @AssistedInject constructor(
      */
     private suspend fun safeUpdateForeground(title: String, text: String, progress: Float) {
         runCatching { setForeground(buildForegroundInfo(title, text, progress)) }
+            .onFailure { Log.w(TAG, "setForeground failed (likely test env or foreground-restricted): $title / $text", it) }
     }
 
     override suspend fun doWork(): Result {
@@ -242,6 +243,7 @@ class DiscoveryDownloadWorker @AssistedInject constructor(
      */
     private fun chainRefresh() {
         runCatching { StashMixRefreshWorker.enqueueOneTime(applicationContext) }
+            .onFailure { Log.w(TAG, "mix refresh chain failed \u2014 mixes may show stale content until next refresh", it) }
     }
 
     /**

--- a/data/download/src/main/kotlin/com/stash/data/download/DiscoveryDownloadWorker.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/DiscoveryDownloadWorker.kt
@@ -1,0 +1,274 @@
+package com.stash.data.download
+
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.stash.core.data.audio.AudioDurationExtractor
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DownloadQueueDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.DownloadQueueEntity
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.mapper.toDomain
+import com.stash.core.data.sync.SyncNotificationManager
+import com.stash.core.data.sync.TrackDownloadOutcome
+import com.stash.core.data.sync.TrackDownloader
+import com.stash.core.data.sync.workers.StashMixRefreshWorker
+import com.stash.core.model.DownloadFailureType
+import com.stash.core.model.DownloadStatus
+import com.stash.core.model.Track
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import java.io.File
+
+/**
+ * Drains `download_queue` rows produced by [StashDiscoveryWorker]
+ * (`sync_id IS NULL`). Parallels [TrackDownloadWorker]'s per-track flow
+ * (blocklist guard -> [TrackDownloader.downloadTrack] -> mark COMPLETED
+ * with isDownloaded=true + filePath, or FAILED with retry accounting)
+ * without the sync-history coupling that worker requires.
+ *
+ * Chained from the tail of [StashDiscoveryWorker.doWork] (REPLACE policy
+ * on the unique work name so a rapid discovery + drain cycle doesn't
+ * double-run). At the end of the drain, enqueues a one-shot
+ * [StashMixRefreshWorker] so mixes re-materialize and the user sees the
+ * newly-downloaded survivors without manual refresh.
+ *
+ * Foreground-service promotion via [getForegroundInfo] is the same
+ * pattern TrackDownloadWorker uses — required for long batches that
+ * outlive normal background limits.
+ */
+@HiltWorker
+class DiscoveryDownloadWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val downloadQueueDao: DownloadQueueDao,
+    private val trackDao: TrackDao,
+    private val trackDownloader: TrackDownloader,
+    private val audioDurationExtractor: AudioDurationExtractor,
+    private val blocklistGuard: BlocklistGuard,
+    private val syncNotificationManager: SyncNotificationManager,
+) : CoroutineWorker(appContext, params) {
+
+    companion object {
+        const val UNIQUE_WORK_NAME = "discovery_download"
+        private const val TAG = "DiscoveryDownload"
+
+        fun enqueueOneTime(context: Context, constraints: Constraints) {
+            val work = OneTimeWorkRequestBuilder<DiscoveryDownloadWorker>()
+                .setConstraints(constraints)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                UNIQUE_WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                work,
+            )
+        }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        return buildForegroundInfo("Downloading discoveries", "Preparing\u2026", progress = -1f)
+    }
+
+    /**
+     * Promote to foreground. Wrapped in runCatching because the JVM unit
+     * tests instantiate the worker directly (no WorkManager runtime) — a
+     * raw setForeground / WorkManager.getInstance call would throw
+     * IllegalStateException there. In production WorkManager invokes
+     * [getForegroundInfo] separately before [doWork], so the loop-level
+     * updates here are best-effort refreshes and a failed mid-run update
+     * doesn't compromise the worker's primary contract (drain the queue,
+     * then re-mix).
+     */
+    private suspend fun safeUpdateForeground(title: String, text: String, progress: Float) {
+        runCatching { setForeground(buildForegroundInfo(title, text, progress)) }
+    }
+
+    override suspend fun doWork(): Result {
+        safeUpdateForeground("Downloading discoveries", "Preparing\u2026", progress = -1f)
+
+        val pending = downloadQueueDao.pendingDiscoveryDownloads()
+        if (pending.isEmpty()) {
+            chainRefresh()
+            return Result.success()
+        }
+
+        Log.i(TAG, "draining ${pending.size} discovery download(s)")
+
+        for ((index, queueItem) in pending.withIndex()) {
+            safeUpdateForeground(
+                title = "Downloading discoveries",
+                text = "${index + 1} of ${pending.size}",
+                progress = (index.toFloat() / pending.size),
+            )
+
+            // v0.9.20: stamp IN_PROGRESS BEFORE invoking the downloader.
+            // REPLACE policy on UNIQUE_WORK_NAME prevents concurrent instances
+            // of THIS worker; the sync-side partition predicate prevents
+            // TrackDownloadWorker from touching the same row. Defense-in-depth:
+            // a stale IN_PROGRESS row left over from a crashed run gets reset
+            // to PENDING on the next sync (the existing `resetStaleInProgress`
+            // sweep in TrackDownloadWorker's startup) — that path is unchanged.
+            downloadQueueDao.updateStatus(
+                id = queueItem.id,
+                status = DownloadStatus.IN_PROGRESS,
+            )
+
+            val trackEntity = trackDao.getById(queueItem.trackId) ?: continue
+
+            if (blocklistGuard.isBlocked(
+                    artist = trackEntity.artist,
+                    title = trackEntity.title,
+                    spotifyUri = null,
+                    youtubeId = null,
+                )) {
+                Log.d(TAG, "Skipping blocked track ${trackEntity.id}")
+                downloadQueueDao.deleteByTrackId(trackEntity.id)
+                continue
+            }
+
+            if (trackEntity.isDownloaded && trackEntity.filePath != null) {
+                downloadQueueDao.updateStatus(
+                    id = queueItem.id,
+                    status = DownloadStatus.COMPLETED,
+                    completedAt = System.currentTimeMillis(),
+                )
+                continue
+            }
+
+            val track = trackEntity.toDomain()
+            val outcome = runCatching {
+                trackDownloader.downloadTrack(track = track, preResolvedUrl = queueItem.youtubeUrl)
+            }.getOrElse {
+                Log.e(TAG, "downloadTrack threw for ${track.artist} - ${track.title}", it)
+                TrackDownloadOutcome.Failed(error = it.message.orEmpty())
+            }
+
+            when (outcome) {
+                is TrackDownloadOutcome.Success -> handleSuccess(queueItem, trackEntity, outcome)
+                is TrackDownloadOutcome.Unmatched -> handleUnmatched(queueItem, track, outcome)
+                is TrackDownloadOutcome.Failed -> handleFailed(queueItem, track, outcome)
+                is TrackDownloadOutcome.Deferred -> {
+                    // Lossless deferred — TrackDownloaderImpl already moved the row
+                    // to WAITING_FOR_LOSSLESS. LosslessRetryWorker owns the
+                    // re-attempt. No-op here.
+                    Log.i(TAG, "Deferred (waiting for lossless): ${track.artist} - ${track.title}")
+                }
+            }
+        }
+
+        chainRefresh()
+        return Result.success()
+    }
+
+    private suspend fun handleSuccess(
+        queueItem: DownloadQueueEntity,
+        trackEntity: TrackEntity,
+        outcome: TrackDownloadOutcome.Success,
+    ) {
+        val fileSize = try { File(outcome.filePath).length() } catch (_: Exception) { 0L }
+        val meta = audioDurationExtractor.extract(outcome.filePath)
+
+        trackDao.markAsDownloaded(
+            trackId = trackEntity.id,
+            filePath = outcome.filePath,
+            fileSizeBytes = fileSize,
+            sampleRateHz = meta?.sampleRateHz,
+            bitsPerSample = meta?.bitsPerSample,
+        )
+
+        if (meta != null && meta.format != "unknown") {
+            runCatching {
+                trackDao.setFormatAndQuality(
+                    trackId = trackEntity.id,
+                    fileFormat = meta.format,
+                    qualityKbps = meta.bitrateKbps,
+                )
+            }
+        }
+
+        downloadQueueDao.updateStatus(
+            id = queueItem.id,
+            status = DownloadStatus.COMPLETED,
+            completedAt = System.currentTimeMillis(),
+        )
+    }
+
+    private suspend fun handleUnmatched(
+        queueItem: DownloadQueueEntity,
+        track: Track,
+        outcome: TrackDownloadOutcome.Unmatched,
+    ) {
+        val err = "No YouTube match for: ${track.artist} - ${track.title}"
+        Log.w(TAG, err)
+        downloadQueueDao.incrementRetryCount(queueItem.id)
+        downloadQueueDao.updateStatus(
+            id = queueItem.id,
+            status = DownloadStatus.FAILED,
+            failureType = DownloadFailureType.NO_MATCH,
+            errorMessage = err,
+            rejectedVideoId = outcome.rejectedVideoId,
+        )
+    }
+
+    private suspend fun handleFailed(
+        queueItem: DownloadQueueEntity,
+        track: Track,
+        outcome: TrackDownloadOutcome.Failed,
+    ) {
+        Log.e(TAG, "Download failed for ${track.artist} - ${track.title}: ${outcome.error}")
+        downloadQueueDao.incrementRetryCount(queueItem.id)
+        downloadQueueDao.updateStatus(
+            id = queueItem.id,
+            status = DownloadStatus.FAILED,
+            failureType = DownloadFailureType.DOWNLOAD_ERROR,
+            errorMessage = outcome.error.take(500),
+        )
+    }
+
+    /**
+     * Always chain — even on all-failure batches. The mix-refresh worker
+     * is a no-op when nothing new is on disk; simpler to unconditionally
+     * fire than to branch. runCatching guards JVM unit tests where
+     * WorkManager isn't initialized; production paths always succeed.
+     */
+    private fun chainRefresh() {
+        runCatching { StashMixRefreshWorker.enqueueOneTime(applicationContext) }
+    }
+
+    /**
+     * Inline mirror of [TrackDownloadWorker]'s private `createForegroundInfo`
+     * helper. Duplicated rather than promoted to a public method on
+     * [SyncNotificationManager] because the WorkManager cancel intent is
+     * per-worker-instance and SyncNotificationManager is a singleton.
+     */
+    private fun buildForegroundInfo(
+        title: String,
+        text: String,
+        progress: Float,
+    ): ForegroundInfo {
+        val notification = syncNotificationManager.buildProgressNotification(
+            title = title,
+            text = text,
+            progress = progress,
+            cancelIntent = WorkManager.getInstance(applicationContext).createCancelPendingIntent(id),
+        )
+        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ForegroundInfo(
+                SyncNotificationManager.NOTIFICATION_ID_PROGRESS,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            ForegroundInfo(SyncNotificationManager.NOTIFICATION_ID_PROGRESS, notification)
+        }
+    }
+}

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessRetryWorker.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessRetryWorker.kt
@@ -46,7 +46,7 @@ class LosslessRetryWorker @AssistedInject constructor(
         val deferred = downloadQueueDao.waitingForLosslessTracks()
         if (deferred.isEmpty()) {
             return Result.success(
-                androidx.work.workDataOf(
+                workDataOf(
                     KEY_RESOLVED to 0,
                     KEY_TOTAL to 0,
                 ),
@@ -80,7 +80,7 @@ class LosslessRetryWorker @AssistedInject constructor(
             }
         }
         return Result.success(
-            androidx.work.workDataOf(
+            workDataOf(
                 KEY_RESOLVED to resolvedCount,
                 KEY_TOTAL to deferred.size,
             ),

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessRetryWorker.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessRetryWorker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import androidx.work.workDataOf
 import com.stash.core.data.db.dao.DownloadQueueDao
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.model.DownloadStatus
@@ -43,8 +44,16 @@ class LosslessRetryWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result {
         val deferred = downloadQueueDao.waitingForLosslessTracks()
-        if (deferred.isEmpty()) return Result.success()
+        if (deferred.isEmpty()) {
+            return Result.success(
+                androidx.work.workDataOf(
+                    KEY_RESOLVED to 0,
+                    KEY_TOTAL to 0,
+                ),
+            )
+        }
 
+        var resolvedCount = 0
         for (entry in deferred) {
             val track = trackDao.getById(entry.trackId) ?: continue
             // runCatching mirrors DownloadManager's defensive pattern:
@@ -67,12 +76,24 @@ class LosslessRetryWorker @AssistedInject constructor(
                     id = entry.id,
                     status = DownloadStatus.PENDING,
                 )
+                resolvedCount++
             }
         }
-        return Result.success()
+        return Result.success(
+            androidx.work.workDataOf(
+                KEY_RESOLVED to resolvedCount,
+                KEY_TOTAL to deferred.size,
+            ),
+        )
     }
 
     companion object {
         const val UNIQUE_WORK_NAME = "lossless-retry"
+
+        /** Output-data key: how many WAITING_FOR_LOSSLESS rows were flipped to PENDING this sweep. */
+        const val KEY_RESOLVED = "lossless_retry_resolved"
+
+        /** Output-data key: how many WAITING_FOR_LOSSLESS rows existed when the sweep started. */
+        const val KEY_TOTAL = "lossless_retry_total"
     }
 }

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessSourcePreferences.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessSourcePreferences.kt
@@ -2,9 +2,11 @@ package com.stash.data.download.lossless
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.stash.core.data.db.dao.DownloadQueueDao
@@ -18,6 +20,7 @@ import kotlinx.coroutines.flow.map
 /** DataStore for lossless-source preferences (priority order, min quality, etc). */
 private val Context.losslessDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "lossless_source_preferences",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
 )
 
 /**

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/inbox/LosslessInboxPreferences.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/inbox/LosslessInboxPreferences.kt
@@ -3,8 +3,10 @@ package com.stash.data.download.lossless.inbox
 import android.content.Context
 import android.net.Uri
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -17,7 +19,10 @@ import kotlinx.coroutines.flow.map
 
 /** DataStore for the inbox config — separate file from other lossless prefs
  *  so the schema can evolve in isolation. */
-private val Context.losslessInboxDataStore by preferencesDataStore(name = "lossless_inbox_prefs")
+private val Context.losslessInboxDataStore by preferencesDataStore(
+    name = "lossless_inbox_prefs",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+)
 
 /**
  * Persists the user's "Lossless Inbox" configuration:

--- a/data/download/src/main/kotlin/com/stash/data/download/prefs/QualityPreferencesManager.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/prefs/QualityPreferencesManager.kt
@@ -2,8 +2,10 @@ package com.stash.data.download.prefs
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.stash.core.data.prefs.QualityPreference
@@ -17,6 +19,7 @@ import javax.inject.Singleton
 /** Extension property providing a singleton DataStore for quality preferences. */
 private val Context.qualityDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "quality_preferences",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
 )
 
 /**

--- a/data/download/src/test/kotlin/com/stash/data/download/DiscoveryDownloadWorkerTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/DiscoveryDownloadWorkerTest.kt
@@ -1,0 +1,208 @@
+package com.stash.data.download
+
+import android.content.Context
+import androidx.work.WorkerParameters
+import com.stash.core.data.audio.AudioDurationExtractor
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DownloadQueueDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.DownloadQueueEntity
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.sync.SyncNotificationManager
+import com.stash.core.data.sync.TrackDownloadOutcome
+import com.stash.core.data.sync.TrackDownloader
+import com.stash.core.model.DownloadStatus
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * MockK tests for [DiscoveryDownloadWorker] — the v0.9.20 worker that
+ * drains discovery_queue PENDING/retryable-FAILED rows (sync_id IS NULL)
+ * via the existing [TrackDownloader] abstraction. Mirrors the
+ * [com.stash.data.download.lossless.LosslessRetryWorkerTest] MockK pattern.
+ */
+class DiscoveryDownloadWorkerTest {
+
+    private val appContext: Context = mockk(relaxed = true)
+    private val workerParams: WorkerParameters = mockk(relaxed = true)
+    private val downloadQueueDao: DownloadQueueDao = mockk(relaxed = true)
+    private val trackDao: TrackDao = mockk(relaxed = true)
+    private val trackDownloader: TrackDownloader = mockk()
+    private val audioDurationExtractor: AudioDurationExtractor = mockk(relaxed = true)
+    private val blocklistGuard: BlocklistGuard = mockk {
+        coEvery { isBlocked(any(), any(), any(), any()) } returns false
+    }
+    private val syncNotificationManager: SyncNotificationManager = mockk(relaxed = true)
+
+    private fun newWorker() = DiscoveryDownloadWorker(
+        appContext, workerParams,
+        downloadQueueDao, trackDao, trackDownloader,
+        audioDurationExtractor, blocklistGuard, syncNotificationManager,
+    )
+
+    @Test fun `empty queue returns success and does not invoke TrackDownloader`() = runTest {
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns emptyList()
+
+        val result = newWorker().doWork()
+
+        assertEquals(androidx.work.ListenableWorker.Result.success(), result)
+        coVerify(exactly = 0) { trackDownloader.downloadTrack(any(), any()) }
+    }
+
+    @Test fun `successful download marks COMPLETED and writes isDownloaded`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { trackDownloader.downloadTrack(any(), any()) } returns TrackDownloadOutcome.Success(
+            filePath = "/tmp/file.flac",
+        )
+        coEvery { audioDurationExtractor.extract(any()) } returns null
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) {
+            trackDao.markAsDownloaded(
+                trackId = 1L,
+                filePath = "/tmp/file.flac",
+                fileSizeBytes = any(),
+                // downloadedAt has a default of System.currentTimeMillis() at call time;
+                // MockK resolves defaults at verification time, so an explicit any()
+                // matcher avoids a sub-millisecond timestamp mismatch.
+                downloadedAt = any(),
+                sampleRateHz = null,
+                bitsPerSample = null,
+            )
+        }
+        coVerify(exactly = 1) {
+            downloadQueueDao.updateStatus(
+                id = 100L,
+                status = DownloadStatus.COMPLETED,
+                completedAt = any(),
+            )
+        }
+    }
+
+    @Test fun `unmatched outcome marks FAILED with NO_MATCH and increments retry count`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { trackDownloader.downloadTrack(any(), any()) } returns TrackDownloadOutcome.Unmatched(
+            rejectedVideoId = "abc123",
+        )
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) { downloadQueueDao.incrementRetryCount(100L) }
+        coVerify(exactly = 1) {
+            downloadQueueDao.updateStatus(
+                id = 100L,
+                status = DownloadStatus.FAILED,
+                failureType = any(),
+                errorMessage = any(),
+                rejectedVideoId = "abc123",
+            )
+        }
+    }
+
+    @Test fun `failed outcome marks FAILED with DOWNLOAD_ERROR`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { trackDownloader.downloadTrack(any(), any()) } returns TrackDownloadOutcome.Failed(
+            error = "yt-dlp timeout",
+        )
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) { downloadQueueDao.incrementRetryCount(100L) }
+        coVerify(exactly = 1) {
+            downloadQueueDao.updateStatus(
+                id = 100L,
+                status = DownloadStatus.FAILED,
+                failureType = any(),
+                errorMessage = match { it.contains("yt-dlp timeout") },
+            )
+        }
+    }
+
+    @Test fun `deferred outcome does NOT touch the queue row`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { trackDownloader.downloadTrack(any(), any()) } returns TrackDownloadOutcome.Deferred
+
+        newWorker().doWork()
+
+        coVerify(exactly = 0) { downloadQueueDao.updateStatus(id = 100L, status = DownloadStatus.FAILED, any(), any(), any(), any()) }
+        coVerify(exactly = 0) { downloadQueueDao.updateStatus(id = 100L, status = DownloadStatus.COMPLETED, completedAt = any()) }
+        coVerify(exactly = 0) { downloadQueueDao.incrementRetryCount(any()) }
+    }
+
+    @Test fun `blocked track deletes the queue row and does NOT invoke TrackDownloader`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { blocklistGuard.isBlocked(any(), any(), any(), any()) } returns true
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) { downloadQueueDao.deleteByTrackId(1L) }
+        coVerify(exactly = 0) { trackDownloader.downloadTrack(any(), any()) }
+    }
+
+    @Test fun `already-downloaded track is idempotently marked COMPLETED without re-downloading`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L, isDownloaded = true, filePath = "/already/here.flac")
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) {
+            downloadQueueDao.updateStatus(id = 100L, status = DownloadStatus.COMPLETED, completedAt = any())
+        }
+        coVerify(exactly = 0) { trackDownloader.downloadTrack(any(), any()) }
+    }
+
+    @Test fun `IN_PROGRESS stamp is written BEFORE invoking TrackDownloader`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { trackDownloader.downloadTrack(any(), any()) } returns TrackDownloadOutcome.Failed("fail")
+
+        newWorker().doWork()
+
+        // The order matters — IN_PROGRESS must land before the downloader runs.
+        // coVerifyOrder enforces sequence; plain coVerify only checks existence.
+        coVerifyOrder {
+            downloadQueueDao.updateStatus(id = 100L, status = DownloadStatus.IN_PROGRESS)
+            trackDownloader.downloadTrack(any(), any())
+        }
+    }
+
+    private fun entry(id: Long, trackId: Long) = DownloadQueueEntity(
+        id = id,
+        trackId = trackId,
+        status = DownloadStatus.PENDING,
+        syncId = null,
+        searchQuery = "artist - title",
+    )
+
+    private fun stubTrack(
+        id: Long,
+        isDownloaded: Boolean = false,
+        filePath: String? = null,
+    ) = TrackEntity(
+        id = id,
+        title = "Track $id",
+        artist = "Artist $id",
+        canonicalTitle = "track $id",
+        canonicalArtist = "artist $id",
+        isDownloaded = isDownloaded,
+        filePath = filePath,
+    )
+}

--- a/data/download/src/test/kotlin/com/stash/data/download/lossless/LosslessRetryWorkerTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/lossless/LosslessRetryWorkerTest.kt
@@ -115,6 +115,15 @@ class LosslessRetryWorkerTest {
 
         assertEquals(2, result.outputData.getInt(LosslessRetryWorker.KEY_RESOLVED, -1))
         assertEquals(3, result.outputData.getInt(LosslessRetryWorker.KEY_TOTAL, -1))
+        coVerify(exactly = 1) {
+            downloadQueueDao.updateStatus(id = 100L, status = DownloadStatus.PENDING)
+        }
+        coVerify(exactly = 1) {
+            downloadQueueDao.updateStatus(id = 102L, status = DownloadStatus.PENDING)
+        }
+        coVerify(exactly = 0) {
+            downloadQueueDao.updateStatus(id = 101L, status = DownloadStatus.PENDING)
+        }
     }
 
     private fun entry(id: Long, trackId: Long) = DownloadQueueEntity(

--- a/data/download/src/test/kotlin/com/stash/data/download/lossless/LosslessRetryWorkerTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/lossless/LosslessRetryWorkerTest.kt
@@ -48,16 +48,17 @@ class LosslessRetryWorkerTest {
     )
 
     @Test
-    fun `resolved row flips to PENDING`() = runTest {
+    fun `resolved row flips to PENDING and reports resolved=1 total=1`() = runTest {
         coEvery { downloadQueueDao.waitingForLosslessTracks() } returns listOf(
             entry(id = 100L, trackId = 1L),
         )
         coEvery { trackDao.getById(1L) } returns stubTrackEntity(1L)
         coEvery { registry.resolve(any()) } returns stubSourceResult()
 
-        val result = newWorker().doWork()
+        val result = newWorker().doWork() as androidx.work.ListenableWorker.Result.Success
 
-        assertEquals(androidx.work.ListenableWorker.Result.success(), result)
+        assertEquals(1, result.outputData.getInt(LosslessRetryWorker.KEY_RESOLVED, -1))
+        assertEquals(1, result.outputData.getInt(LosslessRetryWorker.KEY_TOTAL, -1))
         coVerify(exactly = 1) {
             downloadQueueDao.updateStatus(
                 id = 100L,
@@ -67,30 +68,53 @@ class LosslessRetryWorkerTest {
     }
 
     @Test
-    fun `still-null row stays WAITING_FOR_LOSSLESS`() = runTest {
+    fun `unresolved row stays WAITING_FOR_LOSSLESS and reports resolved=0 total=1`() = runTest {
         coEvery { downloadQueueDao.waitingForLosslessTracks() } returns listOf(
             entry(id = 100L, trackId = 1L),
         )
         coEvery { trackDao.getById(1L) } returns stubTrackEntity(1L)
         coEvery { registry.resolve(any()) } returns null
 
-        newWorker().doWork()
+        val result = newWorker().doWork() as androidx.work.ListenableWorker.Result.Success
 
+        assertEquals(0, result.outputData.getInt(LosslessRetryWorker.KEY_RESOLVED, -1))
+        assertEquals(1, result.outputData.getInt(LosslessRetryWorker.KEY_TOTAL, -1))
         coVerify(exactly = 0) {
             downloadQueueDao.updateStatus(any(), any(), any(), any(), any(), any())
         }
     }
 
     @Test
-    fun `empty deferred set returns success without DB writes`() = runTest {
+    fun `empty deferred set returns resolved=0 total=0`() = runTest {
         coEvery { downloadQueueDao.waitingForLosslessTracks() } returns emptyList()
 
-        val result = newWorker().doWork()
+        val result = newWorker().doWork() as androidx.work.ListenableWorker.Result.Success
 
-        assertEquals(androidx.work.ListenableWorker.Result.success(), result)
+        assertEquals(0, result.outputData.getInt(LosslessRetryWorker.KEY_RESOLVED, -1))
+        assertEquals(0, result.outputData.getInt(LosslessRetryWorker.KEY_TOTAL, -1))
         coVerify(exactly = 0) {
             downloadQueueDao.updateStatus(any(), any(), any(), any(), any(), any())
         }
+    }
+
+    @Test
+    fun `partial match across 3 rows reports resolved=2 total=3`() = runTest {
+        coEvery { downloadQueueDao.waitingForLosslessTracks() } returns listOf(
+            entry(id = 100L, trackId = 1L),
+            entry(id = 101L, trackId = 2L),
+            entry(id = 102L, trackId = 3L),
+        )
+        coEvery { trackDao.getById(1L) } returns stubTrackEntity(1L)
+        coEvery { trackDao.getById(2L) } returns stubTrackEntity(2L)
+        coEvery { trackDao.getById(3L) } returns stubTrackEntity(3L)
+        coEvery { registry.resolve(match { it.title == "Track 1" }) } returns stubSourceResult()
+        coEvery { registry.resolve(match { it.title == "Track 2" }) } returns null
+        coEvery { registry.resolve(match { it.title == "Track 3" }) } returns stubSourceResult()
+
+        val result = newWorker().doWork() as androidx.work.ListenableWorker.Result.Success
+
+        assertEquals(2, result.outputData.getInt(LosslessRetryWorker.KEY_RESOLVED, -1))
+        assertEquals(3, result.outputData.getInt(LosslessRetryWorker.KEY_TOTAL, -1))
     }
 
     private fun entry(id: Long, trackId: Long) = DownloadQueueEntity(

--- a/docs/superpowers/plans/2026-05-08-discovery-survivor-cap.md
+++ b/docs/superpowers/plans/2026-05-08-discovery-survivor-cap.md
@@ -1,0 +1,493 @@
+# Discovery Survivor Cap — v0.9.19 Follow-Up Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cap `StashMixRefreshWorker.materializeMix`'s discovery-survivor re-link at `targetLength * discoveryRatio` (rounded), ordered newest-DONE first. Bundles into the existing v0.9.19 ship as a follow-up commit on `feat/first-listen-tag-fallback` so the same release contains both halves of the mix-sizing fix.
+
+**Architecture:** Single-DAO-query change plus a single call-site math/parameter wire-up in the worker. `DiscoveryQueueDao.getDoneTrackIdsForRecipe` gains a `limit: Int` parameter and an `ORDER BY completed_at DESC LIMIT :limit` clause; `materializeMix` computes `discoveryCap = (recipe.targetLength * recipe.discoveryRatio).roundToInt().coerceAtLeast(0)` and passes it. Library shortfall-fill in `MixGenerator` is intentionally untouched (per spec's path A).
+
+**Tech Stack:** Kotlin / Hilt / Room (no schema change, schema stays at v22) / coroutines. Tests use plain JUnit4 + Robolectric + in-memory Room (matches `DownloadQueueDaoDeferredTest` precedent in the same module).
+
+**Spec:** [docs/superpowers/specs/2026-05-08-first-listen-tag-fallback-design.md](../specs/2026-05-08-first-listen-tag-fallback-design.md) — see the **"v0.9.19 follow-up: discovery survivor cap"** section.
+
+---
+
+## File Map
+
+### Created
+
+- `core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt` — first test class for `DiscoveryQueueDao`; covers the 5-test matrix from the spec.
+
+### Modified
+
+- `core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt` — `getDoneTrackIdsForRecipe` signature change + `ORDER BY` + `LIMIT`.
+- `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt` — call-site cap computation in `materializeMix`.
+
+### NOT modified (per spec path A, explicit non-goals)
+
+- `core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt` — the library shortfall-fill at lines 192-197 stays as-is.
+- `app/build.gradle.kts` — `versionCode` 57, `versionName` "0.9.19" already bumped by commit `ba21749`. NO new bump.
+
+---
+
+## Conventions
+
+- **TDD throughout.** Failing tests → run them (verify the failure mode) → minimal implementation → run them (verify pass) → commit.
+- **One commit per task.** Match the spec'd commit message byte-for-byte.
+- **Co-Authored-By trailer** on every commit: `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+- **No scope creep.** Don't touch `MixGenerator`. Don't add a periodic sweep for old DONE rows. Don't touch other DAO methods.
+- **Pre-existing master test failures** (`YtLibraryCanonicalizerTest.OMV...`, `PlaylistTypeTest.enum...`) still apply. Ignore them.
+- **No push or tag.** The user explicitly defers the ship decision until on-device verification.
+
+---
+
+## Worktree (already exists)
+
+The worktree at `.worktrees/first-listen-tag-fallback` is set up from earlier v0.9.19 work. Branch `feat/first-listen-tag-fallback` currently has 4 commits since master:
+
+```
+b56b239 docs(spec): amend v0.9.19 spec with discovery-survivor cap fix
+ba21749 chore: bump versionCode 56->57, versionName 0.9.18->0.9.19
+e9764c5 feat(mix): library-histogram fallback for First Listen tag seed
+a9864bb docs(plan): v0.9.19 First Listen tag-fallback implementation plan
+```
+
+(`b56b239` is on master only and hasn't been merged into the worktree yet — pull master into the worktree before starting.)
+
+cd into the worktree:
+
+```bash
+cd /c/Users/theno/Projects/MP3APK/.worktrees/first-listen-tag-fallback
+```
+
+Pull the spec amendment from master:
+
+```bash
+git pull --ff-only origin master
+# OR if you have local-only spec commits to integrate:
+git rebase master
+```
+
+(Either works since the worktree's branch `feat/first-listen-tag-fallback` is local-only. The pull/rebase brings the spec amendment into the worktree's checkout for plan-task reference.)
+
+---
+
+## Task 1: DAO change + 5 tests + worker call-site update
+
+**Why this is one task:** the DAO change and the worker change are tightly coupled — a `getDoneTrackIdsForRecipe` signature change with no caller is a compile error. Single TDD cycle, single commit. The 5 DAO tests verify the query in isolation; the worker call-site change is a 4-line edit verified by the existing `:core:data` test sweep continuing green.
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt`
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt`
+- Create: `core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt`
+
+- [ ] **Step 1: Reconnaissance — confirm existing surfaces**
+
+Three things to verify by reading source:
+
+1. `DiscoveryQueueDao.getDoneTrackIdsForRecipe(recipeId: Long): List<Long>` exists today with a `@Query` body of:
+
+```sql
+SELECT track_id FROM discovery_queue
+WHERE dq.recipe_id = :recipeId
+  AND dq.status = 'DONE'
+  AND dq.track_id IS NOT NULL
+```
+
+(The `dq` alias may be present or absent — verify the literal current SQL before writing the patch.)
+
+2. `DiscoveryQueueEntity` has `completedAt: Long?` mapped to a `completed_at` column. Confirm via `core/data/src/main/kotlin/com/stash/core/data/db/entity/DiscoveryQueueEntity.kt` lines 56-61. The column is nullable in the schema, but the project invariant is that any row with `status = 'DONE'` has a non-null `completed_at` (set by the worker on the DONE transition).
+
+3. `DownloadQueueDaoDeferredTest` at `core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoDeferredTest.kt` is the canonical pattern for a Robolectric + in-memory Room DAO test in this module. Read it first to copy the framework setup (`@RunWith(RobolectricTestRunner::class)`, `Room.inMemoryDatabaseBuilder`, `@Before` / `@After`, FK seeding via parent `tracks` row).
+
+4. Confirm `DiscoveryQueueDao.insert(entity: DiscoveryQueueEntity)` (or equivalent insertion method — `insertAll`, `upsert`, etc.) exists and is callable from tests. The plan's test snippets call `dao.insert(...)`; if the actual method is named differently, swap accordingly.
+
+If any of these don't match, surface as `BLOCKED` rather than improvising.
+
+- [ ] **Step 2: Write the failing tests**
+
+`core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt`:
+
+```kotlin
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.DiscoveryQueueEntity
+import com.stash.core.data.db.entity.TrackEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [DiscoveryQueueDao.getDoneTrackIdsForRecipe] — specifically the
+ * v0.9.19 follow-up cap fix that bounds the result at `:limit` ordered by
+ * `completed_at DESC` so newest-DONE survivors win when materializeMix
+ * trims to the recipe's discovery slot count.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DiscoveryQueueDaoCapTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: DiscoveryQueueDao
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.discoveryQueueDao()
+        // Seed a few tracks for FK linkage. Mirror DownloadQueueDaoDeferredTest's
+        // helper if it exposes one; otherwise inline minimal-required fields.
+        // ... seedTracks(ids = listOf(1, 2, 3, 4, 5))
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `respects limit when DONE rows exceed it`() = runTest {
+        val recipeId = 1L
+        // Insert 5 DONE rows with track_id 1..5 and increasing completedAt.
+        for (i in 1..5) {
+            dao.insert(doneRow(recipeId, trackId = i.toLong(), completedAt = 1000L * i))
+        }
+
+        val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 3)
+
+        assertEquals(3, result.size)
+    }
+
+    @Test fun `orders by completed_at DESC (newest-DONE first)`() = runTest {
+        val recipeId = 1L
+        // Insert older row first, newer row second, but verify result is newer-first.
+        dao.insert(doneRow(recipeId, trackId = 1L, completedAt = 1000L))   // older
+        dao.insert(doneRow(recipeId, trackId = 2L, completedAt = 5000L))   // newer
+
+        val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 99)
+
+        assertEquals(listOf(2L, 1L), result)
+    }
+
+    @Test fun `filters status to DONE only`() = runTest {
+        val recipeId = 1L
+        dao.insert(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
+        dao.insert(pendingRow(recipeId, trackId = 2L))   // PENDING — must NOT appear
+        // SEARCHED, DOWNLOADING, FAILED row variants would also be excluded;
+        // PENDING covers the most likely accidental-leak case.
+
+        val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 99)
+
+        assertEquals(listOf(1L), result)
+    }
+
+    @Test fun `excludes rows with null track_id even when status is DONE`() = runTest {
+        // Transient state: a worker may set status=DONE just before linking the
+        // canonical track_id. Such a row must NOT consume a cap slot.
+        val recipeId = 1L
+        dao.insert(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
+        dao.insert(doneRow(recipeId, trackId = null, completedAt = 2000L))
+
+        val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 99)
+
+        assertEquals(listOf(1L), result)
+    }
+
+    @Test fun `limit zero returns empty list`() = runTest {
+        // Deep Cuts hits this on every refresh (discoveryRatio = 0.0).
+        val recipeId = 1L
+        dao.insert(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
+
+        val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 0)
+
+        assertTrue("expected empty, got $result", result.isEmpty())
+    }
+
+    private fun doneRow(recipeId: Long, trackId: Long?, completedAt: Long?) = DiscoveryQueueEntity(
+        recipeId = recipeId,
+        artist = "Artist",
+        title = "Title $trackId",
+        seedArtist = "Seed",
+        status = DiscoveryQueueEntity.STATUS_DONE,
+        trackId = trackId,
+        queuedAt = 0L,
+        completedAt = completedAt,
+        errorMessage = null,
+    )
+
+    private fun pendingRow(recipeId: Long, trackId: Long?) = DiscoveryQueueEntity(
+        recipeId = recipeId,
+        artist = "Artist",
+        title = "Title $trackId",
+        seedArtist = "Seed",
+        status = DiscoveryQueueEntity.STATUS_PENDING,
+        trackId = trackId,
+        queuedAt = 0L,
+        completedAt = null,
+        errorMessage = null,
+    )
+
+    // FK-seeding helper — flesh out from DownloadQueueDaoDeferredTest's pattern.
+    // If DiscoveryQueueEntity has no `@ForeignKey` to `tracks`, the seedTracks
+    // helper isn't required; verify by reading the entity's @Entity annotation.
+    private suspend fun seedTracks(ids: List<Long>) {
+        // ... use TrackDao + TrackEntity if FK is enforced.
+    }
+}
+```
+
+NOTE: Whether `DiscoveryQueueEntity` has a foreign key to `tracks(id)` determines if `seedTracks` is required. Read the `@Entity(... foreignKeys = ...)` annotation; if no FK, drop the helper. The plan's safest assumption is that there IS one (matching the `download_queue → tracks` FK precedent), but verify.
+
+NOTE: Step 5 of the spec's test matrix ("filters out null track_id even when status is DONE") is implementation-dependent — the spec describes this as defensive coverage in case a future bug leaves a DONE row temporarily without `track_id`. Today the production worker may set DONE atomically with `track_id`; either way, the test pins the existing `AND track_id IS NOT NULL` clause's behavior so a future query refactor can't accidentally drop it.
+
+- [ ] **Step 3: Verify all 5 tests fail (and fail for the right reason)**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.DiscoveryQueueDaoCapTest"
+```
+
+Expected results before implementation:
+
+- All 5 tests fail to compile because `getDoneTrackIdsForRecipe` doesn't accept a `limit` parameter today.
+- The compile error is the `Unresolved reference 'limit'` (or "expected 1 arg, got 2") form.
+
+If the failure is anything else (e.g., entity constructor mismatch, FK violation), fix the test wiring first.
+
+- [ ] **Step 4: Modify the DAO**
+
+Open `core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt`. Find `getDoneTrackIdsForRecipe`. Replace its `@Query` and signature with:
+
+```kotlin
+@Query("""
+    SELECT track_id FROM discovery_queue
+    WHERE recipe_id = :recipeId
+      AND status = 'DONE'
+      AND track_id IS NOT NULL
+    ORDER BY completed_at DESC
+    LIMIT :limit
+""")
+suspend fun getDoneTrackIdsForRecipe(recipeId: Long, limit: Int): List<Long>
+```
+
+Notes on the SQL:
+- `ORDER BY completed_at DESC` puts non-null timestamps in descending order. SQLite considers NULL "smaller than any other value", so under `DESC` NULLs naturally fall to the end — they'd only appear in the result if `limit` is large enough to reach them, and the `track_id IS NOT NULL` clause already excludes the most-likely-null-completedAt case (transient pre-link DONE rows).
+- The `WHERE` clause matches the existing query verbatim minus the `dq.` table alias if present. Strip the alias if it exists; the FROM clause has only one table so the alias is unnecessary.
+
+- [ ] **Step 5: Update the call site in `StashMixRefreshWorker.materializeMix`**
+
+Open `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt`. Find the existing `materializeMix` block around line 308-318:
+
+```kotlin
+val candidateIds = discoveryQueueDao
+    .getDoneTrackIdsForRecipe(recipe.id)
+    .filter { it !in librarySet }
+```
+
+Replace with:
+
+```kotlin
+// v0.9.19 follow-up: cap discovery survivors at the recipe's stated
+// slot count (targetLength * discoveryRatio). DAO query orders by
+// completed_at DESC so newest-DONE survivors win when we have to cut.
+// Library shortfall-fill in MixGenerator is intentionally untouched —
+// total playlist size for Daily Discover settles at up-to-50 (library)
+// + up-to-20 (discovery) = ≤70, replacing the previous unbounded growth.
+val discoveryCap = (recipe.targetLength * recipe.discoveryRatio)
+    .roundToInt()
+    .coerceAtLeast(0)
+val candidateIds = discoveryQueueDao
+    .getDoneTrackIdsForRecipe(recipe.id, limit = discoveryCap)
+    .filter { it !in librarySet }
+```
+
+Imports to add at the top of the file (if not already present):
+
+```kotlin
+import kotlin.math.roundToInt
+```
+
+Note on `roundToInt`: `recipe.targetLength` is `Int` per `StashMixRecipeEntity`, `recipe.discoveryRatio` is `Float` per the same entity. The multiplication produces a `Float`. `Float.roundToInt()` is the standard library extension; importing `kotlin.math.roundToInt` resolves it unambiguously.
+
+Verify by reading `core/data/src/main/kotlin/com/stash/core/data/db/entity/StashMixRecipeEntity.kt` — both column types should already be there. If `discoveryRatio` is `Double` for some reason, the same `roundToInt` works on `Double` too.
+
+- [ ] **Step 6: Verify all 5 tests pass**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.DiscoveryQueueDaoCapTest"
+```
+
+Expected: BUILD SUCCESSFUL with 5 tests passing.
+
+- [ ] **Step 7: Run the broader `:core:data` test sweep to catch regressions**
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL except for the known pre-existing failure: `PlaylistTypeTest.enum contains the expected set` (unrelated to this branch). If anything else fails, the cap likely broke something downstream — most likely a different caller of `getDoneTrackIdsForRecipe` that didn't get its signature updated. Search for other call sites:
+
+```bash
+grep -rn "getDoneTrackIdsForRecipe" core/ data/ feature/ app/ --include="*.kt"
+```
+
+Expected: only `StashMixRefreshWorker.kt` uses this DAO method. If any other file shows up, update its call site too.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt \
+        core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt \
+        core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt
+git commit -m "$(cat <<'EOF'
+fix(mix): cap discovery survivor re-link at targetLength * discoveryRatio
+
+materializeMix was re-linking every DONE row in discovery_queue for a
+recipe with no upper bound. Daily Discover went 50 -> 100 in one
+v0.9.19 install transition because ~50 DONE survivors had accumulated
+between v0.9.18 and v0.9.19 — the install-time refresh re-linked them
+all on top of the 50 library tracks. First Listen would have followed
+the same path once StashDiscoveryWorker resolved the histogram-fallback's
+queued candidates.
+
+DiscoveryQueueDao.getDoneTrackIdsForRecipe now takes a limit param and
+orders by completed_at DESC, so newest-DONE survivors win when the cap
+forces a cut. Worker computes
+  discoveryCap = (recipe.targetLength * recipe.discoveryRatio)
+                   .roundToInt().coerceAtLeast(0)
+at the call site. Library shortfall-fill in MixGenerator is intentionally
+untouched — Daily Discover settles at ≤70 (50 library + ≤20 discovery)
+which replaces the previous unbounded growth. If 70 still feels long
+after testing, trimming library is a v0.9.20 follow-up.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Rebase version bump to tip + APK build + install
+
+**Why this isn't a test-driven task:** rebase is git surgery (no behavior change, no new tests). The APK build and install are verification steps — the test sweep already passed in Task 1. The user manually smoke-tests on their device after install.
+
+**Files:**
+- None modified. Just rebase + build + install.
+
+- [ ] **Step 1: Rebase the version-bump commit to the tip**
+
+Currently the branch is:
+
+```
+ba21749 chore: bump versionCode 56->57, versionName 0.9.18->0.9.19  (was tip)
+e9764c5 feat(mix): library-histogram fallback for First Listen tag seed
+... (Task 1's new commit, e.g., 7abc123)
+```
+
+Wait — Task 1's new commit lands on top of `ba21749`, which means after Task 1 the branch order is:
+
+```
+NEW   fix(mix): cap discovery survivor re-link...    ← Task 1's commit (tip)
+ba21749 chore: bump versionCode 56->57, versionName 0.9.18->0.9.19
+e9764c5 feat(mix): library-histogram fallback for First Listen tag seed
+```
+
+Rebase to put `ba21749` (version bump) at the tip so the eventual tag points at the bump commit (per project memory: release notes come from the tagged commit's body).
+
+The Bash harness in this project blocks `-i` flags on `git rebase`, so use the cherry-pick path (matches the v0.9.18 ship pattern):
+
+```bash
+git log --oneline master..HEAD                 # confirm 3 commits on top of master
+git reset --hard e9764c5                       # rewind to the histogram-fallback commit
+git cherry-pick <SHA-Task-1>                   # re-apply the cap-fix commit
+git cherry-pick ba21749                        # re-apply the version-bump commit (now at tip)
+```
+
+The Task-1 commit and `ba21749` get new SHAs after cherry-pick (different parent), but the working-tree content is identical to before — `git diff` between pre-rebase HEAD and post-rebase HEAD should return empty.
+
+Verify the result:
+
+```bash
+git log --oneline master..HEAD
+```
+
+Expected:
+
+```
+ba21749  chore: bump versionCode 56->57, versionName 0.9.18->0.9.19
+<NEW SHA> fix(mix): cap discovery survivor re-link...
+e9764c5  feat(mix): library-histogram fallback for First Listen tag seed
+```
+
+- [ ] **Step 2: Build the release APK**
+
+```bash
+./gradlew :app:assembleRelease
+```
+
+Expected: BUILD SUCCESSFUL. APK at `app/build/outputs/apk/release/app-release.apk` (~155 MB, signed with `stash-release.jks`).
+
+If the build emits a warning about the keystore falling back to debug, it means the worktree is missing `keystore.properties` or `stash-release.jks`. Both should already be there from the v0.9.19 worktree setup; if not, copy them in:
+
+```bash
+cp /c/Users/theno/Projects/MP3APK/keystore.properties .
+cp /c/Users/theno/Projects/MP3APK/stash-release.jks .
+```
+
+- [ ] **Step 3: Install over the existing v0.9.19 build on the user's Pixel**
+
+```bash
+adb devices    # confirm `1A021FDEE002RD` (or whatever) shows up as `device`
+adb install -r app/build/outputs/apk/release/app-release.apk
+```
+
+Expected: `Performing Streamed Install` → `Success`. The `-r` preserves all user data — the discovery queue, listening events, downloaded tracks, prefs, etc.
+
+If `adb devices` shows no device, surface the APK path and stop — the user will install themselves.
+
+- [ ] **Step 4: Surface the manual smoke test for the user**
+
+DO NOT run the smoke test yourself. Document this for the user:
+
+> v0.9.19 build with the discovery survivor cap is now installed. To verify the cap works:
+>
+> 1. **Long-press Daily Discover and tap Refresh.** Wait ~15 seconds. Check the track count.
+>    - Pre-fix: 100 tracks (50 library + ~50 unbounded discovery survivors).
+>    - Expected post-fix: ≤70 tracks (50 library + ≤20 discovery survivors, ordered newest-DONE first).
+> 2. **Long-press Deep Cuts and tap Refresh.** Wait. Check the track count.
+>    - Expected: 50 tracks (library only — `discoveryRatio=0.0` makes the cap 0, no discovery survivors re-linked, no observable change).
+> 3. **First Listen.** Currently 0 tracks because the histogram fallback's 300 PENDING candidates haven't been resolved by `StashDiscoveryWorker` yet. Over the next several hours / next periodic sync, expect First Listen to populate up to ≤50 tracks.
+> 4. **Logcat sanity (optional).** Tail `adb logcat | grep StashMixRefresh` while triggering the refreshes; the log lines `'<recipe>': N candidates via <strategy>` should still fire. They log the count of NEW candidates queued, not the playlist size.
+>
+> If any of those don't match expectations, surface the symptom and we'll go back to systematic debugging.
+
+- [ ] **Step 5: DO NOT push or tag**
+
+The user gates push + tag. Stop here. After the smoke test passes, the user will run:
+
+```bash
+cd /c/Users/theno/Projects/MP3APK
+git checkout master
+git merge --ff-only feat/first-listen-tag-fallback
+git tag -a v0.9.19 -m "v0.9.19 — First Listen tag-fallback + discovery survivor cap"
+git push origin master && git push origin v0.9.19
+```
+
+The release workflow takes over from there.
+
+---
+
+## Notes for the executor
+
+- **The DAO change is the entire feature behaviour.** Don't refactor neighboring DAO methods, don't tweak `MixGenerator`, don't add a periodic DONE-row sweep. All three are documented in the spec's Non-goals.
+- **`completed_at` ordering:** SQLite's default for `ORDER BY ... DESC` puts NULL values *last* (because NULL is treated as smaller than any concrete value). The combination `WHERE … AND track_id IS NOT NULL` plus `ORDER BY completed_at DESC` plus `LIMIT :limit` means null-completedAt rows can only end up in the result if they have non-null `track_id` AND there are fewer than `limit` non-null-completed_at rows. This is acceptable degradation; documented in the spec.
+- **No version bump in this commit.** The version bump (`ba21749`) ALREADY landed on the branch. Adding another bump would be wrong; the rebase in Task 2 just reorders commits so the existing bump ends up at the tip.
+- **Pre-existing test failures still apply.** `YtLibraryCanonicalizerTest.OMV...` and `PlaylistTypeTest.enum...` will continue to fail in the broader sweep. Ignore them.
+- **No push, no tag.** The user defers the ship decision to manual on-device verification.

--- a/docs/superpowers/plans/2026-05-08-first-listen-tag-fallback.md
+++ b/docs/superpowers/plans/2026-05-08-first-listen-tag-fallback.md
@@ -1,0 +1,469 @@
+# First Listen Tag-Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a library-tag-histogram fallback to `MixGenerator.computeUserTopTags()` so the First Listen recipe (`seedStrategy = TAG_GRAPH`, `discoveryRatio = 1.0`) doesn't dead-end with an empty mix when the user's listening-affinity vector is empty.
+
+**Architecture:** Single-function change. When `buildUserTagAffinityVector()` returns an empty map (no listening events in the 180-day window OR all listened-to tracks are unenriched / `__untaggable__`-only), fall back to `TrackTagDao.getTagHistogram()` — already-existing on-device data ordered by `track_count DESC` — filter out the `__untaggable__` sentinel, take the top N. No new DAO methods, no schema change, no new Hilt deps. Daily Discover and Deep Cuts are unaffected (they don't call `computeUserTopTags`).
+
+**Tech Stack:** Kotlin / Hilt / Room (no schema change, schema stays at v22) / coroutines. Tests use plain JUnit4 + mockk + kotlinx-coroutines-test, matching the existing `MixSeedStrategyTest` / `UserTagAffinityTest` siblings in the same package.
+
+**Spec:** [docs/superpowers/specs/2026-05-08-first-listen-tag-fallback-design.md](../specs/2026-05-08-first-listen-tag-fallback-design.md)
+
+---
+
+## File Map
+
+### Created
+
+- `core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorComputeUserTopTagsTest.kt` — first test class for `MixGenerator`; covers the 6-test matrix from the spec.
+
+### Modified
+
+- `core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt` — extend `computeUserTopTags(limit: Int)` with the histogram fallback. Updated KDoc.
+- `app/build.gradle.kts` — bump `versionCode` 56 → 57, `versionName` "0.9.18" → "0.9.19".
+
+---
+
+## Conventions
+
+- **TDD throughout.** Failing test → run it (verify the failure reason) → minimal implementation → run it (verify pass) → commit. Don't skip the "watch it fail" step.
+- **One commit per task.** Match the spec'd commit message byte-for-byte.
+- **Co-Authored-By trailer** on every commit: `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+- **No scope creep.** This plan is one function change + tests + version bump. Don't tweak `TagEnrichmentWorker`, the other recipes, or any unrelated code.
+- **Pre-existing master test failures (`YtLibraryCanonicalizerTest`, `PlaylistTypeTest`)** still apply. Ignore them in test sweeps — they're unrelated.
+
+---
+
+## Worktree setup (do this once, before Task 1)
+
+- [ ] **Step 1: Create the worktree from current master**
+
+```bash
+cd /c/Users/theno/Projects/MP3APK
+git fetch origin
+git worktree add .worktrees/first-listen-tag-fallback -b feat/first-listen-tag-fallback master
+```
+
+(`master` already includes the v0.9.19 spec/plan commits since brainstorming + writing-plans wrote them locally.)
+
+- [ ] **Step 2: Copy `local.properties`, `keystore.properties`, and `stash-release.jks` into the worktree**
+
+Per project memory, `git worktree add` doesn't transfer these gitignored files. Without `local.properties` Last.fm credentials show "Not configured" in debug. Without `keystore.properties` + `stash-release.jks` you can't build a release APK that installs over the existing v0.9.18 on the user's device.
+
+```bash
+cp local.properties .worktrees/first-listen-tag-fallback/local.properties
+cp keystore.properties .worktrees/first-listen-tag-fallback/keystore.properties
+cp stash-release.jks .worktrees/first-listen-tag-fallback/stash-release.jks
+```
+
+- [ ] **Step 3: cd into the worktree**
+
+```bash
+cd .worktrees/first-listen-tag-fallback
+```
+
+All subsequent paths are relative to the worktree root.
+
+---
+
+## Task 1: Add histogram fallback + 6 tests
+
+**Why this is the whole feature in one task:** the change is one function body. The work is overwhelmingly in test design — six cases covering the affinity-path-first contract, the fallback firing conditions, the `__untaggable__` filter, the limit, and the combined filter+limit guard.
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt` — `computeUserTopTags` body + KDoc
+- Create: `core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorComputeUserTopTagsTest.kt`
+
+- [ ] **Step 1: Reconnaissance — confirm the existing surfaces match the plan's assumptions**
+
+Three things to verify by reading source before writing tests:
+
+1. `MixGenerator` constructor injects `trackTagDao: TrackTagDao` (it does — line 70 area). Tests just need to mock that DAO (relaxed mocks for the other 5 deps).
+2. `TrackTagDao.getTagHistogram(): List<TagCount>` exists and returns `data class TagCount(val tag: String, @ColumnInfo(name = "track_count") val trackCount: Int)`. The DAO Q already orders `ORDER BY track_count DESC`, so the SQL produces tags in descending-popularity order. The implementation just needs to filter + take.
+3. `buildUserTagAffinityVector` is `private` (it is) — tests must stimulate it through public `computeUserTopTags`. We control the affinity-vector path's inputs by mocking `listeningEventDao.getPlayCountsSinceWithLatest(any())` and `trackTagDao.getByTrack(any())`.
+
+Sibling test files for the framework precedent: `MixSeedStrategyTest.kt`, `UserTagAffinityTest.kt`. They use plain JUnit4 + `runTest` + mockk. Match that.
+
+If any of these don't match (e.g., the DAO method got renamed, the DTO shape is different), surface as `BLOCKED` before improvising.
+
+- [ ] **Step 2: Write the failing tests**
+
+`core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorComputeUserTopTagsTest.kt`:
+
+```kotlin
+package com.stash.core.data.mix
+
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.ListeningEventDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.dao.TrackSkipEventDao
+import com.stash.core.data.db.dao.TrackTagDao
+import com.stash.core.data.db.dao.TrackTagDao.TagCount
+import com.stash.core.data.db.dao.PlayCountWithLatest
+import com.stash.core.data.db.entity.TrackTagEntity
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [MixGenerator.computeUserTopTags] — specifically the v0.9.19
+ * library-histogram fallback path that fires when the user's
+ * listening-affinity vector is empty.
+ */
+class MixGeneratorComputeUserTopTagsTest {
+
+    private val trackDao: TrackDao = mockk(relaxed = true)
+    private val trackTagDao: TrackTagDao = mockk()
+    private val listeningEventDao: ListeningEventDao = mockk()
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val blocklistGuard: BlocklistGuard = mockk(relaxed = true)
+    private val trackSkipEventDao: TrackSkipEventDao = mockk(relaxed = true)
+
+    private val subject = MixGenerator(
+        trackDao,
+        trackTagDao,
+        listeningEventDao,
+        discoveryQueueDao,
+        blocklistGuard,
+        trackSkipEventDao,
+    )
+
+    // Helper: set up affinity-vector inputs to produce a non-empty vector.
+    // One play row with one real tag is enough for compute() to yield a
+    // non-empty L2-normalized result.
+    private fun stubAffinityVectorNonEmpty(now: Long = System.currentTimeMillis()) {
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns listOf(
+            PlayCountWithLatest(trackId = 1L, plays = 5, latestPlayedAt = now),
+        )
+        coEvery { trackTagDao.getByTrack(1L) } returns listOf(
+            TrackTagEntity(trackId = 1L, tag = "indie", weight = 80f, source = "ARTIST", fetchedAt = now),
+            TrackTagEntity(trackId = 1L, tag = "dream pop", weight = 50f, source = "ARTIST", fetchedAt = now),
+        )
+    }
+
+    // Helper: set up affinity-vector inputs to produce an empty vector
+    // (plays exist but every track is untagged or only __untaggable__).
+    private fun stubAffinityVectorEmpty(now: Long = System.currentTimeMillis()) {
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns listOf(
+            PlayCountWithLatest(trackId = 1L, plays = 5, latestPlayedAt = now),
+        )
+        coEvery { trackTagDao.getByTrack(1L) } returns listOf(
+            TrackTagEntity(trackId = 1L, tag = "__untaggable__", weight = 0f, source = "ARTIST", fetchedAt = now),
+        )
+    }
+
+    @Test fun `returns affinity-vector tags when vector is non-empty (histogram NOT consulted)`() = runTest {
+        stubAffinityVectorNonEmpty()
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertTrue("expected non-empty result, got $result", result.isNotEmpty())
+        assertTrue("indie should be in top tags, got $result", result.contains("indie"))
+        coVerify(exactly = 0) { trackTagDao.getTagHistogram() }
+    }
+
+    @Test fun `falls back to histogram when affinity vector is empty (no listening events)`() = runTest {
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { trackTagDao.getTagHistogram() } returns listOf(
+            TagCount(tag = "rock", trackCount = 100),
+            TagCount(tag = "indie", trackCount = 80),
+            TagCount(tag = "pop", trackCount = 60),
+        )
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertEquals(listOf("rock", "indie", "pop"), result)
+    }
+
+    @Test fun `falls back to histogram when plays exist but all tracks are untagged`() = runTest {
+        stubAffinityVectorEmpty()
+        coEvery { trackTagDao.getTagHistogram() } returns listOf(
+            TagCount(tag = "rock", trackCount = 100),
+            TagCount(tag = "indie", trackCount = 80),
+        )
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertEquals(listOf("rock", "indie"), result)
+    }
+
+    @Test fun `fallback filters out __untaggable__ sentinel`() = runTest {
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { trackTagDao.getTagHistogram() } returns listOf(
+            TagCount(tag = "__untaggable__", trackCount = 200),  // top of histogram
+            TagCount(tag = "rock", trackCount = 100),
+            TagCount(tag = "indie", trackCount = 80),
+        )
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertTrue("__untaggable__ must not appear, got $result", "__untaggable__" !in result)
+        assertEquals(listOf("rock", "indie"), result)
+    }
+
+    @Test fun `returns empty when both affinity vector and histogram are empty`() = runTest {
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { trackTagDao.getTagHistogram() } returns emptyList()
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertEquals(emptyList<String>(), result)
+    }
+
+    @Test fun `respects the limit on the fallback path`() = runTest {
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { trackTagDao.getTagHistogram() } returns (1..15).map {
+            TagCount(tag = "tag$it", trackCount = 100 - it)
+        }
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertEquals(10, result.size)
+        assertEquals("tag1", result.first())
+        assertEquals("tag10", result.last())
+    }
+
+    @Test fun `fallback yields limit real tags even when __untaggable__ tops the histogram`() = runTest {
+        // Combined-case regression guard. If the implementation ever
+        // accidentally swaps to take().filter() (instead of
+        // filter().take()), the sentinel consumes a result slot and
+        // we'd return 9 real tags + a hole. Pin the order.
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { trackTagDao.getTagHistogram() } returns listOf(
+            TagCount(tag = "__untaggable__", trackCount = 999),
+        ) + (1..11).map { TagCount(tag = "tag$it", trackCount = 100 - it) }
+
+        val result = subject.computeUserTopTags(limit = 10)
+
+        assertEquals(10, result.size)
+        assertTrue("sentinel must not appear, got $result", "__untaggable__" !in result)
+        assertEquals("tag1", result.first())
+        assertEquals("tag10", result.last())
+    }
+}
+```
+
+NOTE: The `PlayCountWithLatest` import path is a guess. If `:core:data` puts it elsewhere (e.g., as a nested type in `ListeningEventDao` or in a `*Dtos.kt` file), adjust the import. Find via:
+
+```bash
+grep -rn "data class PlayCountWithLatest\|data class .*PlayCount" core/data/src/main/kotlin/com/stash/core/data/db/dao/ListeningEventDao.kt core/data/src/main/kotlin/com/stash/core/data/db/ | head -5
+```
+
+NOTE: Test count is 7 (the spec listed 6 with the combined case as #6; the plan splits "respects the limit" and the combined filter+limit guard into separate tests for clarity — both still align with the spec's intent). If you'd rather merge them into one mega-test, that's fine — the test surface is what matters, not the count.
+
+NOTE: The first test asserts `coVerify(exactly = 0) { trackTagDao.getTagHistogram() }`. This is the regression guard against "histogram is always called" — a future refactor that accidentally inverted the if/else would fail this test loudly.
+
+- [ ] **Step 3: Verify all 7 tests fail (and fail for the right reason)**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.mix.MixGeneratorComputeUserTopTagsTest"
+```
+
+Expected results before implementation:
+
+- The first test (vector non-empty → histogram not consulted) passes already if `computeUserTopTags` already calls `getTagHistogram` zero times when the vector is non-empty. Today's implementation only calls the affinity-vector path, so this test passes "by accident" pre-fix. That's fine — the test still locks the contract going forward.
+- Tests 2-7 should FAIL because today's implementation returns `emptyList()` whenever the affinity vector is empty, never calling `getTagHistogram`. The expected failure mode for each is `assertEquals(["rock", "indie", "pop"], emptyList())` or similar — i.e., the result list is empty when it should have fallback content. mockk's `coVerify { getTagHistogram() }` (in #2) would fail with `Verification failed: call 0 of 1`.
+
+If the failure reason for any test is something other than "fallback didn't run" (e.g., `Unresolved reference 'TagCount'`, `mockk: no answer for getByTrack`), fix the test wiring before proceeding to Step 4.
+
+- [ ] **Step 4: Implement the fallback**
+
+Open `core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt`. Find `computeUserTopTags` (around line 308):
+
+```kotlin
+suspend fun computeUserTopTags(limit: Int = 10): List<String> {
+    val vector = buildUserTagAffinityVector()
+    return vector.entries
+        .sortedByDescending { it.value }
+        .take(limit)
+        .map { it.key }
+}
+```
+
+Replace with:
+
+```kotlin
+/**
+ * v0.9.16: Top-N user tags ordered by tag-affinity weight. Used by
+ * [com.stash.core.data.sync.workers.StashMixRefreshWorker] to drive
+ * the TAG_GRAPH seed strategy.
+ *
+ * v0.9.19: when the listening-affinity vector is empty (fresh install,
+ * recently played tracks not yet enriched, etc.) falls back to the
+ * library-wide tag histogram. The histogram represents "what kind of
+ * music this user collects" — the right anchor for First Listen's
+ * "wider net" semantics when there's no per-play signal yet. Returns
+ * an empty list ONLY when the user has zero tags anywhere in
+ * `track_tags` (truly fresh install, enrichment hasn't run a single
+ * batch yet) — at which point TAG_GRAPH-driven recipes correctly
+ * stay empty until the user's library has any tag data.
+ */
+suspend fun computeUserTopTags(limit: Int = 10): List<String> {
+    val vector = buildUserTagAffinityVector()
+    if (vector.isNotEmpty()) {
+        return vector.entries
+            .sortedByDescending { it.value }
+            .take(limit)
+            .map { it.key }
+    }
+    return trackTagDao.getTagHistogram()
+        .asSequence()
+        .filter { it.tag != "__untaggable__" }
+        .take(limit)
+        .map { it.tag }
+        .toList()
+}
+```
+
+The `asSequence().filter().take().toList()` pipeline is intentional: filter happens BEFORE take, so the sentinel can never consume a result slot. The seventh test pins this order.
+
+No other changes in `MixGenerator.kt`.
+
+- [ ] **Step 5: Verify all 7 tests pass**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.mix.MixGeneratorComputeUserTopTagsTest"
+```
+
+Expected: BUILD SUCCESSFUL with 7 tests passing.
+
+- [ ] **Step 6: Run the broader `:core:data` sweep to catch regressions**
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL except for the known pre-existing `PlaylistTypeTest.enum contains the expected set` failure (unrelated; was failing on master before this branch). If anything else fails, stop and investigate — the fallback shouldn't affect any other test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt \
+        core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorComputeUserTopTagsTest.kt
+git commit -m "$(cat <<'EOF'
+feat(mix): library-histogram fallback for First Listen tag seed
+
+When MixGenerator.buildUserTagAffinityVector returns empty (fresh
+install, recently played tracks not yet enriched, all listened-to
+tracks resolve as __untaggable__) the TAG_GRAPH seed strategy used
+to dead-end — First Listen has discoveryRatio=1.0 with no library
+fill, so the mix stayed empty. Daily Discover's ARTIST_SIMILAR has
+a multi-tier seed-artist fallback so it kept working; only First
+Listen was affected.
+
+computeUserTopTags now falls back to TrackTagDao.getTagHistogram —
+already-existing on-device data ordered by track_count DESC. Filter
+the __untaggable__ sentinel before the take() so it can't consume a
+result slot. Returns empty only when the user genuinely has zero
+tags anywhere (truly-fresh install, enrichment hasn't completed a
+single batch).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Version bump + ship
+
+**Files:**
+- Modify: `app/build.gradle.kts` — versionCode 56 → 57, versionName "0.9.18" → "0.9.19"
+
+- [ ] **Step 1: Bump versionCode + versionName**
+
+Open `app/build.gradle.kts`, find:
+
+```kotlin
+versionCode = 56
+versionName = "0.9.18"
+```
+
+Update to:
+
+```kotlin
+versionCode = 57
+versionName = "0.9.19"
+```
+
+- [ ] **Step 2: Build the release APK so the user can install over v0.9.18**
+
+```bash
+./gradlew :app:assembleRelease
+```
+
+Expected: BUILD SUCCESSFUL. The APK lands at `app/build/outputs/apk/release/app-release.apk` (~155 MB, signed with `stash-release.jks`).
+
+If the keystore configuration produces a debug-key fallback (you'll see a build log line warning about it), check that `keystore.properties` was copied into the worktree per the worktree-setup section.
+
+- [ ] **Step 3: Install over the existing v0.9.18 on the user's Pixel**
+
+```bash
+adb devices  # confirm `1A021FDEE002RD` (or whatever device is attached) shows up as `device`
+adb install -r app/build/outputs/apk/release/app-release.apk
+```
+
+Expected: `Performing Streamed Install` → `Success`. The `-r` preserves user data — track DB, listening events, prefs, downloaded files all stay.
+
+If `adb devices` reports no device, skip the install — the user will install themselves. Surface the APK path in the report.
+
+- [ ] **Step 4: Manual smoke test (user runs)**
+
+DO NOT execute this yourself — document the procedure for the user.
+
+Procedure:
+1. **Trigger the manual mix refresh.** On Home, long-press the First Listen mix card (or tap the manual refresh action — whichever the v0.9.16 UI exposes for refresh-this-mix). Wait ~15 seconds for the worker to run.
+2. **Open First Listen.** Verify the mix now has tracks (typically 50, per the recipe's `targetLength`). The tracks should be tracks NOT in your library — that's the "First Listen" semantics, unchanged.
+3. **Confirm Daily Discover and Deep Cuts are unchanged.** They should still populate exactly as they did on v0.9.18 — this fix touches only the TAG_GRAPH path that First Listen uses.
+
+If First Listen is STILL empty after refresh:
+- Check `adb logcat` for `StashMixRefresh` lines — the worker should log `'First Listen': N candidates via TAG_GRAPH` if the fallback fires and the histogram has tags. If you see `0 candidates` or no log line, the histogram is also empty and `TagEnrichmentWorker` hasn't yet enriched any track — wait for the next periodic run (24h cadence) or fix enrichment-throughput as a separate v0.9.20 concern.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/build.gradle.kts
+git commit -m "$(cat <<'EOF'
+chore: bump versionCode 56->57, versionName 0.9.18->0.9.19
+
+v0.9.19 — First Listen tag-fallback. When the user's listening-
+affinity vector is empty (recently played tracks not yet enriched),
+MixGenerator.computeUserTopTags falls back to TrackTagDao.getTagHistogram
+so the TAG_GRAPH seed strategy doesn't dead-end. Affects First Listen
+only; Daily Discover and Deep Cuts already had working library
+fallbacks. Single-function change, no schema impact.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 6: DO NOT push or tag**
+
+The user gates push + tag. Stop here. The user will run the manual smoke test (Step 4), then decide to:
+
+```bash
+cd /c/Users/theno/Projects/MP3APK
+git checkout master
+git merge --ff-only feat/first-listen-tag-fallback
+git tag -a v0.9.19 -m "v0.9.19 — First Listen tag-fallback"
+git push origin master && git push origin v0.9.19
+```
+
+The release workflow takes over from there.
+
+---
+
+## Notes for the executor
+
+- **The single-function change is the entire feature.** Don't refactor neighboring functions, don't tweak `buildUserTagAffinityVector`, don't touch `TagEnrichmentWorker`. Each of those is documented in the spec's Non-goals as out of scope.
+- **The KDoc update is part of Task 1's commit.** The function gains a v0.9.19 paragraph explaining the fallback rationale; that's not a separate concern.
+- **The `PlayCountWithLatest` import path is unverified.** Confirm it during Step 1 reconnaissance before writing the test file. If the actual location differs, adjust the test's imports and surface as a benign deviation in your report.
+- **No version bump in Task 1.** The version bump lives in Task 2 alone — keeps the code commit and the release commit cleanly separable in git history.
+- **Pre-existing test failures still apply.** `YtLibraryCanonicalizerTest.OMV...` and `PlaylistTypeTest.enum...` will continue to fail in the broader sweep. Ignore them.

--- a/docs/superpowers/plans/2026-05-11-discovery-downloads-and-per-recipe-dedup.md
+++ b/docs/superpowers/plans/2026-05-11-discovery-downloads-and-per-recipe-dedup.md
@@ -1,0 +1,1610 @@
+# Discovery Downloads + Per-Recipe Dedup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make per-recipe mix refreshes respect other mixes' contents, and make Last.fm-discovered tracks actually download (so the mix isn't "39 tracks but only 4 playable").
+
+**Architecture:** Three components — (1) `StashMixRefreshWorker` pre-populates `excludeIds` from other mixes' playlist contents when invoked with a single `KEY_RECIPE_ID`; (2) new `DiscoveryDownloadWorker` drains `download_queue WHERE sync_id IS NULL` via the existing `TrackDownloader` abstraction, chained from `StashDiscoveryWorker`'s tail with a final mix-refresh chained on; (3) `getDoneTrackIdsForRecipe` adds `AND t.is_downloaded = 1` as defense-in-depth. Sync feeders gain `AND dq.sync_id IS NOT NULL` so the partition between sync-chain and discovery-chain workers is real.
+
+**Tech Stack:** Kotlin, Room, WorkManager, Hilt, MockK + JUnit4 for unit tests, Robolectric + Room in-memory for DAO behavior tests.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-discovery-downloads-and-per-recipe-dedup-design.md` (committed at `d919a43`).
+
+---
+
+## Pre-flight notes for the implementer
+
+Worktree: `C:\Users\theno\Projects\MP3APK\.worktrees\first-listen-tag-fallback`. Branch: `feat/first-listen-tag-fallback`. PR 3 already shipped 6 commits on this branch (tip is `207c93a feat(mix): version-gated retune migration for the recipe pivot` followed by docs/plan commits). PR 4 lands on top.
+
+### Repository conventions
+
+1. **TDD with bite-sized commits.** One commit per task; tests pass before each commit.
+2. **MockK for unit tests over collaborators** (`MixGenerator`, `StashMixRefreshWorker`, `DiscoveryDownloadWorker`). **Robolectric + Room in-memory for DAO behavior tests**. Match existing precedents:
+   - DAO test: `core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt`
+   - Worker test (MockK with manual construction): `data/download/src/test/kotlin/com/stash/data/download/lossless/LosslessRetryWorkerTest.kt` and `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt`
+3. **`ORDER BY created_at ASC` for queue queries** — matches the existing TrackDownloadWorker feeder queries (`getAllPendingBySources`, `getRetryableBySources`).
+4. **No push, no tag.** Implementation ends at APK installed on Pixel + manual verification.
+5. **Always `:app:installDebug` after a fix.** Per memory `feedback_install_after_fix.md`.
+
+### Files you will touch
+
+| Path | What changes |
+|---|---|
+| `core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt` | Add `getTrackIdsForPlaylists(playlistIds: List<Long>): List<Long>`. |
+| `core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoOtherMixTracksTest.kt` | **CREATE** — Robolectric test for the new query. |
+| `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt` | `doWork`: when `targetId > 0L`, pre-populate `excludeIds` from other mixes' current playlist contents. |
+| `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerPerRecipeDedupTest.kt` | **CREATE** — MockK test for the new behavior. |
+| `core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt` | (a) Add `AND dq.sync_id IS NOT NULL` to `getAllPendingBySources` (lines 76-95) and `getRetryableBySources` (lines 105-124). (b) Add new `pendingDiscoveryDownloads(): List<DownloadQueueEntity>` query. |
+| `core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoPartitionTest.kt` | **CREATE** — Robolectric test for the partition + new query. |
+| `data/download/src/main/kotlin/com/stash/data/download/DiscoveryDownloadWorker.kt` | **CREATE** — the new worker. |
+| `data/download/src/test/kotlin/com/stash/data/download/DiscoveryDownloadWorkerTest.kt` | **CREATE** — MockK test for the new worker. |
+| `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt` | Chain `DiscoveryDownloadWorker.enqueueOneTime(...)` at the end of `doWork()`. |
+| `core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt` | Extend `getDoneTrackIdsForRecipe` query with `AND t.is_downloaded = 1`. |
+| `core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt` | Update `trackEntity` helper to default `isDownloaded = true`; add new "stub excluded" test. |
+
+### Reference precedents you should re-read before starting
+
+- `LosslessRetryWorker.kt` (`data/download/.../lossless/`) — the MockK-with-hand-constructed-worker test precedent.
+- `TrackDownloadWorker.kt` lines 240-385 — the per-track flow `DiscoveryDownloadWorker` mirrors (blocklist guard → `trackDownloader.downloadTrack` → outcome handling).
+- `TrackDownloadWorker.kt` lines 497-515 — the `createForegroundInfo` helper pattern `DiscoveryDownloadWorker` duplicates inline.
+- `SyncNotificationManager.kt` lines 33, 141-146 — confirm `NOTIFICATION_ID_PROGRESS = 9001` and `buildProgressNotification` signature before using.
+
+---
+
+## Task 1: Per-recipe dedup (PlaylistDao + StashMixRefreshWorker)
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt`
+- Create: `core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoOtherMixTracksTest.kt`
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt`
+- Create: `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerPerRecipeDedupTest.kt`
+
+### Step 1: Add the new DAO query
+
+In `PlaylistDao.kt`, add (location: alongside the other track-id queries; if no obvious clustering, add at the end of the interface):
+
+```kotlin
+/**
+ * Returns DISTINCT track ids that appear in any of the given playlists.
+ * Used by [com.stash.core.data.sync.workers.StashMixRefreshWorker]'s
+ * single-recipe refresh path to seed `excludeIds` from the user's
+ * currently-materialized OTHER mixes — without this, a manual refresh
+ * of one mix sees an empty exclude set and naturally produces overlap
+ * with the others (the very symptom PR 3's batch-mode dedup was meant
+ * to fix).
+ */
+@Query("SELECT DISTINCT track_id FROM playlist_tracks WHERE playlist_id IN (:playlistIds)")
+suspend fun getTrackIdsForPlaylists(playlistIds: List<Long>): List<Long>
+```
+
+### Step 2: Write the failing DAO test
+
+Create `PlaylistDaoOtherMixTracksTest.kt`:
+
+```kotlin
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.PlaylistTrackCrossRef
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PlaylistDaoOtherMixTracksTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var playlistDao: PlaylistDao
+    private lateinit var trackDao: TrackDao
+
+    @Before fun setUp() = runTest {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        playlistDao = db.playlistDao()
+        trackDao = db.trackDao()
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `returns DISTINCT track ids across multiple playlists`() = runTest {
+        // Seed 3 tracks
+        trackDao.insert(track(1L))
+        trackDao.insert(track(2L))
+        trackDao.insert(track(3L))
+
+        // Two playlists: A = [1, 2], B = [2, 3] (track 2 in both)
+        val playlistA = playlistDao.insert(stashMixPlaylist(name = "Mix A"))
+        val playlistB = playlistDao.insert(stashMixPlaylist(name = "Mix B"))
+        playlistDao.insertCrossRef(crossRef(playlistA, trackId = 1L, position = 0))
+        playlistDao.insertCrossRef(crossRef(playlistA, trackId = 2L, position = 1))
+        playlistDao.insertCrossRef(crossRef(playlistB, trackId = 2L, position = 0))
+        playlistDao.insertCrossRef(crossRef(playlistB, trackId = 3L, position = 1))
+
+        val result = playlistDao.getTrackIdsForPlaylists(listOf(playlistA, playlistB))
+
+        assertEquals(setOf(1L, 2L, 3L), result.toSet())
+        assertEquals("expected DISTINCT — track 2 once", 3, result.size)
+    }
+
+    @Test fun `empty input returns empty list`() = runTest {
+        val result = playlistDao.getTrackIdsForPlaylists(emptyList())
+        assertTrue("expected empty, got $result", result.isEmpty())
+    }
+
+    @Test fun `filters by the given playlist ids — tracks in OTHER playlists are not returned`() = runTest {
+        trackDao.insert(track(1L))
+        trackDao.insert(track(2L))
+
+        val included = playlistDao.insert(stashMixPlaylist(name = "Included"))
+        val excluded = playlistDao.insert(stashMixPlaylist(name = "Excluded"))
+        playlistDao.insertCrossRef(crossRef(included, trackId = 1L, position = 0))
+        playlistDao.insertCrossRef(crossRef(excluded, trackId = 2L, position = 0))
+
+        val result = playlistDao.getTrackIdsForPlaylists(listOf(included))
+
+        assertEquals(listOf(1L), result)
+    }
+
+    private fun track(id: Long) = TrackEntity(
+        id = id,
+        title = "Track $id",
+        artist = "Artist $id",
+        canonicalTitle = "track $id",
+        canonicalArtist = "artist $id",
+        isDownloaded = true,
+    )
+
+    private fun stashMixPlaylist(name: String) = PlaylistEntity(
+        name = name,
+        source = MusicSource.BOTH,
+        sourceId = "stash_mix_$name",
+        type = PlaylistType.STASH_MIX,
+        trackCount = 0,
+        syncEnabled = true,
+        isActive = true,
+    )
+
+    private fun crossRef(playlistId: Long, trackId: Long, position: Int) =
+        PlaylistTrackCrossRef(
+            playlistId = playlistId,
+            trackId = trackId,
+            position = position,
+            addedAt = Instant.EPOCH,
+        )
+}
+```
+
+### Step 3: Run the DAO test — expect compile error then pass
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.PlaylistDaoOtherMixTracksTest"
+```
+
+Expected: compile error if you haven't added the query yet; or 3/3 pass after Step 1.
+
+### Step 4: Read the current StashMixRefreshWorker.doWork iteration
+
+Open `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt`. After PR 3's `5538a66`, `doWork` around lines 219-225 looks like (lines may have drifted slightly — find by the `val orderedRecipes = active.sortedBy { recipeDedupPriority(it) }` declaration):
+
+```kotlin
+val orderedRecipes = active.sortedBy { recipeDedupPriority(it) }
+val excludeIds = mutableSetOf<Long>()
+for (recipe in orderedRecipes) {
+    val excludeSnapshot = excludeIds.toSet()
+    val tracks = mixGenerator.generate(recipe, excludeSnapshot)
+    // ... rest unchanged
+}
+```
+
+`targetId` is already declared just above at lines 179-180 (or wherever it currently is — find the `val targetId = inputData.getLong(KEY_RECIPE_ID, -1L)` line). We reuse it.
+
+### Step 5: Write the failing worker test
+
+Create `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerPerRecipeDedupTest.kt`:
+
+```kotlin
+package com.stash.core.data.sync.workers
+
+import android.content.Context
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.ListeningEventDao
+import com.stash.core.data.db.dao.PlaylistDao
+import com.stash.core.data.db.dao.StashMixRecipeDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.lastfm.LastFmApiClient
+import com.stash.core.data.lastfm.LastFmCredentials
+import com.stash.core.data.lastfm.LastFmSessionPreference
+import com.stash.core.data.mix.MixGenerator
+import com.stash.core.data.mix.MixSeedGenerator
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * MockK end-to-end test for [StashMixRefreshWorker]'s v0.9.20 single-
+ * recipe dedup. When `KEY_RECIPE_ID` is set, the worker pre-populates
+ * `excludeIds` from the OTHER builtin mixes' current playlist contents
+ * so a manual long-press refresh doesn't produce overlap with the
+ * other mixes.
+ */
+class StashMixRefreshWorkerPerRecipeDedupTest {
+
+    private val appContext: Context = mockk(relaxed = true)
+    private val recipeDao: StashMixRecipeDao = mockk(relaxed = true)
+    private val playlistDao: PlaylistDao = mockk(relaxed = true)
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val listeningEventDao: ListeningEventDao = mockk(relaxed = true)
+    private val trackDao: TrackDao = mockk(relaxed = true)
+    private val mixGenerator: MixGenerator = mockk()
+    private val seedGenerator: MixSeedGenerator = mockk(relaxed = true)
+    private val lastFmApiClient: LastFmApiClient = mockk(relaxed = true)
+    private val lastFmCredentials: LastFmCredentials = mockk {
+        coEvery { isConfigured } returns false
+    }
+    private val sessionPreference: LastFmSessionPreference = mockk {
+        coEvery { session } returns flowOf(null)
+    }
+    private val blocklistGuard: BlocklistGuard = mockk {
+        coEvery { isBlockedByTrackId(any()) } returns false
+    }
+
+    private fun newWorker(recipeId: Long): StashMixRefreshWorker {
+        val params: WorkerParameters = mockk(relaxed = true) {
+            coEvery { inputData } returns workDataOf(
+                StashMixRefreshWorker.KEY_RECIPE_ID to recipeId,
+            )
+        }
+        return StashMixRefreshWorker(
+            appContext, params,
+            recipeDao, playlistDao, discoveryQueueDao, listeningEventDao,
+            trackDao, mixGenerator, seedGenerator, lastFmApiClient,
+            lastFmCredentials, sessionPreference, blocklistGuard,
+        )
+    }
+
+    @Test fun `single-recipe path pre-populates excludeIds from other mixes' playlist contents`() = runTest {
+        val targetRecipe = recipe(id = 1L, name = "Daily Discover", playlistId = 100L)
+        val otherRecipe1 = recipe(id = 2L, name = "Deep Cuts", playlistId = 200L)
+        val otherRecipe2 = recipe(id = 3L, name = "First Listen", playlistId = 300L)
+
+        coEvery { recipeDao.getById(1L) } returns targetRecipe
+        coEvery { recipeDao.getActive() } returns listOf(targetRecipe, otherRecipe1, otherRecipe2)
+        coEvery {
+            playlistDao.getTrackIdsForPlaylists(match { it.toSet() == setOf(200L, 300L) })
+        } returns listOf(50L, 51L, 52L)
+        coEvery { playlistDao.getById(any()) } returns null
+        coEvery { playlistDao.insert(any()) } returns 999L
+
+        val excludeCapture = slot<Set<Long>>()
+        coEvery { mixGenerator.generate(targetRecipe, capture(excludeCapture)) } returns emptyList()
+        coEvery {
+            discoveryQueueDao.getDoneTrackIdsForRecipe(any(), any())
+        } returns emptyList()
+
+        newWorker(recipeId = 1L).doWork()
+
+        assertEquals(
+            "single-recipe path must pre-populate excludeIds from other mixes",
+            setOf(50L, 51L, 52L),
+            excludeCapture.captured,
+        )
+    }
+
+    @Test fun `single-recipe path skips lookup when no other mixes have playlist ids`() = runTest {
+        val targetRecipe = recipe(id = 1L, name = "Daily Discover", playlistId = 100L)
+        val otherRecipe = recipe(id = 2L, name = "Deep Cuts", playlistId = null)  // not yet materialized
+
+        coEvery { recipeDao.getById(1L) } returns targetRecipe
+        coEvery { recipeDao.getActive() } returns listOf(targetRecipe, otherRecipe)
+        coEvery { playlistDao.getById(any()) } returns null
+        coEvery { playlistDao.insert(any()) } returns 999L
+
+        val excludeCapture = slot<Set<Long>>()
+        coEvery { mixGenerator.generate(targetRecipe, capture(excludeCapture)) } returns emptyList()
+        coEvery {
+            discoveryQueueDao.getDoneTrackIdsForRecipe(any(), any())
+        } returns emptyList()
+
+        newWorker(recipeId = 1L).doWork()
+
+        assertTrue("expected empty excludeIds when no other mixes have playlists", excludeCapture.captured.isEmpty())
+        coVerify(exactly = 0) { playlistDao.getTrackIdsForPlaylists(any()) }
+    }
+
+    private fun recipe(id: Long, name: String, playlistId: Long?) = StashMixRecipeEntity(
+        id = id,
+        name = name,
+        discoveryRatio = 0.85f,
+        targetLength = 40,
+        playlistId = playlistId,
+        isBuiltin = true,
+        isActive = true,
+    )
+}
+```
+
+### Step 6: Run the worker test — expect failure
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.StashMixRefreshWorkerPerRecipeDedupTest"
+```
+
+Expected: tests fail. The first assertion fails because `excludeIds` starts empty (the current code doesn't seed it from other mixes).
+
+### Step 7: Implement the production change
+
+In `StashMixRefreshWorker.kt`, find the iteration block (after PR 3 it starts with `val orderedRecipes = active.sortedBy { recipeDedupPriority(it) }`). Add the per-recipe seed BEFORE the loop:
+
+```kotlin
+val orderedRecipes = active.sortedBy { recipeDedupPriority(it) }
+val excludeIds = mutableSetOf<Long>()
+
+// v0.9.20 follow-up: single-recipe path needs explicit seeding from the
+// OTHER mixes' current playlist contents. The batch-mode loop accumulates
+// excludeIds naturally as it iterates; the single-element loop has nothing
+// to accumulate, so we seed it manually from the materialized state of the
+// other builtin mixes. Effect: manual refresh of one mix no longer overlaps
+// with whatever is currently in the others.
+if (targetId > 0L) {
+    val otherPlaylistIds = recipeDao.getActive()
+        .filter { it.id != targetId && it.playlistId != null }
+        .mapNotNull { it.playlistId }
+    if (otherPlaylistIds.isNotEmpty()) {
+        excludeIds += playlistDao.getTrackIdsForPlaylists(otherPlaylistIds)
+    }
+}
+
+for (recipe in orderedRecipes) {
+    val excludeSnapshot = excludeIds.toSet()
+    val tracks = mixGenerator.generate(recipe, excludeSnapshot)
+    // ... rest unchanged
+}
+```
+
+### Step 8: Run both tests — expect pass
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.PlaylistDaoOtherMixTracksTest"
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.StashMixRefreshWorkerPerRecipeDedupTest"
+```
+
+Expected: 3/3 + 2/2 pass.
+
+### Step 9: Run the full :core:data module test sweep
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL. The existing `StashMixRefreshWorkerDedupTest` (from PR 3) must still pass — it tests the batch-mode path which is unchanged.
+
+### Step 10: Commit
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt \
+        core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoOtherMixTracksTest.kt \
+        core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt \
+        core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerPerRecipeDedupTest.kt
+git commit -m "feat(mix): per-recipe refresh pre-populates excludeIds from other mixes
+
+PR 3's cross-mix dedup only fired in batch mode (no KEY_RECIPE_ID).
+The single-recipe path that fires on manual long-press refresh had
+nothing to accumulate, so each mix's refresh was effectively
+unaware of the others — producing overlap ('Hold it Down' by
+Jerreau topped both Daily Discover and Deep Cuts on the user's
+device). Now: when the worker is invoked with a target recipe id,
+it seeds excludeIds from the materialized state of the OTHER
+builtin mixes via a new PlaylistDao query.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Partition predicate on sync feeders + new `pendingDiscoveryDownloads` query
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt`
+- Create: `core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoPartitionTest.kt`
+
+### Step 1: Read the existing feeders
+
+Open `DownloadQueueDao.kt`. Confirm:
+- `getAllPendingBySources` at lines 76-95.
+- `getRetryableBySources` at lines 105-124.
+
+Both filter by `t.source IN (:sources)` + EXISTS-clause on sync_enabled playlists. Neither filters by `sync_id` — adding the predicate is what makes the partition real.
+
+### Step 2: Write the failing test
+
+Create `DownloadQueueDaoPartitionTest.kt`:
+
+```kotlin
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.DownloadQueueEntity
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.PlaylistTrackCrossRef
+import com.stash.core.data.db.entity.SyncHistoryEntity
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.model.DownloadStatus
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DownloadQueueDaoPartitionTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: DownloadQueueDao
+    private lateinit var trackDao: TrackDao
+    private lateinit var playlistDao: PlaylistDao
+    private lateinit var syncHistoryDao: SyncHistoryDao
+
+    @Before fun setUp() = runTest {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.downloadQueueDao()
+        trackDao = db.trackDao()
+        playlistDao = db.playlistDao()
+        syncHistoryDao = db.syncHistoryDao()
+
+        // DownloadQueueEntity has FK sync_id → sync_history.id (Room enables
+        // FK enforcement by default). Seed a single sync_history row so the
+        // sync-side test fixtures can reference syncId = 5L without crashing.
+        syncHistoryDao.insert(SyncHistoryEntity(id = 5L))
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `getAllPendingBySources excludes rows with sync_id IS NULL`() = runTest {
+        seedTrackInSyncEnabledPlaylist(trackId = 1L, source = MusicSource.YOUTUBE)
+        seedTrackInSyncEnabledPlaylist(trackId = 2L, source = MusicSource.YOUTUBE)
+
+        // Two PENDING rows for the same source: one with sync_id (sync), one without (discovery).
+        dao.insert(pendingRow(id = 100L, trackId = 1L, syncId = 5L))    // sync row
+        dao.insert(pendingRow(id = 101L, trackId = 2L, syncId = null))   // discovery row
+
+        val result = dao.getAllPendingBySources(listOf("YOUTUBE"))
+
+        assertEquals("expected only sync row", listOf(100L), result.map { it.id })
+    }
+
+    @Test fun `getRetryableBySources excludes rows with sync_id IS NULL`() = runTest {
+        seedTrackInSyncEnabledPlaylist(trackId = 1L, source = MusicSource.YOUTUBE)
+        seedTrackInSyncEnabledPlaylist(trackId = 2L, source = MusicSource.YOUTUBE)
+
+        dao.insert(failedRow(id = 100L, trackId = 1L, syncId = 5L, retryCount = 1))     // sync row
+        dao.insert(failedRow(id = 101L, trackId = 2L, syncId = null, retryCount = 1))   // discovery row
+
+        val result = dao.getRetryableBySources(listOf("YOUTUBE"))
+
+        assertEquals("expected only sync row", listOf(100L), result.map { it.id })
+    }
+
+    @Test fun `pendingDiscoveryDownloads returns only sync_id IS NULL rows in PENDING or retryable FAILED`() = runTest {
+        seedTrack(trackId = 1L)
+        seedTrack(trackId = 2L)
+        seedTrack(trackId = 3L)
+        seedTrack(trackId = 4L)
+
+        dao.insert(pendingRow(id = 100L, trackId = 1L, syncId = 5L))            // sync — excluded
+        dao.insert(pendingRow(id = 101L, trackId = 2L, syncId = null))          // discovery PENDING — included
+        dao.insert(failedRow(id = 102L, trackId = 3L, syncId = null, retryCount = 1))  // discovery retry — included
+        dao.insert(failedRow(id = 103L, trackId = 4L, syncId = null, retryCount = 3))  // discovery exhausted — excluded
+
+        val result = dao.pendingDiscoveryDownloads()
+
+        assertEquals(setOf(101L, 102L), result.map { it.id }.toSet())
+    }
+
+    @Test fun `pendingDiscoveryDownloads excludes WAITING_FOR_LOSSLESS and IN_PROGRESS`() = runTest {
+        seedTrack(trackId = 1L)
+        seedTrack(trackId = 2L)
+
+        dao.insert(
+            DownloadQueueEntity(
+                id = 100L,
+                trackId = 1L,
+                status = DownloadStatus.WAITING_FOR_LOSSLESS,
+                syncId = null,
+                searchQuery = "q",
+            )
+        )
+        dao.insert(
+            DownloadQueueEntity(
+                id = 101L,
+                trackId = 2L,
+                status = DownloadStatus.IN_PROGRESS,
+                syncId = null,
+                searchQuery = "q",
+            )
+        )
+
+        val result = dao.pendingDiscoveryDownloads()
+
+        assertTrue("expected empty, got $result", result.isEmpty())
+    }
+
+    // ---- helpers ----
+
+    private suspend fun seedTrack(trackId: Long) {
+        trackDao.insert(
+            TrackEntity(
+                id = trackId,
+                title = "Track $trackId",
+                artist = "Artist $trackId",
+                canonicalTitle = "track $trackId",
+                canonicalArtist = "artist $trackId",
+                source = MusicSource.YOUTUBE,
+                isDownloaded = false,
+            )
+        )
+    }
+
+    private suspend fun seedTrackInSyncEnabledPlaylist(trackId: Long, source: MusicSource) {
+        trackDao.insert(
+            TrackEntity(
+                id = trackId,
+                title = "Track $trackId",
+                artist = "Artist $trackId",
+                canonicalTitle = "track $trackId",
+                canonicalArtist = "artist $trackId",
+                source = source,
+                isDownloaded = false,
+            )
+        )
+        val playlistId = playlistDao.insert(
+            PlaylistEntity(
+                name = "Test playlist",
+                source = MusicSource.BOTH,
+                sourceId = "test_playlist_$trackId",
+                type = PlaylistType.STASH_MIX,
+                trackCount = 0,
+                syncEnabled = true,
+                isActive = true,
+            )
+        )
+        playlistDao.insertCrossRef(
+            PlaylistTrackCrossRef(
+                playlistId = playlistId,
+                trackId = trackId,
+                position = 0,
+                addedAt = Instant.EPOCH,
+            )
+        )
+    }
+
+    private fun pendingRow(id: Long, trackId: Long, syncId: Long?) = DownloadQueueEntity(
+        id = id,
+        trackId = trackId,
+        status = DownloadStatus.PENDING,
+        syncId = syncId,
+        searchQuery = "artist - title",
+    )
+
+    private fun failedRow(id: Long, trackId: Long, syncId: Long?, retryCount: Int) = DownloadQueueEntity(
+        id = id,
+        trackId = trackId,
+        status = DownloadStatus.FAILED,
+        syncId = syncId,
+        searchQuery = "artist - title",
+        retryCount = retryCount,
+    )
+}
+```
+
+### Step 3: Run tests — expect compile error then partial fail
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.DownloadQueueDaoPartitionTest"
+```
+
+Expected: compile error (no `pendingDiscoveryDownloads` method); after Step 4, the two partition tests fail because the predicate isn't added yet.
+
+### Step 4: Implement the production changes
+
+In `DownloadQueueDao.kt`, modify `getAllPendingBySources` (around lines 76-95). The current WHERE clause is:
+
+```kotlin
+WHERE dq.status = 'PENDING'
+  AND t.source IN (:sources)
+  AND bl.canonical_key IS NULL
+  AND EXISTS (...)
+```
+
+Add the predicate:
+
+```kotlin
+WHERE dq.status = 'PENDING'
+  AND dq.sync_id IS NOT NULL
+  AND t.source IN (:sources)
+  AND bl.canonical_key IS NULL
+  AND EXISTS (...)
+```
+
+Same for `getRetryableBySources` (around lines 105-124). The current WHERE clause:
+
+```kotlin
+WHERE dq.status = 'FAILED' AND dq.retry_count < 3
+  AND t.source IN (:sources)
+  ...
+```
+
+Add the predicate:
+
+```kotlin
+WHERE dq.status = 'FAILED' AND dq.retry_count < 3
+  AND dq.sync_id IS NOT NULL
+  AND t.source IN (:sources)
+  ...
+```
+
+Append the new query at the end of the existing query block (find a sensible spot — alongside the other status-based queries):
+
+```kotlin
+/**
+ * Discovery rows queued for download — `sync_id IS NULL` partitions
+ * them away from sync-chain [TrackDownloadWorker] (which after the
+ * v0.9.20 predicate update only touches rows with non-null sync_id).
+ *
+ * Includes FAILED rows with retry_count < 3 so a transient network
+ * blip doesn't permanently sideline a discovery candidate — matches
+ * the retry posture of [getRetryableBySources].
+ *
+ * Filtered to exclude WAITING_FOR_LOSSLESS (owned by LosslessRetryWorker)
+ * and IN_PROGRESS / COMPLETED (already running or done).
+ */
+@Query(
+    """
+    SELECT * FROM download_queue
+    WHERE sync_id IS NULL
+      AND (status = 'PENDING' OR (status = 'FAILED' AND retry_count < 3))
+    ORDER BY created_at ASC
+    """
+)
+suspend fun pendingDiscoveryDownloads(): List<DownloadQueueEntity>
+```
+
+### Step 5: Run tests — expect 4/4 pass
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.DownloadQueueDaoPartitionTest"
+```
+
+Expected: 4/4 pass.
+
+### Step 6: Run the full :core:data module test sweep
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL. **Watch for regressions**: existing tests that exercise `getAllPendingBySources` / `getRetryableBySources` may have relied on the pre-PR-4 behavior. If any fail, investigate — likely fix is updating the test fixture to seed `syncId != null`.
+
+### Step 7: Commit
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt \
+        core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoPartitionTest.kt
+git commit -m "feat(download): partition sync vs discovery download_queue rows
+
+TrackDownloadWorker's feeders (getAllPendingBySources,
+getRetryableBySources) gain AND dq.sync_id IS NOT NULL. Adds new
+pendingDiscoveryDownloads query (sync_id IS NULL, PENDING + retryable
+FAILED, ORDER BY created_at ASC) for the upcoming
+DiscoveryDownloadWorker. Without this partition, the sync chain
+silently drained discovery rows when the user happened to sync —
+which is why the user has been seeing some-but-not-all discovery
+tracks downloaded.
+
+Sync behavior on its own rows is unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `DiscoveryDownloadWorker`
+
+**Files:**
+- Create: `data/download/src/main/kotlin/com/stash/data/download/DiscoveryDownloadWorker.kt`
+- Create: `data/download/src/test/kotlin/com/stash/data/download/DiscoveryDownloadWorkerTest.kt`
+
+### Step 1: Verify infrastructure exists
+
+Confirm the following symbols are reachable from `:data:download`:
+- `TrackDownloader` interface at `core/data/.../sync/TrackDownloader.kt` (already used by `TrackDownloadWorker`). Verified signature: `suspend fun downloadTrack(track: Track, preResolvedUrl: String? = null): TrackDownloadOutcome`.
+- `TrackDownloadOutcome` sealed class at `core/data/.../sync/` with `Success(filePath)`, `Unmatched(rejectedVideoId)`, `Failed(error)`, `Deferred` variants.
+- `SyncNotificationManager` class at `core/data/.../sync/` — confirmed by source read: has `NOTIFICATION_ID_PROGRESS = 9001` (line 33) and `buildProgressNotification(title, text, progress, cancelIntent)` (line 141, `cancelIntent` defaults to null).
+- `BlocklistGuard.isBlocked` — confirmed signature: `suspend fun isBlocked(artist: String, title: String, spotifyUri: String?, youtubeId: String?): Boolean`. 4-arg matches the test stub.
+- `AudioDurationExtractor`, `DownloadQueueDao`, `TrackDao` — all in `:core:data`.
+- `StashMixRefreshWorker.enqueueOneTime(context)` (no-arg overload) is public (verified — PR 3's spec didn't touch this).
+
+Read `LosslessRetryWorker.kt` for the `@HiltWorker @AssistedInject` precedent — `DiscoveryDownloadWorker` follows the same pattern.
+
+### Step 2: Write the failing worker test
+
+Create `data/download/src/test/kotlin/com/stash/data/download/DiscoveryDownloadWorkerTest.kt`:
+
+```kotlin
+package com.stash.data.download
+
+import android.content.Context
+import androidx.work.WorkerParameters
+import com.stash.core.data.audio.AudioDurationExtractor
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DownloadQueueDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.DownloadQueueEntity
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.sync.SyncNotificationManager
+import com.stash.core.data.sync.TrackDownloadOutcome
+import com.stash.core.data.sync.TrackDownloader
+import com.stash.core.model.DownloadStatus
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * MockK tests for [DiscoveryDownloadWorker] — the v0.9.20 worker that
+ * drains discovery_queue PENDING/retryable-FAILED rows (sync_id IS NULL)
+ * via the existing [TrackDownloader] abstraction. Mirrors the
+ * [com.stash.data.download.lossless.LosslessRetryWorkerTest] MockK pattern.
+ */
+class DiscoveryDownloadWorkerTest {
+
+    private val appContext: Context = mockk(relaxed = true)
+    private val workerParams: WorkerParameters = mockk(relaxed = true)
+    private val downloadQueueDao: DownloadQueueDao = mockk(relaxed = true)
+    private val trackDao: TrackDao = mockk(relaxed = true)
+    private val trackDownloader: TrackDownloader = mockk()
+    private val audioDurationExtractor: AudioDurationExtractor = mockk(relaxed = true)
+    private val blocklistGuard: BlocklistGuard = mockk {
+        coEvery { isBlocked(any(), any(), any(), any()) } returns false
+    }
+    private val syncNotificationManager: SyncNotificationManager = mockk(relaxed = true)
+
+    private fun newWorker() = DiscoveryDownloadWorker(
+        appContext, workerParams,
+        downloadQueueDao, trackDao, trackDownloader,
+        audioDurationExtractor, blocklistGuard, syncNotificationManager,
+    )
+
+    @Test fun `empty queue returns success and does not invoke TrackDownloader`() = runTest {
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns emptyList()
+
+        val result = newWorker().doWork()
+
+        assertEquals(androidx.work.ListenableWorker.Result.success(), result)
+        coVerify(exactly = 0) { trackDownloader.downloadTrack(any(), any()) }
+    }
+
+    @Test fun `successful download marks COMPLETED and writes isDownloaded`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { trackDownloader.downloadTrack(any(), any()) } returns TrackDownloadOutcome.Success(
+            filePath = "/tmp/file.flac",
+        )
+        coEvery { audioDurationExtractor.extract(any()) } returns null
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) {
+            trackDao.markAsDownloaded(
+                trackId = 1L,
+                filePath = "/tmp/file.flac",
+                fileSizeBytes = any(),
+                sampleRateHz = null,
+                bitsPerSample = null,
+            )
+        }
+        coVerify(exactly = 1) {
+            downloadQueueDao.updateStatus(
+                id = 100L,
+                status = DownloadStatus.COMPLETED,
+                completedAt = any(),
+            )
+        }
+    }
+
+    @Test fun `unmatched outcome marks FAILED with NO_MATCH and increments retry count`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { trackDownloader.downloadTrack(any(), any()) } returns TrackDownloadOutcome.Unmatched(
+            rejectedVideoId = "abc123",
+        )
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) { downloadQueueDao.incrementRetryCount(100L) }
+        coVerify(exactly = 1) {
+            downloadQueueDao.updateStatus(
+                id = 100L,
+                status = DownloadStatus.FAILED,
+                failureType = any(),
+                errorMessage = any(),
+                rejectedVideoId = "abc123",
+            )
+        }
+    }
+
+    @Test fun `failed outcome marks FAILED with DOWNLOAD_ERROR`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { trackDownloader.downloadTrack(any(), any()) } returns TrackDownloadOutcome.Failed(
+            error = "yt-dlp timeout",
+        )
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) { downloadQueueDao.incrementRetryCount(100L) }
+        coVerify(exactly = 1) {
+            downloadQueueDao.updateStatus(
+                id = 100L,
+                status = DownloadStatus.FAILED,
+                failureType = any(),
+                errorMessage = match { it.contains("yt-dlp timeout") },
+            )
+        }
+    }
+
+    @Test fun `deferred outcome does NOT touch the queue row`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { trackDownloader.downloadTrack(any(), any()) } returns TrackDownloadOutcome.Deferred
+
+        newWorker().doWork()
+
+        coVerify(exactly = 0) { downloadQueueDao.updateStatus(id = 100L, status = DownloadStatus.FAILED, any(), any(), any(), any()) }
+        coVerify(exactly = 0) { downloadQueueDao.updateStatus(id = 100L, status = DownloadStatus.COMPLETED, completedAt = any()) }
+        coVerify(exactly = 0) { downloadQueueDao.incrementRetryCount(any()) }
+    }
+
+    @Test fun `blocked track deletes the queue row and does NOT invoke TrackDownloader`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { blocklistGuard.isBlocked(any(), any(), any(), any()) } returns true
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) { downloadQueueDao.deleteByTrackId(1L) }
+        coVerify(exactly = 0) { trackDownloader.downloadTrack(any(), any()) }
+    }
+
+    @Test fun `already-downloaded track is idempotently marked COMPLETED without re-downloading`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L, isDownloaded = true, filePath = "/already/here.flac")
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) {
+            downloadQueueDao.updateStatus(id = 100L, status = DownloadStatus.COMPLETED, completedAt = any())
+        }
+        coVerify(exactly = 0) { trackDownloader.downloadTrack(any(), any()) }
+    }
+
+    @Test fun `IN_PROGRESS stamp is written BEFORE invoking TrackDownloader`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { trackDownloader.downloadTrack(any(), any()) } returns TrackDownloadOutcome.Failed("fail")
+
+        newWorker().doWork()
+
+        // The order matters — IN_PROGRESS must land before the downloader runs.
+        // coVerifyOrder enforces sequence; plain coVerify only checks existence.
+        coVerifyOrder {
+            downloadQueueDao.updateStatus(id = 100L, status = DownloadStatus.IN_PROGRESS)
+            trackDownloader.downloadTrack(any(), any())
+        }
+    }
+
+    private fun entry(id: Long, trackId: Long) = DownloadQueueEntity(
+        id = id,
+        trackId = trackId,
+        status = DownloadStatus.PENDING,
+        syncId = null,
+        searchQuery = "artist - title",
+    )
+
+    private fun stubTrack(
+        id: Long,
+        isDownloaded: Boolean = false,
+        filePath: String? = null,
+    ) = TrackEntity(
+        id = id,
+        title = "Track $id",
+        artist = "Artist $id",
+        canonicalTitle = "track $id",
+        canonicalArtist = "artist $id",
+        isDownloaded = isDownloaded,
+        filePath = filePath,
+    )
+}
+```
+
+### Step 3: Run tests — expect compile error
+
+```bash
+./gradlew :data:download:testDebugUnitTest --tests "com.stash.data.download.DiscoveryDownloadWorkerTest"
+```
+
+Expected: compile error — `DiscoveryDownloadWorker` doesn't exist yet.
+
+### Step 4: Implement `DiscoveryDownloadWorker`
+
+Create `data/download/src/main/kotlin/com/stash/data/download/DiscoveryDownloadWorker.kt`:
+
+```kotlin
+package com.stash.data.download
+
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.stash.core.data.audio.AudioDurationExtractor
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DownloadQueueDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.DownloadQueueEntity
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.mapper.toDomain
+import com.stash.core.data.sync.SyncNotificationManager
+import com.stash.core.data.sync.TrackDownloadOutcome
+import com.stash.core.data.sync.TrackDownloader
+import com.stash.core.data.sync.workers.StashMixRefreshWorker
+import com.stash.core.model.DownloadFailureType
+import com.stash.core.model.DownloadStatus
+import com.stash.core.model.Track
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import java.io.File
+
+/**
+ * Drains `download_queue` rows produced by [StashDiscoveryWorker]
+ * (`sync_id IS NULL`). Parallels [TrackDownloadWorker]'s per-track flow
+ * (blocklist guard → [TrackDownloader.downloadTrack] → mark COMPLETED
+ * with isDownloaded=true + filePath, or FAILED with retry accounting)
+ * without the sync-history coupling that worker requires.
+ *
+ * Chained from the tail of [StashDiscoveryWorker.doWork] (REPLACE policy
+ * on the unique work name so a rapid discovery + drain cycle doesn't
+ * double-run). At the end of the drain, enqueues a one-shot
+ * [StashMixRefreshWorker] so mixes re-materialize and the user sees the
+ * newly-downloaded survivors without manual refresh.
+ *
+ * Foreground-service promotion via [getForegroundInfo] is the same
+ * pattern TrackDownloadWorker uses — required for long batches that
+ * outlive normal background limits.
+ */
+@HiltWorker
+class DiscoveryDownloadWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val downloadQueueDao: DownloadQueueDao,
+    private val trackDao: TrackDao,
+    private val trackDownloader: TrackDownloader,
+    private val audioDurationExtractor: AudioDurationExtractor,
+    private val blocklistGuard: BlocklistGuard,
+    private val syncNotificationManager: SyncNotificationManager,
+) : CoroutineWorker(appContext, params) {
+
+    companion object {
+        const val UNIQUE_WORK_NAME = "discovery_download"
+        private const val TAG = "DiscoveryDownload"
+
+        fun enqueueOneTime(context: Context, constraints: Constraints) {
+            val work = OneTimeWorkRequestBuilder<DiscoveryDownloadWorker>()
+                .setConstraints(constraints)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                UNIQUE_WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                work,
+            )
+        }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        return buildForegroundInfo("Downloading discoveries", "Preparing\u2026", progress = -1f)
+    }
+
+    override suspend fun doWork(): Result {
+        setForeground(getForegroundInfo())
+
+        val pending = downloadQueueDao.pendingDiscoveryDownloads()
+        if (pending.isEmpty()) {
+            chainRefresh()
+            return Result.success()
+        }
+
+        Log.i(TAG, "draining ${pending.size} discovery download(s)")
+
+        for ((index, queueItem) in pending.withIndex()) {
+            setForeground(
+                buildForegroundInfo(
+                    title = "Downloading discoveries",
+                    text = "${index + 1} of ${pending.size}",
+                    progress = (index.toFloat() / pending.size),
+                )
+            )
+
+            // v0.9.20: stamp IN_PROGRESS BEFORE invoking the downloader.
+            // REPLACE policy on UNIQUE_WORK_NAME prevents concurrent instances
+            // of THIS worker; the sync-side partition predicate prevents
+            // TrackDownloadWorker from touching the same row. Defense-in-depth:
+            // a stale IN_PROGRESS row left over from a crashed run gets reset
+            // to PENDING on the next sync (the existing `resetStaleInProgress`
+            // sweep in TrackDownloadWorker's startup) — that path is unchanged.
+            downloadQueueDao.updateStatus(
+                id = queueItem.id,
+                status = DownloadStatus.IN_PROGRESS,
+            )
+
+            val trackEntity = trackDao.getById(queueItem.trackId) ?: continue
+
+            if (blocklistGuard.isBlocked(
+                    artist = trackEntity.artist,
+                    title = trackEntity.title,
+                    spotifyUri = null,
+                    youtubeId = null,
+                )) {
+                Log.d(TAG, "Skipping blocked track ${trackEntity.id}")
+                downloadQueueDao.deleteByTrackId(trackEntity.id)
+                continue
+            }
+
+            if (trackEntity.isDownloaded && trackEntity.filePath != null) {
+                downloadQueueDao.updateStatus(
+                    id = queueItem.id,
+                    status = DownloadStatus.COMPLETED,
+                    completedAt = System.currentTimeMillis(),
+                )
+                continue
+            }
+
+            val track = trackEntity.toDomain()
+            val outcome = runCatching {
+                trackDownloader.downloadTrack(track = track, preResolvedUrl = queueItem.youtubeUrl)
+            }.getOrElse {
+                Log.e(TAG, "downloadTrack threw for ${track.artist} - ${track.title}", it)
+                TrackDownloadOutcome.Failed(error = it.message.orEmpty())
+            }
+
+            when (outcome) {
+                is TrackDownloadOutcome.Success -> handleSuccess(queueItem, trackEntity, outcome)
+                is TrackDownloadOutcome.Unmatched -> handleUnmatched(queueItem, track, outcome)
+                is TrackDownloadOutcome.Failed -> handleFailed(queueItem, track, outcome)
+                is TrackDownloadOutcome.Deferred -> {
+                    // Lossless deferred — TrackDownloaderImpl already moved the row
+                    // to WAITING_FOR_LOSSLESS. LosslessRetryWorker owns the
+                    // re-attempt. No-op here.
+                    Log.i(TAG, "Deferred (waiting for lossless): ${track.artist} - ${track.title}")
+                }
+            }
+        }
+
+        chainRefresh()
+        return Result.success()
+    }
+
+    private suspend fun handleSuccess(
+        queueItem: DownloadQueueEntity,
+        trackEntity: TrackEntity,
+        outcome: TrackDownloadOutcome.Success,
+    ) {
+        val fileSize = try { File(outcome.filePath).length() } catch (_: Exception) { 0L }
+        val meta = audioDurationExtractor.extract(outcome.filePath)
+
+        trackDao.markAsDownloaded(
+            trackId = trackEntity.id,
+            filePath = outcome.filePath,
+            fileSizeBytes = fileSize,
+            sampleRateHz = meta?.sampleRateHz,
+            bitsPerSample = meta?.bitsPerSample,
+        )
+
+        if (meta != null && meta.format != "unknown") {
+            runCatching {
+                trackDao.setFormatAndQuality(
+                    trackId = trackEntity.id,
+                    fileFormat = meta.format,
+                    qualityKbps = meta.bitrateKbps,
+                )
+            }
+        }
+
+        downloadQueueDao.updateStatus(
+            id = queueItem.id,
+            status = DownloadStatus.COMPLETED,
+            completedAt = System.currentTimeMillis(),
+        )
+    }
+
+    private suspend fun handleUnmatched(
+        queueItem: DownloadQueueEntity,
+        track: Track,
+        outcome: TrackDownloadOutcome.Unmatched,
+    ) {
+        val err = "No YouTube match for: ${track.artist} - ${track.title}"
+        Log.w(TAG, err)
+        downloadQueueDao.incrementRetryCount(queueItem.id)
+        downloadQueueDao.updateStatus(
+            id = queueItem.id,
+            status = DownloadStatus.FAILED,
+            failureType = DownloadFailureType.NO_MATCH,
+            errorMessage = err,
+            rejectedVideoId = outcome.rejectedVideoId,
+        )
+    }
+
+    private suspend fun handleFailed(
+        queueItem: DownloadQueueEntity,
+        track: Track,
+        outcome: TrackDownloadOutcome.Failed,
+    ) {
+        Log.e(TAG, "Download failed for ${track.artist} - ${track.title}: ${outcome.error}")
+        downloadQueueDao.incrementRetryCount(queueItem.id)
+        downloadQueueDao.updateStatus(
+            id = queueItem.id,
+            status = DownloadStatus.FAILED,
+            failureType = DownloadFailureType.DOWNLOAD_ERROR,
+            errorMessage = outcome.error.take(500),
+        )
+    }
+
+    /**
+     * Always chain — even on all-failure batches. The mix-refresh worker
+     * is a no-op when nothing new is on disk; simpler to unconditionally
+     * fire than to branch.
+     */
+    private fun chainRefresh() {
+        StashMixRefreshWorker.enqueueOneTime(applicationContext)
+    }
+
+    /**
+     * Inline mirror of [TrackDownloadWorker]'s private `createForegroundInfo`
+     * helper. Duplicated rather than promoted to a public method on
+     * [SyncNotificationManager] because the WorkManager cancel intent is
+     * per-worker-instance and SyncNotificationManager is a singleton.
+     */
+    private fun buildForegroundInfo(
+        title: String,
+        text: String,
+        progress: Float,
+    ): ForegroundInfo {
+        val notification = syncNotificationManager.buildProgressNotification(
+            title = title,
+            text = text,
+            progress = progress,
+            cancelIntent = WorkManager.getInstance(applicationContext).createCancelPendingIntent(id),
+        )
+        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ForegroundInfo(
+                SyncNotificationManager.NOTIFICATION_ID_PROGRESS,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            ForegroundInfo(SyncNotificationManager.NOTIFICATION_ID_PROGRESS, notification)
+        }
+    }
+}
+```
+
+**Verification points the implementer should sanity-check before committing:**
+
+1. `SyncNotificationManager.buildProgressNotification` signature — the spec assumes `(title, text, progress, cancelIntent)`. If the actual signature differs, adapt. Grep the source.
+2. `trackDao.markAsDownloaded` parameter shape — copy verbatim from `TrackDownloadWorker.kt:274-280`.
+3. `trackDao.setFormatAndQuality` parameter shape — copy from `TrackDownloadWorker.kt:296-301`.
+4. `downloadQueueDao.updateStatus` overloads — there are multiple. Use the right one per call site (COMPLETED takes completedAt; FAILED takes failureType + errorMessage + optionally rejectedVideoId; IN_PROGRESS takes just id + status).
+
+### Step 5: Run tests — expect 7/7 pass
+
+```bash
+./gradlew :data:download:testDebugUnitTest --tests "com.stash.data.download.DiscoveryDownloadWorkerTest"
+```
+
+Expected: 7/7 pass. If any tests fail, the most likely culprit is a `coVerify` parameter signature mismatch — match the actual method signature of `downloadQueueDao.updateStatus` overloads.
+
+### Step 6: Run the full :data:download module test sweep
+
+```bash
+./gradlew :data:download:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL. Known pre-existing failure may exist for `YtLibraryCanonicalizerTest` (unrelated, from prior PR 1) — note but don't fix.
+
+### Step 7: Commit
+
+```bash
+git add data/download/src/main/kotlin/com/stash/data/download/DiscoveryDownloadWorker.kt \
+        data/download/src/test/kotlin/com/stash/data/download/DiscoveryDownloadWorkerTest.kt
+git commit -m "feat(download): new DiscoveryDownloadWorker drains sync_id IS NULL queue
+
+Parallels TrackDownloadWorker's per-track flow (blocklist guard →
+TrackDownloader.downloadTrack → outcome handling) without the
+sync-history coupling. Foreground service for long batches with
+per-track progress notification. Stamps IN_PROGRESS before each
+invocation as defense-in-depth.
+
+At the end of the drain, always chains
+StashMixRefreshWorker.enqueueOneTime so mixes re-materialize with
+the newly-downloaded survivors without manual refresh.
+
+Code-duplication note: handleSuccess / handleUnmatched / handleFailed
+mirror TrackDownloadWorker.kt:262-380. Extraction would touch the
+sync chain's parallel-execution context (atomic counters, sync-state
+callbacks) — duplication is bounded and the TrackDownloader contract
+is stable.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Chain `DiscoveryDownloadWorker` from `StashDiscoveryWorker`
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt`
+
+No unit test for the chain itself — testing `WorkManager.enqueueUniqueWork` invocation via MockK is fragile; verified by manual on-device test in Task 6.
+
+### Step 1: Read the existing `doWork` end
+
+Open `StashDiscoveryWorker.kt`. Find the bottom of `doWork()` — the last statement before the return.
+
+### Step 2: Add the chain
+
+At the end of `doWork()`, after the existing recipe-iteration loop and any final logging:
+
+```kotlin
+// v0.9.20: after queueing/processing discoveries, kick the downloader
+// so the new tracks become playable in this charging+WiFi window.
+// Mirror this worker's own constraints (charging + batteryNotLow +
+// NetworkType.UNMETERED) — discovery downloads should respect the same
+// posture that gated the discovery itself.
+val downloadConstraints = Constraints.Builder()
+    .setRequiresCharging(true)
+    .setRequiresBatteryNotLow(true)
+    .setRequiredNetworkType(NetworkType.UNMETERED)
+    .build()
+DiscoveryDownloadWorker.enqueueOneTime(applicationContext, downloadConstraints)
+```
+
+Required new imports (add only if not already present — grep first):
+
+```kotlin
+import androidx.work.Constraints
+import androidx.work.NetworkType
+import com.stash.data.download.DiscoveryDownloadWorker
+```
+
+### Step 3: Build to verify
+
+```bash
+./gradlew :core:data:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+### Step 4: Run the :core:data module test sweep
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL.
+
+### Step 5: Commit
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+git commit -m "feat(mix): chain DiscoveryDownloadWorker from StashDiscoveryWorker tail
+
+Discovery downloads now happen in the same charging+WiFi window that
+gated the discovery itself. Constraints mirror StashDiscoveryWorker's
+(charging + batteryNotLow + UNMETERED). REPLACE policy on the unique
+work name means a back-to-back discovery + drain cycle doesn't double-
+run.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `is_downloaded = 1` filter (Path B, defense-in-depth)
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt`
+- Modify: `core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt`
+
+### Step 1: Read the current state of both files
+
+Open `DiscoveryQueueDao.kt`. Find the existing `getDoneTrackIdsForRecipe` query by name — its `@Query` body was updated by PR 1 Task 8 (`f29f6da`) to add `INNER JOIN tracks t ON t.id = dq.track_id`. The current WHERE clause filters on `dq.recipe_id`, `dq.status = 'DONE'`, and `dq.track_id IS NOT NULL`.
+
+Open `DiscoveryQueueDaoCapTest.kt`. Find the existing `trackEntity(id: Long)` helper near the bottom of the file. PR 1 Task 8 added 1 test (`excludes rows whose track_id points to a deleted track`) bringing the count to 6. The helper currently uses TrackEntity defaults — `isDownloaded` defaults to `false`.
+
+### Step 2: Update the test helper to default `isDownloaded = true`
+
+In `DiscoveryQueueDaoCapTest.kt`, find the existing helper:
+
+```kotlin
+private fun trackEntity(id: Long) = TrackEntity(
+    id = id,
+    title = "Track $id",
+    artist = "Artist $id",
+    canonicalTitle = "track $id",
+    canonicalArtist = "artist $id",
+)
+```
+
+Replace with:
+
+```kotlin
+private fun trackEntity(id: Long, isDownloaded: Boolean = true) = TrackEntity(
+    id = id,
+    title = "Track $id",
+    artist = "Artist $id",
+    canonicalTitle = "track $id",
+    canonicalArtist = "artist $id",
+    isDownloaded = isDownloaded,
+)
+```
+
+### Step 3: Add the new failing test
+
+After the existing 6 tests, add:
+
+```kotlin
+@Test fun `excludes rows whose track is not yet downloaded`() = runTest {
+    db.trackDao().insert(trackEntity(id = 1L, isDownloaded = true))
+    db.trackDao().insert(trackEntity(id = 2L, isDownloaded = false))  // stub
+    dao.insertIfNew(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
+    dao.insertIfNew(doneRow(recipeId, trackId = 2L, completedAt = 2000L))
+
+    val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 99)
+
+    assertEquals(listOf(1L), result)
+}
+```
+
+### Step 4: Run tests — expect the new test to fail
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.DiscoveryQueueDaoCapTest"
+```
+
+Expected: 6/7 pass (existing 6 still pass because the helper default change keeps them seeding `isDownloaded = true`); the new test fails because the DAO doesn't filter on `is_downloaded = 1` yet.
+
+### Step 5: Implement the DAO change
+
+In `DiscoveryQueueDao.kt`, the existing query at lines 92-102:
+
+```kotlin
+@Query(
+    """
+    SELECT dq.track_id FROM discovery_queue dq
+    INNER JOIN tracks t ON t.id = dq.track_id
+    WHERE dq.recipe_id = :recipeId
+      AND dq.status = 'DONE'
+      AND dq.track_id IS NOT NULL
+    ORDER BY dq.completed_at DESC
+    LIMIT :limit
+    """
+)
+suspend fun getDoneTrackIdsForRecipe(recipeId: Long, limit: Int): List<Long>
+```
+
+Add `AND t.is_downloaded = 1` and update the KDoc:
+
+```kotlin
+/**
+ * ... existing KDoc paragraphs preserved ...
+ *
+ * v0.9.20 follow-up: AND t.is_downloaded = 1 ensures the mix never
+ * surfaces a stub TrackEntity (a discovery row that was marked DONE
+ * by StashDiscoveryWorker but whose file hasn't landed on disk yet).
+ * Without this filter, a transient window between StashDiscoveryWorker
+ * completion and DiscoveryDownloadWorker completion would put unplayable
+ * tracks in the playlist. DiscoveryDownloadWorker fixes the underlying
+ * issue (downloads run promptly); this filter is defense-in-depth.
+ */
+@Query(
+    """
+    SELECT dq.track_id FROM discovery_queue dq
+    INNER JOIN tracks t ON t.id = dq.track_id
+    WHERE dq.recipe_id = :recipeId
+      AND dq.status = 'DONE'
+      AND dq.track_id IS NOT NULL
+      AND t.is_downloaded = 1
+    ORDER BY dq.completed_at DESC
+    LIMIT :limit
+    """
+)
+suspend fun getDoneTrackIdsForRecipe(recipeId: Long, limit: Int): List<Long>
+```
+
+### Step 6: Run tests — expect 7/7 pass
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.DiscoveryQueueDaoCapTest"
+```
+
+Expected: 7/7 pass.
+
+### Step 7: Run the full :core:data module test sweep
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL.
+
+### Step 8: Commit
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt \
+        core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt
+git commit -m "fix(mix): filter discovery survivors by is_downloaded = 1
+
+Defense-in-depth: even if there's a transient window where
+StashDiscoveryWorker has marked DONE but DiscoveryDownloadWorker
+hasn't finished, the mix won't surface the stub. The real fix is
+the new worker (downloads happen promptly); this filter guarantees
+the mix UI never shows unplayable tracks.
+
+Existing test helper updated to default isDownloaded = true so
+prior tests don't suddenly return empty; new test asserts the
+filter excludes stubs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Build APK + install + on-device verification
+
+**Files:** none — verification task.
+
+### Step 1: Full release build
+
+```bash
+./gradlew :app:assembleRelease
+```
+
+Expected: BUILD SUCCESSFUL. If `packageRelease` fails transiently (observed during PR 1 + PR 3), re-run `./gradlew :app:packageRelease`.
+
+### Step 2: Install over the existing release app on Pixel
+
+```bash
+adb install -r app/build/outputs/apk/release/app-release.apk
+```
+
+Expected: `Success`.
+
+### Step 3: Cold-start the app
+
+```bash
+adb shell monkey -p com.stash.app -c android.intent.category.LAUNCHER 1
+```
+
+Wait ~5 seconds.
+
+### Step 4: Trigger per-recipe refresh on each mix, verify zero overlap
+
+On the Pixel:
+1. Long-press Daily Discover → "Refresh this mix". Wait for the snackbar to confirm `Refreshed Daily Discover`. Note the first ~5 tracks.
+2. Long-press Deep Cuts → "Refresh this mix". Note its first ~5 tracks. They should be DIFFERENT from Daily Discover's.
+3. Long-press First Listen → "Refresh this mix". Note its first ~5 tracks. Different from both above.
+4. **Acceptance**: zero track-title overlap across the three top-5 samples. If any track appears in two mixes, dig in — likely a stub-track race that Task 5's filter should have prevented.
+
+### Step 5: Plug in to charge + connect WiFi, watch the discovery downloader
+
+The `StashDiscoveryWorker` is constrained on charging + batteryNotLow + WiFi. Once those are satisfied, JobScheduler will fire it (within a few minutes; can take longer if Doze is active).
+
+Tail logcat for the chain:
+
+```bash
+adb logcat -t 200 | grep -E "StashDiscovery|DiscoveryDownload|StashMixRefresh"
+```
+
+Expected sequence:
+1. `StashDiscoveryWorker` starts, processes its batch.
+2. `DiscoveryDownload: draining N discovery download(s)` log line.
+3. Per-track progress notification visible in the system shade.
+4. Each track logged on completion (success or failure).
+5. After the drain, `StashMixRefresh` fires (chained refresh).
+
+### Step 6: Verify mixes are now playable
+
+After the drain completes:
+1. Open each mix on the Pixel.
+2. Track counts should reflect playable tracks only (no phantom rows).
+3. Tap several tracks per mix — every one should play immediately.
+
+### Step 7: Reporting
+
+When all manual checks pass, summarize:
+- Commits that landed (likely 5: per-recipe dedup + partition + new worker + chain + filter)
+- APK installed on the Pixel
+- Migration log line observed
+- Manual checks that passed
+- Any deferred items
+
+Do NOT push, do NOT tag.
+
+---
+
+## What's intentionally not in this plan
+
+YAGNI:
+
+- **A new unit test for the StashDiscoveryWorker chain.** WorkManager.enqueueUniqueWork is hard to assert on via MockK without significant test infrastructure. Manual on-device verification is more reliable.
+- **Promoting `createForegroundInfo` to public on SyncNotificationManager.** Duplication inside DiscoveryDownloadWorker is bounded; future divergence between sync and discovery foreground notifications is easier to reason about with two clear sites.
+- **Modifying `TrackDownloadWorker` to accept `syncId = null`.** Explicitly rejected during brainstorming — partition predicate is the cleaner answer.
+- **A "discovery downloads pending" UI surface.** The foreground service notification suffices.
+- **Inline pre-seeding of discovery_queue on migration.** Still deferred from PR 3.

--- a/docs/superpowers/plans/2026-05-11-manual-refresh-kicks-discovery-pipeline.md
+++ b/docs/superpowers/plans/2026-05-11-manual-refresh-kicks-discovery-pipeline.md
@@ -1,0 +1,667 @@
+# Manual Refresh Kicks Discovery Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make "Refresh this mix" fire the full discovery pipeline (StashDiscoveryWorker + DiscoveryDownloadWorker) without waiting for the periodic charging+WiFi cycle, while still respecting the user's `DownloadNetworkMode` preference for cellular gating.
+
+**Architecture:** Five small, focused changes. New `constraintsForManualTrigger` helper drops the charging requirement (keeps network pref). New `StashDiscoveryWorker.enqueueOneTime(context, mode)` entry point uses it. `HomeViewModel.refreshMix` fires the entry point on every tap. `StashApplication.onCreate` enqueues `DiscoveryDownloadWorker.enqueueOneTime` at startup to drain orphan stubs from prior versions. `StashDiscoveryWorker.doWork`'s chain to `DiscoveryDownloadWorker` switches to manual-trigger constraints so the chain inherits the no-charging-required posture end-to-end.
+
+**Tech Stack:** Kotlin, WorkManager 2.10.1, Hilt, MockK + JUnit4 for unit tests.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-manual-refresh-kicks-discovery-pipeline-design.md` (committed at `e687273`).
+
+---
+
+## Pre-flight notes for the implementer
+
+Worktree: `C:\Users\theno\Projects\MP3APK\.worktrees\first-listen-tag-fallback`. Branch: `feat/first-listen-tag-fallback`. PR 4 already shipped 8 commits; PR 5 lands on top.
+
+### Repository conventions
+
+1. **TDD where applicable** — Task 1 (helper fn) uses TDD; Tasks 2-5 are scheduling/wiring changes verified by build + on-device test.
+2. **MockK for unit tests** — pattern: `core/data/src/test/.../DownloadConstraintsTest.kt` may exist; if so, extend; otherwise create.
+3. **No push, no tag**. Implementation ends at APK installed on Pixel + manual verification.
+4. **Always `:app:installDebug` (or `:app:installRelease`) after a fix** — per memory `feedback_install_after_fix.md`.
+
+### Files you will touch
+
+| Path | What changes |
+|---|---|
+| `core/data/src/main/kotlin/com/stash/core/data/sync/workers/DownloadConstraints.kt` | Add `constraintsForManualTrigger(mode)` top-level fn — same as `constraintsFor` minus charging requirement. |
+| `core/data/src/test/kotlin/com/stash/core/data/sync/workers/DownloadConstraintsTest.kt` | **CREATE or EXTEND** — 3 tests covering each `DownloadNetworkMode`. |
+| `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt` | (Task 2) Add `ONE_SHOT_WORK_NAME` constant + `enqueueOneTime(context, mode)` companion fn. (Task 3) Inject `DownloadNetworkPreference` via constructor; replace inline `Constraints.Builder()` at lines 162-167 with `constraintsForManualTrigger(mode)`. |
+| `feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt` | Inject `DownloadNetworkPreference`; after existing `enqueueUniqueWork(StashMixRefreshWorker, ...)` in `refreshMix`, add one line to also fire `StashDiscoveryWorker.enqueueOneTime(context, mode)`. |
+| `app/src/main/kotlin/com/stash/app/StashApplication.kt` | In the `applicationScope.launch { ... }` block at lines 168-177, append `DiscoveryDownloadWorker.enqueueOneTime(this@StashApplication, constraintsForManualTrigger(mode))` after the existing `StashMixRefreshWorker.enqueueOneTime` call. |
+
+### Reference precedents
+
+- **Existing `constraintsFor(mode)`** at `DownloadConstraints.kt:20-34` — `constraintsForManualTrigger` mirrors its shape minus charging.
+- **Existing `StashDiscoveryWorker.schedulePeriodic`** at `StashDiscoveryWorker.kt:87-99` — `enqueueOneTime` follows the same pattern but with `OneTimeWorkRequestBuilder` + `enqueueUniqueWork`.
+- **PR 1 Task 5's `StashMixRefreshWorker.enqueueOneTime(context, recipeId)`** at `StashMixRefreshWorker.kt:154-168` — same shape as the new one.
+- **`DownloadNetworkPreference`** at `core/data/src/main/kotlin/com/stash/core/data/prefs/DownloadNetworkPreference.kt` — `suspend fun current(): DownloadNetworkMode`.
+
+---
+
+## Task 1: `constraintsForManualTrigger` helper
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/DownloadConstraints.kt`
+- Create or extend: `core/data/src/test/kotlin/com/stash/core/data/sync/workers/DownloadConstraintsTest.kt`
+
+### Step 1: Check whether a test file already exists
+
+```bash
+ls core/data/src/test/kotlin/com/stash/core/data/sync/workers/DownloadConstraintsTest.kt
+```
+
+If it exists, you'll extend it. If not, you'll create it.
+
+### Step 2: Write the failing tests
+
+If creating the test file, use this template:
+
+```kotlin
+package com.stash.core.data.sync.workers
+
+import androidx.work.NetworkType
+import com.stash.core.model.DownloadNetworkMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for the [constraintsForManualTrigger] helper — drops charging
+ * requirement compared to [constraintsFor], otherwise honors the user's
+ * [DownloadNetworkMode] preference for cellular gating.
+ */
+class DownloadConstraintsTest {
+
+    @Test fun `constraintsForManualTrigger WIFI_AND_CHARGING requires WiFi but NOT charging`() {
+        val constraints = constraintsForManualTrigger(DownloadNetworkMode.WIFI_AND_CHARGING)
+
+        assertEquals(NetworkType.UNMETERED, constraints.requiredNetworkType)
+        assertFalse("manual trigger drops charging requirement", constraints.requiresCharging())
+        assertTrue("battery-not-low always required", constraints.requiresBatteryNotLow())
+    }
+
+    @Test fun `constraintsForManualTrigger WIFI_ANY requires WiFi but NOT charging`() {
+        val constraints = constraintsForManualTrigger(DownloadNetworkMode.WIFI_ANY)
+
+        assertEquals(NetworkType.UNMETERED, constraints.requiredNetworkType)
+        assertFalse(constraints.requiresCharging())
+        assertTrue(constraints.requiresBatteryNotLow())
+    }
+
+    @Test fun `constraintsForManualTrigger ANY_NETWORK requires any network and NOT charging`() {
+        val constraints = constraintsForManualTrigger(DownloadNetworkMode.ANY_NETWORK)
+
+        assertEquals(NetworkType.CONNECTED, constraints.requiredNetworkType)
+        assertFalse(constraints.requiresCharging())
+        assertTrue(constraints.requiresBatteryNotLow())
+    }
+}
+```
+
+If the test file already exists, add the same three `@Test` methods alongside whatever's there.
+
+### Step 3: Run tests — expect compile error
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.DownloadConstraintsTest"
+```
+
+Expected: compile error — `constraintsForManualTrigger` doesn't exist yet.
+
+### Step 4: Implement the helper
+
+In `DownloadConstraints.kt`, append after the existing `constraintsFor(mode)` definition:
+
+```kotlin
+/**
+ * Constraints for **manual triggers** — when the user explicitly taps
+ * "Refresh this mix" or the app boots and we want to drain orphan
+ * discovery downloads. Same network discipline as [constraintsFor]
+ * (we still respect the user's [DownloadNetworkMode] pref for cellular)
+ * but DROPS the charging requirement: the user is actively asking for
+ * content; honoring that beats waiting for them to plug in.
+ *
+ * `setRequiresBatteryNotLow(true)` stays on — a 5% battery + manual
+ * refresh is still a bad combination.
+ */
+fun constraintsForManualTrigger(mode: DownloadNetworkMode): Constraints = Constraints.Builder().apply {
+    setRequiresBatteryNotLow(true)
+    when (mode) {
+        DownloadNetworkMode.WIFI_AND_CHARGING -> setRequiredNetworkType(NetworkType.UNMETERED)
+        DownloadNetworkMode.WIFI_ANY -> setRequiredNetworkType(NetworkType.UNMETERED)
+        DownloadNetworkMode.ANY_NETWORK -> setRequiredNetworkType(NetworkType.CONNECTED)
+    }
+}.build()
+```
+
+### Step 5: Run tests — expect 3/3 pass
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.DownloadConstraintsTest"
+```
+
+Expected: 3/3 pass.
+
+### Step 6: Run the full :core:data module test sweep
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL.
+
+### Step 7: Commit
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/sync/workers/DownloadConstraints.kt \
+        core/data/src/test/kotlin/com/stash/core/data/sync/workers/DownloadConstraintsTest.kt
+git commit -m "feat(download): add constraintsForManualTrigger helper
+
+Mirrors constraintsFor but drops the charging requirement. Used by
+manual-user-trigger paths (Refresh this mix, app-startup drain of
+orphan discovery downloads) where the user is actively asking for
+content — waiting for them to plug in defeats the trigger.
+
+User's network preference still governs cellular gating: WiFi-only
+users won't burn cellular even on manual trigger. Only the charging
+constraint is dropped.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `StashDiscoveryWorker.enqueueOneTime` companion fn
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt`
+
+No new tests — this is a scheduling helper verified by Task 6's on-device test.
+
+### Step 1: Read the existing companion
+
+Open `StashDiscoveryWorker.kt`. The companion object starts around line 65 and contains:
+- `private const val TAG = "StashDiscovery"`
+- `private const val WORK_NAME = "stash_discovery"` (line 67)
+- The existing `schedulePeriodic(context, mode)` fn (lines 87-99)
+
+The new `enqueueOneTime` slots in alongside `schedulePeriodic`.
+
+### Step 2: Add `ONE_SHOT_WORK_NAME` constant
+
+Inside the companion object, immediately after `WORK_NAME`:
+
+```kotlin
+private const val ONE_SHOT_WORK_NAME = "stash_discovery_oneshot"
+```
+
+### Step 3: Add the `enqueueOneTime` companion fn
+
+After the existing `schedulePeriodic` fn (around line 99), add:
+
+```kotlin
+/**
+ * Fire a one-shot discovery sweep — manual user trigger, no charging
+ * requirement. Respects [DownloadNetworkMode] for cellular gating via
+ * [constraintsForManualTrigger]. Unique work name + REPLACE policy so a
+ * rapid double-tap coalesces. At the end of [doWork], the existing
+ * v0.9.20 chain to [DiscoveryDownloadWorker] fires, completing the
+ * pipeline: discovery_queue PENDING → stubs + download_queue PENDING →
+ * actual downloads.
+ */
+fun enqueueOneTime(context: Context, mode: DownloadNetworkMode) {
+    val work = OneTimeWorkRequestBuilder<StashDiscoveryWorker>()
+        .setConstraints(constraintsForManualTrigger(mode))
+        .build()
+    WorkManager.getInstance(context).enqueueUniqueWork(
+        ONE_SHOT_WORK_NAME,
+        ExistingWorkPolicy.REPLACE,
+        work,
+    )
+}
+```
+
+### Step 4: Add required imports (only if not already present — grep first)
+
+```kotlin
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+```
+
+These may or may not be already imported — `StashDiscoveryWorker` already imports `androidx.work.*` types for `schedulePeriodic`. Check first.
+
+`constraintsForManualTrigger` is a top-level fun in the same package (added by Task 1) — no import needed.
+
+### Step 5: Build to verify
+
+```bash
+./gradlew :core:data:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+### Step 6: Run the :core:data module test sweep
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL.
+
+### Step 7: Commit
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+git commit -m "feat(mix): StashDiscoveryWorker.enqueueOneTime entry point
+
+Lets the UI fire the discovery sweep without waiting for the periodic
+charging+WiFi cycle. Uses constraintsForManualTrigger so the user's
+network preference still gates cellular but charging is no longer
+required. REPLACE policy on the unique work name means rapid taps
+coalesce.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `StashDiscoveryWorker.doWork` chains downloader with manual-trigger constraints
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt`
+
+This task closes the gap reviewer found in the spec: even when Task 2's manual one-shot fires (no charging required), the chained `DiscoveryDownloadWorker` currently inherits hard-coded charging-required constraints from `StashDiscoveryWorker.doWork:162-167`. Defeats the manual-trigger purpose.
+
+No new tests — verified on-device in Task 6.
+
+### Step 1: Read the chain site
+
+Open `StashDiscoveryWorker.kt`. Find the inline `Constraints.Builder()` block at around line 162 (search for `DiscoveryDownloadWorker.enqueueOneTime`). The current code:
+
+```kotlin
+val downloadConstraints = Constraints.Builder()
+    .setRequiresCharging(true)
+    .setRequiresBatteryNotLow(true)
+    .setRequiredNetworkType(NetworkType.UNMETERED)
+    .build()
+DiscoveryDownloadWorker.enqueueOneTime(applicationContext, downloadConstraints)
+```
+
+### Step 2: Inject `DownloadNetworkPreference` into the constructor
+
+Locate the constructor (search for `class StashDiscoveryWorker @AssistedInject constructor`). Add a new injected dependency:
+
+```kotlin
+private val downloadNetworkPreference: DownloadNetworkPreference,
+```
+
+Place it alongside the other injected DAOs / preferences. Add the import at the top:
+
+```kotlin
+import com.stash.core.data.prefs.DownloadNetworkPreference
+```
+
+### Step 3: Replace the inline constraints block
+
+Replace the 4-line `Constraints.Builder()` + `DiscoveryDownloadWorker.enqueueOneTime(...)` block (lines 162-167) with:
+
+```kotlin
+// v0.9.20: use manual-trigger constraints (drop charging, respect user
+// network pref) regardless of whether THIS worker invocation was periodic
+// or manual. For the periodic path, the parent's own charging requirement
+// already gated this worker from running — by the time we chain, we know
+// the device is charging + on WiFi, so dropping the charging req on the
+// chain is a no-op. For the manual path, dropping charging is the whole
+// point: the user is actively asking for content; honor that.
+val mode = downloadNetworkPreference.current()
+DiscoveryDownloadWorker.enqueueOneTime(
+    applicationContext,
+    constraintsForManualTrigger(mode),
+)
+```
+
+### Step 4: Build to verify
+
+```bash
+./gradlew :core:data:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+### Step 5: Run the :core:data module test sweep
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL. Any existing test that hand-constructs `StashDiscoveryWorker` (via MockK or similar) will fail to compile because of the new constructor parameter — flag if so. Fix by adding `downloadNetworkPreference = mockk(relaxed = true)` (and `coEvery { current() } returns DownloadNetworkMode.WIFI_ANY` or whatever's reasonable) to the test fixture.
+
+Likely there's no such test (StashDiscoveryWorker doesn't have a `Test.kt` file per the original module exploration), but verify.
+
+### Step 6: Build the :app module to verify Hilt can resolve the new dependency
+
+```bash
+./gradlew :app:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL. If Hilt complains about missing bindings for `DownloadNetworkPreference`, it means the singleton isn't installed in a compatible component — unlikely since `StashApplication` already uses it.
+
+### Step 7: Commit
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+git commit -m "feat(mix): StashDiscoveryWorker chains downloader with manual-trigger constraints
+
+The inline Constraints.Builder() at the chain site hard-coded
+setRequiresCharging(true), so even when StashDiscoveryWorker was fired
+manually (Task 2's no-charging-required path), the chained
+DiscoveryDownloadWorker would still wait for charging — defeating the
+manual trigger.
+
+Inject DownloadNetworkPreference and use constraintsForManualTrigger
+instead. Safe for both invocation paths:
+- Periodic: parent already gated on charging, so dropping it on chain
+  is a no-op for the current run.
+- Manual: dropping charging is the whole point.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `HomeViewModel.refreshMix` fires `StashDiscoveryWorker.enqueueOneTime`
+
+**Files:**
+- Modify: `feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt`
+
+No new tests — `HomeViewModel` lacks a test file (verified during PR 1 + PR 3 work); verified on-device in Task 6.
+
+### Step 1: Locate the current `refreshMix`
+
+Open `HomeViewModel.kt`. Find `fun refreshMix(playlistId: Long)` — after PR 1 Task 5 + PR 4 Task 1, it's around line 640-689. The function snapshots the recipe, emits a snackbar, enqueues `StashMixRefreshWorker`, and observes its terminal state.
+
+### Step 2: Inject `DownloadNetworkPreference`
+
+Find the constructor (search for `@HiltViewModel` then `class HomeViewModel`). Add to the injected dependencies:
+
+```kotlin
+private val downloadNetworkPreference: DownloadNetworkPreference,
+```
+
+Add the import:
+
+```kotlin
+import com.stash.core.data.prefs.DownloadNetworkPreference
+```
+
+(Grep first — the import may already be present indirectly.)
+
+### Step 3: Add the StashDiscoveryWorker trigger after the existing mix-refresh enqueue
+
+In `refreshMix`, the existing flow is roughly:
+
+```kotlin
+fun refreshMix(playlistId: Long) {
+    viewModelScope.launch {
+        val recipe = recipeDao.findByPlaylistId(playlistId)
+        if (recipe == null) { /* error path */ return@launch }
+        _userMessages.tryEmit("Refreshing ${recipe.name}…")
+
+        // existing: build + enqueue per-recipe StashMixRefreshWorker
+        val request = OneTimeWorkRequestBuilder<StashMixRefreshWorker>()
+            .setConstraints(...)
+            .setInputData(...)
+            .build()
+        val uniqueName = "${StashMixRefreshWorker.ONE_SHOT_WORK_NAME}_${recipe.id}"
+        WorkManager.getInstance(context).enqueueUniqueWork(uniqueName, ExistingWorkPolicy.REPLACE, request)
+
+        // existing: observe WorkInfo for terminal state, emit snackbar
+        ...
+    }
+}
+```
+
+Immediately AFTER the `WorkManager.getInstance(context).enqueueUniqueWork(uniqueName, ...)` call (the per-recipe mix refresh enqueue), and BEFORE the WorkInfo observation block, add:
+
+```kotlin
+// v0.9.20: fire the full discovery pipeline. queueDiscoveryForRecipe
+// inside the mix refresh worker enqueues new Last.fm candidates into
+// discovery_queue PENDING; this trigger processes them right now (subject
+// to user's DownloadNetworkMode pref) instead of waiting up to 24h for
+// the periodic schedule. The chain in StashDiscoveryWorker's tail will
+// fire DiscoveryDownloadWorker, which fires StashMixRefreshWorker again
+// at the end — the mix re-materializes with newly-downloaded survivors
+// without the user lifting another finger.
+val mode = downloadNetworkPreference.current()
+StashDiscoveryWorker.enqueueOneTime(context, mode)
+```
+
+Add the import:
+
+```kotlin
+import com.stash.core.data.sync.workers.StashDiscoveryWorker
+```
+
+(May already be present — grep first.)
+
+### Step 4: Build to verify
+
+```bash
+./gradlew :feature:home:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL. If Hilt complains, the issue is likely an `@HiltViewModel` binding for `DownloadNetworkPreference` — but `DownloadNetworkPreference` is already a Hilt singleton, so this should resolve.
+
+### Step 5: Run the :feature:home module test sweep
+
+```bash
+./gradlew :feature:home:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL or NO-SOURCE (the module has limited unit-test coverage).
+
+### Step 6: Commit
+
+```bash
+git add feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+git commit -m "feat(home): refreshMix fires the full discovery pipeline on every tap
+
+After enqueueing the per-recipe mix refresh, also fire
+StashDiscoveryWorker.enqueueOneTime with manual-trigger constraints
+(no charging required, respects DownloadNetworkMode pref). The
+discovery worker processes the newly-queued candidates, chains
+DiscoveryDownloadWorker, which downloads them and chains a final
+StashMixRefreshWorker — mixes re-materialize with new content
+without the user lifting another finger.
+
+Battery / data: refreshing while on cellular burns data if the user
+explicitly opted into ANY_NETWORK mode; WiFi-only users still wait
+for WiFi. The mode pref governs everything except the charging
+requirement, which is the explicit relaxation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `StashApplication.onCreate` drains orphan stubs at startup
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/stash/app/StashApplication.kt`
+
+No new tests — verified on-device.
+
+### Step 1: Locate the startup `applicationScope.launch` block
+
+Open `StashApplication.kt`. Find the block at lines 168-177 (or near — find by searching for `maybeRetuneStashMixes()`):
+
+```kotlin
+applicationScope.launch {
+    maybeReseedStashMixes()
+    StashMixDefaults.seedIfNeeded(stashMixRecipeDao)
+    maybeRetuneStashDiscover()
+    maybeRetuneStashMixes()
+    StashMixRefreshWorker.enqueueOneTime(this@StashApplication)
+}
+```
+
+`downloadNetworkPreference` is already injected (verified during spec review — confirmed at line 95 of `StashApplication.kt`).
+
+### Step 2: Append the orphan-drain enqueue
+
+Inside that same block, after the `StashMixRefreshWorker.enqueueOneTime(...)` call, add:
+
+```kotlin
+// v0.9.20: drain orphan discovery download rows from prior version
+// installs (stubs that StashDiscoveryWorker created in PR 3 era but
+// were never downloaded because the sync-chain TrackDownloadWorker
+// was always sync-gated). Respects user's network preference; runs
+// when constraints are satisfied.
+val mode = downloadNetworkPreference.current()
+DiscoveryDownloadWorker.enqueueOneTime(
+    this@StashApplication,
+    constraintsForManualTrigger(mode),
+)
+```
+
+### Step 3: Add required imports (grep first)
+
+```kotlin
+import com.stash.core.data.sync.workers.DiscoveryDownloadWorker
+import com.stash.core.data.sync.workers.constraintsForManualTrigger
+```
+
+After PR 4 Task 4's refactor, `DiscoveryDownloadWorker` lives in `core/data/.../sync/workers/`. `constraintsForManualTrigger` was added by PR 5 Task 1 in the same package as `DiscoveryDownloadWorker` — both imports come from `com.stash.core.data.sync.workers`.
+
+### Step 4: Build to verify
+
+```bash
+./gradlew :app:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+### Step 5: Run the :app module test sweep
+
+```bash
+./gradlew :app:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL or NO-SOURCE.
+
+### Step 6: Commit
+
+```bash
+git add app/src/main/kotlin/com/stash/app/StashApplication.kt
+git commit -m "feat(mix): drain orphan discovery downloads on app cold-start
+
+Pre-existing download_queue rows with sync_id IS NULL (stubs from
+prior version installs that StashDiscoveryWorker created but never
+got downloaded because the sync-chain TrackDownloadWorker was always
+sync-gated) get drained by DiscoveryDownloadWorker on every cold
+start, subject to the user's network preference (no charging
+required).
+
+Without this, the orphan stubs only drain when the periodic
+StashDiscoveryWorker happens to find new candidates and chains the
+downloader — which on a fresh PR 5 install could take 24+ hours.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Build APK + install + on-device verification
+
+**Files:** none — verification task.
+
+### Step 1: Full release build
+
+```bash
+./gradlew :app:assembleRelease
+```
+
+Expected: BUILD SUCCESSFUL. (If `packageRelease` fails transiently — observed in prior PRs — re-run `./gradlew :app:packageRelease`.)
+
+### Step 2: Install over the existing release app
+
+```bash
+adb install -r app/build/outputs/apk/release/app-release.apk
+```
+
+Expected: `Success`.
+
+### Step 3: Cold-start
+
+```bash
+adb shell monkey -p com.stash.app -c android.intent.category.LAUNCHER 1
+```
+
+Wait ~5 seconds for the startup `applicationScope.launch` block to complete.
+
+### Step 4: Verify startup orphan-drain fires
+
+```bash
+adb logcat -d -t 500 | grep -E "DiscoveryDownload|StashMigration"
+```
+
+Expected: a `DiscoveryDownload: draining N discovery download(s)` line within a few seconds of launch. If `N > 0`, orphan stubs were drained. If `N = 0`, the discovery_queue is empty (no orphans to drain) — also acceptable.
+
+If you don't see the log line, the worker is queued but waiting for constraints (e.g., WiFi off). Plug in / connect WiFi and wait a moment.
+
+### Step 5: Trigger a manual refresh and verify the full pipeline fires
+
+On the Pixel:
+1. Plug in to WiFi (no charging needed — that's the point of PR 5).
+2. Long-press Daily Discover → "Refresh this mix". Wait for the "Refreshed" snackbar.
+
+Tail logcat:
+
+```bash
+adb logcat -t 500 | grep -E "StashMixRefresh|StashDiscovery|DiscoveryDownload"
+```
+
+Expected sequence within ~30 seconds:
+- `StashMixRefresh: refreshing 1 Stash Mix(es) (single: Daily Discover)`
+- `StashMixRefresh: 'Daily Discover': 120 candidates via ARTIST_SIMILAR` (or similar count)
+- `WM-WorkerWrapper: Starting work for ...StashDiscoveryWorker` — **this is new in PR 5**
+- `StashDiscovery: ...` per-recipe processing logs
+- `WM-WorkerWrapper: Starting work for ...DiscoveryDownloadWorker`
+- `DiscoveryDownload: draining N discovery download(s)` — counts the rows that were just queued
+- After download completes (foreground service notification dismisses): a second `StashMixRefresh: ...` invocation (chained refresh)
+
+### Step 6: Verify new content appears
+
+After the chain completes (couple minutes depending on track count):
+1. Open Daily Discover. Track count should now be larger and include many tracks you don't recognize from your library.
+2. Open Deep Cuts. Same — new TRACK_SIMILAR content.
+3. Open First Listen. Same — new TAG_GRAPH content.
+4. Tap several tracks per mix — each should play immediately.
+
+### Step 7: Reporting
+
+When all manual checks pass, summarize:
+- Commits that landed
+- APK installed on the Pixel
+- Logcat evidence the pipeline fired end-to-end
+- Manual content-quality checks that passed
+- Any deferred or skipped items
+
+Do NOT push, do NOT tag.
+
+---
+
+## What's intentionally not in this plan
+
+YAGNI:
+
+- **No new test for `StashDiscoveryWorker.enqueueOneTime` or `HomeViewModel.refreshMix`.** WorkManager-invocation assertions via MockK are fragile; on-device verification covers it.
+- **No new `DiscoveryDownloadWorker` test.** Already comprehensively tested by PR 4 Task 3; PR 5 doesn't touch its internals.
+- **No UI affordance** ("Refresh + fetch new"). The existing "Refresh this mix" action now does both — no new UI element needed.
+- **No global "refresh all mixes" button.** The per-recipe refresh covers user need; the periodic schedule covers background updates.
+- **No telemetry for refresh latency or download success rate.** Build it if/when we need to optimize, not before.

--- a/docs/superpowers/plans/2026-05-11-mix-refresh-ux-feedback.md
+++ b/docs/superpowers/plans/2026-05-11-mix-refresh-ux-feedback.md
@@ -1,0 +1,800 @@
+# Mix Refresh + Lossless Sweep UX Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add enqueue + completion snackbar feedback to the two silent Home actions (long-press Refresh, banner tap-to-resolve), surface resolved/total counts from `LosslessRetryWorker`, and flip the mix-refresh periodic policy so existing installs reschedule against the current worker spec.
+
+**Architecture:** Three additive changes in three modules — no schema, no new entities, no new workers. Add a `_userMessages` SharedFlow to `HomeViewModel` (mirroring `NowPlayingViewModel`), wire a Toast collector in `HomeScreen` (mirroring `NowPlayingScreen`), emit start + WorkInfo-terminal messages from the two action methods, augment `LosslessRetryWorker.doWork` to return `(resolved, total)` output data, and switch `StashMixRefreshWorker.schedulePeriodic` from `KEEP` to `UPDATE`.
+
+**Tech Stack:** Kotlin, Compose, Hilt, WorkManager 2.10.1, MockK + JUnit4 for unit tests, Room.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-mix-refresh-ux-feedback-design.md` (committed at `3002a95`).
+
+---
+
+## Pre-flight notes for the implementer
+
+You're working in worktree `C:\Users\theno\Projects\MP3APK\.worktrees\first-listen-tag-fallback` on branch `feat/first-listen-tag-fallback`. The spec has been written and reviewed; this plan is what to actually build.
+
+### Repository conventions you must follow
+
+1. **String literals over `strings.xml`.** This codebase keeps user-facing snackbar copy as inline string literals in ViewModels (see `feature/nowplaying/.../NowPlayingViewModel.kt` lines 263, 281, 283, 303, 306). Do **not** introduce new string resources; the spec's copy table is a reference, not an instruction to use Android string resources.
+2. **Toast over Snackbar.** The established pattern (see `feature/nowplaying/.../NowPlayingScreen.kt:97-101`) is `android.widget.Toast.makeText(...).show()` inside a `LaunchedEffect(Unit) { viewModel.userMessages.collect { ... } }` block. There is no app-level `SnackbarHost`. Use Toast.
+3. **`_userMessages` template.** Copy the exact MutableSharedFlow shape from `NowPlayingViewModel.kt:54-67` (extraBufferCapacity = 8, DROP_OLDEST). The buffer-of-8 is load-bearing — `v0.9.18` post-mortem (Find-in-FLAC ships two messages back-to-back; capacity-of-1 race dropped the first).
+4. **TDD on worker changes.** `LosslessRetryWorkerTest.kt` exists and uses MockK with hand-constructed `LosslessRetryWorker` instances; extend it. There is **no** existing `HomeViewModelTest.kt`; the ViewModel changes will be exercised by manual on-device verification (golden-path + edge cases per the spec's Manual Test Plan) rather than by unit tests, because the new VM logic is trivial wiring and the only non-trivial piece — output-data math — is already covered by worker unit tests.
+5. **No push, no tag.** Per user instruction (memory: `feedback_ship_terminology.md`), implementation ends at "APK installed on Pixel + manual verification." Do not push the branch, do not create a release tag.
+6. **No dev-time estimates.** Per memory: `feedback_no_time_estimates.md`.
+7. **Always `:app:installDebug` after a fix.** Per memory: `feedback_install_after_fix.md` — compile-pass isn't enough.
+
+### Files you will touch
+
+| Path | What changes |
+|---|---|
+| `data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessRetryWorker.kt` | Add `KEY_RESOLVED` + `KEY_TOTAL` companion constants; track `resolvedCount`; return `Result.success(workDataOf(...))`. |
+| `data/download/src/test/kotlin/com/stash/data/download/lossless/LosslessRetryWorkerTest.kt` | Update existing tests + add new assertions on output data for empty / no-match / partial-match. |
+| `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt` | One-line flip on line 121: `ExistingPeriodicWorkPolicy.KEEP` → `ExistingPeriodicWorkPolicy.UPDATE`. |
+| `feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt` | Add `_userMessages` SharedFlow + `userMessages` SharedFlow. Modify `refreshMix` (line 554) and `onRetryDeferredRequested` (line 404) to emit start + terminal messages and observe WorkInfo. |
+| `feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt` | Add `LaunchedEffect(Unit) { viewModel.userMessages.collect { ... } }` block near the top of the Composable that hosts `viewModel`. |
+
+### Reference snippets you'll be copy-adapting
+
+**From `NowPlayingViewModel.kt:54-67`** — the SharedFlow declaration template:
+
+```kotlin
+private val _userMessages = MutableSharedFlow<String>(
+    extraBufferCapacity = 8,
+    onBufferOverflow = BufferOverflow.DROP_OLDEST,
+)
+/** One-shot snackbar messages. */
+val userMessages: SharedFlow<String> = _userMessages.asSharedFlow()
+```
+
+**From `NowPlayingScreen.kt:96-101`** — the Toast collector template:
+
+```kotlin
+val toastContext = LocalContext.current
+LaunchedEffect(Unit) {
+    viewModel.userMessages.collect { msg ->
+        android.widget.Toast.makeText(toastContext, msg, android.widget.Toast.LENGTH_LONG).show()
+    }
+}
+```
+
+**WorkInfo observation API (WorkManager 2.10.1):**
+
+```kotlin
+WorkManager.getInstance(context)
+    .getWorkInfosForUniqueWorkFlow(uniqueWorkName)
+    .collect { workInfos ->
+        // List<WorkInfo>. Filter by id if needed.
+    }
+```
+
+---
+
+## Task 1: `LosslessRetryWorker` output data (TDD)
+
+**Files:**
+- Modify: `data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessRetryWorker.kt`
+- Modify: `data/download/src/test/kotlin/com/stash/data/download/lossless/LosslessRetryWorkerTest.kt`
+
+- [ ] **Step 1: Read both files in full so you understand the current shape**
+
+Run:
+
+```bash
+# Read in your editor; no command required.
+```
+
+Confirm: the production file is 79 lines, no companion constants yet for output keys. The test file has 3 existing tests using `assertEquals(Result.success(), result)`. Empty-input early return is at line 46.
+
+- [ ] **Step 2: Write failing tests for output data emission**
+
+Open `LosslessRetryWorkerTest.kt`. Replace the existing three `@Test` methods with the following (adding new `KEY_RESOLVED` / `KEY_TOTAL` assertions). Three test cases stay; assertions get richer.
+
+```kotlin
+@Test
+fun `resolved row flips to PENDING and reports resolved=1 total=1`() = runTest {
+    coEvery { downloadQueueDao.waitingForLosslessTracks() } returns listOf(
+        entry(id = 100L, trackId = 1L),
+    )
+    coEvery { trackDao.getById(1L) } returns stubTrackEntity(1L)
+    coEvery { registry.resolve(any()) } returns stubSourceResult()
+
+    val result = newWorker().doWork() as androidx.work.ListenableWorker.Result.Success
+
+    assertEquals(1, result.outputData.getInt(LosslessRetryWorker.KEY_RESOLVED, -1))
+    assertEquals(1, result.outputData.getInt(LosslessRetryWorker.KEY_TOTAL, -1))
+    coVerify(exactly = 1) {
+        downloadQueueDao.updateStatus(
+            id = 100L,
+            status = DownloadStatus.PENDING,
+        )
+    }
+}
+
+@Test
+fun `unresolved row stays WAITING_FOR_LOSSLESS and reports resolved=0 total=1`() = runTest {
+    coEvery { downloadQueueDao.waitingForLosslessTracks() } returns listOf(
+        entry(id = 100L, trackId = 1L),
+    )
+    coEvery { trackDao.getById(1L) } returns stubTrackEntity(1L)
+    coEvery { registry.resolve(any()) } returns null
+
+    val result = newWorker().doWork() as androidx.work.ListenableWorker.Result.Success
+
+    assertEquals(0, result.outputData.getInt(LosslessRetryWorker.KEY_RESOLVED, -1))
+    assertEquals(1, result.outputData.getInt(LosslessRetryWorker.KEY_TOTAL, -1))
+    coVerify(exactly = 0) {
+        downloadQueueDao.updateStatus(any(), any(), any(), any(), any(), any())
+    }
+}
+
+@Test
+fun `empty deferred set returns resolved=0 total=0`() = runTest {
+    coEvery { downloadQueueDao.waitingForLosslessTracks() } returns emptyList()
+
+    val result = newWorker().doWork() as androidx.work.ListenableWorker.Result.Success
+
+    assertEquals(0, result.outputData.getInt(LosslessRetryWorker.KEY_RESOLVED, -1))
+    assertEquals(0, result.outputData.getInt(LosslessRetryWorker.KEY_TOTAL, -1))
+    coVerify(exactly = 0) {
+        downloadQueueDao.updateStatus(any(), any(), any(), any(), any(), any())
+    }
+}
+
+@Test
+fun `partial match across 3 rows reports resolved=2 total=3`() = runTest {
+    coEvery { downloadQueueDao.waitingForLosslessTracks() } returns listOf(
+        entry(id = 100L, trackId = 1L),
+        entry(id = 101L, trackId = 2L),
+        entry(id = 102L, trackId = 3L),
+    )
+    coEvery { trackDao.getById(1L) } returns stubTrackEntity(1L)
+    coEvery { trackDao.getById(2L) } returns stubTrackEntity(2L)
+    coEvery { trackDao.getById(3L) } returns stubTrackEntity(3L)
+    coEvery { registry.resolve(match { it.title == "Track 1" }) } returns stubSourceResult()
+    coEvery { registry.resolve(match { it.title == "Track 2" }) } returns null
+    coEvery { registry.resolve(match { it.title == "Track 3" }) } returns stubSourceResult()
+
+    val result = newWorker().doWork() as androidx.work.ListenableWorker.Result.Success
+
+    assertEquals(2, result.outputData.getInt(LosslessRetryWorker.KEY_RESOLVED, -1))
+    assertEquals(3, result.outputData.getInt(LosslessRetryWorker.KEY_TOTAL, -1))
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run from worktree root:
+
+```bash
+./gradlew :data:download:testDebugUnitTest --tests "com.stash.data.download.lossless.LosslessRetryWorkerTest"
+```
+
+Expected: 4 tests fail. The first three because the worker doesn't expose `KEY_RESOLVED` / `KEY_TOTAL` constants (compile error). The fourth because `partial match across 3 rows` is brand new.
+
+If the compile errors are about the constants not existing, that confirms the test is wired correctly. Move on.
+
+- [ ] **Step 4: Implement the production change**
+
+Edit `LosslessRetryWorker.kt`. Make four targeted edits:
+
+1. **Add `KEY_RESOLVED` and `KEY_TOTAL` to the companion object** (replacing the existing `companion object`):
+
+```kotlin
+companion object {
+    const val UNIQUE_WORK_NAME = "lossless-retry"
+
+    /** Output-data key: how many WAITING_FOR_LOSSLESS rows were flipped to PENDING this sweep. */
+    const val KEY_RESOLVED = "lossless_retry_resolved"
+
+    /** Output-data key: how many WAITING_FOR_LOSSLESS rows existed when the sweep started. */
+    const val KEY_TOTAL = "lossless_retry_total"
+}
+```
+
+2. **Replace the empty-input early return at line 46** so it carries output data:
+
+```kotlin
+val deferred = downloadQueueDao.waitingForLosslessTracks()
+if (deferred.isEmpty()) {
+    return Result.success(
+        androidx.work.workDataOf(
+            KEY_RESOLVED to 0,
+            KEY_TOTAL to 0,
+        ),
+    )
+}
+```
+
+3. **Track resolved count inside the loop** and **return with output data**:
+
+```kotlin
+var resolvedCount = 0
+for (entry in deferred) {
+    val track = trackDao.getById(entry.trackId) ?: continue
+    val match = runCatching {
+        registry.resolve(
+            TrackQuery(
+                artist = track.artist,
+                title = track.title,
+                album = track.album.takeIf { it.isNotBlank() },
+                isrc = track.isrc,
+                durationMs = track.durationMs.takeIf { it > 0 },
+            ),
+        )
+    }.getOrNull()
+    if (match != null) {
+        downloadQueueDao.updateStatus(
+            id = entry.id,
+            status = DownloadStatus.PENDING,
+        )
+        resolvedCount++
+    }
+}
+return Result.success(
+    androidx.work.workDataOf(
+        KEY_RESOLVED to resolvedCount,
+        KEY_TOTAL to deferred.size,
+    ),
+)
+```
+
+4. **Add the import** at the top if not already present:
+
+```kotlin
+import androidx.work.workDataOf
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+./gradlew :data:download:testDebugUnitTest --tests "com.stash.data.download.lossless.LosslessRetryWorkerTest"
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 6: Run the full module test suite to catch regressions**
+
+```bash
+./gradlew :data:download:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL. No previously-passing tests should fail.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessRetryWorker.kt \
+        data/download/src/test/kotlin/com/stash/data/download/lossless/LosslessRetryWorkerTest.kt
+git commit -m "feat(lossless): emit resolved/total counts from retry worker
+
+Adds KEY_RESOLVED and KEY_TOTAL output-data keys so the Home banner
+tap-to-resolve can show 'Resolved X/Y' or 'None resolved this time'
+after the sweep. No behavior change for the worker itself; the
+PENDING flip on match is unchanged. Empty-queue early return now
+carries (0, 0) output data so UI consumers never read null.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `StashMixRefreshWorker` periodic policy flip
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt:121`
+
+- [ ] **Step 1: Make the one-line change**
+
+Open `StashMixRefreshWorker.kt` and find `schedulePeriodic` (function starts at line 109, the `enqueueUniquePeriodicWork` call is at lines 119-123). Change `ExistingPeriodicWorkPolicy.KEEP` to `ExistingPeriodicWorkPolicy.UPDATE`:
+
+```kotlin
+WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+    WORK_NAME,
+    ExistingPeriodicWorkPolicy.UPDATE,
+    work,
+)
+```
+
+Add a brief comment above the call explaining the choice:
+
+```kotlin
+// v0.9.20: UPDATE (not KEEP) so existing installs reschedule against
+// the current worker spec on the next cold start. KEEP previously meant
+// constraint changes / class changes were ignored across upgrades —
+// a credible cause of "periodic refresh hasn't fired in 3 days" reports.
+WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+    WORK_NAME,
+    ExistingPeriodicWorkPolicy.UPDATE,
+    work,
+)
+```
+
+- [ ] **Step 2: Build the module to verify no regression**
+
+```bash
+./gradlew :core:data:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Run the module test suite**
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL. No tests reference the periodic policy directly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+git commit -m "feat(mix): flip mix-refresh periodic policy to UPDATE
+
+KEEP preserves stale workspecs across upgrades, which can leave
+existing installs running against constraints / worker code from a
+previous version. UPDATE re-applies the current spec on every cold
+start, ensuring constraint and worker changes ship to existing users.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add `_userMessages` SharedFlow to `HomeViewModel`
+
+**Files:**
+- Modify: `feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt`
+
+- [ ] **Step 1: Add the import for `BufferOverflow` and `MutableSharedFlow`**
+
+At the top of `HomeViewModel.kt`, near the other `kotlinx.coroutines.flow.*` imports, add:
+
+```kotlin
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+```
+
+(`asSharedFlow` is already imported on line 40. `SharedFlow` may already be imported — check first.)
+
+- [ ] **Step 2: Add the SharedFlow declaration**
+
+Find an appropriate spot — typically right after the existing `_uiState` / `uiState` declarations, before the `init {}` block. Use the NowPlayingViewModel pattern verbatim:
+
+```kotlin
+private val _userMessages = MutableSharedFlow<String>(
+    // Bumped to 8 to mirror NowPlayingViewModel — actions that emit two
+    // back-to-back messages (refresh start → done, lossless retry start →
+    // result) need headroom against the Toast collector's drain rate.
+    extraBufferCapacity = 8,
+    onBufferOverflow = BufferOverflow.DROP_OLDEST,
+)
+/** One-shot snackbar messages (e.g. "Refreshing Daily Discover…"). */
+val userMessages: SharedFlow<String> = _userMessages.asSharedFlow()
+```
+
+- [ ] **Step 3: Build to verify no regression**
+
+```bash
+./gradlew :feature:home:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+git commit -m "feat(home): add userMessages SharedFlow for one-shot Toast emissions
+
+Mirrors NowPlayingViewModel. Wires the channel without any emitters
+yet — subsequent commits emit from refreshMix and
+onRetryDeferredRequested. Buffer of 8 matches NowPlayingViewModel for
+back-to-back start/result emissions.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire the Toast collector in `HomeScreen`
+
+**Files:**
+- Modify: `feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt`
+
+- [ ] **Step 1: Locate the Composable that holds `viewModel` and the `uiState` collection**
+
+Open `HomeScreen.kt` and find the main `@Composable fun HomeScreen(...)` (or whichever Composable obtains `viewModel: HomeViewModel = hiltViewModel()` and calls `viewModel.uiState.collectAsStateWithLifecycle()`).
+
+You may need to grep for `collectAsStateWithLifecycle` to find it. Example pattern from `NowPlayingScreen.kt:83-101`:
+
+```kotlin
+val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+// ... other state holders ...
+
+val toastContext = LocalContext.current
+LaunchedEffect(Unit) {
+    viewModel.userMessages.collect { msg ->
+        android.widget.Toast.makeText(toastContext, msg, android.widget.Toast.LENGTH_LONG).show()
+    }
+}
+```
+
+- [ ] **Step 2: Add the collector**
+
+Immediately after `viewModel.uiState.collectAsStateWithLifecycle()` (and any other initial state declarations), insert:
+
+```kotlin
+val toastContext = LocalContext.current
+LaunchedEffect(Unit) {
+    viewModel.userMessages.collect { msg ->
+        android.widget.Toast.makeText(toastContext, msg, android.widget.Toast.LENGTH_LONG).show()
+    }
+}
+```
+
+If `LocalContext` is not imported, add:
+
+```kotlin
+import androidx.compose.ui.platform.LocalContext
+```
+
+(It may already be imported — check.)
+
+- [ ] **Step 3: Build and verify**
+
+```bash
+./gradlew :feature:home:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
+git commit -m "feat(home): wire Toast collector for userMessages
+
+Mirrors the NowPlayingScreen pattern — LaunchedEffect(Unit) collects
+viewModel.userMessages and shows each string as a LONG Toast. No
+emitters yet (subsequent commits wire refreshMix and the lossless
+retry banner tap), so this commit is a no-op at runtime.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `refreshMix` snackbar lifecycle
+
+**Files:**
+- Modify: `feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt:546-559`
+
+- [ ] **Step 1: Add the imports for WorkInfo observation**
+
+Near the existing `androidx.work.*` imports in `HomeViewModel.kt`, add:
+
+```kotlin
+import androidx.work.WorkInfo
+import androidx.work.await
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+```
+
+(`first` may already be imported on line 45 — check before adding a duplicate. `await` is the suspend extension on `Operation`/`ListenableFuture` from `work-runtime-ktx`.)
+
+Also add an Android `Log` import if not already present:
+
+```kotlin
+import android.util.Log
+```
+
+For the log tag, use a file-level top-level constant (matches the prevailing pattern elsewhere in the codebase and avoids hunting for an existing companion object inside HomeViewModel). Add this **outside** the class body (above the `@HiltViewModel` annotation, in the file's top-level namespace):
+
+```kotlin
+private const val TAG = "HomeViewModel"
+```
+
+- [ ] **Step 2: Replace `refreshMix` (lines 554-559) with the new implementation**
+
+Old (current code at lines 554-559):
+
+```kotlin
+fun refreshMix(playlistId: Long) {
+    viewModelScope.launch {
+        val recipe = recipeDao.findByPlaylistId(playlistId) ?: return@launch
+        StashMixRefreshWorker.enqueueOneTime(context, recipe.id)
+    }
+}
+```
+
+New (keep the existing KDoc above the function; replace only the function body):
+
+```kotlin
+fun refreshMix(playlistId: Long) {
+    viewModelScope.launch {
+        val recipe = recipeDao.findByPlaylistId(playlistId)
+        if (recipe == null) {
+            // Data-integrity bug: playlist.type == STASH_MIX but no recipe
+            // back-links it. Menu shouldn't have appeared. Log + soft-fail.
+            Log.w(TAG, "refreshMix: no recipe back-links playlistId=$playlistId")
+            _userMessages.tryEmit("Couldn't refresh — this mix isn't linked to a recipe")
+            return@launch
+        }
+
+        _userMessages.tryEmit("Refreshing ${recipe.name}\u2026")
+
+        // Build the request ourselves so we can capture its id for exact-
+        // match WorkInfo filtering below. enqueueUniqueWork uses the same
+        // unique name + REPLACE policy as StashMixRefreshWorker.enqueueOneTime,
+        // mirroring lines 154-168 of that worker.
+        val request = OneTimeWorkRequestBuilder<StashMixRefreshWorker>()
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build(),
+            )
+            .setInputData(workDataOf(StashMixRefreshWorker.KEY_RECIPE_ID to recipe.id))
+            .build()
+        val uniqueName = "${StashMixRefreshWorker.ONE_SHOT_WORK_NAME}_${recipe.id}"
+        WorkManager.getInstance(context)
+            .enqueueUniqueWork(uniqueName, ExistingWorkPolicy.REPLACE, request)
+
+        // Observe the unique-work Flow; filter to OUR enqueued request's id
+        // so historical entries from earlier taps (or earlier sessions)
+        // don't fire stale "Refreshed" Toasts.
+        WorkManager.getInstance(context)
+            .getWorkInfosForUniqueWorkFlow(uniqueName)
+            .firstOrNull { infos ->
+                val ours = infos.firstOrNull { it.id == request.id } ?: return@firstOrNull false
+                when (ours.state) {
+                    WorkInfo.State.SUCCEEDED -> {
+                        _userMessages.tryEmit("Refreshed ${recipe.name}")
+                        true
+                    }
+                    WorkInfo.State.FAILED, WorkInfo.State.CANCELLED -> {
+                        _userMessages.tryEmit("Refresh failed \u2014 try again later")
+                        true
+                    }
+                    else -> false
+                }
+            }
+    }
+}
+```
+
+Add these imports near the existing `androidx.work.*` imports:
+
+```kotlin
+import androidx.work.Constraints
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.workDataOf
+```
+
+(`ExistingWorkPolicy` is already imported on line 31.)
+
+**Why we build the request inline instead of calling `StashMixRefreshWorker.enqueueOneTime(context, recipe.id)`:** the helper doesn't return the `WorkRequest`, so we can't capture its `id`. We need that id to filter the WorkInfo Flow — otherwise `getWorkInfosForUniqueWorkFlow` would surface historical entries from previous sessions and we'd emit a stale "Refreshed X" Toast the moment the user opens the Home screen again. Duplicating the request builder is acceptable because the surface is small (4 lines) and the worker's spec is stable.
+
+**Why a coroutine-suspend `.firstOrNull` instead of `.launchIn`:** the whole `refreshMix` body is already a coroutine via `viewModelScope.launch`; suspending until terminal-state simplifies cancellation and avoids managing a separate Job for the observer. When the ViewModel dies, the parent `viewModelScope.launch` is cancelled, and so is this suspended call.
+
+- [ ] **Step 3: Sanity-check `ONE_SHOT_WORK_NAME` is exposed for use here**
+
+In `StashMixRefreshWorker.kt`, the constant is currently declared `private const val ONE_SHOT_WORK_NAME = "stash_mix_refresh_oneshot"` (line 89). Check whether it is `private` (visible only inside the companion) or `internal` / public. If it's `private`, change it to `const val` (no `private`) — promoting to `internal` within the companion object — and verify the build still passes.
+
+You may need to change:
+
+```kotlin
+private const val ONE_SHOT_WORK_NAME = "stash_mix_refresh_oneshot"
+```
+
+to:
+
+```kotlin
+const val ONE_SHOT_WORK_NAME = "stash_mix_refresh_oneshot"
+```
+
+If the field was already non-private, skip this change.
+
+- [ ] **Step 4: Build and verify**
+
+```bash
+./gradlew :feature:home:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt \
+        core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+git commit -m "feat(home): emit refresh snackbar lifecycle for single-mix refresh
+
+Long-press 'Refresh this mix' now shows 'Refreshing X…' on enqueue
+and 'Refreshed X' (or 'Refresh failed') when the worker reaches a
+terminal WorkInfo state. The data-integrity branch (STASH_MIX
+playlist with no back-linked recipe) now logs and tells the user
+instead of silently no-opping.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `onRetryDeferredRequested` snackbar lifecycle
+
+**Files:**
+- Modify: `feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt:404-411`
+
+- [ ] **Step 1: Verify the DAO Flow that powers the waiting count**
+
+The spec said to confirm the DAO method. We already verified: `DownloadQueueDao.waitingForLosslessCount(): Flow<Int>` (line 60 of `DownloadQueueDao.kt`). Confirm it's already injected — HomeViewModel constructor takes `downloadQueueDao: DownloadQueueDao` (line 76).
+
+- [ ] **Step 2: Replace `onRetryDeferredRequested` (lines 404-411) with the new implementation**
+
+Old:
+
+```kotlin
+fun onRetryDeferredRequested() {
+    val request = OneTimeWorkRequestBuilder<LosslessRetryWorker>().build()
+    WorkManager.getInstance(context).enqueueUniqueWork(
+        LosslessRetryWorker.UNIQUE_WORK_NAME,
+        ExistingWorkPolicy.KEEP,
+        request,
+    )
+}
+```
+
+New (keep the existing KDoc; replace only the body):
+
+```kotlin
+fun onRetryDeferredRequested() {
+    viewModelScope.launch {
+        // Snapshot the current count before we kick the worker so the
+        // start message and the math after both reference the same N.
+        val countAtStart = downloadQueueDao.waitingForLosslessCount().first()
+        if (countAtStart <= 0) return@launch  // banner shouldn't be visible
+
+        _userMessages.tryEmit("Looking for FLAC versions of $countAtStart tracks\u2026")
+
+        val request = OneTimeWorkRequestBuilder<LosslessRetryWorker>().build()
+        // KEEP policy: a rapid double-tap coalesces. Suspend on the
+        // Operation's await() (work-runtime-ktx) so we don't block the
+        // viewModelScope's Main.immediate dispatcher.
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            LosslessRetryWorker.UNIQUE_WORK_NAME,
+            ExistingWorkPolicy.KEEP,
+            request,
+        ).await()
+
+        // Observe the unique-work Flow. Filter to OUR enqueued request's
+        // id so historical entries from earlier sessions don't fire stale
+        // "Resolved …" Toasts. Under KEEP policy a coalesced tap will see
+        // the SAME id as the in-flight work, so this still drains correctly
+        // on every tap.
+        WorkManager.getInstance(context)
+            .getWorkInfosForUniqueWorkFlow(LosslessRetryWorker.UNIQUE_WORK_NAME)
+            .firstOrNull { infos ->
+                val ours = infos.firstOrNull { it.id == request.id } ?: return@firstOrNull false
+                when (ours.state) {
+                    WorkInfo.State.SUCCEEDED -> {
+                        val resolved = ours.outputData.getInt(LosslessRetryWorker.KEY_RESOLVED, 0)
+                        val total = ours.outputData.getInt(LosslessRetryWorker.KEY_TOTAL, 0)
+                        val message = if (resolved == 0) {
+                            "None resolved this time \u2014 we'll keep trying."
+                        } else {
+                            val remaining = total - resolved
+                            "Resolved $resolved/$total. $remaining still waiting."
+                        }
+                        _userMessages.tryEmit(message)
+                        true
+                    }
+                    WorkInfo.State.FAILED, WorkInfo.State.CANCELLED -> {
+                        _userMessages.tryEmit("Sweep failed \u2014 try again later")
+                        true
+                    }
+                    else -> false
+                }
+            }
+    }
+}
+```
+
+**Why exact-id filter:** `getWorkInfosForUniqueWorkFlow` returns historical entries; filtering on `request.id` ensures we only react to the WorkInfo for the work we just enqueued. This closes Failure Mode #6 from the spec (stale "Resolved …" messages on screen re-entry).
+
+**Why `Operation.await()` (suspend) over `Operation.result.get()`:** `viewModelScope.launch` defaults to `Dispatchers.Main.immediate`. `ListenableFuture.get()` blocks the calling thread until the future resolves; doing that on the Main dispatcher would freeze the UI thread, however briefly. `await()` from `androidx.work` (provided by `work-runtime-ktx`, already on the classpath) suspends correctly.
+
+- [ ] **Step 3: Build and verify**
+
+```bash
+./gradlew :feature:home:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+git commit -m "feat(home): emit lossless retry sweep lifecycle messages
+
+Banner tap-to-resolve now shows 'Looking for FLAC versions of N
+tracks…' on enqueue and either 'Resolved X/Y. Z still waiting.' or
+'None resolved this time — we'll keep trying.' when the worker
+returns. Zero-count taps short-circuit before enqueue.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Build APK + install + on-device manual verification
+
+**Files:** none — this is a verification task.
+
+- [ ] **Step 1: Full project build**
+
+```bash
+./gradlew :app:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 2: Install on connected Pixel**
+
+```bash
+./gradlew :app:installDebug
+```
+
+Expected: installation succeeds. If multiple devices, use `-PdeviceSerial=1A021FDEE002RD` or similar.
+
+- [ ] **Step 3: Manual test plan from the spec**
+
+Open the app and confirm each of the following:
+
+1. **Cold start sanity** — Force-stop the app via Android Settings, then relaunch. Verify it doesn't crash on `enqueueUniquePeriodicWork(UPDATE)`. Run `adb logcat -d | grep StashMixRefresh` (one-shot dump of the existing buffer) and confirm no exception.
+2. **Refresh Daily Discover** — Long-press the Daily Discover card → tap "Refresh this mix." Expect:
+   - Bottom sheet dismisses.
+   - Toast: `Refreshing Daily Discover…` within ~100ms.
+   - Toast: `Refreshed Daily Discover` after the worker completes (few seconds).
+3. **Refresh Deep Cuts** — same flow, same expectations.
+4. **Refresh First Listen** — same flow, same expectations.
+5. **Banner tap with non-zero count** — Wait for the "N tracks waiting for lossless" banner to appear, tap it. Expect:
+   - Toast: `Looking for FLAC versions of N tracks…`.
+   - Toast after the sweep: `None resolved this time — we'll keep trying.` (because Symptom 4a's match-quality fix is deferred to a separate PR).
+6. **JobScheduler verification** — Run:
+   ```bash
+   adb shell dumpsys jobscheduler | grep -A 5 -i "stash_mix_refresh"
+   ```
+   Expect: at least one scheduled job for `StashMixRefreshWorker` under the app's uid.
+
+- [ ] **Step 4: If manual testing reveals issues, fix them with TDD-style additions**
+
+Any bug found during manual testing should produce a new failing test or a logcat trace, then a fix commit. Do not push past unfixed issues.
+
+- [ ] **Step 5: Report back to the user**
+
+When all manual steps pass, surface a short status message that lists:
+- The commits that landed on this branch
+- The APK installed on the Pixel
+- The manual checks that passed
+- Any deferred or skipped items
+
+Do **not** push the branch and do **not** create a release tag. The user explicitly gates release on their own on-device verification (per memory `feedback_ship_terminology.md`).
+
+---
+
+## What's intentionally not in this plan
+
+Following YAGNI:
+
+- **No new `HomeViewModelTest.kt`.** The new VM logic is trivial wiring on top of a thoroughly-tested worker. Adding a Robolectric harness + fake WorkManager to test "did we emit the right string" is more setup than the test is worth at this stage. If a regression bites, we add the test then.
+- **No `strings.xml` plumbing.** The codebase convention is inline literals. The spec's copy table is the source of truth for *what* to emit, not *how*.
+- **No SnackbarHost migration.** The Toast pattern is what every other screen uses; switching one screen is inconsistent for no benefit.
+- **No instrumentation/dev surface.** The spec mentioned this as a possible follow-up; defer until PR 1 + 4 ship and we have a baseline to compare against.
+- **No `HomeViewModelTest`.** Repeated for emphasis — adding a Robolectric/fake-WorkManager harness for two methods that emit strings and observe a Flow is more setup than payoff. Manual on-device verification (Task 7) covers the user-facing paths; worker output-data math is covered by Task 1's unit tests.

--- a/docs/superpowers/plans/2026-05-11-stash-mix-recommendation-pivot.md
+++ b/docs/superpowers/plans/2026-05-11-stash-mix-recommendation-pivot.md
@@ -1,0 +1,1288 @@
+# Stash Mix Recommendation Pivot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Shift Daily Discover and Deep Cuts from library-substrate to recommendation-substrate (85% discovery), with cross-mix track dedup and a shortfall-fill gate that stops library backfill on high-discovery recipes.
+
+**Architecture:** Six small, sequential changes across `StashMixRecipeDao` (signature expansion), `MixGenerator` (excludeIds param + shortfall threshold), `StashMixRefreshWorker` (materializeMix returns picked discovery ids; doWork orchestrates dedup ordering), `StashMixDefaults` (retuned builtin entries), and `StashApplication` (new version-gated migration mirroring the existing `maybeRetuneStashDiscover` pattern).
+
+**Tech Stack:** Kotlin, Room, WorkManager, Hilt, MockK + JUnit4 for ViewModel/Worker tests, Robolectric + Room in-memory for DAO behavior tests.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-stash-mix-recommendation-pivot-design.md` (committed at `7744b3a`).
+
+---
+
+## Pre-flight notes for the implementer
+
+Worktree: `C:\Users\theno\Projects\MP3APK\.worktrees\first-listen-tag-fallback`. Branch: `feat/first-listen-tag-fallback`. PR 1 already shipped 11 commits on this branch — verify your work lands on top, don't rebase.
+
+### Repository conventions you must follow
+
+1. **TDD with bite-sized tasks.** Each task either follows the test-first cycle or is mechanical configuration. Build pass + module test sweep after every commit.
+2. **MockK for unit tests over collaborators (MixGenerator, StashMixRefreshWorker); Robolectric + Room in-memory for DAO behavior tests.** This module already mixes the two patterns — match the precedent of `MixGeneratorComputeUserTopTagsTest` (MockK) and `DiscoveryQueueDaoCapTest` (Robolectric + Room).
+3. **Inline string literals** for any user-facing messages, but this PR has none (purely backend).
+4. **No `--no-verify`. No `--amend`. No push, no tag.** Per memory `feedback_ship_terminology.md`, implementation ends at "APK installed on Pixel + manual verification."
+5. **Always `:app:installDebug` after a fix.** Per memory `feedback_install_after_fix.md`.
+6. **No dev-time estimates** anywhere. Per memory `feedback_no_time_estimates.md`.
+
+### Files you will touch
+
+| Path | What changes |
+|---|---|
+| `core/data/src/main/kotlin/com/stash/core/data/db/dao/StashMixRecipeDao.kt` | Expand `retuneBuiltin` signature: add `affinityBias: Float, seedStrategy: String`. |
+| `core/data/src/test/kotlin/com/stash/core/data/db/dao/StashMixRecipeDaoRetuneTest.kt` | **CREATE** — Robolectric + Room in-memory tests for the expanded signature. |
+| `app/src/main/kotlin/com/stash/app/StashApplication.kt` | Fix the existing `maybeRetuneStashDiscover` call site to pass the new params. Add `maybeRetuneStashMixes` + `STASH_MIX_RECIPE_TUNING_VERSION` constant. Wire into startup sequence. |
+| `core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt` | Add `excludeIds: Set<Long> = emptySet()` to `generate`. Raise shortfall-fill threshold from `< 1.0f` to `< 0.5f`. |
+| `core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorExcludeIdsTest.kt` | **CREATE** — MockK tests for the excludeIds filter. |
+| `core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorShortfallFillTest.kt` | **CREATE** — MockK tests for the shortfall-fill gate. |
+| `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt` | Refactor `materializeMix` to return `MaterializeResult(playlistId, discoveryIds)`, accept `excludeIds: Set<Long>`. Add private `recipeDedupPriority` helper. Rewrite `doWork` iteration to accumulate excludeIds across ordered recipes. Over-fetch discovery survivors so post-filter still fills the cap. |
+| `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt` | **CREATE** — MockK end-to-end test of the dedup orchestration. |
+| `core/data/src/main/kotlin/com/stash/core/data/mix/StashMixDefaults.kt` | Retune Daily Discover + Deep Cuts builtin rows. |
+
+### Reference precedents
+
+- **DAO Robolectric test pattern:** `core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt`.
+- **MixGenerator MockK test pattern:** `core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorComputeUserTopTagsTest.kt`.
+- **Worker MockK test pattern:** `data/download/src/test/kotlin/com/stash/data/download/lossless/LosslessRetryWorkerTest.kt`.
+- **Existing version-gated migration:** `app/src/main/kotlin/com/stash/app/StashApplication.kt:335-355` (`maybeRetuneStashDiscover`). Mirror this exactly.
+
+---
+
+## Task 1: Expand `retuneBuiltin` signature + update existing call site
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/db/dao/StashMixRecipeDao.kt`
+- Modify: `app/src/main/kotlin/com/stash/app/StashApplication.kt:339-344` (the existing `maybeRetuneStashDiscover` call to `retuneBuiltin`)
+- Create: `core/data/src/test/kotlin/com/stash/core/data/db/dao/StashMixRecipeDaoRetuneTest.kt`
+
+The DAO currently has a 4-arg `retuneBuiltin`. We need 6 args (add `affinityBias`, `seedStrategy`). Expanding it compile-errors the existing call site in `StashApplication.maybeRetuneStashDiscover`, which we fix in the same commit.
+
+- [ ] **Step 1: Read the current DAO definition**
+
+Open `StashMixRecipeDao.kt`. The current method at lines 79-100 is the 4-arg version. Read it to confirm shape (KDoc + `@Query` + signature).
+
+- [ ] **Step 2: Read the existing call site**
+
+Open `StashApplication.kt`. Lines 335-355 are `maybeRetuneStashDiscover`. The call at lines 339-344 currently passes 4 args (name, discoveryRatio, freshnessWindowDays, targetLength). You'll update it in Step 6.
+
+- [ ] **Step 3: Write the failing DAO test**
+
+Create `core/data/src/test/kotlin/com/stash/core/data/db/dao/StashMixRecipeDaoRetuneTest.kt`:
+
+```kotlin
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [StashMixRecipeDao.retuneBuiltin] — specifically the v0.9.20
+ * expansion that adds affinityBias and seedStrategy to the SET clause so
+ * the recipe-pivot migration can update all five tunable fields in one
+ * UPDATE.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class StashMixRecipeDaoRetuneTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: StashMixRecipeDao
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.stashMixRecipeDao()
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `retuneBuiltin updates all 5 tunable fields including affinityBias and seedStrategy`() = runTest {
+        dao.insert(
+            StashMixRecipeEntity(
+                name = "Daily Discover",
+                discoveryRatio = 0.4f,
+                freshnessWindowDays = 7,
+                targetLength = 50,
+                affinityBias = 0.3f,
+                seedStrategy = "ARTIST_SIMILAR",
+                isBuiltin = true,
+            )
+        )
+
+        val updated = dao.retuneBuiltin(
+            name = "Daily Discover",
+            discoveryRatio = 0.85f,
+            freshnessWindowDays = 7,
+            targetLength = 40,
+            affinityBias = 0.0f,
+            seedStrategy = "ARTIST_SIMILAR",
+        )
+
+        assertEquals(1, updated)
+        val after = dao.getActive().single()
+        assertEquals(0.85f, after.discoveryRatio)
+        assertEquals(40, after.targetLength)
+        assertEquals(0.0f, after.affinityBias)
+        assertEquals("ARTIST_SIMILAR", after.seedStrategy)
+        assertEquals(7, after.freshnessWindowDays)
+    }
+
+    @Test fun `retuneBuiltin is idempotent — second call with same values returns 1 with no state change`() = runTest {
+        dao.insert(
+            StashMixRecipeEntity(
+                name = "Deep Cuts",
+                discoveryRatio = 0.85f,
+                freshnessWindowDays = 90,
+                targetLength = 40,
+                affinityBias = 0.0f,
+                seedStrategy = "TRACK_SIMILAR",
+                isBuiltin = true,
+            )
+        )
+
+        val first = dao.retuneBuiltin("Deep Cuts", 0.85f, 90, 40, 0.0f, "TRACK_SIMILAR")
+        val second = dao.retuneBuiltin("Deep Cuts", 0.85f, 90, 40, 0.0f, "TRACK_SIMILAR")
+
+        assertEquals(1, first)
+        assertEquals(1, second) // SQLite UPDATE rowcount is rows-matched, not rows-changed
+        val after = dao.getActive().single()
+        assertEquals("TRACK_SIMILAR", after.seedStrategy)
+    }
+
+    @Test fun `retuneBuiltin does not touch non-builtin recipes with the same name`() = runTest {
+        dao.insert(
+            StashMixRecipeEntity(
+                name = "Daily Discover",
+                discoveryRatio = 0.4f,
+                affinityBias = 0.3f,
+                seedStrategy = "ARTIST_SIMILAR",
+                isBuiltin = false, // user-created with same name
+            )
+        )
+
+        val updated = dao.retuneBuiltin("Daily Discover", 0.85f, 7, 40, 0.0f, "ARTIST_SIMILAR")
+
+        assertEquals(0, updated)
+        val after = dao.getActive().single()
+        assertEquals(0.4f, after.discoveryRatio) // untouched
+        assertEquals(0.3f, after.affinityBias)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they fail at compile time**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.StashMixRecipeDaoRetuneTest"
+```
+
+Expected: compile error — `retuneBuiltin` doesn't accept `affinityBias` or `seedStrategy` parameters yet.
+
+- [ ] **Step 5: Implement the DAO change**
+
+In `StashMixRecipeDao.kt`, replace the existing `retuneBuiltin` `@Query` + signature (lines 79-100) with:
+
+```kotlin
+/**
+ * Non-destructive tuning migration — updates an individual builtin
+ * recipe's knobs without dropping its materialized playlist or
+ * cascading its discovery_queue. Used when we ship a new default
+ * (e.g. bumping discovery_ratio) and want existing installs to pick
+ * it up without wiping the user's accumulated discovery state.
+ *
+ * v0.9.20: extended from 4 to 6 fields. The recipe-pivot migration
+ * needs to change affinityBias + seedStrategy alongside the original
+ * three knobs in a single atomic UPDATE.
+ */
+@Query(
+    """
+    UPDATE stash_mix_recipes
+    SET discovery_ratio = :discoveryRatio,
+        freshness_window_days = :freshnessWindowDays,
+        target_length = :targetLength,
+        affinity_bias = :affinityBias,
+        seed_strategy = :seedStrategy
+    WHERE is_builtin = 1 AND name = :name
+    """
+)
+suspend fun retuneBuiltin(
+    name: String,
+    discoveryRatio: Float,
+    freshnessWindowDays: Int,
+    targetLength: Int,
+    affinityBias: Float,
+    seedStrategy: String,
+): Int
+```
+
+- [ ] **Step 6: Update the existing v1 migration call site**
+
+In `StashApplication.kt`, the existing `maybeRetuneStashDiscover` at lines 335-355 calls `stashMixRecipeDao.retuneBuiltin(...)` with 4 args. Update that call to pass the two new params with the Stash Discover values from that era — `affinityBias = 0.0f` and `seedStrategy = "TAG_GRAPH"`:
+
+```kotlin
+val updated = stashMixRecipeDao.retuneBuiltin(
+    name = "Stash Discover",
+    discoveryRatio = 1.0f,
+    freshnessWindowDays = 14,
+    targetLength = 50,
+    affinityBias = 0.0f,
+    seedStrategy = "TAG_GRAPH",
+)
+```
+
+This preserves the v1 migration's intent for any user still on v0.9.x who hasn't run it yet.
+
+- [ ] **Step 7: Run tests to verify all 3 pass**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.StashMixRecipeDaoRetuneTest"
+```
+
+Expected: 3/3 pass.
+
+- [ ] **Step 8: Build app module to verify the call-site update compiles**
+
+```bash
+./gradlew :app:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 9: Run the full :core:data module test sweep**
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL. No regressions.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/db/dao/StashMixRecipeDao.kt \
+        core/data/src/test/kotlin/com/stash/core/data/db/dao/StashMixRecipeDaoRetuneTest.kt \
+        app/src/main/kotlin/com/stash/app/StashApplication.kt
+git commit -m "feat(mix): expand retuneBuiltin signature to cover affinityBias + seedStrategy
+
+The recipe-pivot migration needs all 5 tunable fields in a single UPDATE.
+Existing v1 Stash Discover migration call site updated to pass the new
+params (TAG_GRAPH / 0.0f — the Stash Discover values from that era)
+so it continues working for installs that haven't run it yet.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `MixGenerator.generate` accepts `excludeIds`
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt:113-201` (the `generate` function)
+- Create: `core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorExcludeIdsTest.kt`
+
+- [ ] **Step 1: Read the existing MixGenerator MockK test for patterns**
+
+Open `core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorComputeUserTopTagsTest.kt`. Note how it constructs `MixGenerator` with mocked DAOs — copy that constructor pattern verbatim.
+
+- [ ] **Step 2: Write failing tests**
+
+Create `MixGeneratorExcludeIdsTest.kt`:
+
+```kotlin
+package com.stash.core.data.mix
+
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.ListeningEventDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.dao.TrackSkipEventDao
+import com.stash.core.data.db.dao.TrackTagDao
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.db.entity.TrackEntity
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [MixGenerator.generate]'s v0.9.20 `excludeIds` parameter — the
+ * cross-mix dedup primitive. excludeIds filters the library pool BEFORE
+ * scoring + slot allocation, so excluded tracks can never appear in the
+ * result.
+ */
+class MixGeneratorExcludeIdsTest {
+
+    private val trackDao: TrackDao = mockk()
+    private val trackTagDao: TrackTagDao = mockk(relaxed = true)
+    private val listeningEventDao: ListeningEventDao = mockk(relaxed = true)
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val blocklistGuard: BlocklistGuard = mockk(relaxed = true)
+    private val trackSkipEventDao: TrackSkipEventDao = mockk(relaxed = true)
+    private lateinit var generator: MixGenerator
+
+    @Before fun setUp() {
+        generator = MixGenerator(
+            trackDao,
+            trackTagDao,
+            listeningEventDao,
+            discoveryQueueDao,
+            blocklistGuard,
+            trackSkipEventDao,
+        )
+    }
+
+    @Test fun `excludeIds removes matching tracks from the pool before scoring`() = runTest {
+        val tracks = (1L..5L).map { stubTrack(it) }
+        coEvery { trackDao.getAllDownloaded() } returns tracks
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { listeningEventDao.getTrackIdsPlayedSince(any()) } returns emptyList()
+        coEvery { trackTagDao.getByTrack(any()) } returns emptyList()
+
+        val result = generator.generate(
+            recipe = stubRecipe(discoveryRatio = 0.0f, targetLength = 10),
+            excludeIds = setOf(2L, 4L),
+        )
+
+        val ids = result.map { it.id }.toSet()
+        assertEquals(setOf(1L, 3L, 5L), ids)
+        assertTrue("expected 2L excluded", 2L !in ids)
+        assertTrue("expected 4L excluded", 4L !in ids)
+    }
+
+    @Test fun `empty excludeIds preserves the full library pool`() = runTest {
+        val tracks = (1L..5L).map { stubTrack(it) }
+        coEvery { trackDao.getAllDownloaded() } returns tracks
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { listeningEventDao.getTrackIdsPlayedSince(any()) } returns emptyList()
+        coEvery { trackTagDao.getByTrack(any()) } returns emptyList()
+
+        val result = generator.generate(stubRecipe(discoveryRatio = 0.0f, targetLength = 10))
+
+        assertEquals(5, result.size)
+    }
+
+    private fun stubRecipe(discoveryRatio: Float, targetLength: Int) = StashMixRecipeEntity(
+        id = 1L,
+        name = "Test",
+        discoveryRatio = discoveryRatio,
+        targetLength = targetLength,
+        freshnessWindowDays = 0,
+    )
+
+    private fun stubTrack(id: Long) = TrackEntity(
+        id = id,
+        title = "Track $id",
+        artist = "Artist $id",
+        canonicalTitle = "track $id",
+        canonicalArtist = "artist $id",
+        isDownloaded = true,
+    )
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.mix.MixGeneratorExcludeIdsTest"
+```
+
+Expected: compile error — `generate` doesn't accept `excludeIds` parameter yet.
+
+- [ ] **Step 4: Implement the production change**
+
+In `MixGenerator.kt`, change the `generate` signature (around line 113) and add the filter right after `trackDao.getAllDownloaded()`:
+
+```kotlin
+/**
+ * Produces the finalized track list for [recipe]. The worker calling
+ * this replaces the playlist_tracks rows for [recipe.playlistId] with
+ * this ordering.
+ *
+ * v0.9.20: [excludeIds] is the cross-mix dedup primitive — when the
+ * refresh worker iterates multiple recipes back-to-back, it accumulates
+ * track ids already claimed by earlier recipes and passes them here so
+ * the current recipe can't re-pick them.
+ */
+suspend fun generate(
+    recipe: StashMixRecipeEntity,
+    excludeIds: Set<Long> = emptySet(),
+): List<TrackEntity> {
+    // Step 1: candidate pool — start from every downloaded,
+    // non-blacklisted track in the library. v0.9.20: filter through
+    // excludeIds first (cheap O(n) set lookup, before any other filtering).
+    val rawPool = trackDao.getAllDownloaded()
+    val pool0 = if (excludeIds.isEmpty()) rawPool else rawPool.filter { it.id !in excludeIds }
+
+    // Step 2: era filter (cheap, done in-memory).
+    var pool = filterByEra(pool0, recipe)
+
+    // ... rest of existing pipeline unchanged ...
+}
+```
+
+The rest of the function body stays as it is — only the first 3 lines after the KDoc change.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.mix.MixGeneratorExcludeIdsTest"
+```
+
+Expected: 2/2 pass.
+
+- [ ] **Step 6: Run the full :core:data module test sweep**
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt \
+        core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorExcludeIdsTest.kt
+git commit -m "feat(mix): MixGenerator.generate accepts excludeIds for cross-mix dedup
+
+Adds an optional Set<Long> parameter that filters the library pool
+before any scoring or slot allocation. Default emptySet() preserves
+all existing callers. Used by StashMixRefreshWorker to ensure tracks
+picked by an earlier recipe in the iteration aren't re-picked by a
+later one.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `MixGenerator` shortfall-fill threshold
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt:192-198` (the shortfall-fill gate)
+- Create: `core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorShortfallFillTest.kt`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `MixGeneratorShortfallFillTest.kt`:
+
+```kotlin
+package com.stash.core.data.mix
+
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.ListeningEventDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.dao.TrackSkipEventDao
+import com.stash.core.data.db.dao.TrackTagDao
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.db.entity.TrackEntity
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [MixGenerator.generate]'s v0.9.20 shortfall-fill threshold.
+ * The old gate was `discoveryRatio < 1.0f`; the new gate is
+ * `discoveryRatio < 0.5f` — high-discovery recipes return a sparser
+ * library slice rather than backfilling from the rest of the library.
+ */
+class MixGeneratorShortfallFillTest {
+
+    private val trackDao: TrackDao = mockk()
+    private val trackTagDao: TrackTagDao = mockk(relaxed = true)
+    private val listeningEventDao: ListeningEventDao = mockk(relaxed = true)
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val blocklistGuard: BlocklistGuard = mockk(relaxed = true)
+    private val trackSkipEventDao: TrackSkipEventDao = mockk(relaxed = true)
+    private lateinit var generator: MixGenerator
+
+    @Before fun setUp() {
+        generator = MixGenerator(
+            trackDao,
+            trackTagDao,
+            listeningEventDao,
+            discoveryQueueDao,
+            blocklistGuard,
+            trackSkipEventDao,
+        )
+        coEvery { listeningEventDao.getPlayCountsSinceWithLatest(any()) } returns emptyList()
+        coEvery { listeningEventDao.getTrackIdsPlayedSince(any()) } returns emptyList()
+        coEvery { trackTagDao.getByTrack(any()) } returns emptyList()
+    }
+
+    @Test fun `shortfall fill triggers at discoveryRatio = 0_4`() = runTest {
+        coEvery { trackDao.getAllDownloaded() } returns (1L..50L).map { stubTrack(it) }
+
+        val result = generator.generate(
+            stubRecipe(discoveryRatio = 0.4f, targetLength = 50),
+        )
+
+        // librarySlots = 50 * (1 - 0.4) = 30; pool = 50; shortfall fills to 50.
+        assertEquals(50, result.size)
+    }
+
+    @Test fun `shortfall fill does NOT trigger at discoveryRatio = 0_5`() = runTest {
+        coEvery { trackDao.getAllDownloaded() } returns (1L..50L).map { stubTrack(it) }
+
+        val result = generator.generate(
+            stubRecipe(discoveryRatio = 0.5f, targetLength = 50),
+        )
+
+        // librarySlots = 50 * (1 - 0.5) = 25; no shortfall fill.
+        assertEquals(25, result.size)
+    }
+
+    @Test fun `shortfall fill does NOT trigger at discoveryRatio = 0_85`() = runTest {
+        coEvery { trackDao.getAllDownloaded() } returns (1L..50L).map { stubTrack(it) }
+
+        val result = generator.generate(
+            stubRecipe(discoveryRatio = 0.85f, targetLength = 40),
+        )
+
+        // librarySlots = 40 * (1 - 0.85) = 6; no shortfall fill.
+        assertEquals(6, result.size)
+    }
+
+    @Test fun `pure discovery recipe at ratio = 1_0 returns empty library slice`() = runTest {
+        coEvery { trackDao.getAllDownloaded() } returns (1L..50L).map { stubTrack(it) }
+
+        val result = generator.generate(
+            stubRecipe(discoveryRatio = 1.0f, targetLength = 50),
+        )
+
+        // librarySlots = 0; no shortfall fill (already gated by < 0.5).
+        assertTrue("expected empty, got ${result.size}", result.isEmpty())
+    }
+
+    private fun stubRecipe(discoveryRatio: Float, targetLength: Int) = StashMixRecipeEntity(
+        id = 1L,
+        name = "Test",
+        discoveryRatio = discoveryRatio,
+        targetLength = targetLength,
+        freshnessWindowDays = 0,
+    )
+
+    private fun stubTrack(id: Long) = TrackEntity(
+        id = id,
+        title = "Track $id",
+        artist = "Artist $id",
+        canonicalTitle = "track $id",
+        canonicalArtist = "artist $id",
+        isDownloaded = true,
+    )
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.mix.MixGeneratorShortfallFillTest"
+```
+
+Expected: tests fail. With the current gate at `< 1.0f`, recipes with discoveryRatio 0.5 and 0.85 *do* shortfall-fill, so `result.size` will be 50 + 40 respectively (target length, not librarySlots). The `0.4` and `1.0` cases will already pass — partial fail.
+
+- [ ] **Step 3: Implement the production change**
+
+In `MixGenerator.kt`, the existing block runs from line 185 (the comment `// Step 8: shortfall backfill...`) through line 198 (the closing brace of the `if` block). **Replace this entire block** — including the now-misleading commentary that references "Stash Discover (ratio = 1.0)" semantics no longer applicable — with the following:
+
+```kotlin
+// Step 8: shortfall backfill from the remaining library pool.
+// v0.9.20: gate raised from `< 1.0f` to `< 0.5f`. Recipes that should
+// be substantially discovery-driven (>= 50% by ratio) must not silently
+// degrade to library when discovery is sparse — that's exactly what
+// produced the "library-heavy mixes" symptom on existing installs.
+// A sparser-but-honest mix is better than a deceptively library-filled
+// one. Library-only recipes (ratio == 0) and lightly-discovery recipes
+// (< 0.5) still get the original full-fill behavior.
+if (recipe.discoveryRatio < 0.5f) {
+    val shortfall = recipe.targetLength - picked.size
+    if (shortfall > 0 && picked.size < pool.size) {
+        val extra = ordered.filter { it !in picked }.take(shortfall)
+        return picked + extra
+    }
+}
+```
+
+The `return picked` statement at line 200 (or wherever it currently lives — verify) stays as the final fall-through return.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.mix.MixGeneratorShortfallFillTest"
+```
+
+Expected: 4/4 pass.
+
+- [ ] **Step 5: Run the full :core:data module test sweep**
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL. No regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt \
+        core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorShortfallFillTest.kt
+git commit -m "feat(mix): gate shortfall-fill at discoveryRatio >= 0.5
+
+Recipes that should be substantially discovery-driven (>= 50% by ratio)
+no longer silently backfill the library slice up to targetLength when
+discovery survivors are sparse. A sparser-but-honest mix is better than
+a deceptively library-filled one. Library-only and lightly-discovery
+recipes (< 0.5) keep the original behavior.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `StashMixRefreshWorker` cross-mix dedup orchestration
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt` (private `materializeMix` + `doWork`'s iteration block + add `recipeDedupPriority` helper)
+- Create: `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt`
+
+This task is the largest single change in the PR. It bundles:
+
+1. New `MaterializeResult` data class (private to the worker).
+2. `materializeMix` signature change: accepts `excludeIds: Set<Long>`, returns `MaterializeResult`. Over-fetches discovery survivors via `discoveryCap + excludeIds.size` then post-filters and `.take(discoveryCap)`.
+3. New private companion helper `recipeDedupPriority(StashMixRecipeEntity): Int`.
+4. `doWork` iteration: sorts active recipes by priority, threads a mutable `excludeIds` set through `generate` + `materializeMix`, accumulates after each.
+
+All of these compile together as one atomic change because `materializeMix` is private to the file.
+
+- [ ] **Step 1: Read the existing worker thoroughly**
+
+Open `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt`. Read:
+- Constructor at lines 69-84 (note the injected DAOs — you'll need these for the MockK test).
+- `companion object` at lines 86+ (note `ONE_SHOT_WORK_NAME` is already public from PR 1 Task 5).
+- `doWork` at line 172 — specifically the persona-fetch block at lines 199-217 (preserved verbatim) and the iteration starting at line 219 (rewritten).
+- `materializeMix` at line 254 (signature + body changes).
+
+- [ ] **Step 2: Write the failing dedup test**
+
+Create `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt`. Use MockK with hand-constructed `StashMixRefreshWorker`, mirroring the `LosslessRetryWorkerTest` pattern:
+
+```kotlin
+package com.stash.core.data.sync.workers
+
+import android.content.Context
+import androidx.work.WorkerParameters
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.ListeningEventDao
+import com.stash.core.data.db.dao.PlaylistDao
+import com.stash.core.data.db.dao.StashMixRecipeDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.lastfm.LastFmApiClient
+import com.stash.core.data.lastfm.LastFmCredentials
+import com.stash.core.data.lastfm.LastFmSessionPreference
+import com.stash.core.data.mix.MixGenerator
+import com.stash.core.data.mix.MixSeedGenerator
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * End-to-end MockK test for [StashMixRefreshWorker]'s cross-mix dedup
+ * orchestration. Verifies that when multiple builtin recipes run in
+ * priority order, no track id appears in two playlists.
+ */
+class StashMixRefreshWorkerDedupTest {
+
+    private val appContext: Context = mockk(relaxed = true)
+    private val workerParams: WorkerParameters = mockk(relaxed = true)
+    private val recipeDao: StashMixRecipeDao = mockk(relaxed = true)
+    private val playlistDao: PlaylistDao = mockk(relaxed = true)
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val listeningEventDao: ListeningEventDao = mockk(relaxed = true)
+    private val trackDao: TrackDao = mockk(relaxed = true)
+    private val mixGenerator: MixGenerator = mockk()
+    private val seedGenerator: MixSeedGenerator = mockk(relaxed = true)
+    private val lastFmApiClient: LastFmApiClient = mockk(relaxed = true)
+    private val lastFmCredentials: LastFmCredentials = mockk {
+        coEvery { isConfigured } returns false  // skip persona fetch + discovery seeding
+    }
+    private val sessionPreference: LastFmSessionPreference = mockk {
+        coEvery { session } returns flowOf(null)
+    }
+    private val blocklistGuard: BlocklistGuard = mockk {
+        coEvery { isBlockedByTrackId(any()) } returns false
+    }
+
+    private fun newWorker() = StashMixRefreshWorker(
+        appContext, workerParams,
+        recipeDao, playlistDao, discoveryQueueDao, listeningEventDao,
+        trackDao, mixGenerator, seedGenerator, lastFmApiClient,
+        lastFmCredentials, sessionPreference, blocklistGuard,
+    )
+
+    @Test fun `excludeIds accumulates across recipes — no track appears in two playlists`() = runTest {
+        // Three active recipes in priority order: First Listen, Deep Cuts, Daily Discover.
+        val firstListen = recipe(id = 1L, name = "First Listen", ratio = 1.0f)
+        val deepCuts = recipe(id = 2L, name = "Deep Cuts", ratio = 0.85f)
+        val dailyDiscover = recipe(id = 3L, name = "Daily Discover", ratio = 0.85f)
+        coEvery { recipeDao.getActive() } returns listOf(dailyDiscover, deepCuts, firstListen) // unsorted
+
+        // Capture excludeIds passed to each generate() call.
+        val excludeCaptureFirstListen = slot<Set<Long>>()
+        val excludeCaptureDeepCuts = slot<Set<Long>>()
+        val excludeCaptureDailyDiscover = slot<Set<Long>>()
+        coEvery { mixGenerator.generate(firstListen, capture(excludeCaptureFirstListen)) } returns emptyList()
+        coEvery { mixGenerator.generate(deepCuts, capture(excludeCaptureDeepCuts)) } returns listOf(track(10L), track(11L))
+        coEvery { mixGenerator.generate(dailyDiscover, capture(excludeCaptureDailyDiscover)) } returns listOf(track(20L), track(21L))
+
+        // First Listen brings 5 discovery survivors; Deep Cuts brings 6; Daily Discover 7.
+        coEvery { discoveryQueueDao.getDoneTrackIdsForRecipe(firstListen.id, any()) } returns listOf(1L, 2L, 3L, 4L, 5L)
+        coEvery { discoveryQueueDao.getDoneTrackIdsForRecipe(deepCuts.id, any()) } returns listOf(6L, 7L, 8L, 9L, 10L, 11L) // 10, 11 are also library
+        coEvery { discoveryQueueDao.getDoneTrackIdsForRecipe(dailyDiscover.id, any()) } returns listOf(1L, 12L, 13L, 14L, 15L, 16L, 17L) // 1L is already in First Listen
+
+        coEvery { playlistDao.getById(any()) } returns null
+        coEvery { playlistDao.insert(any()) } returnsMany listOf(100L, 200L, 300L)
+
+        newWorker().doWork()
+
+        // First Listen runs first (priority 1) — exclude set is empty.
+        assertTrue("first listen excludeIds should start empty", excludeCaptureFirstListen.captured.isEmpty())
+
+        // Deep Cuts runs second — exclude set has First Listen's 5 discovery ids.
+        assertEquals(setOf(1L, 2L, 3L, 4L, 5L), excludeCaptureDeepCuts.captured)
+
+        // Daily Discover runs third — exclude set has First Listen's 5 + Deep Cuts's 2 library + Deep Cuts's 4 NEW survivors (6,7,8,9 — 10 and 11 are in library so filtered by librarySet, not excludeIds).
+        // Detailed: after First Listen, exclude = {1..5}. After Deep Cuts: + {10, 11} (library) + {6, 7, 8, 9} (discovery survivors, excluding 10/11 which are in library).
+        assertEquals(setOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L), excludeCaptureDailyDiscover.captured)
+    }
+
+    private fun recipe(id: Long, name: String, ratio: Float) = StashMixRecipeEntity(
+        id = id, name = name,
+        discoveryRatio = ratio, targetLength = 40,
+        isBuiltin = true, isActive = true,
+    )
+
+    private fun track(id: Long) = TrackEntity(
+        id = id, title = "Track $id", artist = "Artist $id",
+        canonicalTitle = "track $id", canonicalArtist = "artist $id",
+        isDownloaded = true,
+    )
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail at compile time**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.StashMixRefreshWorkerDedupTest"
+```
+
+Expected: compile errors — `mixGenerator.generate` doesn't accept 2 args, or runtime mismatches if it does (Task 2 already shipped). Either way, the test should not pass against the current `doWork` (which doesn't accumulate excludeIds).
+
+- [ ] **Step 4: Add the `MaterializeResult` data class and `recipeDedupPriority` helper**
+
+At the bottom of `StashMixRefreshWorker.kt` (above the closing `}` of the class), or in a sensible spot near the existing private helpers:
+
+```kotlin
+    /**
+     * Output of [materializeMix]. Carries the just-created/updated
+     * playlist id (existing return) AND the discovery-survivor track ids
+     * the materialization inserted, so [doWork]'s outer cross-mix dedup
+     * loop can add them to its accumulating excludeIds set.
+     */
+    private data class MaterializeResult(
+        val playlistId: Long,
+        val discoveryIds: List<Long>,
+    )
+
+    /**
+     * Cross-mix track-dedup priority. Most-restrictive recipes go first
+     * so they claim their natural picks; most-permissive last so it
+     * picks up the leftovers.
+     *
+     *  - First Listen (1.0 discovery, library-blind) — has no opinion on
+     *    the library pool; claims TAG_GRAPH survivors first.
+     *  - Deep Cuts (0.85 discovery) — claims TRACK_SIMILAR survivors and
+     *    a sparse library slice next.
+     *  - Daily Discover (0.85 discovery) — most permissive on the
+     *    library slice; claims ARTIST_SIMILAR survivors last.
+     *  - Non-builtins / unknown — last (99).
+     *
+     * Keyed by name rather than id because builtin id values aren't
+     * stable across reseeds.
+     */
+    private fun recipeDedupPriority(recipe: StashMixRecipeEntity): Int = when (recipe.name) {
+        "First Listen" -> 1
+        "Deep Cuts" -> 2
+        "Daily Discover" -> 3
+        else -> 99
+    }
+```
+
+- [ ] **Step 5: Refactor `materializeMix` to accept excludeIds and return MaterializeResult**
+
+In `StashMixRefreshWorker.kt`, find `materializeMix` (around line 254). Update its signature + return + the discovery survivor query:
+
+```kotlin
+private suspend fun materializeMix(
+    recipe: StashMixRecipeEntity,
+    tracks: List<TrackEntity>,
+    now: Long,
+    excludeIds: Set<Long>,
+): MaterializeResult {
+    // ... existing find-or-create-playlist + library-track inserts unchanged ...
+
+    // Discovery survivor re-link section (around lines 311-337).
+    // v0.9.20: filter via excludeIds; over-fetch so post-filter still fills the cap.
+    val discoveryCap = (recipe.targetLength * recipe.discoveryRatio)
+        .roundToInt()
+        .coerceAtLeast(0)
+    val librarySet = tracks.mapTo(HashSet(tracks.size)) { it.id }
+    val rawCandidateIds = discoveryQueueDao
+        .getDoneTrackIdsForRecipe(recipe.id, limit = discoveryCap + excludeIds.size)
+    val filteredCandidateIds = rawCandidateIds
+        .filter { it !in librarySet && it !in excludeIds }
+        .take(discoveryCap)
+    val discoveryTrackIds = buildList {
+        for (trackId in filteredCandidateIds) {
+            if (!blocklistGuard.isBlockedByTrackId(trackId)) add(trackId)
+        }
+    }
+    discoveryTrackIds.forEachIndexed { offset, trackId ->
+        playlistDao.insertCrossRef(
+            PlaylistTrackCrossRef(
+                playlistId = playlistId,
+                trackId = trackId,
+                position = tracks.size + offset,
+                addedAt = nowInstant,
+            )
+        )
+    }
+    val totalCount = tracks.size + discoveryTrackIds.size
+
+    // ... existing cover-art update + updateTrackCount unchanged ...
+
+    return MaterializeResult(playlistId, discoveryTrackIds)
+}
+```
+
+Make sure to update the local variable name `candidateIds` everywhere it's referenced — the existing block uses `candidateIds`; we now have `rawCandidateIds` and `filteredCandidateIds`. The KDoc comment block about v0.9.15 blocklist filter / v0.9.19 cap (lines 305-316) should be preserved; add a paragraph noting the v0.9.20 over-fetch.
+
+- [ ] **Step 6: Rewrite `doWork`'s recipe iteration block**
+
+In `StashMixRefreshWorker.doWork`, the iteration currently at lines 219-242 (`for (recipe in active) { ... }`) needs to:
+- Pre-sort by `recipeDedupPriority`.
+- Thread a mutable `excludeIds` set through `generate` + `materializeMix`.
+- Accumulate after each.
+
+Replace the existing iteration with:
+
+```kotlin
+val orderedRecipes = active.sortedBy { recipeDedupPriority(it) }
+val excludeIds = mutableSetOf<Long>()
+for (recipe in orderedRecipes) {
+    val tracks = mixGenerator.generate(recipe, excludeIds)
+
+    // Empty-tracks skip is only safe for library-only recipes
+    // (discoveryRatio == 0). Pure-discovery recipes like "Stash
+    // Discover" (ratio = 1.0) produce an empty generator result
+    // by design — the playlist gets its content from the
+    // discovery re-link pass inside materializeMix + the async
+    // StashDiscoveryWorker. Skipping them here would keep stale
+    // pre-retune content in the playlist forever.
+    if (tracks.isEmpty() && recipe.discoveryRatio == 0f) {
+        Log.d(TAG, "'${recipe.name}' produced 0 tracks and has no discovery — skipping materialize")
+        continue
+    }
+
+    val result = materializeMix(recipe, tracks, now, excludeIds)
+    recipeDao.setPlaylistId(recipe.id, result.playlistId)
+    recipeDao.setLastRefreshedAt(recipe.id, now)
+
+    // v0.9.20: accumulate so the next recipe in the ordering doesn't re-pick these.
+    excludeIds += tracks.map { it.id }
+    excludeIds += result.discoveryIds
+
+    // Discovery — opportunistic. Don't block refresh success on it.
+    if (recipe.discoveryRatio > 0f && lastFmConfigured) {
+        runCatching { queueDiscoveryForRecipe(recipe, personas) }
+            .onFailure { Log.w(TAG, "discovery queueing failed for '${recipe.name}'", it) }
+    }
+}
+```
+
+Preserve the existing surrounding code — persona-fetch block above (lines 199-217), `return Result.success()` at line 243 below.
+
+- [ ] **Step 7: Run the dedup test**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.StashMixRefreshWorkerDedupTest"
+```
+
+Expected: 1/1 pass.
+
+- [ ] **Step 8: Run the full :core:data module test sweep**
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL. Any pre-existing failures noted in PR 1 (e.g., `YtLibraryCanonicalizerTest`) stay — they're not in this module anyway.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt \
+        core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt
+git commit -m "feat(mix): cross-mix dedup orchestration in StashMixRefreshWorker
+
+materializeMix now returns MaterializeResult(playlistId, discoveryIds)
+and accepts excludeIds. doWork pre-sorts active recipes by dedup
+priority (First Listen → Deep Cuts → Daily Discover → others), threads
+a mutable Set<Long> through generate + materializeMix, and accumulates
+both library and discovery-survivor ids after each iteration so the
+next recipe can't re-pick them.
+
+Discovery survivor query over-fetches discoveryCap + excludeIds.size
+rows then post-filters and .take(discoveryCap) — guarantees the
+discovery slot fills even when many ids are excluded.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Retune builtin recipe defaults
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/mix/StashMixDefaults.kt`
+
+This is data-only — no new tests (the DAO + worker tests from Tasks 1 and 4 cover the behavior; Task 6's migration test exercises the migration that ships these values to existing installs).
+
+- [ ] **Step 1: Replace the three builtin entries**
+
+Open `StashMixDefaults.kt`. The current `ALL` list has three entries. Replace Daily Discover and Deep Cuts; keep First Listen unchanged. Result:
+
+```kotlin
+val ALL: List<StashMixRecipeEntity> = listOf(
+    StashMixRecipeEntity(
+        name = "Daily Discover",
+        description = "Mostly fresh finds via similar-artists. A pinch of your library.",
+        affinityBias = 0.0f,
+        freshnessWindowDays = 7,
+        discoveryRatio = 0.85f,
+        targetLength = 40,
+        seedStrategy = "ARTIST_SIMILAR",
+        isBuiltin = true,
+    ),
+    StashMixRecipeEntity(
+        name = "Deep Cuts",
+        description = "Mostly fresh finds via similar-tracks. A pinch of your library.",
+        affinityBias = 0.0f,
+        freshnessWindowDays = 90,
+        discoveryRatio = 0.85f,
+        targetLength = 40,
+        seedStrategy = "TRACK_SIMILAR",
+        isBuiltin = true,
+    ),
+    StashMixRecipeEntity(
+        name = "First Listen",
+        description = "Tracks you've never heard. Wider net.",
+        affinityBias = 0.0f,
+        freshnessWindowDays = 14,
+        discoveryRatio = 1.0f,
+        targetLength = 50,
+        seedStrategy = "TAG_GRAPH",
+        isBuiltin = true,
+    ),
+)
+```
+
+Also update the file's top-level KDoc to reflect the new design intent (the existing one mentions ARTIST_SIMILAR / NONE / TAG_GRAPH and the "forgotten favorites" semantic for Deep Cuts — replace with the new recommendation-driven semantic):
+
+```kotlin
+/**
+ * Ships Stash's built-in mix recipes. As of v0.9.20, all three builtins
+ * are recommendation-substrate-with-library-seasoning — Daily Discover
+ * and Deep Cuts at 85% discovery, First Listen at 100% discovery. Each
+ * uses a distinct [com.stash.core.data.mix.MixSeedStrategy] so their
+ * discovery-survivor pools are naturally differentiated:
+ *
+ *  - **Daily Discover** — ARTIST_SIMILAR; recommendations from artists
+ *    similar to your top artists.
+ *  - **Deep Cuts** — TRACK_SIMILAR; recommendations from tracks similar
+ *    to your top tracks (deeper-dive flavor).
+ *  - **First Listen** — TAG_GRAPH; top tracks across your taste tags
+ *    (widest net).
+ *
+ * Only seeds when [StashMixRecipeDao.countBuiltins] is zero, so users
+ * don't get defaults re-inserted every launch. Upgrades from earlier
+ * installs that already have the previous builtin set go through
+ * `StashApplication.maybeRetuneStashMixes` which non-destructively
+ * updates the rows in place via [StashMixRecipeDao.retuneBuiltin].
+ */
+```
+
+- [ ] **Step 2: Build to verify**
+
+```bash
+./gradlew :core:data:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Run the :core:data module test sweep**
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL. Any test that hard-codes the OLD Daily Discover or Deep Cuts values would fail — flag if so; we'd need to update that test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/mix/StashMixDefaults.kt
+git commit -m "feat(mix): retune Daily Discover + Deep Cuts to 85% discovery
+
+Daily Discover: ratio 0.4 -> 0.85, affinityBias 0.3 -> 0.0,
+targetLength 50 -> 40. Stays ARTIST_SIMILAR.
+
+Deep Cuts: ratio 0.0 -> 0.85, affinityBias 0.6 -> 0.0,
+targetLength 50 -> 40. seedStrategy NONE -> TRACK_SIMILAR
+(drops library-only rediscovery use case; user explicitly chose the
+recommendations-first design).
+
+First Listen unchanged. Fresh installs get the new defaults on first
+seed; existing installs get them via the v0.9.20 retune migration
+shipped in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Version-gated migration hook in `StashApplication`
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/stash/app/StashApplication.kt`
+
+Mirror the existing `maybeRetuneStashDiscover` precedent verbatim. No new unit test — the DAO behavior is covered by Task 1's `StashMixRecipeDaoRetuneTest`; this hook is plumbing verified by the manual on-device test.
+
+- [ ] **Step 1: Add the version constant**
+
+In `StashApplication.kt`, the companion object holds existing version constants (around line 493). Add:
+
+```kotlin
+private const val STASH_MIX_RECIPE_TUNING_VERSION = 1
+```
+
+Next to `STASH_DISCOVER_TUNING_VERSION`.
+
+- [ ] **Step 2: Add the migration method**
+
+After `maybeRetuneStashDiscover` (at line 355), add:
+
+```kotlin
+/**
+ * v0.9.20 pivot: Daily Discover + Deep Cuts move from library-substrate
+ * to recommendation-substrate (85% discovery, 15% library). Deep Cuts
+ * switches seed strategy from NONE to TRACK_SIMILAR. Gated by
+ * [STASH_MIX_RECIPE_TUNING_VERSION] so the migration runs exactly once
+ * per install. Fresh installs skip this because [StashMixDefaults]
+ * already seeds with the new values.
+ */
+private suspend fun maybeRetuneStashMixes() {
+    val prefs = getSharedPreferences("stash_migrations", MODE_PRIVATE)
+    val stored = prefs.getInt("stash_mix_recipe_tuning_version", 0)
+    if (stored >= STASH_MIX_RECIPE_TUNING_VERSION) return
+
+    var totalUpdated = 0
+    for (recipe in StashMixDefaults.ALL.filter { it.isBuiltin }) {
+        val updated = stashMixRecipeDao.retuneBuiltin(
+            name = recipe.name,
+            discoveryRatio = recipe.discoveryRatio,
+            freshnessWindowDays = recipe.freshnessWindowDays,
+            targetLength = recipe.targetLength,
+            affinityBias = recipe.affinityBias,
+            seedStrategy = recipe.seedStrategy,
+        )
+        totalUpdated += updated
+    }
+    Log.i(
+        "StashMigration",
+        "Retuned $totalUpdated builtin mix recipe(s) to v$STASH_MIX_RECIPE_TUNING_VERSION",
+    )
+    prefs.edit()
+        .putInt("stash_mix_recipe_tuning_version", STASH_MIX_RECIPE_TUNING_VERSION)
+        .apply()
+}
+```
+
+- [ ] **Step 3: Wire into the startup sequence**
+
+In `StashApplication.kt`, the `applicationScope.launch { ... }` block at lines 168-176 contains the existing migrations. Add the new call between `maybeRetuneStashDiscover()` and the `StashMixRefreshWorker.enqueueOneTime` call:
+
+```kotlin
+applicationScope.launch {
+    maybeReseedStashMixes()
+    StashMixDefaults.seedIfNeeded(stashMixRecipeDao)
+    maybeRetuneStashDiscover()
+    maybeRetuneStashMixes()  // NEW
+    StashMixRefreshWorker.enqueueOneTime(this@StashApplication)
+}
+```
+
+Order matters: `seedIfNeeded` first (for fresh installs), then both retune migrations (for upgrades), then enqueue the one-shot refresh which will materialize against the (now-retuned) recipes.
+
+- [ ] **Step 4: Build to verify**
+
+```bash
+./gradlew :app:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Run the :app module test sweep (if any)**
+
+```bash
+./gradlew :app:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL or UP-TO-DATE.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/kotlin/com/stash/app/StashApplication.kt
+git commit -m "feat(mix): version-gated retune migration for the recipe pivot
+
+Mirrors the existing maybeRetuneStashDiscover precedent — separate
+SharedPreferences key (stash_mix_recipe_tuning_version), idempotent,
+runs once per upgrade. Iterates StashMixDefaults.ALL.filter { isBuiltin }
+and applies retuneBuiltin to each. Fresh installs skip this because
+seedIfNeeded already provides the new defaults.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Build APK + install + manual on-device verification
+
+**Files:** none — verification task.
+
+- [ ] **Step 1: Full project build**
+
+```bash
+./gradlew :app:assembleRelease
+```
+
+Expected: BUILD SUCCESSFUL. (If `packageRelease` fails transiently with `IncrementalSplitterRunnable` — observed during PR 1's Task 7 — re-run `./gradlew :app:packageRelease`; second run usually succeeds.)
+
+- [ ] **Step 2: Install over the existing release app on Pixel**
+
+```bash
+adb install -r app/build/outputs/apk/release/app-release.apk
+```
+
+Expected: `Success`. Library, settings, downloads preserved (same package id, `com.stash.app`).
+
+- [ ] **Step 3: Cold-start the app to trigger `maybeRetuneStashMixes`**
+
+```bash
+adb shell monkey -p com.stash.app -c android.intent.category.LAUNCHER 1
+```
+
+Wait ~3 seconds.
+
+- [ ] **Step 4: Verify migration ran**
+
+```bash
+adb logcat -d -t 200 | grep StashMigration
+```
+
+Expected: a log line like `Retuned 3 builtin mix recipe(s) to v1`.
+
+- [ ] **Step 5: Trigger a refresh of each mix on-device**
+
+On the Pixel:
+1. Long-press each Stash Mix card (Daily Discover, Deep Cuts, First Listen) → tap "Refresh this mix" (the snackbar lifecycle from PR 1 will confirm).
+2. Watch the Home screen — each mix should show updated track counts and covers.
+
+- [ ] **Step 6: Verify the recommendation-first composition**
+
+Tap each mix to view its track list. For Daily Discover and Deep Cuts:
+- Most tracks (~85%) should be ones you don't recognize from your usual rotation — they're discovery survivors from the Last.fm pipeline.
+- A small slice (~15%) should be your own library tracks.
+- For the first refresh post-upgrade, Deep Cuts may be sparse (~6 tracks) because TRACK_SIMILAR discovery_queue rows haven't accumulated yet. This is expected (failure mode #1 in spec). Plug in to charge + WiFi and wait for `StashDiscoveryWorker` to fill the queue (next periodic run; can also be triggered by the app's existing nightly schedule). Refresh Deep Cuts again afterwards and verify it's now ~40 tracks.
+
+- [ ] **Step 7: Verify cross-mix dedup**
+
+Sample 10 track titles from Daily Discover and 10 from Deep Cuts. Expect zero overlap.
+
+Optional: use ADB to query the DB directly for a hard verification:
+```bash
+adb shell run-as com.stash.app sqlite3 \
+  /data/data/com.stash.app/databases/stash.db \
+  "SELECT t.title, t.artist, p.name FROM tracks t \
+   JOIN playlist_tracks pt ON pt.track_id = t.id \
+   JOIN playlists p ON p.id = pt.playlist_id \
+   WHERE p.type = 'STASH_MIX' \
+   ORDER BY t.id, p.name;"
+```
+A row with the same `track_id` appearing under two playlist names = dedup failure. Otherwise pass.
+
+- [ ] **Step 8: Report back**
+
+When the manual checks pass, summarize:
+- Commits that landed on the branch
+- APK installed on the Pixel
+- Migration log line observed
+- Manual checks that passed (with caveat about Deep Cuts sparseness on first refresh)
+- Any deferred/skipped items
+
+Do not push or tag. Per memory `feedback_ship_terminology.md`, release happens separately after verification.
+
+---
+
+## What's intentionally not in this plan
+
+Following YAGNI:
+
+- **No pre-seeding `discovery_queue` inline on retune.** Failure mode #1 acknowledged — Deep Cuts is sparse for a day. The user explicitly chose this trade-off.
+- **No new "Rediscovery" mix** to replace the dropped Deep Cuts semantic. Per brainstorm decision.
+- **No edits to `MixSeedGenerator`** — TRACK_SIMILAR is already implemented and tested.
+- **No "if a user edited the builtin, skip retune" logic** — the recipe-editing UI doesn't ship yet. When it does, that guard becomes urgent.
+- **No new schema migration** — schema v22 stays; only row content + DAO query change.
+- **No automated UI test for the snackbar lifecycle** — covered by manual on-device verification.

--- a/docs/superpowers/plans/2026-05-12-genuinely-new-discovery-and-skip-feedback.md
+++ b/docs/superpowers/plans/2026-05-12-genuinely-new-discovery-and-skip-feedback.md
@@ -1,0 +1,1128 @@
+# Phase 1: Genuinely-New Discovery + Skip-Feedback Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop surfacing library content in Stash Mix discovery slots. Pre-filter Last.fm candidates against the user's library AND against tracks they've early-skipped 3+ times in 90 days. Plus: relax manual-trigger network constraint so refresh fires on any network.
+
+**Architecture:** Three independent surgical changes. `constraintsForManualTrigger` becomes mode-independent (`CONNECTED + battery-not-low`). Two new DAO queries return canonical-key sets. `StashMixRefreshWorker.queueDiscoveryForRecipe` loads both sets, filters Last.fm candidates against them at the seed-generator boundary, falls back to TAG_GRAPH (with timeout) when filtered pool is too small.
+
+**Tech Stack:** Kotlin, Room, WorkManager 2.10.1, Hilt, MockK + JUnit4 for unit tests, Robolectric + Room in-memory for DAO tests.
+
+**Spec:** `docs/superpowers/specs/2026-05-12-genuinely-new-discovery-and-skip-feedback-design.md` (committed at `79a4d7e`).
+
+---
+
+## Pre-flight notes for the implementer
+
+Worktree: `C:\Users\theno\Projects\MP3APK\.worktrees\first-listen-tag-fallback`. Branch: `feat/first-listen-tag-fallback`. PR 5 + corruption hotfix already shipped 18 commits; PR 6 lands on top.
+
+### Repository conventions
+
+1. **TDD**: failing test first for DAOs and worker logic; build/run verification for config changes.
+2. **MockK** for worker unit tests (precedent: `StashMixRefreshWorkerDedupTest`, `LosslessRetryWorkerTest`).
+3. **Robolectric + Room in-memory** for DAO behavior tests (precedent: `DiscoveryQueueDaoCapTest`, `DownloadQueueDaoPartitionTest`).
+4. **No push, no tag.** Implementation ends at APK installed on Pixel + manual verification.
+5. **Always `:app:installRelease` after a fix** — per memory `feedback_install_after_fix.md`.
+
+### Files you will touch
+
+| Path | What changes |
+|---|---|
+| `core/data/src/main/kotlin/com/stash/core/data/sync/workers/DownloadConstraints.kt` | `constraintsForManualTrigger(mode)` body becomes mode-independent: `CONNECTED + battery-not-low + no charging`. |
+| `core/data/src/test/kotlin/com/stash/core/data/sync/workers/DownloadConstraintsTest.kt` | Rewrite the three per-mode tests as one mode-independence test (or three explicit ones — pick the cleaner shape). |
+| `core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt` | Add `getLibraryCanonicalKeys(): List<String>` query. |
+| `core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackDaoCanonicalKeysTest.kt` | **CREATE** — Robolectric tests for the new DAO method. |
+| `core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackSkipEventDao.kt` | Add `getEarlySkipBannedCanonicalKeys(minSkips, sinceMs, maxPositionMs): List<String>`. |
+| `core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackSkipEventDaoBanListTest.kt` | **CREATE** — Robolectric tests for the new DAO method. |
+| `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt` | Inject `TrackSkipEventDao` and `TrackMatcher`. Add constants. Modify `queueDiscoveryForRecipe` to apply the library + skip-ban filters and the TAG_GRAPH fallback with timeout. |
+| `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerSeedFilterTest.kt` | **CREATE** — MockK test for the new filter behavior + fallback path. |
+
+### Reference precedents
+
+- DAO Robolectric test: `core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt`.
+- Worker MockK test: `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt`.
+- Constraints behavior test: `core/data/src/test/kotlin/com/stash/core/data/sync/workers/DownloadConstraintsTest.kt` (from PR 5 Task 1).
+- `TrackMatcher` location: `com.stash.core.data.sync.TrackMatcher` (verified — `@Singleton class TrackMatcher @Inject constructor()`; non-suspend `canonicalArtist(s)` / `canonicalTitle(s)` methods produce lowercase + trim same as the sync writer's normalization).
+
+---
+
+## Task 1: Relax `constraintsForManualTrigger` to be mode-independent
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/DownloadConstraints.kt`
+- Modify: `core/data/src/test/kotlin/com/stash/core/data/sync/workers/DownloadConstraintsTest.kt`
+
+### Step 1: Read the current state
+
+Open `DownloadConstraints.kt`. The current `constraintsForManualTrigger(mode)` (added in PR 5 Task 1) branches on mode to set `UNMETERED` vs `CONNECTED`. We're collapsing that to always `CONNECTED`.
+
+### Step 2: Rewrite the production fn
+
+Replace the body of `constraintsForManualTrigger` with:
+
+```kotlin
+/**
+ * Constraints for **manual user-initiated triggers** — the user explicitly
+ * tapped "Refresh this mix" or the app booted with orphan downloads to
+ * drain. They're asking for content right now; the system honors that on
+ * whatever network is available.
+ *
+ * Differs from [constraintsFor]:
+ *  - Charging requirement DROPPED (user is actively using the app).
+ *  - Network requirement RELAXED from UNMETERED to CONNECTED — manual
+ *    triggers don't gate on cellular preference. The user's
+ *    DownloadNetworkMode pref still governs the periodic background
+ *    cycle (via [constraintsFor]); it doesn't govern foreground intent.
+ *
+ * `setRequiresBatteryNotLow(true)` stays on — a 5% battery + manual
+ * refresh is still a bad combination.
+ *
+ * v0.9.20 history: shipped in PR 5 respecting DownloadNetworkMode for
+ * cellular gating. After a corruption-induced pref reset left the user
+ * stuck (default mode = WIFI_AND_CHARGING → manual triggers required
+ * unmetered → no firing on cellular), we relaxed to CONNECTED to match
+ * how every major music app handles user-initiated downloads.
+ */
+@Suppress("UNUSED_PARAMETER")
+fun constraintsForManualTrigger(mode: DownloadNetworkMode): Constraints = Constraints.Builder()
+    .setRequiresBatteryNotLow(true)
+    .setRequiredNetworkType(NetworkType.CONNECTED)
+    .build()
+```
+
+The `mode` parameter is preserved so callers don't break; `@Suppress("UNUSED_PARAMETER")` quiets the warning.
+
+### Step 3: Rewrite the test
+
+In `DownloadConstraintsTest.kt`, the three existing per-mode tests assert different `NetworkType` for `WIFI_AND_CHARGING` (UNMETERED) vs `ANY_NETWORK` (CONNECTED). After this change they're all CONNECTED. Replace them with a single mode-independence assertion:
+
+```kotlin
+@Test fun `constraintsForManualTrigger ignores mode — always CONNECTED + battery-not-low + no charging`() {
+    for (mode in DownloadNetworkMode.values()) {
+        val constraints = constraintsForManualTrigger(mode)
+        assertEquals("mode=$mode", NetworkType.CONNECTED, constraints.requiredNetworkType)
+        assertFalse("mode=$mode", constraints.requiresCharging())
+        assertTrue("mode=$mode", constraints.requiresBatteryNotLow())
+    }
+}
+```
+
+Delete the three old per-mode tests. Keep imports.
+
+### Step 4: Run tests — expect pass
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.DownloadConstraintsTest"
+```
+
+Expected: 1 test passes (after the fn rewrite).
+
+### Step 5: Run the :core:data full sweep
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL.
+
+### Step 6: Commit
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/sync/workers/DownloadConstraints.kt \
+        core/data/src/test/kotlin/com/stash/core/data/sync/workers/DownloadConstraintsTest.kt
+git commit -m "feat(download): manual-trigger constraints relax to CONNECTED, mode-independent
+
+PR 5 shipped constraintsForManualTrigger respecting DownloadNetworkMode
+for cellular gating. After a corruption-induced pref reset left the
+user stuck (default mode = WIFI_AND_CHARGING → manual triggers required
+unmetered → no firing on cellular WiFi reporting as metered), we relax
+the manual path to always CONNECTED.
+
+Industry pattern: background = respect WiFi-only toggle; manual user
+action = honor on whatever network. Periodic StashDiscoveryWorker still
+uses constraintsFor(mode) which strictly respects the user pref.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `TrackDao.getLibraryCanonicalKeys`
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt`
+- Create: `core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackDaoCanonicalKeysTest.kt`
+
+### Step 1: Write the failing test
+
+Create `TrackDaoCanonicalKeysTest.kt`:
+
+```kotlin
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.TrackEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [TrackDao.getLibraryCanonicalKeys] — the v0.9.20 method
+ * used by [StashMixRefreshWorker]'s discovery pre-filter to drop
+ * Last.fm candidates that would dedup to library content.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class TrackDaoCanonicalKeysTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: TrackDao
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.trackDao()
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `returns canonical keys only for downloaded tracks`() = runTest {
+        dao.insert(trackEntity(id = 1L, canonicalArtist = "tame impala", canonicalTitle = "borderline", isDownloaded = true))
+        dao.insert(trackEntity(id = 2L, canonicalArtist = "tame impala", canonicalTitle = "the less i know the better", isDownloaded = true))
+        dao.insert(trackEntity(id = 3L, canonicalArtist = "stub artist", canonicalTitle = "stub title", isDownloaded = false))
+
+        val result = dao.getLibraryCanonicalKeys()
+
+        assertEquals(setOf("tame impala|borderline", "tame impala|the less i know the better"), result.toSet())
+        assertFalse("stub track must be excluded", "stub artist|stub title" in result)
+    }
+
+    @Test fun `returns DISTINCT keys — duplicate canonical-pairs collapse to one row`() = runTest {
+        // Two tracks with identical canonical-keys (e.g. same song from two sources).
+        dao.insert(trackEntity(id = 1L, canonicalArtist = "kanye west", canonicalTitle = "runaway", isDownloaded = true))
+        dao.insert(trackEntity(id = 2L, canonicalArtist = "kanye west", canonicalTitle = "runaway", isDownloaded = true))
+
+        val result = dao.getLibraryCanonicalKeys()
+
+        assertEquals(listOf("kanye west|runaway"), result)
+    }
+
+    @Test fun `empty library returns empty list`() = runTest {
+        val result = dao.getLibraryCanonicalKeys()
+        assertEquals(emptyList<String>(), result)
+    }
+
+    private fun trackEntity(
+        id: Long,
+        canonicalArtist: String,
+        canonicalTitle: String,
+        isDownloaded: Boolean,
+    ) = TrackEntity(
+        id = id,
+        title = "Title $id",
+        artist = "Artist $id",
+        canonicalTitle = canonicalTitle,
+        canonicalArtist = canonicalArtist,
+        isDownloaded = isDownloaded,
+    )
+}
+```
+
+### Step 2: Run tests — expect compile error
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.TrackDaoCanonicalKeysTest"
+```
+
+Expected: compile error — `getLibraryCanonicalKeys` doesn't exist.
+
+### Step 3: Implement the DAO method
+
+In `TrackDao.kt`, add (sensible spot: alongside `findDownloadedByCanonical` at line 1084, since they're related lookups):
+
+```kotlin
+/**
+ * Returns the canonical-key set ("$canonicalArtist|$canonicalTitle")
+ * for every downloaded track. Used by [com.stash.core.data.sync.workers.StashMixRefreshWorker]'s
+ * discovery pre-filter to drop Last.fm candidates that would dedup
+ * to library content downstream — keeping discovery_queue PENDING
+ * rows representative of genuinely-new music instead of "rediscovery"
+ * hits.
+ *
+ * `is_downloaded = 1` restricts to playable content. Stub TrackEntities
+ * (created by StashDiscoveryWorker before their files land) are excluded
+ * so we don't double-filter against in-flight discoveries.
+ */
+@Query(
+    """
+    SELECT DISTINCT (canonical_artist || '|' || canonical_title) AS k
+    FROM tracks
+    WHERE is_downloaded = 1
+    """
+)
+suspend fun getLibraryCanonicalKeys(): List<String>
+```
+
+### Step 4: Run tests — expect 3/3 pass
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.TrackDaoCanonicalKeysTest"
+```
+
+Expected: 3/3 pass.
+
+### Step 5: Run the :core:data full sweep
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL.
+
+### Step 6: Commit
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt \
+        core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackDaoCanonicalKeysTest.kt
+git commit -m "feat(prefs): TrackDao.getLibraryCanonicalKeys for discovery pre-filter
+
+Returns the DISTINCT (canonical_artist || '|' || canonical_title)
+set across all downloaded tracks. The discovery seed pre-filter
+(coming next) uses this to drop Last.fm candidates that would
+canonical-dedup to library content — moving the filter earlier so
+mix discovery slots actually surface new music instead of
+'rediscovery' hits.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `TrackSkipEventDao.getEarlySkipBannedCanonicalKeys`
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackSkipEventDao.kt`
+- Create: `core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackSkipEventDaoBanListTest.kt`
+
+### Step 1: Write the failing test
+
+Create `TrackSkipEventDaoBanListTest.kt`:
+
+```kotlin
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.db.entity.TrackSkipEventEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.TimeUnit
+
+/**
+ * Tests for [TrackSkipEventDao.getEarlySkipBannedCanonicalKeys] — the
+ * v0.9.20 method used by [StashMixRefreshWorker]'s discovery pre-filter
+ * to ban tracks the user has repeatedly rejected from future discovery.
+ *
+ * "Early skip": skip event with position_ms <= maxPositionMs (default
+ * 30_000ms in the worker — first 30 seconds of playback). Skips later
+ * in the track ("done listening, moving on") don't count as rejection.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class TrackSkipEventDaoBanListTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: TrackSkipEventDao
+    private lateinit var trackDao: TrackDao
+
+    @Before fun setUp() = runTest {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.trackSkipEventDao()
+        trackDao = db.trackDao()
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `bans canonical key with 3+ early skips inside time window`() = runTest {
+        trackDao.insert(track(id = 1L, canonicalArtist = "the strokes", canonicalTitle = "last nite"))
+
+        val now = System.currentTimeMillis()
+        repeat(4) { i -> dao.insert(skip(trackId = 1L, positionMs = 1000L, skippedAt = now - i * 1000L)) }
+
+        val result = dao.getEarlySkipBannedCanonicalKeys(
+            minSkips = 3,
+            sinceMs = now - TimeUnit.DAYS.toMillis(90),
+            maxPositionMs = 30_000L,
+        )
+
+        assertEquals(listOf("the strokes|last nite"), result)
+    }
+
+    @Test fun `excludes canonical keys with skips beyond position cutoff`() = runTest {
+        trackDao.insert(track(id = 1L, canonicalArtist = "arctic monkeys", canonicalTitle = "do i wanna know"))
+
+        val now = System.currentTimeMillis()
+        repeat(4) { dao.insert(skip(trackId = 1L, positionMs = 90_000L, skippedAt = now)) }   // 90s in — "done listening"
+
+        val result = dao.getEarlySkipBannedCanonicalKeys(
+            minSkips = 3,
+            sinceMs = now - TimeUnit.DAYS.toMillis(90),
+            maxPositionMs = 30_000L,
+        )
+
+        assertTrue("expected empty, got $result", result.isEmpty())
+    }
+
+    @Test fun `excludes canonical keys below skip count threshold`() = runTest {
+        trackDao.insert(track(id = 1L, canonicalArtist = "radiohead", canonicalTitle = "creep"))
+
+        val now = System.currentTimeMillis()
+        repeat(2) { dao.insert(skip(trackId = 1L, positionMs = 1000L, skippedAt = now)) }   // only 2 skips
+
+        val result = dao.getEarlySkipBannedCanonicalKeys(
+            minSkips = 3,
+            sinceMs = now - TimeUnit.DAYS.toMillis(90),
+            maxPositionMs = 30_000L,
+        )
+
+        assertTrue("expected empty, got $result", result.isEmpty())
+    }
+
+    @Test fun `excludes skips outside time window`() = runTest {
+        trackDao.insert(track(id = 1L, canonicalArtist = "blur", canonicalTitle = "song 2"))
+
+        val now = System.currentTimeMillis()
+        val veryOld = now - TimeUnit.DAYS.toMillis(100)
+        repeat(4) { dao.insert(skip(trackId = 1L, positionMs = 1000L, skippedAt = veryOld)) }
+
+        val result = dao.getEarlySkipBannedCanonicalKeys(
+            minSkips = 3,
+            sinceMs = now - TimeUnit.DAYS.toMillis(90),
+            maxPositionMs = 30_000L,
+        )
+
+        assertTrue("expected empty (events outside window), got $result", result.isEmpty())
+    }
+
+    @Test fun `bans multiple distinct canonical keys when each has 3+ qualifying skips`() = runTest {
+        trackDao.insert(track(id = 1L, canonicalArtist = "a", canonicalTitle = "x"))
+        trackDao.insert(track(id = 2L, canonicalArtist = "b", canonicalTitle = "y"))
+
+        val now = System.currentTimeMillis()
+        repeat(3) { dao.insert(skip(trackId = 1L, positionMs = 5000L, skippedAt = now)) }
+        repeat(3) { dao.insert(skip(trackId = 2L, positionMs = 5000L, skippedAt = now)) }
+
+        val result = dao.getEarlySkipBannedCanonicalKeys(
+            minSkips = 3,
+            sinceMs = now - TimeUnit.DAYS.toMillis(90),
+            maxPositionMs = 30_000L,
+        )
+
+        assertEquals(setOf("a|x", "b|y"), result.toSet())
+    }
+
+    private fun track(id: Long, canonicalArtist: String, canonicalTitle: String) = TrackEntity(
+        id = id,
+        title = "Title $id",
+        artist = "Artist $id",
+        canonicalTitle = canonicalTitle,
+        canonicalArtist = canonicalArtist,
+        isDownloaded = true,
+    )
+
+    private fun skip(trackId: Long, positionMs: Long, skippedAt: Long) = TrackSkipEventEntity(
+        trackId = trackId,
+        positionMs = positionMs,
+        skippedAt = skippedAt,
+    )
+}
+```
+
+**Important:** verify the exact `TrackSkipEventEntity` constructor by reading `core/data/src/main/kotlin/com/stash/core/data/db/entity/TrackSkipEventEntity.kt` first. Some fields (e.g. `durationMs`, `source`, etc.) may be required by the entity but not relevant to this test — use default values or whatever the entity demands.
+
+### Step 2: Run tests — expect compile error
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.TrackSkipEventDaoBanListTest"
+```
+
+Expected: compile error — `getEarlySkipBannedCanonicalKeys` doesn't exist.
+
+### Step 3: Implement the DAO method
+
+In `TrackSkipEventDao.kt`, add alongside the existing queries:
+
+```kotlin
+/**
+ * Returns canonical-key set ("$canonicalArtist|$canonicalTitle") for
+ * tracks that have been "early-skipped" at least [minSkips] times since
+ * [sinceMs], where "early" means within the first [maxPositionMs]
+ * milliseconds of playback. Used by [com.stash.core.data.sync.workers.StashMixRefreshWorker]'s
+ * discovery pre-filter to ban candidates the user has repeatedly
+ * rejected.
+ *
+ * Position-aware: a skip 90% of the way through a song is "finished
+ * listening, moving on," not a verdict. Only skips in the first
+ * [maxPositionMs] count.
+ *
+ * Joins to `tracks` to look up the canonical key. Tracks deleted from
+ * the library are naturally excluded (INNER JOIN) — acceptable; if a
+ * track is gone we don't need to ban it from future re-discovery.
+ */
+@Query(
+    """
+    SELECT (t.canonical_artist || '|' || t.canonical_title) AS k
+    FROM track_skip_events s
+    INNER JOIN tracks t ON t.id = s.track_id
+    WHERE s.skipped_at >= :sinceMs
+      AND s.position_ms <= :maxPositionMs
+    GROUP BY k
+    HAVING COUNT(*) >= :minSkips
+    """
+)
+suspend fun getEarlySkipBannedCanonicalKeys(
+    minSkips: Int,
+    sinceMs: Long,
+    maxPositionMs: Long,
+): List<String>
+```
+
+### Step 4: Run tests — expect 5/5 pass
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.TrackSkipEventDaoBanListTest"
+```
+
+Expected: 5/5 pass.
+
+### Step 5: Run the :core:data full sweep
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL.
+
+### Step 6: Commit
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackSkipEventDao.kt \
+        core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackSkipEventDaoBanListTest.kt
+git commit -m "feat(prefs): TrackSkipEventDao.getEarlySkipBannedCanonicalKeys
+
+Position-aware skip-count GROUP BY canonical-key query. Tracks the
+user has skipped 3+ times within the first 30 seconds of playback
+across the last 90 days get their canonical keys returned —
+StashMixRefreshWorker's discovery pre-filter (coming next) uses
+this to ban repeatedly-rejected tracks from future candidate pools.
+
+Position filter matters: a skip 80% through a song is 'done
+listening,' not a verdict — only early skips count as rejection.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `StashMixRefreshWorker.queueDiscoveryForRecipe` filter + fallback
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt`
+- Create: `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerSeedFilterTest.kt`
+
+This is the largest change in the PR. Bundles:
+
+1. Constructor injection: `TrackSkipEventDao`, `TrackMatcher`.
+2. New constants in the companion.
+3. Modified `queueDiscoveryForRecipe`: load filter sets, apply, fall back to TAG_GRAPH with timeout if below floor.
+4. New private `canonicalKey(artist, title)` helper.
+5. New MockK test class for the filter + fallback behavior.
+
+### Step 1: Read the current `queueDiscoveryForRecipe`
+
+Open `StashMixRefreshWorker.kt`. Find the function by name. Note its current shape — typically:
+
+```kotlin
+private suspend fun queueDiscoveryForRecipe(
+    recipe: StashMixRecipeEntity,
+    personas: LastFmPersonas,
+) {
+    val strategy = MixSeedStrategy.fromStored(recipe.seedStrategy)
+    if (strategy == MixSeedStrategy.NONE) return
+
+    val since = System.currentTimeMillis() - AFFINITY_LOOKBACK_DAYS * ...
+    val seedArtists = ...
+    val seedTracks = ...
+    val topTags = mixGenerator.computeUserTopTags(limit = 10)
+
+    val candidates = seedGenerator.generate(
+        strategy = strategy,
+        seedArtists = seedArtists,
+        topTags = topTags,
+        seedTracks = seedTracks,
+        personas = personas,
+    )
+    if (candidates.isEmpty()) return
+    Log.i(TAG, "'${recipe.name}': ${candidates.size} candidates via $strategy")
+    mixGenerator.queueDiscoveryCandidates(recipe, candidates)
+}
+```
+
+Locate it; confirm shape. Also confirm `trackDao` is in the constructor (it is — PR 4 era).
+
+### Step 2: Write the failing MockK test
+
+Create `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerSeedFilterTest.kt`:
+
+```kotlin
+package com.stash.core.data.sync.workers
+
+import android.content.Context
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.ListeningEventDao
+import com.stash.core.data.db.dao.PlaylistDao
+import com.stash.core.data.db.dao.StashMixRecipeDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.dao.TrackSkipEventDao
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.lastfm.LastFmApiClient
+import com.stash.core.data.lastfm.LastFmCredentials
+import com.stash.core.data.lastfm.LastFmSessionPreference
+import com.stash.core.data.mix.MixGenerator
+import com.stash.core.data.mix.MixSeedGenerator
+import com.stash.core.data.mix.MixSeedStrategy
+import com.stash.core.data.sync.TrackMatcher
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * MockK tests for [StashMixRefreshWorker]'s v0.9.20 discovery pre-filter:
+ *  - Filter Last.fm candidates against library canonical keys.
+ *  - Filter against early-skip-banned canonical keys.
+ *  - Fall back to TAG_GRAPH when the filtered pool is below floor.
+ *
+ * Verifies what gets passed to mixGenerator.queueDiscoveryCandidates,
+ * which is the boundary where filtered candidates enter discovery_queue.
+ */
+class StashMixRefreshWorkerSeedFilterTest {
+
+    private val appContext: Context = mockk(relaxed = true)
+    private val recipeDao: StashMixRecipeDao = mockk(relaxed = true)
+    private val playlistDao: PlaylistDao = mockk(relaxed = true)
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val listeningEventDao: ListeningEventDao = mockk(relaxed = true)
+    private val trackDao: TrackDao = mockk(relaxed = true)
+    private val mixGenerator: MixGenerator = mockk(relaxed = true)
+    private val seedGenerator: MixSeedGenerator = mockk()
+    private val lastFmApiClient: LastFmApiClient = mockk(relaxed = true)
+    private val lastFmCredentials: LastFmCredentials = mockk {
+        coEvery { isConfigured } returns true   // gate the discovery branch on
+    }
+    private val sessionPreference: LastFmSessionPreference = mockk {
+        coEvery { session } returns flowOf(null)
+    }
+    private val blocklistGuard: BlocklistGuard = mockk(relaxed = true)
+    private val trackSkipEventDao: TrackSkipEventDao = mockk(relaxed = true)
+    private val trackMatcher: TrackMatcher = mockk()
+
+    private fun newWorker(recipeId: Long): StashMixRefreshWorker {
+        val params: WorkerParameters = mockk(relaxed = true) {
+            coEvery { inputData } returns workDataOf(
+                StashMixRefreshWorker.KEY_RECIPE_ID to recipeId,
+            )
+        }
+        return StashMixRefreshWorker(
+            appContext, params,
+            recipeDao, playlistDao, discoveryQueueDao, listeningEventDao,
+            trackDao, mixGenerator, seedGenerator, lastFmApiClient,
+            lastFmCredentials, sessionPreference, blocklistGuard,
+            trackSkipEventDao, trackMatcher,
+        )
+    }
+
+    @Test fun `filters library-canonical-keys + skip-banned-keys before queueing`() = runTest {
+        val recipe = recipe(id = 1L, name = "Daily Discover", seedStrategy = "ARTIST_SIMILAR")
+        coEvery { recipeDao.getById(1L) } returns recipe
+        coEvery { recipeDao.getActive() } returns listOf(recipe)
+
+        // Stub canonicalArtist/canonicalTitle as identity-lowercase for predictability
+        coEvery { trackMatcher.canonicalArtist(any()) } answers { firstArg<String>().lowercase() }
+        coEvery { trackMatcher.canonicalTitle(any()) } answers { firstArg<String>().lowercase() }
+
+        // 5 candidates: 2 match library, 1 banned, 2 keepers
+        val candidates = listOf(
+            candidate("In Library 1", "Track A"),
+            candidate("In Library 2", "Track B"),
+            candidate("Banned Artist", "Banned Song"),
+            candidate("New Artist 1", "New Track 1"),
+            candidate("New Artist 2", "New Track 2"),
+        )
+        coEvery {
+            seedGenerator.generate(MixSeedStrategy.ARTIST_SIMILAR, any(), any(), any(), any())
+        } returns candidates
+
+        coEvery { trackDao.getLibraryCanonicalKeys() } returns listOf(
+            "in library 1|track a",
+            "in library 2|track b",
+        )
+        coEvery {
+            trackSkipEventDao.getEarlySkipBannedCanonicalKeys(any(), any(), any())
+        } returns listOf("banned artist|banned song")
+
+        // For the test we want filtered pool ≥ floor (2 keepers + floor of 20 means fallback fires).
+        // Make floor's effect irrelevant by stubbing fallback too, then assert only ARTIST_SIMILAR ran:
+        coEvery {
+            seedGenerator.generate(MixSeedStrategy.TAG_GRAPH, any(), any(), any(), any())
+        } returns emptyList()
+
+        // Capture what gets queued
+        val queuedSlot = slot<List<MixGenerator.DiscoveryCandidate>>()
+        coEvery { mixGenerator.queueDiscoveryCandidates(recipe, capture(queuedSlot)) } returns Unit
+
+        newWorker(recipeId = 1L).doWork()
+
+        // Should queue ONLY the 2 keepers
+        val keys = queuedSlot.captured.map { "${it.artist.lowercase()}|${it.title.lowercase()}" }.toSet()
+        assertEquals(setOf("new artist 1|new track 1", "new artist 2|new track 2"), keys)
+    }
+
+    @Test fun `falls back to TAG_GRAPH when filtered pool is below floor`() = runTest {
+        val recipe = recipe(id = 1L, name = "Daily Discover", seedStrategy = "ARTIST_SIMILAR")
+        coEvery { recipeDao.getById(1L) } returns recipe
+        coEvery { recipeDao.getActive() } returns listOf(recipe)
+        coEvery { trackMatcher.canonicalArtist(any()) } answers { firstArg<String>().lowercase() }
+        coEvery { trackMatcher.canonicalTitle(any()) } answers { firstArg<String>().lowercase() }
+
+        // 3 candidates, all filtered out — primary pool ends at size 0
+        val primary = listOf(
+            candidate("LibA", "TA"),
+            candidate("LibB", "TB"),
+            candidate("LibC", "TC"),
+        )
+        coEvery { seedGenerator.generate(MixSeedStrategy.ARTIST_SIMILAR, any(), any(), any(), any()) } returns primary
+        coEvery { trackDao.getLibraryCanonicalKeys() } returns listOf("liba|ta", "libb|tb", "libc|tc")
+        coEvery { trackSkipEventDao.getEarlySkipBannedCanonicalKeys(any(), any(), any()) } returns emptyList()
+
+        // Fallback returns plenty of new content
+        val fallback = (1..25).map { candidate("Fallback Artist $it", "Fallback Title $it") }
+        coEvery { seedGenerator.generate(MixSeedStrategy.TAG_GRAPH, any(), any(), any(), any()) } returns fallback
+
+        val queuedSlot = slot<List<MixGenerator.DiscoveryCandidate>>()
+        coEvery { mixGenerator.queueDiscoveryCandidates(recipe, capture(queuedSlot)) } returns Unit
+
+        newWorker(recipeId = 1L).doWork()
+
+        // All 25 fallback candidates should be queued (none filtered by library or bans in this test)
+        assertEquals(25, queuedSlot.captured.size)
+        coVerify { seedGenerator.generate(MixSeedStrategy.TAG_GRAPH, any(), any(), any(), any()) }
+    }
+
+    @Test fun `does NOT queue when all candidates filter out and fallback also empty`() = runTest {
+        val recipe = recipe(id = 1L, name = "Daily Discover", seedStrategy = "ARTIST_SIMILAR")
+        coEvery { recipeDao.getById(1L) } returns recipe
+        coEvery { recipeDao.getActive() } returns listOf(recipe)
+        coEvery { trackMatcher.canonicalArtist(any()) } answers { firstArg<String>().lowercase() }
+        coEvery { trackMatcher.canonicalTitle(any()) } answers { firstArg<String>().lowercase() }
+
+        // Single candidate, filtered out
+        coEvery {
+            seedGenerator.generate(MixSeedStrategy.ARTIST_SIMILAR, any(), any(), any(), any())
+        } returns listOf(candidate("Only", "Match"))
+        coEvery { trackDao.getLibraryCanonicalKeys() } returns listOf("only|match")
+        coEvery { trackSkipEventDao.getEarlySkipBannedCanonicalKeys(any(), any(), any()) } returns emptyList()
+
+        // Fallback also produces nothing
+        coEvery { seedGenerator.generate(MixSeedStrategy.TAG_GRAPH, any(), any(), any(), any()) } returns emptyList()
+
+        newWorker(recipeId = 1L).doWork()
+
+        coVerify(exactly = 0) { mixGenerator.queueDiscoveryCandidates(any(), any()) }
+    }
+
+    private fun recipe(id: Long, name: String, seedStrategy: String) = StashMixRecipeEntity(
+        id = id, name = name,
+        discoveryRatio = 0.85f, targetLength = 40,
+        seedStrategy = seedStrategy,
+        isBuiltin = true, isActive = true,
+    )
+
+    private fun candidate(artist: String, title: String) = MixGenerator.DiscoveryCandidate(
+        artist = artist, title = title, seedArtist = "test",
+    )
+}
+```
+
+**Note on the `trackMatcher` mock stubs**: the production `TrackMatcher.canonicalArtist` is NOT simple lowercase — it splits on `,;&/`, sorts alphabetically, rejoins with `", "`. We deliberately stub the mock as `lowercase()` because the test is exercising the FILTER LOGIC, not canonicalization. The test verifies "if `trackMatcher.canonicalArtist(c.artist)` produces a key that's in `libraryKeys`, the candidate is filtered." The actual canonicalization is exercised by integration via the on-device test in Task 5.
+
+**Production-correctness invariant** (the implementer must verify): the canonical form produced by `TrackMatcher.canonicalArtist(candidate.artist) + "|" + TrackMatcher.canonicalTitle(candidate.title)` MUST be the same format as `tracks.canonical_artist || '|' || tracks.canonical_title` stored by the sync writer. Since the sync writer uses this same `TrackMatcher` instance, this should hold — but if anything in the code path bypasses TrackMatcher (e.g., writes canonical fields manually), the keys won't match and the filter silently fails. **Action:** spot-check by reading one or two sync-writer call sites that populate `tracks.canonical_artist` to confirm they use `TrackMatcher.canonicalArtist(...)`. Five-minute task.
+
+### Step 3: Run tests — expect compile errors / failures
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.StashMixRefreshWorkerSeedFilterTest"
+```
+
+Expected: compile errors — the worker constructor doesn't accept `TrackSkipEventDao` or `TrackMatcher` yet, and `getLibraryCanonicalKeys` / `getEarlySkipBannedCanonicalKeys` from Tasks 2-3 are referenced.
+
+### Step 4: Implement the worker change
+
+In `StashMixRefreshWorker.kt`:
+
+**4a.** Add the new constructor parameters (alongside existing DAOs):
+
+```kotlin
+@HiltWorker
+class StashMixRefreshWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val recipeDao: StashMixRecipeDao,
+    // ... existing deps ...
+    private val blocklistGuard: BlocklistGuard,
+    private val trackSkipEventDao: TrackSkipEventDao,   // NEW
+    private val trackMatcher: TrackMatcher,              // NEW
+) : CoroutineWorker(appContext, params) {
+```
+
+Imports:
+
+```kotlin
+import com.stash.core.data.db.dao.TrackSkipEventDao
+import com.stash.core.data.sync.TrackMatcher
+import androidx.work.WorkManager   // unrelated — may already be there
+import kotlinx.coroutines.withTimeout   // for the fallback timeout
+```
+
+**4b.** Add the new constants in the companion object:
+
+```kotlin
+companion object {
+    // existing constants ...
+
+    /**
+     * Floor for the filtered discovery pool. Below this, the TAG_GRAPH
+     * fallback fires.
+     *
+     * Why 20 and not the recipe's discoveryCap (e.g. 34 for an 85%-discovery
+     * recipe with targetLength 40)? Downstream attrition: not every queued
+     * candidate becomes a viable survivor. StashDiscoveryWorker.handle()
+     * applies an additional blocklist check; some candidates fail at the
+     * download stage (yt-dlp can't match, no audio available, etc.); and
+     * some get canonical-deduped against tracks added to the library AFTER
+     * the seed-gen filter ran. Twenty pre-filter survivors typically yields
+     * ~10-15 actually-downloaded DONE rows — enough to fill a 6-slot mix
+     * slot AND leave a queue buffer for tomorrow's refresh. The fallback
+     * is a viability gate, not a precise capacity match.
+     */
+    private const val MIN_DISCOVERY_POOL_AFTER_FILTER = 20
+
+    /** Skip-event ban threshold: this many "early" skips in the time window → ban. */
+    private const val DISCOVERY_SKIP_BAN_MIN_COUNT = 3
+
+    /** Skip-event ban time window in milliseconds. */
+    private val DISCOVERY_SKIP_BAN_WINDOW_MS = TimeUnit.DAYS.toMillis(90)
+
+    /** Skip-position cutoff: skips in the first this-many ms count as rejection. */
+    private const val DISCOVERY_SKIP_BAN_MAX_POSITION_MS = 30_000L
+
+    /** Timeout for the TAG_GRAPH fallback Last.fm call. */
+    private const val SEED_FALLBACK_TIMEOUT_MS = 30_000L
+}
+```
+
+**4c.** Modify `queueDiscoveryForRecipe`. Replace the section AFTER `seedGenerator.generate(...)` call with:
+
+```kotlin
+val candidates = seedGenerator.generate(
+    strategy = strategy,
+    seedArtists = seedArtists,
+    topTags = topTags,
+    seedTracks = seedTracks,
+    personas = personas,
+)
+if (candidates.isEmpty()) return
+
+// v0.9.20: pre-filter against library + skip-ban so discovery_queue
+// PENDING rows represent genuinely-new music, not "rediscovery" hits.
+val libraryKeys = trackDao.getLibraryCanonicalKeys().toHashSet()
+val skipBannedKeys = trackSkipEventDao
+    .getEarlySkipBannedCanonicalKeys(
+        minSkips = DISCOVERY_SKIP_BAN_MIN_COUNT,
+        sinceMs = System.currentTimeMillis() - DISCOVERY_SKIP_BAN_WINDOW_MS,
+        maxPositionMs = DISCOVERY_SKIP_BAN_MAX_POSITION_MS,
+    )
+    .toHashSet()
+
+val filtered = candidates.filter { candidate ->
+    val key = canonicalKey(candidate.artist, candidate.title)
+    key !in libraryKeys && key !in skipBannedKeys
+}
+
+val final = if (filtered.size >= MIN_DISCOVERY_POOL_AFTER_FILTER) {
+    filtered
+} else {
+    // Fallback: top off with TAG_GRAPH candidates (different strategy
+    // typically yields different artists, so library overlap is lower).
+    // Same filters applied. withTimeout protects WorkManager's
+    // 10-minute budget — mirrors the existing 30s persona-fetch timeout.
+    val tagFallback = runCatching {
+        withTimeout(SEED_FALLBACK_TIMEOUT_MS) {
+            seedGenerator.generate(
+                strategy = MixSeedStrategy.TAG_GRAPH,
+                seedArtists = emptyList(),
+                topTags = topTags,
+                seedTracks = emptyList(),
+                personas = personas,
+            )
+        }
+    }.getOrElse {
+        Log.w(TAG, "'${recipe.name}': TAG_GRAPH fallback timed out / failed", it)
+        emptyList()
+    }.filter { candidate ->
+        val key = canonicalKey(candidate.artist, candidate.title)
+        key !in libraryKeys && key !in skipBannedKeys
+    }
+    Log.i(
+        TAG,
+        "'${recipe.name}': filtered pool (${filtered.size}) below floor; " +
+            "appending ${tagFallback.size} TAG_GRAPH fallback candidates",
+    )
+    filtered + tagFallback
+}
+
+if (final.isEmpty()) {
+    Log.w(TAG, "'${recipe.name}': all candidates filtered out (library + skips); skipping queue")
+    return
+}
+
+Log.i(
+    TAG,
+    "'${recipe.name}': ${final.size} candidates via $strategy " +
+        "(${candidates.size - filtered.size} filtered as library/banned)",
+)
+mixGenerator.queueDiscoveryCandidates(recipe, final)
+```
+
+**4d.** Add the private helper method anywhere in the worker class:
+
+```kotlin
+/**
+ * Canonical key used by the discovery pre-filter — must match the
+ * format the DAOs store and return: lowercased artist + "|" + lowercased
+ * title via [TrackMatcher]'s normalization (same as the sync writer
+ * uses to populate tracks.canonical_artist / canonical_title).
+ */
+private fun canonicalKey(artist: String, title: String): String =
+    "${trackMatcher.canonicalArtist(artist)}|${trackMatcher.canonicalTitle(title)}"
+```
+
+### Step 5: Run the new MockK test
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.StashMixRefreshWorkerSeedFilterTest"
+```
+
+Expected: 3/3 pass.
+
+### Step 6: Update existing PR 4 worker tests for the new constructor
+
+The constructor expanded from 13 → 15 args (added `trackSkipEventDao` + `trackMatcher`). Two existing test files have `newWorker()` fixtures that hand-construct `StashMixRefreshWorker`. **They WILL fail to compile** until updated:
+
+1. `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt` (PR 4 Task 4)
+2. `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerPerRecipeDedupTest.kt` (PR 4 Task 1)
+
+In each, find the `newWorker()` helper (around lines 54-67 in each file) and add two fields + pass them to the constructor:
+
+```kotlin
+// Add to the field declarations:
+private val trackSkipEventDao: TrackSkipEventDao = mockk(relaxed = true)
+private val trackMatcher: TrackMatcher = mockk(relaxed = true)
+
+// Update the StashMixRefreshWorker(...) constructor call to pass them
+// as the last two args (mirror the order in the production constructor).
+```
+
+Add imports:
+
+```kotlin
+import com.stash.core.data.db.dao.TrackSkipEventDao
+import com.stash.core.data.sync.TrackMatcher
+```
+
+Run both existing tests after updating:
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.StashMixRefreshWorkerDedupTest"
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.StashMixRefreshWorkerPerRecipeDedupTest"
+```
+
+Expected: both pass.
+
+### Step 7: Run the full :core:data module test sweep
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: BUILD SUCCESSFUL.
+
+### Step 8: Build the :app module (Hilt resolution check)
+
+```bash
+./gradlew :app:assembleDebug
+```
+
+Expected: BUILD SUCCESSFUL.
+
+### Step 9: Commit
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt \
+        core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerSeedFilterTest.kt
+# Test fixtures for the constructor-arity change (both files must be updated):
+git add core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt
+git add core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerPerRecipeDedupTest.kt
+git commit -m "feat(mix): pre-filter discovery candidates against library + skip-bans
+
+StashMixRefreshWorker.queueDiscoveryForRecipe now drops Last.fm
+candidates whose canonical artist+title key matches existing library
+tracks OR matches the early-skip-ban list (3+ skips in first 30s,
+last 90 days). Filter applied at the seed-generator boundary so
+discovery_queue PENDING rows are guaranteed to be genuinely-new
+music — not the canonical-dedup 'rediscovery' hits that were
+flooding mixes with library content.
+
+When the filtered pool falls below 20 candidates, fall back to
+TAG_GRAPH seed strategy (different artist surface) with a 30s
+timeout so the worker stays within WorkManager's budget.
+
+Constructor expands to inject TrackSkipEventDao + TrackMatcher.
+Existing tests updated to pass relaxed mocks for the new deps.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Build APK + install + on-device verification
+
+**Files:** none — verification task.
+
+### Step 1: Full release build
+
+```bash
+./gradlew :app:assembleRelease
+```
+
+Expected: BUILD SUCCESSFUL. (Re-run `:app:packageRelease` if transient Windows file-lock occurs.)
+
+### Step 2: Install over the existing release app
+
+```bash
+adb install -r app/build/outputs/apk/release/app-release.apk
+```
+
+Expected: `Success`.
+
+### Step 3: Cold-start the app
+
+```bash
+adb shell monkey -p com.stash.app -c android.intent.category.LAUNCHER 1
+```
+
+### Step 4: Confirm the orphan-drain still fires (PR 5 sanity check)
+
+```bash
+adb logcat -d -t 500 | grep -E "DiscoveryDownload"
+```
+
+Expected: `DiscoveryDownload: draining N discovery download(s)` (any N).
+
+### Step 5: Trigger a manual refresh and verify the pre-filter signal in logcat
+
+On the Pixel, long-press Daily Discover → "Refresh this mix."
+
+Tail logcat:
+
+```bash
+adb logcat -t 500 | grep -iE "stashmixrefresh|stashdiscovery|discoverydownload"
+```
+
+Expected logs within ~30 seconds:
+
+- `StashMixRefresh: refreshing 1 Stash Mix(es) (single: Daily Discover)` — existing
+- `StashMixRefresh: 'Daily Discover': N candidates via ARTIST_SIMILAR (M filtered as library/banned)` — **NEW in PR 6**; M should be substantial (likely >50% of N for a large library)
+- (Optional, only if filtered pool < 20) `'Daily Discover': filtered pool (X) below floor; appending Y TAG_GRAPH fallback candidates`
+- `WM-WorkerWrapper: Starting work for ...StashDiscoveryWorker` — PR 5 chain
+- `StashDiscovery: ...` per-recipe processing
+- `WM-WorkerWrapper: Starting work for ...DiscoveryDownloadWorker` — PR 5 chain
+- `DiscoveryDownload: draining N discovery download(s)`
+
+### Step 6: Verify mix content quality
+
+After the download chain completes (foreground service notification dismisses), open Daily Discover. Sample 10 random tracks — verify by name/artist that you don't recognize them from your existing library. Tap a few to confirm they play.
+
+Repeat for Deep Cuts and First Listen.
+
+### Step 7: Verify skip-ban semantic (optional smoke test)
+
+On the Pixel: tap a recommended track in Daily Discover, immediately skip it (within 5 seconds). Repeat that exact track 3 times across the next refresh cycles. After the 3rd skip, refresh Daily Discover again. The skipped track should NOT reappear in the mix (or in any other mix) for 90 days.
+
+This test is slow to fully validate end-to-end. The DAO test (Task 3) covers the unit behavior; the on-device test is just confirming the worker actually calls the DAO and uses the result.
+
+### Step 8: Report back
+
+When all manual checks pass, summarize:
+- Commits that landed
+- APK installed
+- Logcat evidence (the pre-filter signal in particular: `(M filtered as library/banned)`)
+- Manual content-quality checks (mostly new content; tracks play)
+- Any deferred or skipped items
+
+Do NOT push, do NOT tag.
+
+---
+
+## What's intentionally not in this plan
+
+YAGNI:
+
+- **No "un-ban" UI affordance.** Phase 3 work. Skip events age out of the 90-day window naturally.
+- **No tunable thresholds in app settings.** Hardcoded for now; can extract later if signal is off.
+- **No retroactive cleanup of pre-PR-6 `discovery_queue` rows.** New rows post-PR-6 are clean; old rows trim naturally as materializeMix re-links the discoveryCap newest.
+- **No new schema migration.** All changes use existing tables.
+- **No DataStore corruption-handler audit beyond what the hotfix already did.** Separate concern.

--- a/docs/superpowers/specs/2026-05-08-first-listen-tag-fallback-design.md
+++ b/docs/superpowers/specs/2026-05-08-first-listen-tag-fallback-design.md
@@ -1,0 +1,151 @@
+# v0.9.19 — First Listen Tag-Fallback
+
+**Date:** 2026-05-08
+**Status:** Design
+**Branch:** `feat/first-listen-tag-fallback` (worktree path: `.worktrees/first-listen-tag-fallback`)
+
+## Problem
+
+In v0.9.16 the Stash Mix surface expanded from a single "Stash Discover" flagship to three recipes:
+
+| Recipe | Seed strategy | `discoveryRatio` | Library fallback chain |
+|---|---|---|---|
+| Daily Discover | `ARTIST_SIMILAR` | 0.4 (40% discovery) | persona → listening events → top artists by track count |
+| Deep Cuts | `NONE` | 0.0 (pure library) | n/a — uses library directly |
+| **First Listen** | **`TAG_GRAPH`** | **1.0 (100% discovery)** | **none** |
+
+Real user observation on a v0.9.18 release build with a vast library: Daily Discover and Deep Cuts populate normally; **First Listen is empty**.
+
+Trace of `StashMixRefreshWorker.queueDiscoveryForRecipe` for First Listen:
+
+```
+topTags = mixGenerator.computeUserTopTags(limit = 10)
+  └─ buildUserTagAffinityVector()
+        ├─ listening_events from last 180d  ← user has plays, OK
+        ├─ for each row: trackTagDao.getByTrack(trackId).filter { it.tag != "__untaggable__" }
+        │  └─ returns empty for tracks not yet enriched, or tracks Last.fm has no real tags for
+        └─ if all per-play tag maps end up empty → user vector is empty
+      → returns []
+candidates = seedGenerator.generate(TAG_GRAPH, topTags = [], …)
+  └─ generateTagGraph([]).also { for (tag in [].take(10)) { … } } → []
+if (candidates.isEmpty()) return  ← early exit, no discovery queued
+discoveryRatio = 1.0 means 0% library fill → mix stays empty
+```
+
+Concretely: when the user has listening events but their listened-to tracks aren't yet enriched by `TagEnrichmentWorker` (which runs daily, batches of 200, so a multi-thousand-track library takes many days to fully enrich), the listening-affinity vector is empty. The user's library *itself* contains tagged tracks (visible via `TrackTagDao.getTagHistogram()`) — but no path consumes that signal for the TAG_GRAPH seed.
+
+This is a contained design gap, not a regression. v0.9.16 shipped with no fallback for empty `topTags`.
+
+## Goals
+
+- A v0.9.18 user with a vast library and any subset of enriched tracks has a non-empty First Listen mix after the next `StashMixRefreshWorker` run.
+- The fallback uses on-device data already produced by the enrichment pipeline — no extra Last.fm round-trips at refresh time, no UI changes, no preference flips.
+- The semantic of First Listen ("Tracks you've never heard. Wider net.") is preserved — the fallback's input is still a "what kind of music does this user like" signal, just sourced from library breadth instead of recent listening.
+- The fix is contained to one function in `MixGenerator`; tests live in the same file's existing test class.
+
+## Non-goals
+
+- **No tweak to `TagEnrichmentWorker`'s throughput.** Its 200-tracks-per-day cadence is a separate optimization concern. The fallback handles the gap until enrichment catches up; widening enrichment's bandwidth is a future YAGNI revisit.
+- **No new prefs.** The fallback fires automatically whenever `buildUserTagAffinityVector()` returns empty; no opt-in toggle.
+- **No `MixGenerator.computeUserTopTags()` signature change.** Same suspending fn, same return type, same caller invocations.
+- **No change to other recipes.** Daily Discover and Deep Cuts already have working fallback paths; touching them risks regressing what works.
+- **No spec for "the user's listened tracks aren't getting enriched fast enough."** That's a different bug class. This spec only fixes the dead-end when the listening-affinity vector is empty.
+- **No tag deduplication / canonicalization.** Library histogram tags ship as-is; whatever Last.fm returned (lowercased and stored) is what we use. Future cleanup is out of scope.
+- **No `__untaggable__` sentinel cleanup.** The filter at the consumer is sufficient.
+
+## Design
+
+### 1. Code change
+
+**One function modified.** `core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt`:
+
+```kotlin
+/**
+ * v0.9.16: Top-N user tags ordered by tag-affinity weight. Used by
+ * [com.stash.core.data.sync.workers.StashMixRefreshWorker] to drive
+ * the TAG_GRAPH seed strategy.
+ *
+ * v0.9.19: when the listening-affinity vector is empty (fresh install,
+ * recently played tracks not yet enriched, etc.) falls back to the
+ * library-wide tag histogram. The histogram represents "what kind of
+ * music this user collects" — the right anchor for First Listen's
+ * "wider net" semantics when there's no per-play signal yet.
+ *
+ * Returns an empty list ONLY when the user has zero tags anywhere in
+ * `track_tags` (truly fresh install, enrichment hasn't run a single
+ * batch yet) — at which point TAG_GRAPH-driven recipes correctly
+ * stay empty until the user's library has any tag data.
+ */
+suspend fun computeUserTopTags(limit: Int = 10): List<String> {
+    val vector = buildUserTagAffinityVector()
+    if (vector.isNotEmpty()) {
+        return vector.entries
+            .sortedByDescending { it.value }
+            .take(limit)
+            .map { it.key }
+    }
+    return trackTagDao.getTagHistogram()
+        .asSequence()
+        .filter { it.tag != "__untaggable__" }
+        .take(limit)
+        .map { it.tag }
+        .toList()
+}
+```
+
+The fallback's filter mirrors the same `__untaggable__` exclusion `buildUserTagAffinityVector` applies to per-play tags, so neither path can leak the sentinel into seed input.
+
+### 2. Test surface (TDD)
+
+| Test | What it asserts |
+|---|---|
+| `computeUserTopTags returns affinity-vector tags when vector is non-empty` | When `buildUserTagAffinityVector` would produce a non-empty vector (i.e., listening events exist for tagged tracks), the existing path runs and the histogram is NOT consulted. |
+| `computeUserTopTags falls back to histogram when affinity vector is empty` | When the affinity vector is empty (no plays, OR plays only on untagged tracks), `getTagHistogram` is called and its top N tags returned. |
+| `computeUserTopTags fallback filters out __untaggable__ sentinel` | When the histogram includes the sentinel row (which it always does once `TagEnrichmentWorker` has hit any unmatched track), the fallback filters it out — the seed loop must never iterate `__untaggable__` as a Last.fm tag. |
+| `computeUserTopTags returns empty when histogram is also empty` | Truly-fresh-install case (tag enrichment hasn't run any batch yet). Fallback gracefully returns empty rather than throwing. The `TAG_GRAPH` consumer's existing `if (candidates.isEmpty()) return` guard handles this case correctly. |
+| `computeUserTopTags respects the limit on the fallback path` | When the histogram has more than `limit` rows, only the top `limit` are returned. |
+
+The first test guards against a regression where the histogram fallback "always runs" — if the listening-affinity signal exists, it should be the source of truth.
+
+Test file: existing `core/data/src/test/kotlin/com/stash/core/data/mix/MixGeneratorTest.kt` if it exists, otherwise `MixGeneratorComputeUserTopTagsTest.kt` as a sibling.
+
+### 3. No schema change
+
+The fallback consumes existing tables (`track_tags`) via an existing DAO method (`TrackTagDao.getTagHistogram()`). No migration. Schema stays at v22.
+
+### 4. Edge cases
+
+#### 4.1 Empty histogram (truly-fresh install)
+
+If both the affinity vector AND the histogram are empty (the user just installed v0.9.19 and `TagEnrichmentWorker` hasn't run a single batch yet), `computeUserTopTags` returns `emptyList()`. `MixSeedGenerator.generateTagGraph(emptyList())` returns `emptyList()`, the worker's `if (candidates.isEmpty()) return` early-exits, and First Listen stays empty. After enrichment runs once, the next refresh produces tags via the fallback. No additional code change needed.
+
+#### 4.2 Histogram polluted with `__untaggable__` only
+
+If every track in the user's library returns `__untaggable__` from Last.fm (vanishingly unlikely — typical Last.fm coverage is high for mainstream tracks), the filter strips them all and the fallback returns `emptyList()`. Same downstream behavior as 4.1.
+
+#### 4.3 Listening-affinity vector becomes non-empty after enrichment catches up
+
+The fallback's `if (vector.isNotEmpty()) return …` short-circuit ensures the affinity-vector path takes over the moment the user has any plays on enriched tracks. No persistent state to flip; the choice is computed per-refresh.
+
+#### 4.4 Daily Discover unaffected
+
+Daily Discover uses `ARTIST_SIMILAR`, which doesn't call `computeUserTopTags`. Untouched.
+
+#### 4.5 Deep Cuts unaffected
+
+Deep Cuts uses `NONE` strategy — short-circuits before the seed-generator dispatch. Untouched.
+
+### 5. Versioning + ship
+
+- `versionCode`: 56 → 57
+- `versionName`: 0.9.18 → 0.9.19
+- Schema: 22 (unchanged)
+- New branch: `feat/first-listen-tag-fallback`, worktree at `.worktrees/first-listen-tag-fallback`. Per project memory: copy `local.properties` AND `keystore.properties` AND `stash-release.jks` into the worktree (`local.properties` for Last.fm credentials at build time; signing files for release-APK install over existing v0.9.18).
+
+## Open questions
+
+None blocking implementation. Possible follow-ups deferred to later releases:
+
+- **Tag-enrichment throughput.** 200 tracks/day on a vast library is slow. Doubling the batch (or adding a "catch-up" mode that runs hourly until the untagged backlog is < N) would reduce the window during which the fallback is the only source of truth. Worth doing if users with >5000 tracks repeatedly ask why their listening history doesn't bias First Listen.
+- **Hybrid weighting.** When the affinity vector exists but is *thin* (few plays on enriched tracks), blending with the histogram could produce better signal than either alone. Worth exploring if v0.9.19's binary "vector if present, histogram otherwise" feels sharp at the boundary.
+- **Listening events trigger immediate tag-enrichment.** Currently `TagEnrichmentWorker` walks `findUntaggedDownloadedTrackIds` from the top — there's no "prioritize tracks the user is actively playing" signal. A small tweak would re-order the queue to enrich played-but-untagged tracks first. Different bug class; out of scope here.

--- a/docs/superpowers/specs/2026-05-08-first-listen-tag-fallback-design.md
+++ b/docs/superpowers/specs/2026-05-08-first-listen-tag-fallback-design.md
@@ -143,10 +143,113 @@ Deep Cuts uses `NONE` strategy — short-circuits before the seed-generator disp
 - Schema: 22 (unchanged)
 - New branch: `feat/first-listen-tag-fallback`, worktree at `.worktrees/first-listen-tag-fallback`. Per project memory: copy `local.properties` AND `keystore.properties` AND `stash-release.jks` into the worktree (`local.properties` for Last.fm credentials at build time; signing files for release-APK install over existing v0.9.18).
 
+## v0.9.19 follow-up: discovery survivor cap
+
+### Why this is in the same spec
+
+Phase 1 debugging on the v0.9.19 install surfaced a second, latent bug: `materializeMix` re-links **every** DONE row in `discovery_queue` for a recipe with no upper bound. Over many refreshes, the playlist grows past `targetLength`. Concrete observed effect: Daily Discover went from 50 tracks pre-v0.9.19 to 100 tracks immediately after the v0.9.19 install's app-startup all-recipes refresh, because ~50 DONE survivors had accumulated between v0.9.18 install and v0.9.19 install. The first-section histogram fallback above will produce the same drift on First Listen once `StashDiscoveryWorker` chews through the 300 PENDING candidates the fallback queues.
+
+This isn't a regression introduced by v0.9.19 — it's a pre-existing structural cap miss. But the same install that exposed it (the histogram fallback driving more candidates into the discovery queue) makes shipping the fallback alone awkward: First Listen would steadily creep past 50 tracks the way Daily Discover did. Keeping both fixes in the v0.9.19 ship avoids that intermediate broken state.
+
+### Goals
+
+- Discovery survivor re-link in `materializeMix` is bounded at `targetLength * discoveryRatio` (rounded). Enforces the recipe's stated discovery slot count.
+- Newest-DONE survivors win when the cap forces us to cut. Older survivors rotate out naturally on subsequent refreshes — matches each recipe's "freshness window" framing.
+- Library shortfall-fill (`MixGenerator.kt` line 192) is **untouched** — the cap applies only to discovery survivors, not to library tracks. Daily Discover keeps its current "fill library to 50 if pool is large enough" behavior.
+
+### Non-goals
+
+- **No change to library shortfall-fill.** Trimming library tracks to `(1 - discoveryRatio) * targetLength` when discovery survivors are present would make Daily Discover exactly 30+20=50, but that's a behavior change in `MixGenerator` that v0.9.16 has shipped with for months. Out of scope here. The cap fixes the unbounded-growth bug without touching working code.
+- **No DONE-row cleanup in the discovery queue itself.** The DAO query just LIMITs what's returned; old DONE rows past the cap stay in `discovery_queue` (still useful for diagnostics, future cap-bumps, etc.). A separate sweep that deletes long-stale DONE rows is a future YAGNI revisit.
+- **No new schema column or index.** `discovery_queue.completed_at` already exists and is set when the worker transitions to DONE; that's the ordering signal.
+
+### Design
+
+**File 1: `core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt`**
+
+Modify `getDoneTrackIdsForRecipe` to take a `limit` parameter and add `ORDER BY completed_at DESC LIMIT :limit`:
+
+```kotlin
+@Query("""
+    SELECT track_id FROM discovery_queue
+    WHERE recipe_id = :recipeId
+      AND status = 'DONE'
+      AND track_id IS NOT NULL
+    ORDER BY completed_at DESC
+    LIMIT :limit
+""")
+suspend fun getDoneTrackIdsForRecipe(recipeId: Long, limit: Int): List<Long>
+```
+
+`completed_at` is non-null for any row where `status = 'DONE'` (`DiscoveryQueueEntity.completedAt: Long?` is set inside the worker on the DONE transition; the schema doesn't enforce non-null but the data invariant holds in practice).
+
+**File 2: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt`**
+
+In `materializeMix`, compute the cap at the call site and pass it. The existing in-Kotlin `librarySet` filter and blocklist loop operate on the already-capped list — no change to that logic:
+
+```kotlin
+val discoveryCap = (recipe.targetLength * recipe.discoveryRatio)
+    .roundToInt()
+    .coerceAtLeast(0)
+val candidateIds = discoveryQueueDao
+    .getDoneTrackIdsForRecipe(recipe.id, limit = discoveryCap)
+    .filter { it !in librarySet }
+val discoveryTrackIds = buildList {
+    for (trackId in candidateIds) {
+        if (!blocklistGuard.isBlockedByTrackId(trackId)) add(trackId)
+    }
+}
+// ... existing forEachIndexed insertion and totalCount = tracks.size + discoveryTrackIds.size
+```
+
+### Behavior matrix
+
+| Recipe | targetLength | discoveryRatio | New cap | Total bound (library + cap) |
+|---|---|---|---|---|
+| Daily Discover | 50 | 0.4 | 20 | up to 70 (50 library w/ shortfall fill + ≤20 discovery) |
+| Deep Cuts | 50 | 0.0 | 0 | 50 (library only; LIMIT 0 returns empty) |
+| First Listen | 50 | 1.0 | 50 | up to 50 (0 library + ≤50 discovery — pure discovery) |
+
+Daily Discover settling at 70 instead of 50 is intentional and matches the spec's intent above (no library trim). The user's observation of "Daily Discover at 100" becomes "≤70" after the cap — acceptable; the unbounded growth is the real bug.
+
+### Test surface (TDD)
+
+| Test | What it asserts |
+|---|---|
+| `getDoneTrackIdsForRecipe respects limit` | Seed N+M DONE rows for one recipe, request `limit = N`, verify N rows returned. |
+| `getDoneTrackIdsForRecipe orders by completed_at DESC` | Seed two DONE rows with `completedAt = (older, newer)`, request `limit = 2`, verify newer-first. |
+| `getDoneTrackIdsForRecipe filters status=DONE` | Seed PENDING + DONE rows for the same recipe, request `limit = 99`, verify only DONE returned. |
+| `getDoneTrackIdsForRecipe filters out null track_id` | Seed a DONE row where the worker hasn't yet linked a `track_id` (transient state — possible if a row updates status before linking the final track id), verify it's excluded. |
+| `getDoneTrackIdsForRecipe with limit=0 returns empty` | Edge case: Deep Cuts hits this on every refresh. Result must be empty list, no exception. |
+
+The first four tests live in an existing `DiscoveryQueueDao` test class if one exists, otherwise a new `DiscoveryQueueDaoCapTest.kt` sibling. The `materializeMix` integration is verified manually on-device after install (no Compose/UI test added — the cap is a count check that's already exercised by the on-device smoke test).
+
+### Edge cases
+
+#### `discoveryCap = 0`
+
+Daily Discover with the user's `discoveryRatio = 0.4` rounds to 20 — non-zero. Deep Cuts with `discoveryRatio = 0.0` rounds to 0 — `LIMIT 0` returns empty list. Sqlite tolerates `LIMIT 0` natively.
+
+#### Blocklist removes some of the top `cap` rows
+
+Cap = 20, but 5 of the top 20 are blocked. Result: 15 discovery survivors re-linked. The cap is a max, not a target — we don't re-query to backfill. Matches the existing semantic (the blocklist filter has always been post-fetch; the new code just runs it on a smaller fetch).
+
+#### `completed_at` is null on a row marked DONE
+
+Possible if a future bug or an incomplete migration leaves a DONE row without a timestamp. SQLite's `ORDER BY` puts NULLs last by default — those rows sink to the bottom and get cut first under the LIMIT. Acceptable degradation; flagged here so a future audit knows where to look.
+
+### Versioning + ship
+
+Same v0.9.19 ship — no separate version bump for this fix. The version bump commit (currently `ba21749`) gets rebased to the tip after the cap-fix commit lands, so the tagged commit at release time has both fixes plus the version bump in its merge base.
+
+User explicitly defers the ship decision until manual on-device verification — the worktree-build-install steps land in this iteration, but `git push` and `git tag` wait for user sign-off after testing.
+
 ## Open questions
 
 None blocking implementation. Possible follow-ups deferred to later releases:
 
 - **Tag-enrichment throughput.** 200 tracks/day on a vast library is slow. Doubling the batch (or adding a "catch-up" mode that runs hourly until the untagged backlog is < N) would reduce the window during which the fallback is the only source of truth. Worth doing if users with >5000 tracks repeatedly ask why their listening history doesn't bias First Listen.
 - **Hybrid weighting.** When the affinity vector exists but is *thin* (few plays on enriched tracks), blending with the histogram could produce better signal than either alone. Worth exploring if v0.9.19's binary "vector if present, histogram otherwise" feels sharp at the boundary.
+- **DONE-row cleanup in `discovery_queue`.** With the cap, old DONE rows past the survivor window stay in the queue indefinitely — useful for diagnostics, but accumulates over time. A periodic sweep to prune rows older than (say) 90 days could keep the table size in check.
+- **Library shortfall-fill rebalance.** Trimming library tracks to `(1 - discoveryRatio) * targetLength` when discovery survivors are present would tighten the total to exactly `targetLength`. Worth doing if `targetLength + discoveryCap` (e.g., 70 for Daily Discover) feels too long in practice.
 - **Listening events trigger immediate tag-enrichment.** Currently `TagEnrichmentWorker` walks `findUntaggedDownloadedTrackIds` from the top — there's no "prioritize tracks the user is actively playing" signal. A small tweak would re-order the queue to enrich played-but-untagged tracks first. Different bug class; out of scope here.

--- a/docs/superpowers/specs/2026-05-08-first-listen-tag-fallback-design.md
+++ b/docs/superpowers/specs/2026-05-08-first-listen-tag-fallback-design.md
@@ -104,6 +104,7 @@ The fallback's filter mirrors the same `__untaggable__` exclusion `buildUserTagA
 | `computeUserTopTags fallback filters out __untaggable__ sentinel` | When the histogram includes the sentinel row (which it always does once `TagEnrichmentWorker` has hit any unmatched track), the fallback filters it out — the seed loop must never iterate `__untaggable__` as a Last.fm tag. |
 | `computeUserTopTags returns empty when histogram is also empty` | Truly-fresh-install case (tag enrichment hasn't run any batch yet). Fallback gracefully returns empty rather than throwing. The `TAG_GRAPH` consumer's existing `if (candidates.isEmpty()) return` guard handles this case correctly. |
 | `computeUserTopTags respects the limit on the fallback path` | When the histogram has more than `limit` rows, only the top `limit` are returned. |
+| `computeUserTopTags fallback yields `limit` real tags even when `__untaggable__` appears in the histogram top` | Combined-case regression guard. Histogram `[__untaggable__(top), tag1, tag2, …]` with `limit = 10` must yield 10 real tags (the implementation must filter BEFORE take, not AFTER, otherwise the sentinel consumes a slot). The existing implementation chains `.filter { … }.take(limit)`; this test pins that order. |
 
 The first test guards against a regression where the histogram fallback "always runs" — if the listening-affinity signal exists, it should be the source of truth.
 

--- a/docs/superpowers/specs/2026-05-11-discovery-downloads-and-per-recipe-dedup-design.md
+++ b/docs/superpowers/specs/2026-05-11-discovery-downloads-and-per-recipe-dedup-design.md
@@ -1,0 +1,628 @@
+# Discovery Downloads + Per-Recipe Dedup Design
+
+> **Status:** Design — pending implementation plan.
+> **Scope:** PR 4 of the post-v0.9.19 audit (PR 1: snackbar lifecycle + orphan-FK fix; PR 3: recipe pivot to 85% discovery + batch-mode cross-mix dedup). PR 4 closes two remaining symptoms surfaced after the PR 3 install: per-recipe refresh still produces overlapping mixes, and recommendation tracks are present-but-unplayable because the existing download pipeline is sync-gated.
+> **Related:** continues from `2026-05-11-stash-mix-recommendation-pivot-design.md`.
+
+---
+
+## Goal
+
+After PR 3 install, the user observed three concrete problems:
+
+1. **Daily Discover and Deep Cuts still share top tracks** ("Hold it Down" by Jerreau was #1 in both; "Lye" by Earl Sweatshirt appeared in both). The cross-mix dedup we shipped only fires when the worker is invoked in batch mode (full sweep). Per-recipe refresh — the path that fires when the user long-presses → "Refresh this mix" — bypasses dedup entirely.
+2. **First Listen says it refreshed but didn't change.** The 42 tracks shown are discovery stubs (TrackEntity rows with `isDownloaded = false`); none are playable.
+3. **Daily Discover has 39 tracks but only 4 are playable.** Same root cause — discovery survivors are marked `STATUS_DONE` in `discovery_queue` the moment the stub TrackEntity is inserted, but the actual download requires `TrackDownloadWorker` which hard-rejects work without a `syncId` (`TrackDownloadWorker.kt:87-91`). The download stays queued indefinitely unless the user manually triggers a sync.
+
+This PR fixes both at the root:
+
+- **Per-recipe refresh respects cross-mix dedup** by pre-populating `excludeIds` from the OTHER builtin mixes' current playlist contents.
+- **Discovery candidates actually download** via a new `DiscoveryDownloadWorker` that drains `download_queue WHERE syncId IS NULL` using the existing `TrackDownloader` abstraction. Chained from the tail of `StashDiscoveryWorker.doWork`, plus a final `StashMixRefreshWorker.enqueueOneTime` to re-materialize mixes once new tracks land.
+- **Defense in depth**: `getDoneTrackIdsForRecipe` adds `AND t.is_downloaded = 1` so the mix never surfaces an undownloaded stub even in a transient window.
+
+## Non-goals
+
+- **Modifying `TrackDownloadWorker` to accept `syncId = null`.** Explicitly rejected — the sync chain is working and the cost of a subtle sync regression is higher than the cost of a parallel worker.
+- **Modifying `StashDiscoveryWorker`'s "mark DONE before file lands" semantic.** The DONE rows are still useful as a discovery-history record (per-recipe-weekly cap, blocklist guard, etc.); we just stop surfacing them in the playlist until they're playable.
+- **A sync-history entry for discovery downloads.** No coupling to `SyncHistoryEntity`, `SyncStateManager`, or `SyncNotificationManager`. Discovery downloads are not "syncs" in the user's mental model.
+- **A UI surface for in-flight discovery downloads.** Out of scope; the foreground-service notification already gives the user signal that work is happening.
+- **A "discovery-pending" filter chip on the mix screen.** YAGNI — once Path B's `is_downloaded = 1` filter is in place, mixes show only playable tracks; phantom UI states aren't a thing.
+- **Pre-seeding discovery_queue inline on retune (deferred from PR 3).** Still rejected.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ core:data  ::  PlaylistDao                                              │
+│   NEW: getTrackIdsForPlaylists(playlistIds: List<Long>): List<Long>     │
+│                                                                         │
+│ core:data  ::  DownloadQueueDao                                         │
+│   NEW: pendingDiscoveryDownloads(): List<DownloadQueueEntity>           │
+│        (sync_id IS NULL AND status IN ('PENDING', 'FAILED' < 3 retry)) │
+│   MODIFY: getAllPendingBySources + getRetryableBySources add            │
+│           AND dq.sync_id IS NOT NULL — partitions sync-chain workers    │
+│           off discovery rows (Failure mode #1).                         │
+│                                                                         │
+│ core:data  ::  DiscoveryQueueDao  (PR 1 Task 8 extension)               │
+│   getDoneTrackIdsForRecipe: add AND t.is_downloaded = 1 to WHERE.       │
+│                                                                         │
+│ core:data  ::  StashMixRefreshWorker                                    │
+│   doWork: when targetId > 0 (single-recipe path), pre-populate          │
+│           excludeIds from other builtin mixes' current playlist         │
+│           contents via the new PlaylistDao query.                       │
+│                                                                         │
+│ core:data  ::  StashDiscoveryWorker                                     │
+│   doWork end: enqueue DiscoveryDownloadWorker.enqueueOneTime(context)   │
+│                                                                         │
+│ data:download  ::  DiscoveryDownloadWorker  (NEW)                       │
+│   doWork:                                                               │
+│     1. Promote to foreground service via inline ForegroundInfo builder  │
+│     2. Drain pendingDiscoveryDownloads()                                │
+│     3. For each: same per-track flow as TrackDownloadWorker (blocklist  │
+│        guard → TrackDownloader.downloadTrack → mark COMPLETED/FAILED    │
+│        + isDownloaded=true on success, with format/quality + duration   │
+│        reconciliation)                                                  │
+│     4. Always enqueue StashMixRefreshWorker.enqueueOneTime so the       │
+│        mixes re-materialize with the newly-downloaded survivors.        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+No schema migration. Room schema v22 stays. All changes are new queries, new worker, tightened existing queries, and a single-line partition predicate on the two sync feeders.
+
+## Component 1 — Per-recipe dedup (Bug A)
+
+`core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt`. Add:
+
+```kotlin
+/**
+ * Returns DISTINCT track ids that appear in any of the given playlists.
+ * Used by [com.stash.core.data.sync.workers.StashMixRefreshWorker]'s
+ * single-recipe refresh path to seed `excludeIds` from the user's
+ * currently-materialized OTHER mixes — without this, a manual refresh
+ * of one mix sees an empty exclude set and naturally produces overlap
+ * with the others (the very symptom PR 3's batch-mode dedup was meant
+ * to fix).
+ */
+@Query("SELECT DISTINCT track_id FROM playlist_tracks WHERE playlist_id IN (:playlistIds)")
+suspend fun getTrackIdsForPlaylists(playlistIds: List<Long>): List<Long>
+```
+
+`core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt`, modify `doWork` around lines 219-225 (just before the `val orderedRecipes = active.sortedBy { ... }` line, after the `active` list is constructed):
+
+```kotlin
+val orderedRecipes = active.sortedBy { recipeDedupPriority(it) }
+val excludeIds = mutableSetOf<Long>()
+
+// v0.9.20 follow-up: single-recipe path needs explicit seeding from the
+// OTHER mixes' current playlist contents. The batch-mode loop accumulates
+// excludeIds naturally as it iterates; the single-element loop has nothing
+// to accumulate, so we seed it manually from the materialized state of the
+// other builtin mixes. Effect: manual refresh of one mix no longer overlaps
+// with whatever is currently in the others.
+if (targetId > 0L) {
+    val otherPlaylistIds = recipeDao.getActive()
+        .filter { it.id != targetId && it.playlistId != null }
+        .mapNotNull { it.playlistId }
+    if (otherPlaylistIds.isNotEmpty()) {
+        excludeIds += playlistDao.getTrackIdsForPlaylists(otherPlaylistIds)
+    }
+}
+
+for (recipe in orderedRecipes) {
+    val excludeSnapshot = excludeIds.toSet()
+    val tracks = mixGenerator.generate(recipe, excludeSnapshot)
+    // ... rest unchanged
+}
+```
+
+**Why this works correctly across the three single-recipe refreshes:**
+- User refreshes Daily Discover → reads current Deep Cuts + First Listen playlists, picks fresh tracks not in either.
+- User refreshes Deep Cuts → reads current Daily Discover (now updated) + First Listen, picks fresh tracks not in either.
+- User refreshes First Listen → reads current Daily Discover + Deep Cuts (both now updated), picks fresh tracks not in either.
+
+After one round of refreshes, the three mixes naturally diverge. Subsequent refreshes maintain the divergence as long as each recipe has enough fresh discovery survivors to pick from.
+
+## Component 2 — `DiscoveryDownloadWorker` (Bugs B + C)
+
+`data/download/src/main/kotlin/com/stash/data/download/DiscoveryDownloadWorker.kt` (NEW).
+
+### 2a. New `DownloadQueueDao` query + partition predicate on existing sync feeders
+
+**The new query** in `core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt`:
+
+```kotlin
+/**
+ * Discovery rows queued for download — `sync_id IS NULL` partitions
+ * them away from sync-chain TrackDownloadWorker (which after the
+ * v0.9.20 partition predicate only touches rows with non-null sync_id).
+ *
+ * Includes FAILED rows with retry_count < 3 so a transient network
+ * blip doesn't permanently sideline a discovery candidate — matches
+ * the retry posture of TrackDownloadWorker's getRetryableBySources.
+ *
+ * Filtered to exclude WAITING_FOR_LOSSLESS (owned by LosslessRetryWorker)
+ * and IN_PROGRESS / COMPLETED (already running or done).
+ */
+@Query(
+    """
+    SELECT * FROM download_queue
+    WHERE sync_id IS NULL
+      AND (status = 'PENDING' OR (status = 'FAILED' AND retry_count < 3))
+    ORDER BY id ASC
+    """
+)
+suspend fun pendingDiscoveryDownloads(): List<DownloadQueueEntity>
+```
+
+**Partition predicate on the existing sync feeders** — required to honor the "zero risk to sync path" promise. Without this, `TrackDownloadWorker` would race the new worker on the same rows (both queries match discovery rows today because STASH_MIX playlists are created with `syncEnabled = true` and discovery stubs have `source = MusicSource.YOUTUBE`).
+
+In `getAllPendingBySources` (lines 76-95), add `AND dq.sync_id IS NOT NULL` to the WHERE clause:
+
+```kotlin
+WHERE dq.status = 'PENDING'
+  AND dq.sync_id IS NOT NULL   -- v0.9.20: partition off discovery rows
+  AND t.source IN (:sources)
+  ...
+```
+
+In `getRetryableBySources` (lines 105-124), the same predicate:
+
+```kotlin
+WHERE dq.status = 'FAILED' AND dq.retry_count < 3
+  AND dq.sync_id IS NOT NULL   -- v0.9.20: partition off discovery rows
+  AND t.source IN (:sources)
+  ...
+```
+
+**Why these are safe edits to the sync path:**
+- Every sync-initiated row in `download_queue` has a non-null `sync_id` (set by `DiffWorker` when it queues the row).
+- Every discovery-initiated row has `sync_id = null` (set by `StashDiscoveryWorker.handle()` at line 222).
+- The predicate makes explicit a partition that was previously implicit (discovery rows happened to be drained by sync only because nothing prevented it).
+- Sync's actual behavior on its own rows is unchanged.
+
+**Risk assessment:** if there are any in-the-wild rows where `sync_id IS NULL AND source IN (Spotify, YouTube)` that don't fall under "discovery" (i.e., some other producer puts rows with null sync_id), those would stop being drained by sync. After grepping the codebase, the only producers of `download_queue` rows are `DiffWorker` (sets sync_id) and `StashDiscoveryWorker.handle` (sets sync_id = null). So the partition is exhaustive.
+
+### 2b. The worker
+
+```kotlin
+package com.stash.data.download
+
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.stash.core.data.audio.AudioDurationExtractor
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DownloadQueueDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.DownloadQueueEntity
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.mapper.toDomain
+import com.stash.core.data.sync.SyncNotificationManager
+import com.stash.core.data.sync.TrackDownloadOutcome
+import com.stash.core.data.sync.TrackDownloader
+import com.stash.core.data.sync.workers.StashMixRefreshWorker
+import com.stash.core.model.DownloadFailureType
+import com.stash.core.model.DownloadStatus
+import com.stash.core.model.Track
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import java.io.File
+
+/**
+ * Drains `download_queue` rows produced by [StashDiscoveryWorker]
+ * (`sync_id IS NULL`). Parallels [TrackDownloadWorker]'s per-track
+ * flow (blocklist guard → [TrackDownloader.downloadTrack] → mark
+ * COMPLETED with isDownloaded=true + filePath, or FAILED with retry
+ * accounting) without the sync-history coupling that worker requires.
+ *
+ * Chained from the tail of [StashDiscoveryWorker.doWork] (REPLACE
+ * policy on a unique work name so a rapid discovery + drain cycle
+ * doesn't double-run). At the end of the drain, enqueues a one-shot
+ * [StashMixRefreshWorker] so mixes re-materialize and the user sees
+ * the newly-downloaded survivors without manual refresh.
+ *
+ * Foreground-service promotion via [getForegroundInfo] is the same
+ * pattern TrackDownloadWorker uses — required for long batches that
+ * outlive normal background limits.
+ */
+@HiltWorker
+class DiscoveryDownloadWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val downloadQueueDao: DownloadQueueDao,
+    private val trackDao: TrackDao,
+    private val trackDownloader: TrackDownloader,
+    private val audioDurationExtractor: AudioDurationExtractor,
+    private val blocklistGuard: BlocklistGuard,
+    private val syncNotificationManager: SyncNotificationManager,
+) : CoroutineWorker(appContext, params) {
+
+    companion object {
+        const val UNIQUE_WORK_NAME = "discovery_download"
+        private const val TAG = "DiscoveryDownload"
+
+        /**
+         * Constraints mirror TrackDownloadWorker's posture: respects the
+         * user's DownloadNetworkMode preference. Wire whatever
+         * constraint-builder the existing sync chain uses — search the
+         * codebase for `NetworkType.UNMETERED` and `downloadNetworkPreference`
+         * to find the existing helper.
+         */
+        fun enqueueOneTime(context: Context, constraints: Constraints) {
+            val work = OneTimeWorkRequestBuilder<DiscoveryDownloadWorker>()
+                .setConstraints(constraints)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                UNIQUE_WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                work,
+            )
+        }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        return buildForegroundInfo("Downloading discoveries", "Preparing\u2026", progress = -1f)
+    }
+
+    /**
+     * Inline mirror of [TrackDownloadWorker]'s private `createForegroundInfo`
+     * helper (which lives at lines 497-515 of that file). Duplicated rather
+     * than promoted to a public method on `SyncNotificationManager` because
+     * the WorkManager cancel intent is per-worker-instance and SyncNotification
+     * Manager is a singleton.
+     */
+    private fun buildForegroundInfo(
+        title: String,
+        text: String,
+        progress: Float,
+    ): ForegroundInfo {
+        val notification = syncNotificationManager.buildProgressNotification(
+            title = title,
+            text = text,
+            progress = progress,
+            cancelIntent = WorkManager.getInstance(applicationContext).createCancelPendingIntent(id),
+        )
+        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ForegroundInfo(
+                SyncNotificationManager.NOTIFICATION_ID_PROGRESS,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            ForegroundInfo(SyncNotificationManager.NOTIFICATION_ID_PROGRESS, notification)
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        setForeground(getForegroundInfo())
+
+        val pending = downloadQueueDao.pendingDiscoveryDownloads()
+        if (pending.isEmpty()) {
+            // Still chain the refresh — keeps the contract simple
+            // (the mix-refresh worker is a no-op when nothing changed).
+            chainRefresh()
+            return Result.success()
+        }
+
+        Log.i(TAG, "draining ${pending.size} discovery download(s)")
+
+        for ((index, queueItem) in pending.withIndex()) {
+            // Progress notification update
+            setForeground(
+                buildForegroundInfo(
+                    title = "Downloading discoveries",
+                    text = "${index + 1} of ${pending.size}",
+                    progress = (index.toFloat() / pending.size),
+                )
+            )
+
+            // v0.9.20: stamp IN_PROGRESS BEFORE invoking the downloader.
+            // REPLACE policy on UNIQUE_WORK_NAME prevents concurrent instances
+            // of THIS worker; the sync-side partition predicate prevents
+            // TrackDownloadWorker from touching the same row. Defense-in-depth:
+            // a stale IN_PROGRESS row left over from a crashed run gets reset
+            // to PENDING on the next sync (the existing `resetStaleInProgress`
+            // sweep in TrackDownloadWorker's startup) — that path is unchanged.
+            downloadQueueDao.updateStatus(
+                id = queueItem.id,
+                status = DownloadStatus.IN_PROGRESS,
+            )
+
+            val trackEntity = trackDao.getById(queueItem.trackId) ?: continue
+
+            // Blocklist guard (mirror TrackDownloadWorker)
+            if (blocklistGuard.isBlocked(
+                    artist = trackEntity.artist,
+                    title = trackEntity.title,
+                    spotifyUri = null,
+                    youtubeId = null,
+                )) {
+                Log.d(TAG, "Skipping blocked track ${trackEntity.id}")
+                downloadQueueDao.deleteByTrackId(trackEntity.id)
+                continue
+            }
+
+            // Already downloaded? Idempotent COMPLETED stamp.
+            if (trackEntity.isDownloaded && trackEntity.filePath != null) {
+                downloadQueueDao.updateStatus(
+                    id = queueItem.id,
+                    status = DownloadStatus.COMPLETED,
+                    completedAt = System.currentTimeMillis(),
+                )
+                continue
+            }
+
+            val track = trackEntity.toDomain()
+            val outcome = runCatching {
+                trackDownloader.downloadTrack(track = track, preResolvedUrl = queueItem.youtubeUrl)
+            }.getOrElse {
+                Log.e(TAG, "downloadTrack threw for ${track.artist} - ${track.title}", it)
+                TrackDownloadOutcome.Failed(error = it.message.orEmpty())
+            }
+
+            when (outcome) {
+                is TrackDownloadOutcome.Success -> handleSuccess(queueItem, trackEntity, outcome)
+                is TrackDownloadOutcome.Unmatched -> handleUnmatched(queueItem, track, outcome)
+                is TrackDownloadOutcome.Failed -> handleFailed(queueItem, track, outcome)
+                is TrackDownloadOutcome.Deferred -> {
+                    // Lossless deferred — TrackDownloaderImpl already moved
+                    // the row to WAITING_FOR_LOSSLESS. LosslessRetryWorker
+                    // owns the re-attempt. No-op here.
+                    Log.i(TAG, "Deferred (waiting for lossless): ${track.artist} - ${track.title}")
+                }
+            }
+        }
+
+        chainRefresh()
+        return Result.success()
+    }
+
+    private suspend fun handleSuccess(
+        queueItem: DownloadQueueEntity,
+        trackEntity: TrackEntity,
+        outcome: TrackDownloadOutcome.Success,
+    ) {
+        val fileSize = try { File(outcome.filePath).length() } catch (_: Exception) { 0L }
+        val meta = audioDurationExtractor.extract(outcome.filePath)
+
+        trackDao.markAsDownloaded(
+            trackId = trackEntity.id,
+            filePath = outcome.filePath,
+            fileSizeBytes = fileSize,
+            sampleRateHz = meta?.sampleRateHz,
+            bitsPerSample = meta?.bitsPerSample,
+        )
+
+        if (meta != null && meta.format != "unknown") {
+            runCatching {
+                trackDao.setFormatAndQuality(
+                    trackId = trackEntity.id,
+                    fileFormat = meta.format,
+                    qualityKbps = meta.bitrateKbps,
+                )
+            }
+        }
+
+        downloadQueueDao.updateStatus(
+            id = queueItem.id,
+            status = DownloadStatus.COMPLETED,
+            completedAt = System.currentTimeMillis(),
+        )
+    }
+
+    private suspend fun handleUnmatched(
+        queueItem: DownloadQueueEntity,
+        track: Track,
+        outcome: TrackDownloadOutcome.Unmatched,
+    ) {
+        val err = "No YouTube match for: ${track.artist} - ${track.title}"
+        Log.w(TAG, err)
+        downloadQueueDao.incrementRetryCount(queueItem.id)
+        downloadQueueDao.updateStatus(
+            id = queueItem.id,
+            status = DownloadStatus.FAILED,
+            failureType = DownloadFailureType.NO_MATCH,
+            errorMessage = err,
+            rejectedVideoId = outcome.rejectedVideoId,
+        )
+    }
+
+    private suspend fun handleFailed(
+        queueItem: DownloadQueueEntity,
+        track: Track,
+        outcome: TrackDownloadOutcome.Failed,
+    ) {
+        Log.e(TAG, "Download failed for ${track.artist} - ${track.title}: ${outcome.error}")
+        downloadQueueDao.incrementRetryCount(queueItem.id)
+        downloadQueueDao.updateStatus(
+            id = queueItem.id,
+            status = DownloadStatus.FAILED,
+            failureType = DownloadFailureType.DOWNLOAD_ERROR,
+            errorMessage = outcome.error.take(500),
+        )
+    }
+
+    private fun chainRefresh() {
+        // Always chain — even on all-failure batches. The mix-refresh
+        // worker is a no-op when nothing new is on disk; simpler to
+        // unconditionally fire than to branch.
+        StashMixRefreshWorker.enqueueOneTime(applicationContext)
+    }
+}
+```
+
+**Code-duplication note:** the `handleSuccess` / `handleUnmatched` / `handleFailed` methods mirror logic in `TrackDownloadWorker.kt:262-380`. We intentionally duplicate rather than refactor: TrackDownloadWorker's per-track block is inside a `coroutineScope.launch` parallel-execution context with shared atomic counters and sync-state callbacks; surgically extracting it would touch the sync chain. The duplication is bounded (~80 lines), the contract surface (TrackDownloader interface) is stable, and any future divergence between sync and discovery download behaviors is easier to reason about with two clear sites.
+
+### 2c. `StashDiscoveryWorker` chains the downloader
+
+`core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt`, at the end of `doWork()` after the existing recipe loop:
+
+```kotlin
+// v0.9.20: after queueing/processing discoveries, kick the downloader
+// so the new tracks become playable in this charging+WiFi window.
+// Mirror this worker's own constraints (charging + batteryNotLow +
+// NetworkType.UNMETERED) — discovery downloads should respect the same
+// posture that gated the discovery itself.
+val downloadConstraints = Constraints.Builder()
+    .setRequiresCharging(true)
+    .setRequiresBatteryNotLow(true)
+    .setRequiredNetworkType(NetworkType.UNMETERED)
+    .build()
+DiscoveryDownloadWorker.enqueueOneTime(applicationContext, downloadConstraints)
+```
+
+**Required new imports** in `StashDiscoveryWorker.kt`:
+
+```kotlin
+import androidx.work.Constraints
+import androidx.work.NetworkType
+import com.stash.data.download.DiscoveryDownloadWorker
+```
+
+The first two may already be imported via existing scheduling helpers — check before adding to avoid duplicates. The third is the new worker class.
+
+**On constraint choice:** the spec earlier said "respects DownloadNetworkMode pref." After re-reading the existing infrastructure, the simpler honest answer is: StashDiscoveryWorker already runs on charging + battery-not-low + WiFi, so the downloader chained from its tail runs in the same window. The user pref governs sync downloads (which respond to user-driven sync actions); discovery is opportunistic by design. Pinning the downloader to the discovery-worker's constraints is consistent and avoids a new dependency on `downloadNetworkPreference`. If we later want this to vary, it's a one-line change to the constraint builder.
+
+### 2d. `applicationContext` access in the worker
+
+`CoroutineWorker.applicationContext` is exposed via the `appContext` constructor parameter (already standard in this codebase — `StashDiscoveryWorker` uses the same pattern). Use it directly in `chainRefresh()`.
+
+## Component 3 — `is_downloaded = 1` filter (Path B, defense-in-depth)
+
+`core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt` lines 92-102 currently has the v0.9.20 query from PR 1 Task 8. Extend:
+
+```kotlin
+@Query(
+    """
+    SELECT dq.track_id FROM discovery_queue dq
+    INNER JOIN tracks t ON t.id = dq.track_id
+    WHERE dq.recipe_id = :recipeId
+      AND dq.status = 'DONE'
+      AND dq.track_id IS NOT NULL
+      AND t.is_downloaded = 1
+    ORDER BY dq.completed_at DESC
+    LIMIT :limit
+    """
+)
+suspend fun getDoneTrackIdsForRecipe(recipeId: Long, limit: Int): List<Long>
+```
+
+KDoc gets an additional paragraph:
+
+```
+ * v0.9.20 follow-up: AND t.is_downloaded = 1 ensures the mix never
+ * surfaces a stub TrackEntity (a discovery row that was marked DONE
+ * by StashDiscoveryWorker but whose file hasn't landed on disk yet).
+ * Without this filter, a transient window between StashDiscoveryWorker
+ * completion and DiscoveryDownloadWorker completion would put unplayable
+ * tracks in the playlist. DiscoveryDownloadWorker fixes the underlying
+ * issue (downloads run promptly); this filter is defense-in-depth.
+```
+
+### 3a. Existing test updates
+
+`core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoCapTest.kt` already has 6 tests after PR 1 Task 8. The current `trackEntity(id: Long)` helper relies on `TrackEntity` defaults — `isDownloaded` defaults to `false`. With the new filter, all existing test inserts would return empty results.
+
+**Fix:** update the helper to default to `isDownloaded = true`:
+
+```kotlin
+private fun trackEntity(id: Long, isDownloaded: Boolean = true) = TrackEntity(
+    id = id,
+    title = "Track $id",
+    artist = "Artist $id",
+    canonicalTitle = "track $id",
+    canonicalArtist = "artist $id",
+    isDownloaded = isDownloaded,   // NEW
+)
+```
+
+Then add a new test:
+
+```kotlin
+@Test fun `excludes rows whose track is not yet downloaded`() = runTest {
+    db.trackDao().insert(trackEntity(id = 1L, isDownloaded = true))
+    db.trackDao().insert(trackEntity(id = 2L, isDownloaded = false))  // stub
+    dao.insertIfNew(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
+    dao.insertIfNew(doneRow(recipeId, trackId = 2L, completedAt = 2000L))
+
+    val result = dao.getDoneTrackIdsForRecipe(recipeId, limit = 99)
+
+    assertEquals(listOf(1L), result)
+}
+```
+
+## Migration story
+
+No schema migration. Room schema v22 stays. Existing installs pick up the changes on next cold start:
+
+1. `StashApplication.onCreate` enqueues the existing `StashMixRefreshWorker.enqueueOneTime` (already in place).
+2. The first mix refresh now runs against the tightened `getDoneTrackIdsForRecipe` (Component 3) — stubs are filtered, mixes shrink to only playable tracks.
+3. `StashDiscoveryWorker` (which already runs daily on charging + WiFi) now chains `DiscoveryDownloadWorker` at the end. Within one charging window, the discovery_queue's PENDING-with-null-syncId backlog drains into actual downloads.
+4. After the drain, the chained `StashMixRefreshWorker.enqueueOneTime` re-materializes mixes against the now-downloaded survivors — mixes fill out to their target sizes (~40 tracks for Daily Discover + Deep Cuts; ~50 for First Listen).
+5. Per-recipe refresh (Component 1) immediately respects the other mixes' contents, so manual long-press refreshes converge to non-overlapping mixes within one round.
+
+## Tests
+
+### Robolectric + Room in-memory (DAO behavior)
+
+- **`PlaylistDaoOtherMixTracksTest`** (new): verify `getTrackIdsForPlaylists` returns DISTINCT ids; verify empty input returns empty list; verify a track appearing in two playlists shows once.
+- **`DiscoveryQueueDaoCapTest`** (extend): update `trackEntity` helper to default `isDownloaded = true`; add the "stub track excluded" test (Component 3a).
+
+### MockK (worker behavior)
+
+- **`StashMixRefreshWorkerPerRecipeDedupTest`** (new): hand-construct the worker; stub `recipeDao.getActive()` to return 3 recipes (two with playlistIds, one without); stub `playlistDao.getTrackIdsForPlaylists` to return a known set; invoke `doWork` with `KEY_RECIPE_ID = 1L`; capture `excludeIds` passed to `mixGenerator.generate(recipe1, ...)` and assert it equals the pre-seeded set. Mirrors the precedent at `StashMixRefreshWorkerDedupTest` from PR 3.
+- **`DiscoveryDownloadWorkerTest`** (new): cases:
+  - `empty queue → Result.success, refresh still chained`
+  - `single PENDING row, TrackDownloader returns Success → marks COMPLETED + isDownloaded=true`
+  - `single PENDING row, TrackDownloader returns Failed → marks FAILED with retry increment, isDownloaded stays false`
+  - `single PENDING row, TrackDownloader returns Deferred → row untouched (status stays as TrackDownloaderImpl set it — WAITING_FOR_LOSSLESS)`
+  - `blocked track → row deleted via deleteByTrackId, TrackDownloader NOT called`
+  - `chainRefresh always enqueues StashMixRefreshWorker, even on all-failure batches`
+
+## Failure modes + edge cases
+
+1. **`DiscoveryDownloadWorker` and `TrackDownloadWorker` race on `download_queue`.** Mitigated by the partition predicates added in Component 2a — `TrackDownloadWorker`'s feeders (`getAllPendingBySources`, `getRetryableBySources`) gain `AND dq.sync_id IS NOT NULL`; `DiscoveryDownloadWorker`'s feeder (`pendingDiscoveryDownloads`) requires `sync_id IS NULL`. The two workers operate on disjoint row sets. `DiscoveryDownloadWorker` additionally stamps `IN_PROGRESS` before each download as defense-in-depth.
+
+2. **A discovery row was canonical-matched to an existing library track during `StashDiscoveryWorker.handle()`.** That row's `trackId` points to an already-downloaded track row (`isDownloaded = true`); the worker's "already downloaded? idempotent COMPLETED stamp" branch handles it cleanly.
+
+3. **`StashDiscoveryWorker` enqueues `DiscoveryDownloadWorker` but the downloader's constraints aren't met immediately.** Constraints match the discovery worker's own (charging + batteryNotLow + UNMETERED). If the user unplugs mid-flight, JobScheduler defers the downloader until conditions are met again. Acceptable — the work is opportunistic by design.
+
+4. **`StashMixRefreshWorker.enqueueOneTime` chained at the end of `DiscoveryDownloadWorker` runs in parallel with any in-flight per-recipe refresh.** The chained call uses the no-arg overload of `enqueueOneTime` (unique work name `stash_mix_refresh_oneshot`) while a manual long-press refresh uses `enqueueOneTime(context, recipeId)` (unique work name `stash_mix_refresh_oneshot_$recipeId`). The two have **different** unique work names, so they do NOT coalesce — both run independently. This is the right behavior: the user's per-recipe refresh updates ONE mix; the chained full refresh updates ALL mixes against the newly-downloaded survivors. The mix the user refreshed manually gets re-written by whichever finishes second, but both wrote correct content so there's no race-induced inconsistency.
+
+5. **Per-recipe refresh with all three mixes having empty playlists (first cold-start install).** `recipeDao.getActive().mapNotNull { it.playlistId }` returns an empty list; `getTrackIdsForPlaylists(emptyList())` is skipped via the `if (otherPlaylistIds.isNotEmpty())` guard. `excludeIds` stays empty for the first round of refreshes — acceptable since there's no overlap to dedup against.
+
+6. **A user-created (non-builtin) recipe with name colliding with a builtin.** The dedup ordering keys by name (PR 3 design), the per-recipe seed reads `recipeDao.getActive()` (all active recipes, not just builtins). So a user recipe participates in the exclude set on either side. Probably the right behavior — if you have a "Daily Discover" custom and the builtin, you don't want them overlapping either.
+
+7. **Discovery download succeeds but the chained mix-refresh runs before the file is fully flushed to disk.** `markAsDownloaded` writes `isDownloaded = true` synchronously after `audioDurationExtractor.extract` returns (which reads the file). The file is committed before the row write. By the time `StashMixRefreshWorker` reads, the JOIN to `tracks` returns the new state.
+
+8. **`pendingDiscoveryDownloads()` returns a very large list (say, 100+).** Foreground service handles long-running execution; WorkManager's default 10-minute limit doesn't apply once `setForeground` is called. Progress notification updates per-track keep the user informed.
+
+9. **A discovery_queue DONE row whose track_id was deleted from `tracks` after Component 3's JOIN filter.** Same orphan-FK case PR 1 Task 8 already addresses — INNER JOIN excludes it from the result.
+
+## Rollout
+
+Single APK install on Pixel, manual verification:
+1. Trigger Daily Discover refresh. Note its first track.
+2. Trigger Deep Cuts refresh. Verify its first track is DIFFERENT from Daily Discover's.
+3. Trigger First Listen refresh. Same — different top.
+4. Plug in to charge + WiFi. Wait for StashDiscoveryWorker to fire (or trigger via dev menu if available).
+5. Watch logcat for `DiscoveryDownload` lines (`draining N discovery download(s)`, progress per track).
+6. After the drain, the chained refresh fires automatically. Re-open each mix and verify track counts shrink to "playable count" (e.g., Daily Discover goes from 39 phantom to ~20-40 real).
+7. Tap several tracks in each mix — every one should play.
+
+No push, no tag. Per memory `feedback_ship_terminology.md`, release happens separately after on-device verification.
+
+## Open questions
+
+None. All design decisions resolved during brainstorming:
+- Path C2 (new worker, not modify TrackDownloadWorker) — user picked **b**.
+- Constraint posture (mirror StashDiscoveryWorker's charging+UNMETERED) — user picked **a** (match TrackDownloadWorker's existing behavior; the simpler reading lands on StashDiscoveryWorker's constraints since the downloader is chained from there).
+- Always-chain the refresh after the drain (vs. only on ≥1 success) — user picked **b**.

--- a/docs/superpowers/specs/2026-05-11-manual-refresh-kicks-discovery-pipeline-design.md
+++ b/docs/superpowers/specs/2026-05-11-manual-refresh-kicks-discovery-pipeline-design.md
@@ -1,0 +1,327 @@
+# Manual Refresh Kicks the Discovery Pipeline Design
+
+> **Status:** Design — pending implementation plan.
+> **Scope:** PR 5 of the post-v0.9.19 audit. After PR 4 install, the user reports mixes are entirely library tracks (zero new Last.fm content visible), Daily=11/Deep=5/First-Listen=3-5. Root cause: `StashMixRefreshWorker.queueDiscoveryForRecipe` correctly queues 420+ new Last.fm candidates per refresh (logcat confirmed), but those PENDING `discovery_queue` rows need `StashDiscoveryWorker` to process them — which only runs on charging+WiFi+24h cycle. And pre-existing orphan stubs from prior versions sit in `download_queue` waiting for `DiscoveryDownloadWorker`, which only fires when chained from `StashDiscoveryWorker`. Neither chain has fired on the current install yet.
+> **Related:** PR 3 (recipe pivot), PR 4 (per-recipe dedup, partition, `DiscoveryDownloadWorker`, `is_downloaded=1` filter).
+
+---
+
+## Goal
+
+Make "Refresh this mix" actually deliver new content. Specifically:
+
+1. **Tapping refresh fires the full discovery pipeline** — not just the mix re-shuffle. The 120/300/N Last.fm candidates that `queueDiscoveryForRecipe` enqueues should be processed (stubs created, files downloaded) within minutes if the user's network preference allows, not 24+ hours from now when the periodic schedule next fires.
+2. **App startup drains orphan stubs** — pre-existing `download_queue` rows from prior versions get processed on every cold-start (assuming user's network preference allows), independent of whether `StashDiscoveryWorker` happens to fire.
+3. **User's `DownloadNetworkMode` preference is respected** — manual triggers don't burn cellular for WiFi-only users.
+
+The architecture today treats `StashDiscoveryWorker` and `DiscoveryDownloadWorker` as strictly periodic+chained-from-discovery workers. PR 5 adds one-shot entry points the UI and startup hook can call.
+
+## Non-goals
+
+- **Removing the charging requirement from the PERIODIC `StashDiscoveryWorker` schedule.** Daily background discovery stays conservative; only manual triggers relax it.
+- **Removing the user's network preference as a gate.** A WIFI_AND_CHARGING user explicitly opted to never download on cellular — that pref is honored even on manual triggers (we only drop the charging requirement, not the network requirement).
+- **A UI surface telling the user "downloads pending, plug in for more."** The foreground-service notification from `DiscoveryDownloadWorker` already provides visible progress.
+- **Modifying `StashMixRefreshWorker` to internally trigger the discovery pipeline.** The trigger happens at the user-action layer (`HomeViewModel.refreshMix`) and at app-startup (`StashApplication`). Keeping `StashMixRefreshWorker` ignorant of the pipeline keeps it simple and reusable.
+- **Removing the `is_downloaded = 1` filter from PR 4 Task 5.** The filter is correct; the issue is the pipeline downstream of it not firing. PR 5 fixes the pipeline; the filter stays.
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│ User taps "Refresh this mix" on a Stash Mix card                           │
+│   ↓                                                                        │
+│ HomeViewModel.refreshMix(playlistId):                                      │
+│   - Existing: emit "Refreshing X…", enqueueOneTime(StashMixRefreshWorker)  │
+│   - NEW: enqueueOneTime(StashDiscoveryWorker, manual constraints)          │
+│       constraints: drop charging req, keep network req from user pref      │
+│   ↓                                                                        │
+│ StashMixRefreshWorker.doWork (instant, network-only):                      │
+│   - Re-materializes mix from current local state                           │
+│   - queueDiscoveryForRecipe → INSERT discovery_queue PENDING rows          │
+│   ↓                                                                        │
+│ StashDiscoveryWorker.doWork (manual one-shot, fires when constraints met): │
+│   - For each discovery_queue PENDING row:                                  │
+│       create stub TrackEntity (isDownloaded=false) +                       │
+│       insert download_queue (status=PENDING, sync_id=NULL) +               │
+│       mark discovery_queue DONE                                            │
+│   - At end: chain DiscoveryDownloadWorker (existing PR 4 Task 4 chain)     │
+│   ↓                                                                        │
+│ DiscoveryDownloadWorker.doWork:                                            │
+│   - Drains download_queue (sync_id IS NULL, status=PENDING or retry-FAILED)│
+│   - Per-track: download via TrackDownloader → markAsDownloaded + COMPLETED │
+│   - At end: chain StashMixRefreshWorker.enqueueOneTime (full sweep)        │
+│   ↓                                                                        │
+│ StashMixRefreshWorker.doWork (second invocation, full sweep):              │
+│   - Mixes re-materialize with newly-downloaded survivors                   │
+│   - is_downloaded=1 filter (PR 4 Task 5) now passes the freshly downloaded │
+│     ones; user sees new Last.fm content in their mixes                     │
+└────────────────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────────────────┐
+│ App cold-start (existing StashApplication.onCreate sequence):              │
+│   - maybeReseedStashMixes                                                  │
+│   - StashMixDefaults.seedIfNeeded                                          │
+│   - maybeRetuneStashDiscover                                               │
+│   - maybeRetuneStashMixes                                                  │
+│   - StashMixRefreshWorker.enqueueOneTime                                   │
+│   - NEW: DiscoveryDownloadWorker.enqueueOneTime(manual constraints)        │
+│     ↓ drains orphan stubs from prior version installs                      │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+No schema migration. Room schema v22 stays.
+
+## Component 1 — `constraintsForManualTrigger` helper
+
+`core/data/src/main/kotlin/com/stash/core/data/sync/workers/DownloadConstraints.kt`.
+
+Add a sibling helper to the existing `constraintsFor(mode)`:
+
+```kotlin
+/**
+ * Constraints for **manual triggers** — when the user explicitly taps
+ * "Refresh this mix" or the app boots and we want to drain orphan
+ * discovery downloads. Same network discipline as [constraintsFor]
+ * (we still respect the user's [DownloadNetworkMode] pref for cellular)
+ * but DROPS the charging requirement: the user is actively asking for
+ * content; honoring that beats waiting for them to plug in.
+ *
+ * `setRequiresBatteryNotLow(true)` stays on — a 5% battery + manual
+ * refresh is still a bad combination.
+ */
+fun constraintsForManualTrigger(mode: DownloadNetworkMode): Constraints = Constraints.Builder().apply {
+    setRequiresBatteryNotLow(true)
+    when (mode) {
+        DownloadNetworkMode.WIFI_AND_CHARGING -> setRequiredNetworkType(NetworkType.UNMETERED)
+        DownloadNetworkMode.WIFI_ANY -> setRequiredNetworkType(NetworkType.UNMETERED)
+        DownloadNetworkMode.ANY_NETWORK -> setRequiredNetworkType(NetworkType.CONNECTED)
+    }
+}.build()
+```
+
+`WIFI_AND_CHARGING` and `WIFI_ANY` produce identical constraints under manual trigger (both just require WiFi) — the charging distinction only matters for background work.
+
+## Component 2 — `StashDiscoveryWorker.enqueueOneTime`
+
+`core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt`.
+
+Add a companion function alongside the existing `schedulePeriodic`:
+
+```kotlin
+private const val ONE_SHOT_WORK_NAME = "stash_discovery_oneshot"
+
+/**
+ * Fire a one-shot discovery sweep — manual user trigger, no charging
+ * requirement. Respects [DownloadNetworkMode] for cellular gating via
+ * [constraintsForManualTrigger]. Unique work name + REPLACE policy so a
+ * rapid double-tap coalesces. At the end of [doWork], the existing
+ * v0.9.20 chain to [DiscoveryDownloadWorker] fires, completing the
+ * pipeline: discovery_queue PENDING → stubs + download_queue PENDING →
+ * actual downloads.
+ */
+fun enqueueOneTime(context: Context, mode: DownloadNetworkMode) {
+    val work = OneTimeWorkRequestBuilder<StashDiscoveryWorker>()
+        .setConstraints(constraintsForManualTrigger(mode))
+        .build()
+    WorkManager.getInstance(context).enqueueUniqueWork(
+        ONE_SHOT_WORK_NAME,
+        ExistingWorkPolicy.REPLACE,
+        work,
+    )
+}
+```
+
+Required imports (check before adding to avoid duplicates):
+
+```kotlin
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+```
+
+## Component 3 — `HomeViewModel.refreshMix` fires `StashDiscoveryWorker`
+
+`feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt`.
+
+The current `refreshMix` (post PR 1) emits a snackbar, enqueues `StashMixRefreshWorker`, and observes its terminal state. PR 5 adds one line: enqueue `StashDiscoveryWorker.enqueueOneTime` so the full pipeline fires.
+
+Add a new injected dependency:
+
+```kotlin
+private val downloadNetworkPreference: DownloadNetworkPreference,
+```
+
+(`DownloadNetworkPreference` is the existing user-preference holder — locate it via grep; it has a `.current(): DownloadNetworkMode` or similar suspend accessor. Adapt the spec to the actual API name once verified.)
+
+Then in `refreshMix`, after the existing `enqueueUniqueWork` for the mix refresh and after the `WorkManager.await()` snapshot for the mix terminal observation, add:
+
+```kotlin
+// v0.9.20: fire the full discovery pipeline. queueDiscoveryForRecipe
+// inside the mix refresh worker enqueues new Last.fm candidates into
+// discovery_queue PENDING; this trigger processes them right now (subject
+// to user's DownloadNetworkMode pref) instead of waiting up to 24h for
+// the periodic schedule. The chain in StashDiscoveryWorker's tail will
+// fire DiscoveryDownloadWorker, which fires StashMixRefreshWorker again
+// at the end — the mix re-materializes with newly-downloaded survivors
+// without the user lifting another finger.
+val mode = downloadNetworkPreference.current()
+StashDiscoveryWorker.enqueueOneTime(context, mode)
+```
+
+**Placement note:** this fires alongside the per-recipe `StashMixRefreshWorker` — they're independent unique-work names and can run concurrently. The mix-refresh worker queues candidates into `discovery_queue`; the discovery worker (when constraints permit) processes them. No race on row visibility because Room transactions are serialized.
+
+## Component 4 — `StashApplication.onCreate` drains orphans
+
+`app/src/main/kotlin/com/stash/app/StashApplication.kt`.
+
+The existing `applicationScope.launch { ... }` block at lines 168-176 (post PR 3 Task 6 wiring) currently ends with:
+
+```kotlin
+applicationScope.launch {
+    maybeReseedStashMixes()
+    StashMixDefaults.seedIfNeeded(stashMixRecipeDao)
+    maybeRetuneStashDiscover()
+    maybeRetuneStashMixes()
+    StashMixRefreshWorker.enqueueOneTime(this@StashApplication)
+}
+```
+
+Add a final call to drain orphans:
+
+```kotlin
+applicationScope.launch {
+    maybeReseedStashMixes()
+    StashMixDefaults.seedIfNeeded(stashMixRecipeDao)
+    maybeRetuneStashDiscover()
+    maybeRetuneStashMixes()
+    StashMixRefreshWorker.enqueueOneTime(this@StashApplication)
+    // v0.9.20: drain orphan discovery download rows from prior version
+    // installs (stubs that StashDiscoveryWorker created in PR 3 era but
+    // were never downloaded because the sync-chain TrackDownloadWorker
+    // was always sync-gated). Respects user's network preference; runs
+    // when constraints are satisfied.
+    val mode = downloadNetworkPreference.current()
+    DiscoveryDownloadWorker.enqueueOneTime(
+        this@StashApplication,
+        constraintsForManualTrigger(mode),
+    )
+}
+```
+
+`StashApplication` likely already injects `downloadNetworkPreference` for some existing worker scheduling. Verify and reuse if so; otherwise inject it.
+
+Required imports:
+
+```kotlin
+import com.stash.core.data.sync.workers.DiscoveryDownloadWorker
+import com.stash.core.data.sync.workers.constraintsForManualTrigger
+```
+
+(Or whatever paths resolve to the actual symbols after PR 4 Task 4's refactor moved `DiscoveryDownloadWorker` to `core/data/.../sync/workers/`.)
+
+## Component 5 — `StashDiscoveryWorker.doWork` uses manual-trigger constraints when chaining
+
+`core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt`.
+
+**The gap:** When `StashDiscoveryWorker.doWork` chains `DiscoveryDownloadWorker` at its tail (PR 4 Task 4), the constraints are currently hard-coded inline with `setRequiresCharging(true)` (lines 162-167). This means: even when `StashDiscoveryWorker` was triggered manually via Component 2's new `enqueueOneTime` (no charging required), the downloader STILL waits for charging — defeating Component 2's purpose entirely.
+
+**Fix:** Replace the inline constraint builder with a `constraintsForManualTrigger(mode)` call, which requires injecting `DownloadNetworkPreference` into the worker.
+
+Add to the constructor:
+
+```kotlin
+private val downloadNetworkPreference: DownloadNetworkPreference,
+```
+
+Replace the chain site at lines 162-167 (the existing inline `Constraints.Builder()` block followed by `DiscoveryDownloadWorker.enqueueOneTime(...)`):
+
+```kotlin
+// v0.9.20: use manual-trigger constraints (drop charging, respect user
+// network pref) regardless of whether THIS worker invocation was periodic
+// or manual. For the periodic path, the parent's own charging requirement
+// already gated this worker from running — by the time we chain, we know
+// the device is charging + on WiFi, so dropping the charging req on the
+// chain is a no-op. For the manual path, dropping charging is the whole
+// point: the user is actively asking for content; honor that.
+val mode = downloadNetworkPreference.current()
+DiscoveryDownloadWorker.enqueueOneTime(
+    applicationContext,
+    constraintsForManualTrigger(mode),
+)
+```
+
+Required new imports (check before adding):
+
+```kotlin
+import com.stash.core.data.prefs.DownloadNetworkPreference
+```
+
+(`constraintsForManualTrigger` is a top-level fun in the same package as `StashDiscoveryWorker` after Component 1 lands — no import needed.)
+
+**Safety analysis:** the change is safe for both invocation paths:
+- **Periodic + `WIFI_AND_CHARGING`** mode: parent worker only ran because charging + WiFi were both satisfied. Dropping `setRequiresCharging(true)` on the chained downloader is a no-op for the current state (still charging).
+- **Manual + `WIFI_AND_CHARGING`** mode: parent worker only ran because WiFi was satisfied (manual constraints). Dropping charging means the downloader fires immediately on WiFi — exactly what the user wanted.
+- **Any mode without WiFi**: parent didn't run; chain doesn't fire.
+
+## Tests
+
+### Robolectric + Room in-memory
+
+None required — the changes are workers + scheduling helpers + a top-level fun. DAO behavior is unchanged.
+
+### MockK / unit tests
+
+1. **`DownloadConstraintsTest`** (new) — verify `constraintsForManualTrigger(mode)` returns the expected `Constraints` for each `DownloadNetworkMode`:
+   - `WIFI_AND_CHARGING` → `UNMETERED`, `batteryNotLow`, `charging=false`
+   - `WIFI_ANY` → `UNMETERED`, `batteryNotLow`, `charging=false`
+   - `ANY_NETWORK` → `CONNECTED`, `batteryNotLow`, `charging=false`
+   Compare against `Constraints.requiredNetworkType`, `Constraints.requiresCharging()`, `Constraints.requiresBatteryNotLow()` accessors.
+
+2. **No new worker test for `StashDiscoveryWorker.enqueueOneTime`** — testing `WorkManager.enqueueUniqueWork` invocation via MockK is fragile; verified by manual on-device test.
+
+3. **No new test for `HomeViewModel.refreshMix`'s additional enqueue call** — same rationale. Manual on-device test covers it.
+
+4. **`StashApplication` startup hook** — verified at app cold-start during manual on-device test.
+
+## Manual on-device verification
+
+1. Cold-start the app. Check logcat for `DiscoveryDownload: draining N discovery download(s)` — confirms the startup chain fires. If `N > 0`, orphan stubs were drained.
+2. Plug in to WiFi (no charging needed — that's the point of PR 5).
+3. Long-press Daily Discover → Refresh. Wait for the "Refreshed" snackbar.
+4. Watch logcat:
+   - `StashMixRefresh: 'Daily Discover': N candidates via ARTIST_SIMILAR` (existing)
+   - `WM-WorkerWrapper: Starting work for ...StashDiscoveryWorker` (NEW — one-shot fires)
+   - `StashDiscovery: ...` per-recipe processing logs (existing format)
+   - `WM-WorkerWrapper: Starting work for ...DiscoveryDownloadWorker` (PR 4 chain)
+   - `DiscoveryDownload: draining N discovery download(s)` (existing format)
+5. After the downloader completes (foreground service notification dismisses), open Daily Discover. Track count should grow as new Last.fm tracks land. Many tracks should be ones you DON'T recognize from your library.
+6. Repeat for Deep Cuts and First Listen. Each should now have new TRACK_SIMILAR / TAG_GRAPH content respectively.
+
+## Failure modes + edge cases
+
+1. **User's `DownloadNetworkMode = WIFI_AND_CHARGING` and they refresh while on cellular without charging.** `constraintsForManualTrigger(WIFI_AND_CHARGING)` requires `UNMETERED`. WorkManager won't run the worker until WiFi is connected. The mix refresh itself completes (its constraints are met), candidates are queued in `discovery_queue` PENDING, but the discovery worker waits for WiFi. User sees the same outcome as today: queued but not processed. Acceptable — the pref explicitly said WiFi-only.
+
+2. **User's `DownloadNetworkMode = WIFI_ANY` and they refresh while on cellular.** Same as #1 — waits for WiFi.
+
+3. **User's `DownloadNetworkMode = ANY_NETWORK` and they refresh while on cellular.** Discovery worker fires immediately; downloads on cellular. The user explicitly opted into this.
+
+4. **Rapid double-tap of "Refresh this mix" on the same recipe.** `StashDiscoveryWorker.enqueueOneTime` uses unique-work-name `stash_discovery_oneshot` with `REPLACE` policy — second tap cancels the first invocation, second invocation runs. Slight wasted work; acceptable.
+
+5. **App cold-start triggers the orphan-drain `DiscoveryDownloadWorker`, then user refreshes a mix mid-drain.** The user's refresh triggers `StashDiscoveryWorker.enqueueOneTime`, which (when its constraints are met) chains a fresh `DiscoveryDownloadWorker` invocation with `REPLACE` policy — that cancels the running orphan-drain. Wasted partial work. Mitigation: not worth complicating policy. The cancelled work picks up cleanly on next invocation; rows in `IN_PROGRESS` are reset by `TrackDownloadWorker`'s existing `resetStaleInProgress` sweep at next sync.
+
+6. **`StashDiscoveryWorker` already running (periodic cycle) when user refreshes.** `enqueueOneTime` with `REPLACE` policy cancels the periodic-cycle run and starts the manual run. Edge case but harmless — the manual run does the same work the periodic run was doing.
+
+7. **`downloadNetworkPreference.current()` is suspend or async.** Need to read it inside the `viewModelScope.launch { ... }` coroutine in `refreshMix`, not synchronously at the call site. Implementer to verify the API shape.
+
+8. **Battery cost of running discovery downloads on cellular.** User explicitly opted into `ANY_NETWORK` mode; respecting the pref is the contract. If they're alarmed by battery drain, they can switch to `WIFI_ANY`.
+
+## Rollout
+
+Single APK install on Pixel, manual verification of the test plan above. No flag, no staged rollout.
+
+## Open questions
+
+None. All design decisions resolved during brainstorming:
+- User chose **Option (a)** during the brainstorm: trigger full pipeline immediately, no charging requirement, respect `DownloadNetworkMode` pref.
+- `constraintsForManualTrigger` is the right level of abstraction (shared helper alongside the existing `constraintsFor`).
+- `HomeViewModel.refreshMix` is the right trigger site (user-action layer; `StashMixRefreshWorker` itself stays ignorant of the discovery pipeline).
+- App-startup drains orphans via `DiscoveryDownloadWorker.enqueueOneTime` directly (no need to also trigger `StashDiscoveryWorker` on startup — the daily periodic handles fresh content; the manual trigger handles user-initiated refreshes).

--- a/docs/superpowers/specs/2026-05-11-mix-refresh-ux-feedback-design.md
+++ b/docs/superpowers/specs/2026-05-11-mix-refresh-ux-feedback-design.md
@@ -1,0 +1,295 @@
+# Mix Refresh + Lossless Sweep UX Feedback Design
+
+> **Status:** Design — pending implementation plan.
+> **Scope:** PR 1 of a 4-PR series. UX feedback gaps only (Symptoms 1 + 4).
+> **Related design docs:** none new; touches code from `2026-05-08-flac-only-mode-design.md` and `2026-05-08-find-in-flac-design.md`.
+
+---
+
+## Goal
+
+Make two fire-and-forget user actions on the Home screen produce visible acknowledgment, so the user can tell the difference between "I tapped nothing" and "the system did its job."
+
+The two actions are:
+
+1. **Long-press a Stash Mix card → tap "Refresh this mix."** Today the bottom sheet just closes; whether the worker succeeded, failed, or was never enqueued at all, the user sees nothing.
+2. **Tap the "N tracks waiting for lossless" banner.** Today the `LosslessRetryWorker` runs (or doesn't), the DB count flow updates (or doesn't), and the user has no signal that anything happened.
+
+Both flows already have a working `_userMessages` channel and a Toast collector in the UI layer. We just need to wire enqueue-time + completion-time messages and surface output data from the lossless retry worker.
+
+A secondary goal: address one credible cause of "the periodic refresh hasn't fired in 3 days" — `ExistingPeriodicWorkPolicy.KEEP` ignores changes to constraints + worker spec across upgrades. Flipping to `UPDATE` ensures every cold start re-applies the current spec.
+
+## Non-goals
+
+Things explicitly **out of scope** for this PR (they belong to follow-up PRs):
+
+- Match-quality fix for `QobuzSource.normalize` (Symptom 4a — separate PR 2).
+- Inter-mix dedup logic (Symptom 3 — separate PR 3).
+- Non-sync downloader for discovery rows (Symptom 2 — separate PR 4).
+- Recipe parameter retuning + shortfall-fill gate (Symptom 5 — bundled with PR 3).
+- A debug "Mixes diagnostics" screen — defer until PR 1 ships and we can observe whether the periodic + manual flows now look healthy.
+
+## Architecture
+
+Three small, additive changes in three separate modules — no schema migration, no new entities, no new workers.
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│ feature:home                                                           │
+│                                                                        │
+│   HomeViewModel.refreshMix(playlistId)                                 │
+│     ├── emit "Refreshing $name…"                                       │
+│     ├── recipe = recipeDao.findByPlaylistId(playlistId)                │
+│     │     ├── null branch → Log.w + emit "Couldn't refresh — …"        │
+│     │     └── found branch → enqueueOneTime(context, recipe.id)        │
+│     └── observe WorkInfo for "${ONE_SHOT_WORK_NAME}_${recipe.id}"      │
+│           └── on SUCCEEDED → emit "Refreshed $name"                    │
+│                                                                        │
+│   HomeViewModel.onRetryDeferredRequested()                             │
+│     ├── snapshot waitingForLosslessCount                               │
+│     ├── emit "Looking for FLAC versions of N tracks…"                  │
+│     ├── enqueueUniqueWork(LosslessRetryWorker.UNIQUE_WORK_NAME, KEEP)  │
+│     └── observe WorkInfo for UNIQUE_WORK_NAME                          │
+│           └── on SUCCEEDED → read output data (resolved, total)        │
+│                 ├── resolved == 0 → "None resolved this time —         │
+│                 │                    we'll keep trying."               │
+│                 └── resolved > 0  → "Resolved $resolved/$total.        │
+│                                       $remaining still waiting."       │
+└────────────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────────────┐
+│ data:download                                                          │
+│                                                                        │
+│   LosslessRetryWorker.doWork()                                         │
+│     ├── deferred = downloadQueueDao.waitingForLosslessTracks()         │
+│     ├── for each → resolve via registry; if match → flip to PENDING    │
+│     ├── resolvedCount = count of flips                                 │
+│     └── Result.success(workDataOf(                                     │
+│           KEY_RESOLVED to resolvedCount,                               │
+│           KEY_TOTAL to deferred.size,                                  │
+│         ))                                                             │
+└────────────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────────────┐
+│ core:data                                                              │
+│                                                                        │
+│   StashMixRefreshWorker.schedulePeriodic(context)                      │
+│     ExistingPeriodicWorkPolicy.KEEP → ExistingPeriodicWorkPolicy.UPDATE│
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+## Detailed component design
+
+### Component 1 — `HomeViewModel.refreshMix` snackbar lifecycle
+
+**Responsibility:** Surface enqueue-time + completion-time messages for the single-recipe refresh action.
+
+**Current state (`HomeViewModel.kt:554-559`):**
+
+```kotlin
+fun refreshMix(playlistId: Long) {
+    viewModelScope.launch {
+        val recipe = recipeDao.findByPlaylistId(playlistId) ?: return@launch
+        StashMixRefreshWorker.enqueueOneTime(context, recipe.id)
+    }
+}
+```
+
+**New behavior:**
+
+1. Look up the recipe via `recipeDao.findByPlaylistId(playlistId)`.
+2. If recipe is **null** (data-integrity bug — `playlist.type == STASH_MIX` but no back-linked recipe):
+   - `Log.w(TAG, "refreshMix: no recipe back-links playlistId=$playlistId")`
+   - Emit `"Couldn't refresh — this mix isn't linked to a recipe"` to `_userMessages`.
+   - Return.
+3. If recipe is **found**:
+   - Emit `"Refreshing ${recipe.name}…"` to `_userMessages`.
+   - Enqueue the worker via `StashMixRefreshWorker.enqueueOneTime(context, recipe.id)`.
+   - Subscribe to `WorkManager.getInstance(context).getWorkInfosForUniqueWorkFlow("${StashMixRefreshWorker.ONE_SHOT_WORK_NAME}_${recipe.id}")` inside `viewModelScope`.
+   - When the WorkInfo list contains a terminal-state entry:
+     - `WorkInfo.State.SUCCEEDED` → emit `"Refreshed ${recipe.name}"`.
+     - `WorkInfo.State.FAILED` or `CANCELLED` → emit `"Refresh failed — try again later"`. (Worker today returns `Result.success()` on every path, but cancellation is still possible via REPLACE-on-rapid-tap.)
+     - `WorkInfo.State.RUNNING` → no-op (we already emitted the start message).
+   - Cancel the subscription once a terminal state is observed, to keep the viewModelScope clean across many taps.
+
+**Why observe a Flow rather than fire-and-forget:** the worker may take several seconds when discovery seeding hits Last.fm; the user deserves a "done" signal, not just a "started" signal. The `getWorkInfosForUniqueWorkFlow` API was introduced in WorkManager 2.8 and is already in use elsewhere in the codebase (verify on read).
+
+**Concurrency note:** the worker uses `ExistingWorkPolicy.REPLACE`, so a rapid double-tap on the same mix coalesces into one job. The Flow returns a list, not a single value; take the most recent entry by `id` to compare against terminal states. If two distinct refresh actions are in flight for different recipes, each has its own unique work name (`"${ONE_SHOT_WORK_NAME}_$recipeId"`), so their flows are independent.
+
+### Component 2 — `LosslessRetryWorker` output data
+
+**Responsibility:** Return enough information for the calling UI to render a result snackbar.
+
+**Current state (`LosslessRetryWorker.kt:44-73`):**
+
+The worker iterates `WAITING_FOR_LOSSLESS` rows, flips each successful match to `PENDING`, and returns `Result.success()` with no output data.
+
+**New behavior:**
+
+- Add `companion object` constants:
+
+  ```kotlin
+  const val KEY_RESOLVED = "lossless_retry_resolved"
+  const val KEY_TOTAL = "lossless_retry_total"
+  ```
+
+- Track `resolvedCount` locally inside the loop:
+
+  ```kotlin
+  var resolvedCount = 0
+  for (entry in deferred) {
+      // existing resolve logic
+      if (match != null) {
+          downloadQueueDao.updateStatus(id = entry.id, status = DownloadStatus.PENDING)
+          resolvedCount++
+      }
+  }
+  ```
+
+- Return with output data:
+
+  ```kotlin
+  return Result.success(
+      workDataOf(
+          KEY_RESOLVED to resolvedCount,
+          KEY_TOTAL to deferred.size,
+      ),
+  )
+  ```
+
+- The empty-input early return (line 46) also needs `Result.success(workDataOf(KEY_RESOLVED to 0, KEY_TOTAL to 0))` so the UI consumer doesn't get null output data when called against an empty queue.
+
+### Component 3 — `HomeViewModel.onRetryDeferredRequested` snackbar lifecycle
+
+**Responsibility:** Surface enqueue-time + completion-time messages for the banner-tap retry sweep.
+
+**Current state (`HomeViewModel.kt:404-411`):**
+
+```kotlin
+fun onRetryDeferredRequested() {
+    val request = OneTimeWorkRequestBuilder<LosslessRetryWorker>().build()
+    WorkManager.getInstance(context).enqueueUniqueWork(
+        LosslessRetryWorker.UNIQUE_WORK_NAME,
+        ExistingWorkPolicy.KEEP,
+        request,
+    )
+}
+```
+
+**New behavior:**
+
+1. Snapshot the current waiting count by collecting one value from whatever flow drives `waitingForLosslessBanner.count` (likely a DAO Flow — verify on read).
+2. Emit `"Looking for FLAC versions of $count tracks…"` to `_userMessages`. If `count == 0`, skip the start message and the enqueue (early return — there's nothing to sweep, and the banner shouldn't be visible anyway, but this is defensive).
+3. Enqueue the worker (existing code path).
+4. Subscribe to `getWorkInfosForUniqueWorkFlow(LosslessRetryWorker.UNIQUE_WORK_NAME)` in `viewModelScope`.
+5. On the first `WorkInfo.State.SUCCEEDED` after enqueue:
+   - Read `KEY_RESOLVED` and `KEY_TOTAL` from `outputData`. Defensively default to `0`.
+   - `resolved == 0` → emit `"None resolved this time — we'll keep trying."`
+   - `resolved > 0` → compute `remaining = total - resolved`; emit `"Resolved $resolved/$total. $remaining still waiting."`
+6. On `FAILED` or `CANCELLED`: emit `"Sweep failed — try again later"`.
+7. Cancel the subscription after the terminal state.
+
+**Subtle concurrency case:** because of `ExistingWorkPolicy.KEEP`, a rapid double-tap returns the *same* WorkInfo. The subscription started by the second tap may observe a `SUCCEEDED` state for work that was already complete *before* the second tap fired. That would emit a duplicate "Resolved …" message. To handle: filter the Flow on enqueue-time `id` — observe only the WorkInfo whose `id` matches the `WorkContinuation`/`Operation` result returned by `enqueueUniqueWork`.
+
+### Component 4 — Periodic refresh policy flip
+
+**Responsibility:** Ensure every cold start re-applies the current periodic worker spec.
+
+**Current state (`StashMixRefreshWorker.kt:119-123`):**
+
+```kotlin
+WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+    WORK_NAME,
+    ExistingPeriodicWorkPolicy.KEEP,
+    work,
+)
+```
+
+**Change:**
+
+```kotlin
+WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+    WORK_NAME,
+    ExistingPeriodicWorkPolicy.UPDATE,
+    work,
+)
+```
+
+**Side effect:** existing installs that already have a periodic spec will have it overwritten on next cold start. WorkManager preserves the *next-run* clock when the policy is `UPDATE` and the constraints + initial delay haven't moved, so this should not delay the next firing. (Verify against WorkManager 2.9+ semantics during implementation — Android docs are explicit about this for `UPDATE` since 2.8.)
+
+**No data migration needed.** This is a one-line change that takes effect on the next cold start after the user installs PR 1's APK.
+
+## User-facing copy
+
+All strings live in `feature/home/.../strings.xml` (or wherever the existing `_userMessages` strings are sourced — verify during implementation). Proposed keys + values:
+
+| Key                                            | Value                                                         |
+| ---------------------------------------------- | ------------------------------------------------------------- |
+| `home_mix_refresh_starting`                    | `Refreshing %1$s…`                                            |
+| `home_mix_refresh_done`                        | `Refreshed %1$s`                                              |
+| `home_mix_refresh_failed`                      | `Refresh failed — try again later`                            |
+| `home_mix_refresh_no_recipe`                   | `Couldn't refresh — this mix isn't linked to a recipe`        |
+| `home_lossless_retry_starting`                 | `Looking for FLAC versions of %1$d tracks…`                   |
+| `home_lossless_retry_done_partial`             | `Resolved %1$d/%2$d. %3$d still waiting.`                     |
+| `home_lossless_retry_done_zero`                | `None resolved this time — we'll keep trying.`                |
+| `home_lossless_retry_failed`                   | `Sweep failed — try again later`                              |
+
+Use the same Material 3 Snackbar surface that the existing `_userMessages` Toast collector renders — no new UI primitive.
+
+## Failure modes + edge cases
+
+1. **`findByPlaylistId` returns null on a `STASH_MIX` playlist.** Data-integrity bug (recipe → playlist linkage lost via FK SET_NULL on a deleted-and-replayed playlist). User sees `"Couldn't refresh — this mix isn't linked to a recipe"`. Diagnostic log captures `playlistId`. Follow-up: a separate PR can add a self-heal that calls `enqueueOneTime(context)` (the no-arg full-set refresh) which will create-or-relink the recipe's playlist on its next pass.
+
+2. **WorkManager unique work name collision.** The single-recipe refresh uses `"${ONE_SHOT_WORK_NAME}_$recipeId"`. The full-set refresh uses `ONE_SHOT_WORK_NAME` (no suffix). They are distinct, so observing one Flow doesn't pick up the other. The periodic uses `WORK_NAME` (also distinct).
+
+3. **User taps "Refresh" then closes the app before work completes.** The viewModelScope subscription dies with the ViewModel. No snackbar fires. Acceptable — the worker still finishes and updates the DB; on next app launch the new track list is visible. The lost "Refreshed" message is not worth persistent state.
+
+4. **User taps "Refresh" twice in 1 second.** REPLACE policy means the second enqueue cancels the first. The first subscription observes `CANCELLED`, emits the failure snackbar, and exits. The second subscription observes `SUCCEEDED` on completion and emits the success snackbar. Net UX: a brief "failed → succeeded" flicker. Mitigation deferred — not a real-world pattern.
+
+5. **Lossless sweep finds zero matches against an empty queue.** Worker early returns `Result.success()` with output data `(resolved=0, total=0)`. The start message has already been emitted with `count=0`, which is awkward (`"Looking for FLAC versions of 0 tracks…"`). Defense: skip the start message and the enqueue entirely when the snapshot count is 0.
+
+6. **`getWorkInfosForUniqueWorkFlow` returns historical entries.** The Flow includes work that has already completed before the subscription started. Filter by enqueue-time `WorkInfo.id` to avoid emitting stale "Refreshed" / "Resolved" messages from a previous session.
+
+## Testing strategy
+
+### Unit tests
+
+- **`LosslessRetryWorkerTest`** — extend existing tests to assert output data emission:
+  - Empty queue → `Result.success` with `(resolved=0, total=0)`.
+  - 3 tracks, 0 matches → `(resolved=0, total=3)`.
+  - 3 tracks, 2 matches → `(resolved=2, total=3)`.
+- **`StashMixRefreshWorkerTest`** — no new tests; the policy flip is configuration only.
+- **`HomeViewModelTest`** — add unit tests for `refreshMix` and `onRetryDeferredRequested` exercising:
+  - Null recipe → no-recipe snackbar fires, no enqueue happens.
+  - Found recipe → "starting" snackbar fires immediately.
+  - Use a fake `WorkManager` (Robolectric or hand-rolled) to drive WorkInfo states and assert the terminal snackbars.
+
+### Manual test plan on Pixel after install
+
+1. Reboot device → wait for app to cold-start. Verify no crash on `enqueueUniquePeriodicWork(UPDATE)`.
+2. Long-press Daily Discover → tap "Refresh this mix." Expect:
+   - Bottom sheet dismisses.
+   - Snackbar: `"Refreshing Daily Discover…"` within ~100ms.
+   - Snackbar: `"Refreshed Daily Discover"` when the worker finishes (typically a few seconds).
+3. Repeat for Deep Cuts and First Listen.
+4. Tap the "N tracks waiting for lossless" banner. Expect:
+   - Snackbar: `"Looking for FLAC versions of N tracks…"`.
+   - Snackbar after the sweep: `"None resolved this time — we'll keep trying."` (because Symptom 4a's match-quality bug isn't fixed in this PR).
+5. Force-stop the app → reopen. Verify the periodic worker is now showing as scheduled in `dumpsys jobscheduler` (search for the StashMixRefreshWorker class).
+
+### Regression checks
+
+- Existing `WaitingForLosslessBannerTest` must still pass — the banner state-machine is untouched.
+- Existing `LosslessRetryWorkerTest` cases for "no work → success" must still pass with the new output-data shape.
+
+## Open questions for implementation phase
+
+None blocking the spec. During the writing-plans phase, the implementer should:
+
+1. Verify the exact name of the user-messages flow used by the Toast collector (likely `_userMessages` per memory of prior work, but confirm the buffer capacity is ≥ 8 so messages don't get dropped — already raised to 8 in v0.9.18 per session memory).
+2. Verify the exact DAO method that powers the banner's waiting count, and ensure it's a Flow we can collect a single snapshot from without subscribing forever.
+3. Confirm `WorkManager.getWorkInfosForUniqueWorkFlow` is available in the project's WorkManager version. If not, fall back to `getWorkInfosForUniqueWorkLiveData().asFlow()`.
+
+## Rollout
+
+Single APK install on the Pixel, manual verification of the test plan above. No flag, no staged rollout. If verification passes, push the branch and tag as v0.9.20.

--- a/docs/superpowers/specs/2026-05-11-stash-mix-recommendation-pivot-design.md
+++ b/docs/superpowers/specs/2026-05-11-stash-mix-recommendation-pivot-design.md
@@ -1,0 +1,419 @@
+# Stash Mix Recommendation Pivot Design
+
+> **Status:** Design — pending implementation plan.
+> **Scope:** PR 3 of the post-v0.9.19 audit (PR 1 shipped: snackbar lifecycle + orphan-FK fix; PR 2 deferred: QobuzSource normalize). Recipe redesign to shift Stash Mix from library-substrate-with-discovery-seasoning to recommendation-substrate-with-library-seasoning. Also closes the inter-mix track overlap problem.
+> **Related design docs:** none new; touches the seed-strategy infrastructure shipped in `2026-05-08-first-listen-tag-fallback-design.md` (TAG_GRAPH) and the cap fix from `2026-05-08-discovery-survivor-cap.md`.
+
+---
+
+## Goal
+
+Make Daily Discover and Deep Cuts feel like recommendation feeds, not curated library views. Specifically:
+
+1. ~80-90% of tracks in each of the three builtin mixes should come from the Last.fm-driven discovery pipeline (`MixSeedGenerator` → `discovery_queue` → `StashDiscoveryWorker` → DONE survivors). The remaining 10-20% library slice is acceptable seasoning, not the substrate.
+2. Daily Discover and Deep Cuts should share minimal tracks. The current "dozens of overlap" problem must go to zero in steady state.
+3. Each of the three mixes should have a distinct discovery flavor (Daily Discover = similar artists, Deep Cuts = similar tracks, First Listen = your taste tags).
+
+## Non-goals
+
+- **Library rediscovery use case**: The current Deep Cuts surfaces "tracks you used to love but haven't heard." This use case is intentionally dropped. The user confirmed they'd rather have all three mixes be recommendation-driven than preserve rediscovery.
+- **QobuzSource normalize / match-quality fix**: separate PR (PR 2). Out of scope here.
+- **Lossless retry UX feedback**: shipped in PR 1, no further work.
+- **First Listen redesign**: First Listen already meets the 100%-discovery goal via TAG_GRAPH. Leave it alone.
+- **A "global recommendation intensity" preference slider**: out of scope. Three recipes with hardcoded ratios is the right grain for now.
+- **Pre-seeding discovery_queue inline on retune**: explicitly considered and rejected. Transient sparseness after upgrade is acceptable.
+
+## Architecture
+
+Three concerns are bundled here because they're coupled — changing the ratio without dedup leaves overlaps; changing the dedup without the ratio leaves library-heavy mixes; the migration ties both to existing installs.
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ core:data  ::  StashMixDefaults.kt                                   │
+│   Retune Daily Discover + Deep Cuts seed configs (Section 1).        │
+│                                                                      │
+│ core:data  ::  MixGenerator.kt                                       │
+│   - generate(recipe, excludeIds: Set<Long>) → filtered pool.         │
+│   - Shortfall-fill gate: discoveryRatio >= 0.5 → no library backfill.│
+│                                                                      │
+│ core:data  ::  StashMixRefreshWorker.kt                              │
+│   - materializeMix returns MaterializeResult(playlistId,             │
+│     discoveryIds: List<Long>).                                       │
+│   - doWork iterates recipes in dedup-priority order, threads a       │
+│     mutable excludeIds set through both generate() and               │
+│     materializeMix().                                                │
+│                                                                      │
+│ core:data  ::  StashMixRecipeDao.kt                                  │
+│   - retuneBuiltin signature expands to cover affinityBias and        │
+│     seedStrategy fields.                                             │
+│                                                                      │
+│ app  ::  StashApplication.kt (or a focused helper)                   │
+│   - On cold start, retune builtins to current StashMixDefaults       │
+│     values. Idempotent — no-op if values already match.              │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+No schema migration. Room schema v22 stays. All changes are query, generator, and recipe-row content.
+
+## Component 1 — Recipe parameter changes
+
+`core/data/src/main/kotlin/com/stash/core/data/mix/StashMixDefaults.kt`. Replace the three builtin entries with:
+
+```kotlin
+StashMixRecipeEntity(
+    name = "Daily Discover",
+    description = "Mostly fresh finds via similar-artists. A pinch of your library.",
+    affinityBias = 0.0f,
+    freshnessWindowDays = 7,
+    discoveryRatio = 0.85f,
+    targetLength = 40,
+    seedStrategy = "ARTIST_SIMILAR",
+    isBuiltin = true,
+),
+StashMixRecipeEntity(
+    name = "Deep Cuts",
+    description = "Mostly fresh finds via similar-tracks. A pinch of your library.",
+    affinityBias = 0.0f,
+    freshnessWindowDays = 90,
+    discoveryRatio = 0.85f,
+    targetLength = 40,
+    seedStrategy = "TRACK_SIMILAR",
+    isBuiltin = true,
+),
+StashMixRecipeEntity(
+    name = "First Listen",
+    // unchanged
+    description = "Tracks you've never heard. Wider net.",
+    affinityBias = 0.0f,
+    freshnessWindowDays = 14,
+    discoveryRatio = 1.0f,
+    targetLength = 50,
+    seedStrategy = "TAG_GRAPH",
+    isBuiltin = true,
+),
+```
+
+| Recipe | Library slots | Discovery slots | Total | Distinct discovery flavor |
+| --- | --- | --- | --- | --- |
+| Daily Discover | 6 (15%) | 34 (85%) | up to 40 | Similar artists (`artist.getSimilar`) |
+| Deep Cuts | 6 (15%) | 34 (85%) | up to 40 | Similar tracks (`track.getSimilar`) |
+| First Listen | 0 | 50 (100%) | up to 50 | Top-track-by-tag (`tag.getTopTracks`) |
+
+`affinityBias = 0.0` because the library slice is tiny — bias shifting library ranking matters less than the strategy producing distinct discovery candidates. Freshness windows (7d / 90d / 14d) are preserved; they now only affect the small library slice and preserve the recipe's "don't repeat too soon" intent on that slice.
+
+## Component 2 — `MixGenerator` changes
+
+`core/data/src/main/kotlin/com/stash/core/data/mix/MixGenerator.kt`.
+
+### 2a. `generate` signature extension
+
+```kotlin
+suspend fun generate(
+    recipe: StashMixRecipeEntity,
+    excludeIds: Set<Long> = emptySet(),
+): List<TrackEntity> {
+    val rawPool = trackDao.getAllDownloaded()
+    val pool0 = if (excludeIds.isEmpty()) rawPool else rawPool.filter { it.id !in excludeIds }
+    var pool = filterByEra(pool0, recipe)
+    // ... rest of existing pipeline unchanged ...
+}
+```
+
+`excludeIds` is read-only. Empty default preserves backward compatibility with any caller that doesn't need dedup.
+
+### 2b. Shortfall-fill threshold
+
+`MixGenerator.kt` lines 192-198:
+
+```kotlin
+// Old:
+if (recipe.discoveryRatio < 1.0f) {
+    val shortfall = recipe.targetLength - picked.size
+    if (shortfall > 0 && picked.size < pool.size) {
+        val extra = ordered.filter { it !in picked }.take(shortfall)
+        return picked + extra
+    }
+}
+```
+
+```kotlin
+// New:
+// v0.9.20: gate raised from < 1.0f to < 0.5f. Recipes that should be
+// substantially discovery-driven (>= 50% by ratio) must not silently
+// degrade to library when discovery is sparse — that's exactly what
+// produced the "library-heavy mixes" symptom on existing installs.
+// A sparse-but-honest mix is better than a deceptively library-filled one.
+if (recipe.discoveryRatio < 0.5f) {
+    val shortfall = recipe.targetLength - picked.size
+    if (shortfall > 0 && picked.size < pool.size) {
+        val extra = ordered.filter { it !in picked }.take(shortfall)
+        return picked + extra
+    }
+}
+```
+
+Threshold of 0.5 means library-only recipes (discoveryRatio = 0) still get the original full-fill behavior — preserving any user-created recipes that lean library. The three builtins all land outside the gate after retune (0.85, 0.85, 1.0).
+
+## Component 3 — `StashMixRefreshWorker` orchestration
+
+`core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt`.
+
+### 3a. `materializeMix` returns picked discovery ids
+
+Refactor the private function to return both the playlist id and the discovery-survivor ids it inserted:
+
+```kotlin
+private data class MaterializeResult(
+    val playlistId: Long,
+    val discoveryIds: List<Long>,
+)
+
+private suspend fun materializeMix(
+    recipe: StashMixRecipeEntity,
+    tracks: List<TrackEntity>,
+    now: Long,
+    excludeIds: Set<Long>,
+): MaterializeResult {
+    // ... existing find-or-create-playlist + insert library tracks ...
+
+    val discoveryCap = (recipe.targetLength * recipe.discoveryRatio)
+        .roundToInt()
+        .coerceAtLeast(0)
+    val librarySet = tracks.mapTo(HashSet(tracks.size)) { it.id }
+
+    // Over-fetch by `excludeIds.size` so post-filter survivors still fill
+    // the cap. Worst case: every excluded id was a survivor — we still
+    // come back with `discoveryCap` distinct ids. Bounded — the DAO's
+    // ORDER BY completed_at DESC + LIMIT means we just slide the window.
+    val rawCandidateIds = discoveryQueueDao
+        .getDoneTrackIdsForRecipe(recipe.id, limit = discoveryCap + excludeIds.size)
+    val filteredCandidateIds = rawCandidateIds
+        .filter { it !in librarySet && it !in excludeIds }
+        .take(discoveryCap)
+    val discoveryTrackIds = buildList {
+        for (trackId in filteredCandidateIds) {
+            if (!blocklistGuard.isBlockedByTrackId(trackId)) add(trackId)
+        }
+    }
+    // ... existing cross-ref inserts + cover-art update ...
+
+    return MaterializeResult(playlistId, discoveryTrackIds)
+}
+```
+
+### 3b. `doWork` iterates with dedup ordering + exclude set
+
+After the existing persona-fetch block (currently lines 199-217), replace the iteration starting at line 219:
+
+```kotlin
+val orderedRecipes = active.sortedBy { recipeDedupPriority(it) }
+val excludeIds = mutableSetOf<Long>()
+for (recipe in orderedRecipes) {
+    val tracks = mixGenerator.generate(recipe, excludeIds)
+
+    if (tracks.isEmpty() && recipe.discoveryRatio == 0f) {
+        Log.d(TAG, "'${recipe.name}' produced 0 tracks and has no discovery — skipping materialize")
+        continue
+    }
+
+    val result = materializeMix(recipe, tracks, now, excludeIds)
+    recipeDao.setPlaylistId(recipe.id, result.playlistId)
+    recipeDao.setLastRefreshedAt(recipe.id, now)
+
+    // Accumulate so the next recipe in the ordering doesn't re-pick these.
+    excludeIds += tracks.map { it.id }
+    excludeIds += result.discoveryIds
+
+    if (recipe.discoveryRatio > 0f && lastFmConfigured) {
+        runCatching { queueDiscoveryForRecipe(recipe, personas) }
+            .onFailure { Log.w(TAG, "discovery queueing failed for '${recipe.name}'", it) }
+    }
+}
+```
+
+### 3c. `recipeDedupPriority`
+
+A small companion helper:
+
+```kotlin
+/**
+ * Ordering for cross-mix track dedup. Most-restrictive recipes go first
+ * so they get first pick; most-permissive last so it claims leftovers.
+ *
+ *  - First Listen (1.0 discovery, library-blind) — has no opinion on the
+ *    library pool; claims TAG_GRAPH survivors first.
+ *  - Deep Cuts (0.85 discovery, 90d freshness on the slim library slice)
+ *    — claims TRACK_SIMILAR survivors and a sparse library slice next.
+ *  - Daily Discover (0.85 discovery, 7d freshness) — most permissive on
+ *    the library slice; claims ARTIST_SIMILAR survivors last.
+ *  - Non-builtins / unknown — last (99).
+ */
+private fun recipeDedupPriority(recipe: StashMixRecipeEntity): Int = when (recipe.name) {
+    "First Listen" -> 1
+    "Deep Cuts" -> 2
+    "Daily Discover" -> 3
+    else -> 99
+}
+```
+
+Keyed by name rather than id because builtin id values aren't stable across reseeds.
+
+## Component 4 — Builtin tuning migration
+
+`core/data/src/main/kotlin/com/stash/core/data/db/dao/StashMixRecipeDao.kt`.
+
+Expand `retuneBuiltin` to cover the two new fields:
+
+```kotlin
+@Query(
+    """
+    UPDATE stash_mix_recipes
+    SET discovery_ratio = :discoveryRatio,
+        freshness_window_days = :freshnessWindowDays,
+        target_length = :targetLength,
+        affinity_bias = :affinityBias,
+        seed_strategy = :seedStrategy
+    WHERE is_builtin = 1 AND name = :name
+    """
+)
+suspend fun retuneBuiltin(
+    name: String,
+    discoveryRatio: Float,
+    freshnessWindowDays: Int,
+    targetLength: Int,
+    affinityBias: Float,
+    seedStrategy: String,
+): Int
+```
+
+**Backward compat note:** the existing call site at `StashApplication.kt:339-344` (`maybeRetuneStashDiscover`) uses the 4-arg form. After the signature expansion, it must be updated to pass the new fields as well — pass `affinityBias = 0.0f` and `seedStrategy = "TAG_GRAPH"` (the Stash Discover values from before that migration's era) so the v1 migration continues to work for users still on v0.9.x who haven't run the v2 migration yet. Single Kotlin compile error to chase; trivial.
+
+### 4a. Version-gated migration hook (mirror existing precedent)
+
+`app/src/main/kotlin/com/stash/app/StashApplication.kt` already implements `maybeRetuneStashDiscover()` (lines 335-355) with `STASH_DISCOVER_TUNING_VERSION` gating it via `getSharedPreferences("stash_migrations", MODE_PRIVATE)`. This recipe pivot adopts that pattern verbatim.
+
+Add a new constant in the companion object (around line 493 where the existing version constants live):
+
+```kotlin
+private const val STASH_MIX_RECIPE_TUNING_VERSION = 1
+```
+
+Add a new private suspend function alongside `maybeRetuneStashDiscover`:
+
+```kotlin
+/**
+ * Pivot Daily Discover + Deep Cuts to recommendation-substrate
+ * (85% discovery, 15% library). Gated by
+ * [STASH_MIX_RECIPE_TUNING_VERSION] so each release that adjusts these
+ * builtins ships exactly once per install. Fresh installs skip this
+ * because [StashMixDefaults] already seeds with the new values.
+ */
+private suspend fun maybeRetuneStashMixes() {
+    val prefs = getSharedPreferences("stash_migrations", MODE_PRIVATE)
+    val stored = prefs.getInt("stash_mix_recipe_tuning_version", 0)
+    if (stored >= STASH_MIX_RECIPE_TUNING_VERSION) return
+
+    var totalUpdated = 0
+    for (recipe in StashMixDefaults.ALL.filter { it.isBuiltin }) {
+        val updated = stashMixRecipeDao.retuneBuiltin(
+            name = recipe.name,
+            discoveryRatio = recipe.discoveryRatio,
+            freshnessWindowDays = recipe.freshnessWindowDays,
+            targetLength = recipe.targetLength,
+            affinityBias = recipe.affinityBias,
+            seedStrategy = recipe.seedStrategy,
+        )
+        totalUpdated += updated
+    }
+    Log.i("StashMigration", "Retuned $totalUpdated builtin mix recipe(s) to v$STASH_MIX_RECIPE_TUNING_VERSION")
+    prefs.edit()
+        .putInt("stash_mix_recipe_tuning_version", STASH_MIX_RECIPE_TUNING_VERSION)
+        .apply()
+}
+```
+
+Wire it into the existing startup sequence next to `maybeRetuneStashDiscover()` (line 171):
+
+```kotlin
+maybeRetuneStashDiscover()
+maybeRetuneStashMixes()  // NEW
+```
+
+Both migrations run sequentially on cold start, both are idempotent via separate version keys, both are no-ops once their version pref matches the current constant.
+
+**Why a separate version key and not just bumping `STASH_DISCOVER_TUNING_VERSION`:** the Stash Discover migration targets only the now-legacy "Stash Discover" recipe row. The pivot targets Daily Discover + Deep Cuts. Conflating them would re-run the Stash Discover migration unnecessarily on installs that already ran it.
+
+## Tests
+
+### Unit tests
+
+**Testing-framework convention for this module** (verified against existing tests):
+- `MixGenerator*Test.kt` files use **MockK** with hand-mocked DAOs (see `MixGeneratorComputeUserTopTagsTest`). Use MockK for the new `MixGenerator` and `StashMixRefreshWorker` tests.
+- DAO behavior tests use **Robolectric + Room in-memory** (see `DiscoveryQueueDaoCapTest`). Use this for the new `StashMixRecipeDao` test because idempotency + actual SQL behavior need a real DB.
+
+Concrete test classes:
+
+- **`MixGeneratorShortfallFillTest`** (new, MockK): mock `trackDao.getAllDownloaded()`, `listeningEventDao`, `trackTagDao`. Cases:
+  - `shortfall fill triggers when discoveryRatio = 0.4 and library pool > librarySlots` — picks up to targetLength.
+  - `shortfall fill does NOT trigger when discoveryRatio = 0.5` — picks exactly librarySlots.
+  - `shortfall fill does NOT trigger when discoveryRatio = 0.85` — same.
+  - `shortfall fill still gated off at discoveryRatio = 1.0` — same (pre-existing behavior preserved).
+
+- **`MixGeneratorExcludeIdsTest`** (new, MockK):
+  - `excludeIds removes matching tracks from the pool before scoring` — seed 5 tracks, exclude 2, assert remaining 3 in result.
+  - `empty excludeIds preserves current behavior` — same library returned as the no-arg case.
+
+- **`StashMixRefreshWorkerDedupTest`** (new, MockK — no existing `StashMixRefreshWorkerTest.kt` to extend, so this is a fresh test class; follow `LosslessRetryWorkerTest` for the MockK worker-instantiation pattern):
+  - End-to-end with 3 recipes, shared library pool, shared discovery survivors:
+    - Recipe A picks track 1, 2, 3 (library).
+    - Recipe B's generate() call receives excludeIds containing {1, 2, 3} → it picks 4, 5, 6.
+    - Recipe C receives {1..6} → picks 7, 8, 9.
+    - No track id appears in two playlists.
+  - `recipeDedupPriority` orders First Listen → Deep Cuts → Daily Discover; other recipes go last.
+
+- **`StashMixRecipeDaoRetuneTest`** (new, Robolectric + Room in-memory — follow `DiscoveryQueueDaoCapTest` for the pattern):
+  - `retuneBuiltin updates all 5 fields including affinityBias and seedStrategy`.
+  - `retuneBuiltin is idempotent — second call with same values returns rowcount but no state change`.
+  - `retuneBuiltin does not touch non-builtin recipes with the same name`.
+
+### Manual test on Pixel
+
+1. Cold start the app post-install. Confirm no crash on retune.
+2. Wait or trigger a refresh — long-press each mix card, tap "Refresh this mix".
+3. Daily Discover: expect a sparser playlist (40 tracks max, only ~6 from library, the rest discovery survivors that have already been downloaded). May initially show fewer if survivors haven't accumulated.
+4. Deep Cuts: expect EITHER a 6-track playlist (no TRACK_SIMILAR survivors yet — likely on first day) OR a full 40-track playlist once StashDiscoveryWorker has filled the queue.
+5. Sample 10 tracks from Daily Discover and 10 from Deep Cuts. Expect zero overlap of track ids.
+6. First Listen: should look the same as before.
+7. Plug in to charge + connect WiFi to let StashDiscoveryWorker run. After it finishes, refresh Deep Cuts again — should now have ~34 discovery survivors.
+
+## Failure modes + edge cases
+
+1. **Deep Cuts goes sparse for ~1 day after upgrade**. TRACK_SIMILAR `discovery_queue` rows haven't accumulated (Deep Cuts had `seedStrategy = NONE` before). First refresh post-retune: ~6 library tracks + 0 discovery survivors = 6-track Deep Cuts until `StashDiscoveryWorker` runs. Accepted — user explicitly chose the recommendations-first design over preserving instant content.
+
+2. **A user-edited builtin gets retuned over**. `retuneBuiltin` doesn't check whether the user has manually changed values; it blindly overwrites. This is intentional for v0.9.x — the recipe-editing UI isn't shipped yet. If/when it is, the migration logic will need a "last-touched-by-user" guard.
+
+3. **Cross-mix dedup gives Daily Discover the worst leftovers**. Daily Discover is ordered last, so its library slice and discovery survivors are filtered through the most exclude IDs. If the library is small and the user has few discovery survivors, Daily Discover could come back nearly empty. Mitigation: `MixGenerator.generate` returns an empty list rather than crashing; `materializeMix` is fine with empty `tracks`. The Home card shows the (small) playlist; user pulls to refresh later.
+
+4. **TRACK_SIMILAR has no seed tracks**. `seedTracks` is sourced from `personas.topTracksByPeriod[ONE_MONTH]` (Last.fm). If the user has no scrobbles or the API fails, the seed list is empty → MixSeedGenerator returns empty candidates → Deep Cuts stays library-only. This is the same fallback behavior as ARTIST_SIMILAR with no seed artists, which already works.
+
+5. **Race between cold-start retune and the periodic StashMixRefreshWorker**. If WorkManager fires the periodic refresh in the same second the retune runs, the worker could read pre-retune values. Acceptable — the next periodic run (or any manual refresh) picks up the new values. Idempotent migration tolerates this.
+
+6. **A non-builtin recipe with name "Daily Discover"**. The `recipeDedupPriority` function keys by name. A user-created recipe with the same name as a builtin would get the builtin's priority slot. Acceptable — collision is rare; if it happens, the worst case is the dedup ordering surfaces one mix earlier than expected.
+
+7. **First-refresh path with null `playlistId` interacts safely with cross-mix dedup.** When `materializeMix` runs for the first time post-seed, `recipe.playlistId` is null and a new playlist is inserted. The cross-mix dedup `excludeIds` accumulates only AFTER each recipe's `materializeMix` returns; the next iteration's `generate(recipe, excludeIds)` call already sees the populated set. So the null-playlistId path is safe within a single `doWork` invocation — each recipe's playlist insert + cross-ref inserts happen atomically before the next recipe consults `excludeIds`.
+
+8. **TRACK_SIMILAR with empty `seedTracks`**. Verified at `MixSeedStrategy.kt:78-90` — `generateTrackSimilar` iterates `seedTracks.take(10)`; empty input means the loop doesn't run and the function returns an empty list. No crash. Deep Cuts would simply have zero new discovery candidates that refresh; existing DONE survivors (if any) still re-link. Same fallback behavior as ARTIST_SIMILAR with no seed artists.
+
+9. **`maybeRetuneStashDiscover` (v1 migration) breaks at compile time** when `retuneBuiltin` signature expands. The existing call site at `StashApplication.kt:339-344` uses the 4-arg form. Implementer must update that call site too (pass `affinityBias = 0.0f, seedStrategy = "TAG_GRAPH"` to preserve the v1 migration's intent — those were the Stash Discover values before this PR). Single Kotlin compile error to chase; trivial fix.
+
+## Rollout
+
+Single APK install on the Pixel after implementation, manual verification of the test plan above. No flag, no staged rollout. PR 1 already shipped on this branch; PR 3 is additive on top.
+
+## Open questions
+
+None. All previously-listed open questions resolved during spec review:
+
+1. Test-framework choice — committed to MockK for `MixGenerator*` + `StashMixRefreshWorker*` tests (matches `MixGeneratorComputeUserTopTagsTest` and `LosslessRetryWorkerTest`); Robolectric + Room in-memory for `StashMixRecipeDaoRetuneTest` (matches `DiscoveryQueueDaoCapTest`).
+2. Migration hook — adopt the existing `maybeRetuneStashDiscover` pattern with a separate `STASH_MIX_RECIPE_TUNING_VERSION` SharedPreferences key.
+3. `generateTrackSimilar` empty-input behavior — verified safe at `MixSeedStrategy.kt:78-90` (for-loop doesn't iterate; returns empty list).

--- a/docs/superpowers/specs/2026-05-12-genuinely-new-discovery-and-skip-feedback-design.md
+++ b/docs/superpowers/specs/2026-05-12-genuinely-new-discovery-and-skip-feedback-design.md
@@ -1,0 +1,413 @@
+# Phase 1: Genuinely-New Discovery + Skip-Feedback Loop Design
+
+> **Status:** Design — pending implementation plan.
+> **Scope:** PR 6 of the post-v0.9.19 audit. After 5 PRs of plumbing, the Stash Mix experience still feels like a library re-shuffle. Phase 1 addresses the actual algorithmic root cause: Last.fm candidates that already exist in the user's library get canonical-deduplicated into "rediscovery" hits instead of generating new content; and the system has no negative-feedback signal to learn from skips. This PR (a) makes manual triggers fire on any network, (b) hard-filters library-overlapping candidates at the seed-generator boundary, and (c) bans tracks with ≥3 early skips in 90 days from future discovery.
+> **Related:** continues from PR 5 (manual refresh kicks pipeline). Sets foundation for Phases 2-4 (seed diversity, tag-graph adjacency, feedback UI, embeddings).
+
+---
+
+## Goal
+
+Three changes, in order of user-visible impact:
+
+1. **Manual-trigger network constraint relaxes to `CONNECTED`.** When the user explicitly taps "Refresh this mix," the pipeline fires on whatever network is available. Background periodic discovery still respects `DownloadNetworkMode` strictly. Closes the "I tap refresh and nothing happens because I'm not on WiFi" trap that the PR 5 design walked into and that the corruption hotfix's pref-reset made unavoidable for the user.
+
+2. **Last.fm candidates are hard-filtered against the user's library at the seed-generator boundary.** Today, `StashDiscoveryWorker.handle()` does canonical-match dedup AFTER fetching — turning library-overlap candidates into "rediscovery" hits that re-link existing tracks into the playlist. The user observed mixes filled with library content because the seeds for ARTIST_SIMILAR / TRACK_SIMILAR queries hit artists they already have many tracks from. We move the filter EARLIER: candidates whose canonical artist+title key matches the library get dropped before they ever enter `discovery_queue`. Every queued candidate is genuinely new.
+
+3. **Tracks the user has skipped ≥3 times in the first 30 seconds within the last 90 days are banned from discovery candidates.** Negative-feedback signal that propagates from the user's behavior into seed selection. The existing `track_skip_events` table (with `positionMs` column, verified) gives us the data; we just need to use it.
+
+## Non-goals
+
+- **No new UI for thumbs-up/down feedback.** Phase 3 work. Phase 1 uses only existing skip signals.
+- **No multi-strategy fan-out per recipe** (Phase 2).
+- **No tag-graph adjacency exploration beyond top-10 tags** (Phase 2).
+- **No audio-feature embeddings or vector similarity** (Phase 4 — the "world-class" pivot).
+- **No change to the existing `MixGenerator` library-scorer.** The library slice of each mix still comes from there. Phase 1 only changes the discovery pipeline's content quality.
+- **No retroactive cleanup of existing `discovery_queue` PENDING/DONE rows.** Pre-PR-6 rows that happen to be library-overlapping will continue to flow through. Acceptable — new rows added after PR 6 are clean, and the materialize step will naturally trim to capacity. The user's library can re-emerge in mixes as the affinity-scored library slice, not as discovery survivors.
+- **No tunable thresholds in app settings.** The 3-skip / 90-day / 30s-position numbers are hardcoded for now. Can extract to settings later if signal proves to be off.
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│ User taps "Refresh this mix"                                               │
+│   ↓                                                                        │
+│ HomeViewModel.refreshMix                                                   │
+│   ↓                                                                        │
+│ StashMixRefreshWorker.doWork (or manual one-shot from PR 5)                │
+│   ↓                                                                        │
+│ queueDiscoveryForRecipe(recipe, personas):                                 │
+│   1. MixSeedGenerator.generate(strategy, seedArtists, topTags, seedTracks, │
+│      personas) → List<DiscoveryCandidate>      (unchanged)                 │
+│   2. NEW: load libraryKeys = trackDao.getLibraryCanonicalKeys()            │
+│   3. NEW: load skipBannedKeys = trackSkipEventDao                          │
+│           .getEarlySkipBannedCanonicalKeys(                                │
+│             minSkips = 3,                                                  │
+│             sinceMs = now - 90.days,                                       │
+│             maxPositionMs = 30_000,                                        │
+│           )                                                                │
+│   4. NEW: filteredCandidates = candidates.filter { c ->                    │
+│        val key = "${canonicalArtist(c.artist)}|${canonicalTitle(c.title)}" │
+│        key !in libraryKeys && key !in skipBannedKeys                       │
+│      }                                                                     │
+│   5. NEW: if filteredCandidates.size < MIN_POOL_AFTER_FILTER:              │
+│        // Fall back: append TAG_GRAPH candidates from adjacent tags        │
+│        val fallback = seedGenerator.generate(TAG_GRAPH, ...)               │
+│            .filter { ... same library + skip filters ... }                 │
+│        filteredCandidates += fallback                                      │
+│   6. mixGenerator.queueDiscoveryCandidates(recipe, filteredCandidates)     │
+│                                                                            │
+│ Result: discovery_queue PENDING rows for THIS recipe are guaranteed        │
+│ to be (a) not in the user's library, (b) not heavily-skipped, (c) at      │
+│ least MIN_POOL_AFTER_FILTER in number when seed signal is sparse.          │
+└────────────────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────────────────┐
+│ Network constraint relaxation (Decision 1)                                 │
+│                                                                            │
+│ DownloadConstraints.kt:                                                    │
+│   constraintsForManualTrigger(mode) becomes mode-INDEPENDENT:              │
+│     Network: CONNECTED (any internet)                                      │
+│     BatteryNotLow: true                                                    │
+│     Charging: false                                                        │
+│                                                                            │
+│   constraintsFor(mode) (periodic background) stays unchanged —             │
+│   respects DownloadNetworkMode strictly.                                   │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+No schema migration. Room schema v22 stays. All new data flows through existing tables.
+
+## Component 1 — Manual-trigger constraints become network-mode-independent
+
+`core/data/src/main/kotlin/com/stash/core/data/sync/workers/DownloadConstraints.kt`.
+
+Replace the body of `constraintsForManualTrigger(mode)`:
+
+```kotlin
+/**
+ * Constraints for **manual user-initiated triggers** — the user explicitly
+ * tapped "Refresh this mix" or the app booted with orphan downloads to
+ * drain. They're asking for content right now; the system honors that on
+ * whatever network is available.
+ *
+ * Differs from [constraintsFor]:
+ *  - Charging requirement DROPPED (user is actively using the app).
+ *  - Network requirement RELAXED from UNMETERED to CONNECTED — manual
+ *    triggers don't gate on cellular preference. The user's
+ *    DownloadNetworkMode pref still governs the periodic background
+ *    cycle (via [constraintsFor]); it doesn't govern foreground intent.
+ *
+ * `setRequiresBatteryNotLow(true)` stays on — a 5% battery + manual
+ * refresh is still a bad combination.
+ *
+ * v0.9.20 history: shipped in PR 5 respecting DownloadNetworkMode for
+ * cellular gating. After a corruption-induced pref reset left the user
+ * stuck (default mode = WIFI_AND_CHARGING → manual triggers required
+ * unmetered → no firing on cellular), we relaxed to CONNECTED to match
+ * how every major music app handles user-initiated downloads.
+ */
+@Suppress("UNUSED_PARAMETER")
+fun constraintsForManualTrigger(mode: DownloadNetworkMode): Constraints = Constraints.Builder()
+    .setRequiresBatteryNotLow(true)
+    .setRequiredNetworkType(NetworkType.CONNECTED)
+    .build()
+```
+
+The `mode` parameter is preserved in the signature (suppressed unused warning) so callers don't need to change, AND so a future iteration could re-thread it (e.g., if we re-add user-pref respect for a "strict WiFi-only even for manual" toggle later).
+
+**Callers unchanged:**
+- `StashDiscoveryWorker.enqueueOneTime(context, mode)` still passes mode through; constraint just stops looking at it.
+- `StashDiscoveryWorker.doWork`'s chain to `DiscoveryDownloadWorker` still passes mode through.
+- `HomeViewModel.refreshMix` still reads pref + passes through.
+- `StashApplication.onCreate` startup drain still passes through.
+
+Each caller's `downloadNetworkPreference.current()` call becomes dead-weight reading, but harmless. Cleaning it up isn't necessary for this PR; can be tidied in a follow-up.
+
+**Tests:** the existing `DownloadConstraintsTest` (PR 5 Task 1) had three tests asserting per-mode behavior. Two of them now assert the SAME outcome (`UNMETERED` → no longer required). Rewrite to three tests asserting mode-independence:
+
+```kotlin
+@Test fun `constraintsForManualTrigger ignores mode — always CONNECTED + battery_not_low + no charging`() {
+    for (mode in DownloadNetworkMode.values()) {
+        val constraints = constraintsForManualTrigger(mode)
+        assertEquals("mode=$mode", NetworkType.CONNECTED, constraints.requiredNetworkType)
+        assertFalse("mode=$mode", constraints.requiresCharging())
+        assertTrue("mode=$mode", constraints.requiresBatteryNotLow())
+    }
+}
+```
+
+Or three explicit per-mode tests if `assertEquals` in a loop is awkward. Either works.
+
+## Component 2 — Pre-filter Last.fm candidates against library
+
+### 2a. `TrackDao.getLibraryCanonicalKeys`
+
+`core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt`. Add:
+
+```kotlin
+/**
+ * Returns the canonical-key set ("$canonicalArtist|$canonicalTitle")
+ * for every downloaded track. Used by [MixSeedGenerator]'s pre-filter
+ * to drop Last.fm candidates that would dedup to library content
+ * downstream — keeping `discovery_queue` PENDING rows representative
+ * of genuinely-new music instead of "rediscovery" hits.
+ *
+ * `is_downloaded = 1` filter restricts to playable content. Stub
+ * TrackEntities (created by StashDiscoveryWorker before their files
+ * land) are excluded so we don't double-filter against in-flight
+ * discoveries.
+ */
+@Query(
+    """
+    SELECT DISTINCT (canonical_artist || '|' || canonical_title) AS k
+    FROM tracks
+    WHERE is_downloaded = 1
+    """
+)
+suspend fun getLibraryCanonicalKeys(): List<String>
+```
+
+`String` not `Set<String>` because Room doesn't return Sets natively; the caller converts to a `Set` once for O(1) membership lookups.
+
+### 2b. `MixSeedGenerator.generate` filters before returning (OR call-site filters)
+
+**Decision: filter at the call site in `StashMixRefreshWorker.queueDiscoveryForRecipe`.**
+
+Rationale: `MixSeedGenerator` is a pure Last.fm-API wrapper. Injecting `TrackDao` + `TrackSkipEventDao` + `TrackMatcher` into it pollutes its role. Cleaner: keep it pure, filter at the boundary in the worker.
+
+In `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt`, modify `queueDiscoveryForRecipe(recipe, personas)`:
+
+```kotlin
+private suspend fun queueDiscoveryForRecipe(
+    recipe: StashMixRecipeEntity,
+    personas: LastFmPersonas,
+) {
+    val strategy = MixSeedStrategy.fromStored(recipe.seedStrategy)
+    if (strategy == MixSeedStrategy.NONE) return
+
+    // ... existing seed-artist + seed-track + topTags assembly unchanged ...
+
+    val candidates = seedGenerator.generate(
+        strategy = strategy,
+        seedArtists = seedArtists,
+        topTags = topTags,
+        seedTracks = seedTracks,
+        personas = personas,
+    )
+    if (candidates.isEmpty()) return
+
+    // NEW: pre-filter against library + skip-ban
+    val libraryKeys = trackDao.getLibraryCanonicalKeys().toHashSet()
+    val skipBannedKeys = trackSkipEventDao
+        .getEarlySkipBannedCanonicalKeys(
+            minSkips = DISCOVERY_SKIP_BAN_MIN_COUNT,
+            sinceMs = System.currentTimeMillis() - DISCOVERY_SKIP_BAN_WINDOW_MS,
+            maxPositionMs = DISCOVERY_SKIP_BAN_MAX_POSITION_MS,
+        )
+        .toHashSet()
+
+    val filtered = candidates.filter { candidate ->
+        val key = canonicalKey(candidate.artist, candidate.title)
+        key !in libraryKeys && key !in skipBannedKeys
+    }
+
+    val final = if (filtered.size >= MIN_DISCOVERY_POOL_AFTER_FILTER) {
+        filtered
+    } else {
+        // Fallback: top off with TAG_GRAPH candidates (different strategy
+        // typically yields different artists, so library overlap is lower).
+        // Same filters applied so we still don't surface library/banned.
+        //
+        // withTimeout protects WorkManager's 10-minute budget: the first
+        // seedGenerator.generate() can take up to 30s on a slow connection,
+        // and this fallback runs sequentially. 30s cap matches the persona-
+        // fetch timeout already in doWork. On timeout we fall through to
+        // whatever `filtered` had (could be empty — handled below).
+        val tagFallback = runCatching {
+            withTimeout(SEED_FALLBACK_TIMEOUT_MS) {
+                seedGenerator.generate(
+                    strategy = MixSeedStrategy.TAG_GRAPH,
+                    seedArtists = emptyList(),
+                    topTags = topTags,
+                    seedTracks = emptyList(),
+                    personas = personas,
+                )
+            }
+        }.getOrElse {
+            Log.w(TAG, "'${recipe.name}': TAG_GRAPH fallback timed out / failed", it)
+            emptyList()
+        }.filter { candidate ->
+            val key = canonicalKey(candidate.artist, candidate.title)
+            key !in libraryKeys && key !in skipBannedKeys
+        }
+        Log.i(
+            TAG,
+            "'${recipe.name}': filtered pool (${filtered.size}) below floor; " +
+                "appending ${tagFallback.size} TAG_GRAPH fallback candidates",
+        )
+        filtered + tagFallback
+    }
+
+    if (final.isEmpty()) {
+        Log.w(TAG, "'${recipe.name}': all candidates filtered out (library + skips); skipping queue")
+        return
+    }
+
+    Log.i(
+        TAG,
+        "'${recipe.name}': ${final.size} candidates via $strategy " +
+            "(${candidates.size - filtered.size} filtered as library/banned)",
+    )
+    mixGenerator.queueDiscoveryCandidates(recipe, final)
+}
+
+private fun canonicalKey(artist: String, title: String): String {
+    return "${trackMatcher.canonicalArtist(artist)}|${trackMatcher.canonicalTitle(title)}"
+}
+```
+
+New constants on the worker:
+
+```kotlin
+companion object {
+    // existing ...
+    private const val MIN_DISCOVERY_POOL_AFTER_FILTER = 20
+    private const val DISCOVERY_SKIP_BAN_MIN_COUNT = 3
+    private val DISCOVERY_SKIP_BAN_WINDOW_MS = TimeUnit.DAYS.toMillis(90)
+    private const val DISCOVERY_SKIP_BAN_MAX_POSITION_MS = 30_000L
+    private const val SEED_FALLBACK_TIMEOUT_MS = 30_000L
+}
+```
+
+**New constructor dependencies on `StashMixRefreshWorker`** (verified against the current source — `trackDao` and `mixGenerator` are already injected; the other two are not):
+
+```kotlin
+private val trackSkipEventDao: TrackSkipEventDao,
+private val trackMatcher: TrackMatcher,
+```
+
+Both are Hilt-resolvable: `TrackSkipEventDao` is exposed via the existing Room database module; `TrackMatcher` is `@Singleton class TrackMatcher @Inject constructor()` so Hilt resolves it directly.
+
+## Component 3 — Skip-event ban-list query
+
+`core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackSkipEventDao.kt`.
+
+Add:
+
+```kotlin
+/**
+ * Returns canonical-key set ("$canonicalArtist|$canonicalTitle") for
+ * tracks that have been "early-skipped" at least [minSkips] times since
+ * [sinceMs], where "early" means within the first [maxPositionMs]
+ * milliseconds of playback. Used by the discovery pre-filter to ban
+ * candidates the user has repeatedly rejected.
+ *
+ * Position-aware: a skip 90% of the way through a song is "finished
+ * listening, moving on," not a verdict. Only skips in the first
+ * [maxPositionMs] count.
+ *
+ * Joins to `tracks` to look up the canonical key. Tracks deleted from
+ * the library are naturally excluded (INNER JOIN). Acceptable — if a
+ * track is gone we don't need to ban it from future re-discovery.
+ */
+@Query(
+    """
+    SELECT (t.canonical_artist || '|' || t.canonical_title) AS k
+    FROM track_skip_events s
+    INNER JOIN tracks t ON t.id = s.track_id
+    WHERE s.skipped_at >= :sinceMs
+      AND s.position_ms <= :maxPositionMs
+    GROUP BY k
+    HAVING COUNT(*) >= :minSkips
+    """
+)
+suspend fun getEarlySkipBannedCanonicalKeys(
+    minSkips: Int,
+    sinceMs: Long,
+    maxPositionMs: Long,
+): List<String>
+```
+
+Index check: `track_skip_events` already has index on `skipped_at` (per `StashDatabase.kt:623`). The join uses `track_id` index. The position filter is in-row, no index needed. Query should be fast for typical histories.
+
+## Component 4 — TrackMatcher injection into StashMixRefreshWorker
+
+`TrackMatcher` is the existing helper used by `StashDiscoveryWorker.handle()` for canonical-title / canonical-artist normalization. We need the same canonical-key construction in `StashMixRefreshWorker.queueDiscoveryForRecipe` to match against `getLibraryCanonicalKeys` / `getEarlySkipBannedCanonicalKeys`.
+
+**Verified import path:** `com.stash.core.data.sync.TrackMatcher`.
+
+Both `TrackMatcher.canonicalArtist(artist)` and `TrackMatcher.canonicalTitle(title)` are non-suspend, deterministic, lowercase + trim — same normalization that the sync writer uses to populate `tracks.canonical_artist` and `tracks.canonical_title`. No normalization drift risk between filter keys and library keys.
+
+Injection (already detailed in Component 2 above; restating for clarity): add `trackMatcher: TrackMatcher` and `trackSkipEventDao: TrackSkipEventDao` to the worker constructor. Hilt resolves both.
+
+## Tests
+
+### MockK unit tests
+
+- **Extend `MixSeedStrategyTest.kt`**: no change — MixSeedGenerator itself is untouched.
+- **`StashMixRefreshWorkerSeedFilterTest`** (new): MockK worker test that:
+  - Stubs `seedGenerator.generate` to return a known candidate list (e.g., 50 candidates).
+  - Stubs `trackDao.getLibraryCanonicalKeys` to return keys matching 20 of those candidates.
+  - Stubs `trackSkipEventDao.getEarlySkipBannedCanonicalKeys` to return keys matching 5 different candidates.
+  - Asserts `mixGenerator.queueDiscoveryCandidates` is called with exactly the 25 remaining (50 - 20 - 5).
+  - Edge case: when filtered pool falls below `MIN_DISCOVERY_POOL_AFTER_FILTER`, verify the TAG_GRAPH fallback fires (stub seedGenerator.generate for both ARTIST_SIMILAR and TAG_GRAPH and assert both are called).
+  - Edge case: when all candidates filter out, verify `queueDiscoveryCandidates` is NOT called and the log line fires.
+- **Update `DownloadConstraintsTest.kt`**: three existing tests assert mode-dependent behavior; rewrite as mode-independent (all three modes produce the same constraints now).
+
+### Robolectric + Room in-memory tests
+
+- **`TrackDaoCanonicalKeysTest`** (new):
+  - Seed 3 downloaded tracks + 2 undownloaded.
+  - Assert `getLibraryCanonicalKeys()` returns exactly the 3 keys for downloaded tracks.
+  - Verify DISTINCT — two downloaded tracks with identical canonical key return ONE row.
+- **`TrackSkipEventDaoBanListTest`** (new):
+  - Seed 3 tracks: A, B, C.
+  - Seed skip events:
+    - A: 4 events at position 1000ms (within window) → SHOULD ban
+    - B: 4 events at position 60000ms (outside position cutoff) → should NOT ban
+    - C: 2 events at position 1000ms (below count threshold) → should NOT ban
+  - Assert `getEarlySkipBannedCanonicalKeys(3, sinceMs = far past, maxPositionMs = 30_000)` returns only A's canonical key.
+  - Edge: time window — seed an event from 100 days ago for A; verify it's excluded from a 90-day query.
+
+### Manual on-device verification
+
+1. Cold-start the app. Watch logcat: `StashMigration` fires; `DiscoveryDownloadWorker` orphan drain queues (PR 5).
+2. Plug in to charge + WiFi if not already; OR stay on cellular (PR 6 change means manual trigger fires on cellular too).
+3. Long-press Daily Discover → Refresh. Snackbar "Refreshing Daily Discover…" appears.
+4. Tail logcat:
+   ```
+   adb logcat -t 500 | grep -iE "stashmixrefresh|stashdiscovery|discoverydownload"
+   ```
+   Expected line: `StashMixRefresh: 'Daily Discover': N candidates via ARTIST_SIMILAR (M filtered as library/banned)`. M should be substantial (likely >50% of N for a large library).
+5. Wait for `StashDiscoveryWorker` and `DiscoveryDownloadWorker` to fire and complete (foreground notification visible).
+6. Re-open Daily Discover. Track count should grow. Sample 5-10 random tracks — none should be ones you recognize from your library. Tap several to verify they play.
+7. Repeat for Deep Cuts and First Listen.
+8. Spot-check: tap a recommended track in Daily Discover, immediately skip it (within 5 seconds). Repeat with the same track 3 times across the next refresh cycles. After the 3rd skip, refresh Daily Discover again. The skipped track should NOT reappear in the mix.
+
+## Failure modes + edge cases
+
+1. **Library is enormous, every Last.fm candidate dedups to library.** `filtered.size` is 0; TAG_GRAPH fallback fires. If that ALSO returns 0 (extremely unlikely for any active Last.fm user), the worker logs `all candidates filtered out` and skips the queue insert. The mix retains its existing state. Next refresh tries again — Last.fm's `artist.getSimilar` returns slightly different candidates per call (rate-limit jitter), so a few cycles may yield candidates.
+
+2. **Library is empty (fresh install).** `getLibraryCanonicalKeys` returns `[]`. Filter is a no-op. Pipeline behaves as if PR 6 wasn't applied — appropriate for a new user with nothing to compare against.
+
+3. **A track in the user's library AND in the skip-ban set.** Filter checks both sets independently; tracks fail both. Net effect: skipped library tracks are excluded from discovery candidates (which they would be anyway via the library filter). Fine.
+
+4. **A canonical-key collision between two distinct tracks** (e.g., two different songs both canonicalizing to `"the_beatles|yesterday"`). Filter treats them as same. Affects ALL canonical-dedup logic in the codebase — not introduced by this PR; consistent with how `StashDiscoveryWorker.handle()` already operates.
+
+5. **User skipped a track 3 times but loves it now.** Currently no "un-ban" affordance. After 90 days the skip events age out of the window naturally. If the user wants to re-discover something they skipped recently, they can add it via Search. Phase 3 (feedback UI) will add explicit un-ban via thumbs-up.
+
+6. **Manual-trigger network relaxation surprises a user on a limited data plan.** They explicitly tapped refresh — they're aware. Their `DownloadNetworkMode` pref STILL governs the periodic background cycle (most data usage by far). The manual trigger downloads at most ~30-40 tracks worth of yt-dlp downloads on cellular — measurable but not catastrophic.
+
+7. **`TrackMatcher` is the right canonicalizer.** Verify during implementation that the canonical-key produced by `TrackMatcher.canonicalArtist(c.artist) + "|" + TrackMatcher.canonicalTitle(c.title)` matches the format stored in `tracks.canonical_artist || '|' || tracks.canonical_title`. If there's any normalization drift (e.g., the DAO stores lowercased but TrackMatcher returns title-case), the filter silently fails. Add a smoke-test if uncertain.
+
+## Rollout
+
+Single APK install on the Pixel, manual verification of the test plan above. No flag, no staged rollout.
+
+## Open questions
+
+None. All three design decisions made (delegated to my judgment, justified above):
+- Manual-trigger constraint: relaxed to `CONNECTED`, mode-independent.
+- Library pre-filter: HARD, at the seed-generator-call boundary in the worker.
+- Skip ban: 3 skips in 90 days, position-aware (first 30 seconds only).

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
@@ -81,6 +81,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.animation.Crossfade
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
@@ -131,6 +132,13 @@ fun HomeScreen(
     var playlistToDelete by remember { mutableStateOf<Playlist?>(null) }
     // Controls the "New Playlist" naming dialog launched from the Playlists section.
     var showCreateDialog by remember { mutableStateOf(false) }
+
+    val toastContext = LocalContext.current
+    LaunchedEffect(Unit) {
+        viewModel.userMessages.collect { msg ->
+            android.widget.Toast.makeText(toastContext, msg, android.widget.Toast.LENGTH_LONG).show()
+        }
+    }
 
     // Pre-computed 2-column chunking for the Playlists grid. Hoisted out
     // of the LazyColumn's item{} so the chunked() + buildList{} only runs

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
@@ -35,7 +35,6 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
-import androidx.work.await
 import androidx.work.workDataOf
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -566,12 +565,16 @@ class HomeViewModel @Inject constructor(
     }
 
     /**
-     * v0.9.16: Manually re-run the Stash Mix refresh worker for a single
-     * recipe (the one whose materialized playlist is [playlistId]). Used by
-     * the long-press "Refresh this mix" action on Stash Mix cards. No-op if
-     * the playlist doesn't belong to a Stash Mix recipe — the menu item is
-     * already gated on `playlist.type == STASH_MIX`, so the lookup miss is
-     * a defensive guard, not a user-facing error path.
+     * Manually re-run the Stash Mix refresh worker for a single recipe (the
+     * one whose materialized playlist is [playlistId]). Used by the long-
+     * press "Refresh this mix" action on Stash Mix cards.
+     *
+     * Emits snackbar lifecycle messages via [userMessages]: "Refreshing X…"
+     * on enqueue, then "Refreshed X" or "Refresh failed" on the worker's
+     * terminal WorkInfo state. If the playlist is tagged `STASH_MIX` but no
+     * recipe back-links it (data-integrity bug — menu shouldn't have
+     * appeared), logs a warning and surfaces a "not linked to a recipe"
+     * message instead of silently no-opping.
      */
     fun refreshMix(playlistId: Long) {
         viewModelScope.launch {

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
@@ -35,6 +35,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import androidx.work.await
 import androidx.work.workDataOf
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -423,12 +424,54 @@ class HomeViewModel @Inject constructor(
      * the work.
      */
     fun onRetryDeferredRequested() {
-        val request = OneTimeWorkRequestBuilder<LosslessRetryWorker>().build()
-        WorkManager.getInstance(context).enqueueUniqueWork(
-            LosslessRetryWorker.UNIQUE_WORK_NAME,
-            ExistingWorkPolicy.KEEP,
-            request,
-        )
+        viewModelScope.launch {
+            // Snapshot the current count before we kick the worker so the
+            // start message and the math after both reference the same N.
+            val countAtStart = downloadQueueDao.waitingForLosslessCount().first()
+            if (countAtStart <= 0) return@launch  // banner shouldn't be visible
+
+            _userMessages.tryEmit("Looking for FLAC versions of $countAtStart tracks\u2026")
+
+            val request = OneTimeWorkRequestBuilder<LosslessRetryWorker>().build()
+            // KEEP policy: a rapid double-tap coalesces. Suspend on the
+            // Operation's await() (work-runtime-ktx) so we don't block the
+            // viewModelScope's Main.immediate dispatcher.
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                LosslessRetryWorker.UNIQUE_WORK_NAME,
+                ExistingWorkPolicy.KEEP,
+                request,
+            ).await()
+
+            // Observe the unique-work Flow. Filter to OUR enqueued request's
+            // id so historical entries from earlier sessions don't fire stale
+            // "Resolved …" Toasts. Under KEEP policy a coalesced tap will see
+            // the SAME id as the in-flight work, so this still drains correctly
+            // on every tap.
+            WorkManager.getInstance(context)
+                .getWorkInfosForUniqueWorkFlow(LosslessRetryWorker.UNIQUE_WORK_NAME)
+                .firstOrNull { infos ->
+                    val ours = infos.firstOrNull { it.id == request.id } ?: return@firstOrNull false
+                    when (ours.state) {
+                        WorkInfo.State.SUCCEEDED -> {
+                            val resolved = ours.outputData.getInt(LosslessRetryWorker.KEY_RESOLVED, 0)
+                            val total = ours.outputData.getInt(LosslessRetryWorker.KEY_TOTAL, 0)
+                            val message = if (resolved == 0) {
+                                "None resolved this time \u2014 we'll keep trying."
+                            } else {
+                                val remaining = total - resolved
+                                "Resolved $resolved/$total. $remaining still waiting."
+                            }
+                            _userMessages.tryEmit(message)
+                            true
+                        }
+                        WorkInfo.State.FAILED, WorkInfo.State.CANCELLED -> {
+                            _userMessages.tryEmit("Sweep failed \u2014 try again later")
+                            true
+                        }
+                        else -> false
+                    }
+                }
+        }
     }
 
     /**

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package com.stash.feature.home
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.stash.core.auth.TokenManager
@@ -28,9 +29,14 @@ import com.stash.data.download.lossless.kennyy.KennyySource
 import com.stash.data.download.lossless.qobuz.QobuzSource
 import com.stash.feature.home.banner.WaitingForLosslessBannerState
 import com.stash.feature.home.banner.bannerStateFor
+import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import androidx.work.await
+import androidx.work.workDataOf
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.BufferOverflow
@@ -46,12 +52,15 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+private const val TAG = "HomeViewModel"
 
 /**
  * ViewModel for the Home screen. Collects playlist, track, sync data,
@@ -566,8 +575,52 @@ class HomeViewModel @Inject constructor(
      */
     fun refreshMix(playlistId: Long) {
         viewModelScope.launch {
-            val recipe = recipeDao.findByPlaylistId(playlistId) ?: return@launch
-            StashMixRefreshWorker.enqueueOneTime(context, recipe.id)
+            val recipe = recipeDao.findByPlaylistId(playlistId)
+            if (recipe == null) {
+                // Data-integrity bug: playlist.type == STASH_MIX but no recipe
+                // back-links it. Menu shouldn't have appeared. Log + soft-fail.
+                Log.w(TAG, "refreshMix: no recipe back-links playlistId=$playlistId")
+                _userMessages.tryEmit("Couldn't refresh \u2014 this mix isn't linked to a recipe")
+                return@launch
+            }
+
+            _userMessages.tryEmit("Refreshing ${recipe.name}\u2026")
+
+            // Build the request ourselves so we can capture its id for exact-
+            // match WorkInfo filtering below. enqueueUniqueWork uses the same
+            // unique name + REPLACE policy as StashMixRefreshWorker.enqueueOneTime,
+            // mirroring lines 154-168 of that worker.
+            val request = OneTimeWorkRequestBuilder<StashMixRefreshWorker>()
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build(),
+                )
+                .setInputData(workDataOf(StashMixRefreshWorker.KEY_RECIPE_ID to recipe.id))
+                .build()
+            val uniqueName = "${StashMixRefreshWorker.ONE_SHOT_WORK_NAME}_${recipe.id}"
+            WorkManager.getInstance(context)
+                .enqueueUniqueWork(uniqueName, ExistingWorkPolicy.REPLACE, request)
+
+            // Observe the unique-work Flow; filter to OUR enqueued request's id
+            // so historical entries from earlier taps (or earlier sessions)
+            // don't fire stale "Refreshed" Toasts.
+            WorkManager.getInstance(context)
+                .getWorkInfosForUniqueWorkFlow(uniqueName)
+                .firstOrNull { infos ->
+                    val ours = infos.firstOrNull { it.id == request.id } ?: return@firstOrNull false
+                    when (ours.state) {
+                        WorkInfo.State.SUCCEEDED -> {
+                            _userMessages.tryEmit("Refreshed ${recipe.name}")
+                            true
+                        }
+                        WorkInfo.State.FAILED, WorkInfo.State.CANCELLED -> {
+                            _userMessages.tryEmit("Refresh failed \u2014 try again later")
+                            true
+                        }
+                        else -> false
+                    }
+                }
         }
     }
 

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
@@ -426,7 +426,12 @@ class HomeViewModel @Inject constructor(
     fun onRetryDeferredRequested() {
         viewModelScope.launch {
             // Snapshot the current count before we kick the worker so the
-            // start message and the math after both reference the same N.
+            // start message has a number to show. This is an approximation:
+            // a concurrent TrackDownloadWorker flipping rows out of
+            // WAITING_FOR_LOSSLESS between this read and the sweep can make
+            // countAtStart drift from the worker's own KEY_TOTAL. The result
+            // message below uses the worker-authoritative total, so the math
+            // stays consistent — only the start-message N can be stale.
             val countAtStart = downloadQueueDao.waitingForLosslessCount().first()
             if (countAtStart <= 0) return@launch  // banner shouldn't be visible
 

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
@@ -447,15 +447,28 @@ class HomeViewModel @Inject constructor(
                 request,
             ).await()
 
-            // Observe the unique-work Flow. Filter to OUR enqueued request's
-            // id so historical entries from earlier sessions don't fire stale
-            // "Resolved …" Toasts. Under KEEP policy a coalesced tap will see
-            // the SAME id as the in-flight work, so this still drains correctly
-            // on every tap.
+            // Under KEEP policy a coalesced tap means WorkManager kept the
+            // existing work's id and dropped our request.id entirely. Filtering
+            // on request.id would hang forever waiting for an id that never
+            // gets enqueued. So we take a snapshot of the current WorkInfo list
+            // for this unique name and lock in whichever is most relevant:
+            //   1) the in-flight (non-terminal) WorkInfo if one exists
+            //   2) else the most-recent WorkInfo in the list (already terminal,
+            //      e.g. the sweep finished between await() and our snapshot —
+            //      fire its result immediately)
+            //   3) else our own request.id as a defensive fallback (truly nothing
+            //      yet — the Flow will emit again when our work materializes).
+            val initial = WorkManager.getInstance(context)
+                .getWorkInfosForUniqueWorkFlow(LosslessRetryWorker.UNIQUE_WORK_NAME)
+                .first()
+            val targetId = initial.firstOrNull { !it.state.isFinished }?.id
+                ?: initial.firstOrNull()?.id
+                ?: request.id
+
             WorkManager.getInstance(context)
                 .getWorkInfosForUniqueWorkFlow(LosslessRetryWorker.UNIQUE_WORK_NAME)
                 .firstOrNull { infos ->
-                    val ours = infos.firstOrNull { it.id == request.id } ?: return@firstOrNull false
+                    val ours = infos.firstOrNull { it.id == targetId } ?: return@firstOrNull false
                     when (ours.state) {
                         WorkInfo.State.SUCCEEDED -> {
                             val resolved = ours.outputData.getInt(LosslessRetryWorker.KEY_RESOLVED, 0)

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
@@ -33,8 +33,11 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -78,6 +81,16 @@ class HomeViewModel @Inject constructor(
     private val aggregatorRateLimiter: AggregatorRateLimiter,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
+
+    private val _userMessages = MutableSharedFlow<String>(
+        // Bumped to 8 to mirror NowPlayingViewModel — actions that emit two
+        // back-to-back messages (refresh start → done, lossless retry start →
+        // result) need headroom against the Toast collector's drain rate.
+        extraBufferCapacity = 8,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    /** One-shot snackbar messages (e.g. "Refreshing Daily Discover…"). */
+    val userMessages: SharedFlow<String> = _userMessages.asSharedFlow()
 
     init {
         // v0.9.13: warm the tip-jar cache on cold-start, then trigger a

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
@@ -11,8 +11,10 @@ import com.stash.core.data.db.dao.ListeningEventDao
 import com.stash.core.data.db.dao.StashMixRecipeDao
 import com.stash.core.data.lastfm.LastFmCredentials
 import com.stash.core.data.lastfm.LastFmSessionPreference
+import com.stash.core.data.prefs.DownloadNetworkPreference
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.data.sync.toDisplayStatus
+import com.stash.core.data.sync.workers.StashDiscoveryWorker
 import com.stash.core.data.sync.workers.StashMixRefreshWorker
 import com.stash.core.media.PlayerRepository
 import com.stash.core.model.MusicSource
@@ -88,6 +90,7 @@ class HomeViewModel @Inject constructor(
     private val downloadQueueDao: DownloadQueueDao,
     private val qobuzSource: QobuzSource,
     private val aggregatorRateLimiter: AggregatorRateLimiter,
+    private val downloadNetworkPreference: DownloadNetworkPreference,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
@@ -665,6 +668,17 @@ class HomeViewModel @Inject constructor(
             val uniqueName = "${StashMixRefreshWorker.ONE_SHOT_WORK_NAME}_${recipe.id}"
             WorkManager.getInstance(context)
                 .enqueueUniqueWork(uniqueName, ExistingWorkPolicy.REPLACE, request)
+
+            // v0.9.20: fire the full discovery pipeline. queueDiscoveryForRecipe
+            // inside the mix refresh worker enqueues new Last.fm candidates into
+            // discovery_queue PENDING; this trigger processes them right now (subject
+            // to user's DownloadNetworkMode pref) instead of waiting up to 24h for
+            // the periodic schedule. The chain in StashDiscoveryWorker's tail will
+            // fire DiscoveryDownloadWorker, which fires StashMixRefreshWorker again
+            // at the end — the mix re-materializes with newly-downloaded survivors
+            // without the user lifting another finger.
+            val mode = downloadNetworkPreference.current()
+            StashDiscoveryWorker.enqueueOneTime(context, mode)
 
             // Observe the unique-work Flow; filter to OUR enqueued request's id
             // so historical entries from earlier taps (or earlier sessions)


### PR DESCRIPTION
## Summary

Six atomic fixes that together unstuck Deep Cuts (was capped at 5 library tracks) and cleaned several related pipeline bugs surfaced during diagnosis.

- **Cap counts on-disk downloads, not pending stubs** — `countRecentCompletedForRecipe` now JOINs `tracks.is_downloaded=1` to match `getDoneTrackIdsForRecipe`. Stops the "100 intended but 0 downloaded" trap.
- **Soft cross-mix dedup + diagnostic logs** — when overlapping Last.fm pools left a mix below its cap, backfill from the shared pool instead of shipping an empty discovery section.
- **Fairness in PENDING fetch** — `findRecipesAtWeeklyCap` + `getPendingExcludingRecipes` skip at-cap recipes so one recipe's deferred backlog can't starve another. **This was the actual root cause of Deep Cuts being stuck.**
- **Race fix** — removed `StashDiscoveryWorker.handle()`'s playlist insert; `materializeMix` is now the sole owner of playlist contents (no more 5→13→5 flash).
- **Persist duration after discovery download** — mirrors the sync path's behavior; new discovery tracks no longer show 0:00.
- **Startup file-integrity sweep** — finds `is_downloaded=1` rows whose file is gone (user delete, SAF revoke, etc.) and resets them. First run on-device cleaned 45 / 2408 ghost tracks.

## Test plan
- [x] On-device: Deep Cuts long-press → Refresh produces real downloads (was: 5 tracks, after: 39)
- [x] On-device: Daily Discover + First Listen continue refreshing normally
- [x] On-device: durations populate for new discovery downloads
- [x] On-device: file-integrity sweep logs `file integrity: scanned N downloaded rows, reset M with missing files` at startup
- [x] On-device: no 5→13→5 playlist flash on refresh
- [x] `:core:data:compileDebugKotlin` BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)