### PR TITLE
feat(player): heart button in notification toggles Stash Liked

### DIFF
--- a/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
@@ -9,15 +9,27 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.CommandButton
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionResult
+import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.social.stash.StashLikedPlaylistRepository
+import com.stash.core.media.R
 import com.stash.core.media.equalizer.EqController
 import com.stash.core.media.equalizer.StashRenderersFactory
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -27,11 +39,17 @@ import javax.inject.Inject
  * Custom session commands:
  * - [COMMAND_TOGGLE_SHUFFLE] -- toggles shuffle mode on/off
  * - [COMMAND_CYCLE_REPEAT]   -- cycles repeat mode: OFF -> ALL -> ONE -> OFF
+ * - [COMMAND_TOGGLE_LIKE]    -- toggles Stash Liked Songs membership for the
+ *   currently playing track. Surfaced as a heart icon in the system
+ *   notification (expanded view) so the user can like/unlike from the
+ *   lockscreen without opening Now Playing.
  */
 @AndroidEntryPoint
 class StashPlaybackService : MediaSessionService() {
 
     @Inject lateinit var eqController: EqController
+    @Inject lateinit var trackDao: TrackDao
+    @Inject lateinit var stashLikedRepository: StashLikedPlaylistRepository
 
     companion object {
         /** Custom command action for toggling shuffle mode. */
@@ -39,9 +57,18 @@ class StashPlaybackService : MediaSessionService() {
 
         /** Custom command action for cycling repeat mode. */
         const val COMMAND_CYCLE_REPEAT = "com.stash.CYCLE_REPEAT"
+
+        /** Custom command action for toggling Stash Liked on the current track. */
+        const val COMMAND_TOGGLE_LIKE = "com.stash.TOGGLE_LIKE"
     }
 
     private var mediaSession: MediaSession? = null
+
+    // Service-scoped CoroutineScope for the like-state observer + toggle
+    // suspending calls. Cancelled in onDestroy so the observer doesn't leak
+    // when the service stops.
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var likeObserverJob: Job? = null
 
     @OptIn(UnstableApi::class)
     override fun onCreate() {
@@ -102,6 +129,64 @@ class StashPlaybackService : MediaSessionService() {
         val session = sessionBuilder.build()
 
         mediaSession = session
+
+        // Heart-button wiring: rebuild the notification's custom layout
+        // whenever the playing track changes so the icon (filled vs.
+        // outlined) reflects the new track's Stash-Liked state. The
+        // per-track observe loop inside [refreshLikeButton] keeps the
+        // icon in sync if the user toggles like from elsewhere
+        // (Now Playing, Library, etc.) while audio is playing.
+        player.addListener(object : Player.Listener {
+            override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                refreshLikeButton()
+            }
+        })
+        refreshLikeButton()
+    }
+
+    /**
+     * Cancels any existing like-state observer and starts a new one for
+     * the player's current media item. Each emission rebuilds the
+     * MediaSession's custom layout with the appropriate heart icon.
+     * When there's no current track the custom layout is cleared so the
+     * notification doesn't render a stale heart.
+     */
+    @OptIn(UnstableApi::class)
+    private fun refreshLikeButton() {
+        likeObserverJob?.cancel()
+        val session = mediaSession ?: return
+        val trackId = session.player.currentMediaItem?.mediaId?.toLongOrNull()
+        if (trackId == null) {
+            session.setCustomLayout(ImmutableList.of())
+            return
+        }
+        likeObserverJob = serviceScope.launch {
+            trackDao.observeLikeState(trackId).collect { state ->
+                val isLiked = state?.stashLikedAt != null
+                session.setCustomLayout(ImmutableList.of(buildLikeButton(isLiked)))
+            }
+        }
+    }
+
+    @OptIn(UnstableApi::class)
+    private fun buildLikeButton(isLiked: Boolean): CommandButton {
+        val iconRes = if (isLiked) {
+            R.drawable.ic_notification_heart_filled
+        } else {
+            R.drawable.ic_notification_heart_outlined
+        }
+        val displayNameRes = if (isLiked) {
+            R.string.notification_action_unlike
+        } else {
+            R.string.notification_action_like
+        }
+        return CommandButton.Builder()
+            .setDisplayName(getString(displayNameRes))
+            .setIconResId(iconRes)
+            .setSessionCommand(
+                SessionCommand(COMMAND_TOGGLE_LIKE, android.os.Bundle.EMPTY),
+            )
+            .build()
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? {
@@ -117,6 +202,8 @@ class StashPlaybackService : MediaSessionService() {
     }
 
     override fun onDestroy() {
+        likeObserverJob?.cancel()
+        serviceScope.cancel()
         mediaSession?.run {
             player.release()
             release()
@@ -161,6 +248,7 @@ class StashPlaybackService : MediaSessionService() {
             val customCommands = listOf(
                 SessionCommand(COMMAND_TOGGLE_SHUFFLE, /* extras = */ android.os.Bundle.EMPTY),
                 SessionCommand(COMMAND_CYCLE_REPEAT, /* extras = */ android.os.Bundle.EMPTY),
+                SessionCommand(COMMAND_TOGGLE_LIKE, /* extras = */ android.os.Bundle.EMPTY),
             )
             val sessionCommands = MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS.buildUpon()
             customCommands.forEach { sessionCommands.add(it) }
@@ -200,6 +288,22 @@ class StashPlaybackService : MediaSessionService() {
                         Player.REPEAT_MODE_OFF -> Player.REPEAT_MODE_ALL
                         Player.REPEAT_MODE_ALL -> Player.REPEAT_MODE_ONE
                         else -> Player.REPEAT_MODE_OFF
+                    }
+                }
+                COMMAND_TOGGLE_LIKE -> {
+                    // Read the mediaId on the caller thread (Player APIs are
+                    // main-thread-only) but do the DAO/repo work in the
+                    // service scope so the callback returns immediately.
+                    val trackId = session.player.currentMediaItem?.mediaId?.toLongOrNull()
+                    if (trackId != null) {
+                        serviceScope.launch {
+                            val current = trackDao.observeLikeState(trackId).firstOrNull()
+                            if (current?.stashLikedAt != null) {
+                                stashLikedRepository.remove(trackId)
+                            } else {
+                                stashLikedRepository.add(trackId)
+                            }
+                        }
                     }
                 }
             }

--- a/core/media/src/main/res/drawable/ic_notification_heart_filled.xml
+++ b/core/media/src/main/res/drawable/ic_notification_heart_filled.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z" />
+</vector>

--- a/core/media/src/main/res/drawable/ic_notification_heart_outlined.xml
+++ b/core/media/src/main/res/drawable/ic_notification_heart_outlined.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16.5,3c-1.74,0 -3.41,0.81 -4.5,2.09C10.91,3.81 9.24,3 7.5,3 4.42,3 2,5.42 2,8.5c0,3.78 3.4,6.86 8.55,11.54L12,21.35l1.45,-1.32C18.6,15.36 22,12.28 22,8.5 22,5.42 19.58,3 16.5,3zM12.1,18.55l-0.1,0.1 -0.1,-0.1C7.14,14.24 4,11.39 4,8.5 4,6.5 5.5,5 7.5,5c1.54,0 3.04,0.99 3.57,2.36h1.87C13.46,5.99 14.96,5 16.5,5c2,0 3.5,1.5 3.5,3.5 0,2.89 -3.14,5.74 -7.9,10.05z" />
+</vector>

--- a/core/media/src/main/res/values/strings.xml
+++ b/core/media/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="notification_action_like">Add to Liked Songs</string>
+    <string name="notification_action_unlike">Remove from Liked Songs</string>
+</resources>


### PR DESCRIPTION
## Summary

Adds a heart icon to the system notification's expanded view that toggles the currently-playing track's Stash Liked Songs membership. Mirrors the in-app Now Playing heart.

Closes #33

## Implementation

- New \`COMMAND_TOGGLE_LIKE\` SessionCommand alongside the existing shuffle/repeat commands in \`StashPlaybackService\`.
- \`CommandButton\` registered via \`MediaSession.setCustomLayout\` — surfaces in the notification expanded view (compact stays as prev/play-pause/next).
- Filled vs. outlined icon swapped via \`TrackDao.observeLikeState\` on the current \`mediaId\`. Rebuilds on every \`Player.Listener.onMediaItemTransition\`.
- Toggle handler reuses \`StashLikedPlaylistRepository.add\`/\`.remove\` — single source of truth shared with the Now Playing heart, so toggling from either surface updates the other.

## Test plan
- [x] On-device: heart visible in expanded notification while playback active
- [x] On-device: tap fills heart; Now Playing heart updates in sync
- [x] On-device: outlined heart on next-track when that track isn't liked
- [x] On-device: tap outlined heart adds to Stash Liked Songs playlist
- [x] \`:core:media:compileDebugKotlin\` BUILD SUCCESSFUL
- [x] \`:app:assembleRelease\` BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)