### PR TITLE
feat(playlists): add Stash tracks to imported playlists (closes #42)

### DIFF
--- a/core/data/schemas/com.stash.core.data.db.StashDatabase/23.json
+++ b/core/data/schemas/com.stash.core.data.db.StashDatabase/23.json
@@ -1,0 +1,1620 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 23,
+    "identityHash": "b7bc2ae9758d13f8eb8092508def47d5",
+    "entities": [
+      {
+        "tableName": "tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `duration_ms` INTEGER NOT NULL, `file_path` TEXT, `file_format` TEXT NOT NULL, `quality_kbps` INTEGER NOT NULL, `file_size_bytes` INTEGER NOT NULL, `source` TEXT NOT NULL, `spotify_uri` TEXT, `youtube_id` TEXT, `album_art_url` TEXT, `album_art_path` TEXT, `date_added` INTEGER NOT NULL, `last_played` INTEGER, `play_count` INTEGER NOT NULL, `is_downloaded` INTEGER NOT NULL, `canonical_title` TEXT NOT NULL, `canonical_artist` TEXT NOT NULL, `match_confidence` REAL NOT NULL, `match_dismissed` INTEGER NOT NULL, `match_flagged` INTEGER NOT NULL DEFAULT 0, `isrc` TEXT, `explicit` INTEGER, `music_video_type` TEXT, `yt_canonical_video_id` TEXT, `bits_per_sample` INTEGER, `sample_rate_hz` INTEGER, `spotify_saved_at` INTEGER, `ytmusic_saved_at` INTEGER, `stash_liked_at` INTEGER, `mbid` TEXT, `lastfm_user_playcount` INTEGER, `lastfm_listeners` INTEGER, `lastfm_user_loved` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileFormat",
+            "columnName": "file_format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "qualityKbps",
+            "columnName": "quality_kbps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "file_size_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotify_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeId",
+            "columnName": "youtube_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtUrl",
+            "columnName": "album_art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtPath",
+            "columnName": "album_art_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayed",
+            "columnName": "last_played",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDownloaded",
+            "columnName": "is_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalTitle",
+            "columnName": "canonical_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalArtist",
+            "columnName": "canonical_artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchConfidence",
+            "columnName": "match_confidence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchDismissed",
+            "columnName": "match_dismissed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchFlagged",
+            "columnName": "match_flagged",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "musicVideoType",
+            "columnName": "music_video_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ytCanonicalVideoId",
+            "columnName": "yt_canonical_video_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitsPerSample",
+            "columnName": "bits_per_sample",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRateHz",
+            "columnName": "sample_rate_hz",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "spotifySavedAt",
+            "columnName": "spotify_saved_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "ytMusicSavedAt",
+            "columnName": "ytmusic_saved_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "stashLikedAt",
+            "columnName": "stash_liked_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mbid",
+            "columnName": "mbid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastfmUserPlaycount",
+            "columnName": "lastfm_user_playcount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastfmListeners",
+            "columnName": "lastfm_listeners",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastfmUserLoved",
+            "columnName": "lastfm_user_loved",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tracks_spotify_uri",
+            "unique": true,
+            "columnNames": [
+              "spotify_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tracks_spotify_uri` ON `${TABLE_NAME}` (`spotify_uri`)"
+          },
+          {
+            "name": "index_tracks_youtube_id",
+            "unique": true,
+            "columnNames": [
+              "youtube_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tracks_youtube_id` ON `${TABLE_NAME}` (`youtube_id`)"
+          },
+          {
+            "name": "index_tracks_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_artist` ON `${TABLE_NAME}` (`artist`)"
+          },
+          {
+            "name": "index_tracks_album",
+            "unique": false,
+            "columnNames": [
+              "album"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_album` ON `${TABLE_NAME}` (`album`)"
+          },
+          {
+            "name": "index_tracks_date_added",
+            "unique": false,
+            "columnNames": [
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_date_added` ON `${TABLE_NAME}` (`date_added`)"
+          },
+          {
+            "name": "index_tracks_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_last_played` ON `${TABLE_NAME}` (`last_played`)"
+          },
+          {
+            "name": "index_tracks_play_count",
+            "unique": false,
+            "columnNames": [
+              "play_count"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_play_count` ON `${TABLE_NAME}` (`play_count`)"
+          },
+          {
+            "name": "index_tracks_title_artist",
+            "unique": false,
+            "columnNames": [
+              "title",
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_title_artist` ON `${TABLE_NAME}` (`title`, `artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `source` TEXT NOT NULL, `source_id` TEXT NOT NULL, `type` TEXT NOT NULL, `mix_number` INTEGER, `last_synced` INTEGER, `track_count` INTEGER NOT NULL, `is_active` INTEGER NOT NULL, `art_url` TEXT, `snapshot_id` TEXT, `sync_enabled` INTEGER NOT NULL DEFAULT 1, `date_added` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mixNumber",
+            "columnName": "mix_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastSynced",
+            "columnName": "last_synced",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artUrl",
+            "columnName": "art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snapshotId",
+            "columnName": "snapshot_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncEnabled",
+            "columnName": "sync_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_source_id",
+            "unique": true,
+            "columnNames": [
+              "source_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playlists_source_id` ON `${TABLE_NAME}` (`source_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `track_id` INTEGER NOT NULL, `position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `removed_at` INTEGER, `locally_added` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`playlist_id`, `track_id`), FOREIGN KEY(`playlist_id`) REFERENCES `playlists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "removedAt",
+            "columnName": "removed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "locallyAdded",
+            "columnName": "locally_added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "track_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_tracks_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_tracks_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `started_at` INTEGER NOT NULL, `completed_at` INTEGER, `status` TEXT NOT NULL, `playlists_checked` INTEGER NOT NULL, `new_tracks_found` INTEGER NOT NULL, `tracks_downloaded` INTEGER NOT NULL, `tracks_failed` INTEGER NOT NULL, `bytes_downloaded` INTEGER NOT NULL, `error_message` TEXT, `diagnostics` TEXT, `trigger` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistsChecked",
+            "columnName": "playlists_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newTracksFound",
+            "columnName": "new_tracks_found",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tracksDownloaded",
+            "columnName": "tracks_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tracksFailed",
+            "columnName": "tracks_failed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bytesDownloaded",
+            "columnName": "bytes_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "diagnostics",
+            "columnName": "diagnostics",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trigger",
+            "columnName": "trigger",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "download_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `track_id` INTEGER NOT NULL, `sync_id` INTEGER, `status` TEXT NOT NULL, `search_query` TEXT NOT NULL, `youtube_url` TEXT, `retry_count` INTEGER NOT NULL, `error_message` TEXT, `failure_type` TEXT NOT NULL, `rejected_video_id` TEXT, `created_at` INTEGER NOT NULL, `completed_at` INTEGER, FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`sync_id`) REFERENCES `sync_history`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchQuery",
+            "columnName": "search_query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeUrl",
+            "columnName": "youtube_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retry_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "failureType",
+            "columnName": "failure_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rejectedVideoId",
+            "columnName": "rejected_video_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_queue_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          },
+          {
+            "name": "index_download_queue_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          },
+          {
+            "name": "index_download_queue_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sync_history",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sync_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "source_accounts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `source` TEXT NOT NULL, `display_name` TEXT NOT NULL, `email` TEXT NOT NULL, `avatar_url` TEXT, `is_connected` INTEGER NOT NULL, `connected_at` INTEGER, `last_sync_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatar_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isConnected",
+            "columnName": "is_connected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connectedAt",
+            "columnName": "connected_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastSyncAt",
+            "columnName": "last_sync_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_source_accounts_source",
+            "unique": true,
+            "columnNames": [
+              "source"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_source_accounts_source` ON `${TABLE_NAME}` (`source`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tracks_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, tokenize=unicode61, content=`tracks`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "tracks",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_BEFORE_UPDATE BEFORE UPDATE ON `tracks` BEGIN DELETE FROM `tracks_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_BEFORE_DELETE BEFORE DELETE ON `tracks` BEGIN DELETE FROM `tracks_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_AFTER_UPDATE AFTER UPDATE ON `tracks` BEGIN INSERT INTO `tracks_fts`(`docid`, `title`, `artist`, `album`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`artist`, NEW.`album`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_AFTER_INSERT AFTER INSERT ON `tracks` BEGIN INSERT INTO `tracks_fts`(`docid`, `title`, `artist`, `album`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`artist`, NEW.`album`); END"
+        ]
+      },
+      {
+        "tableName": "remote_playlist_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `source_playlist_id` TEXT NOT NULL, `playlist_name` TEXT NOT NULL, `playlist_type` TEXT NOT NULL, `mix_number` INTEGER, `snapshot_id` TEXT, `track_count` INTEGER NOT NULL, `art_url` TEXT, `fetched_at` INTEGER NOT NULL, `partial` INTEGER NOT NULL, `expected_count` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePlaylistId",
+            "columnName": "source_playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistName",
+            "columnName": "playlist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistType",
+            "columnName": "playlist_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mixNumber",
+            "columnName": "mix_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "snapshotId",
+            "columnName": "snapshot_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artUrl",
+            "columnName": "art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partial",
+            "columnName": "partial",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedCount",
+            "columnName": "expected_count",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_playlist_snapshots_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_playlist_snapshots_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          },
+          {
+            "name": "index_remote_playlist_snapshots_sync_id_source_playlist_id",
+            "unique": true,
+            "columnNames": [
+              "sync_id",
+              "source_playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_remote_playlist_snapshots_sync_id_source_playlist_id` ON `${TABLE_NAME}` (`sync_id`, `source_playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "remote_track_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_id` INTEGER NOT NULL, `snapshot_playlist_id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT, `duration_ms` INTEGER NOT NULL, `spotify_uri` TEXT, `youtube_id` TEXT, `album_art_url` TEXT, `position` INTEGER NOT NULL, `isrc` TEXT, `explicit` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snapshotPlaylistId",
+            "columnName": "snapshot_playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotify_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeId",
+            "columnName": "youtube_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtUrl",
+            "columnName": "album_art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_track_snapshots_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_track_snapshots_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          },
+          {
+            "name": "index_remote_track_snapshots_snapshot_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "snapshot_playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_track_snapshots_snapshot_playlist_id` ON `${TABLE_NAME}` (`snapshot_playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist_profile_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artist_id` TEXT NOT NULL, `json` TEXT NOT NULL, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`artist_id`))",
+        "fields": [
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artist_id"
+          ]
+        }
+      },
+      {
+        "tableName": "listening_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `track_id` INTEGER NOT NULL, `started_at` INTEGER NOT NULL, `scrobbled` INTEGER NOT NULL, `yt_scrobbled` INTEGER NOT NULL DEFAULT 0, `completed_at` INTEGER, FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrobbled",
+            "columnName": "scrobbled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ytScrobbled",
+            "columnName": "yt_scrobbled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_listening_events_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          },
+          {
+            "name": "index_listening_events_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          },
+          {
+            "name": "index_listening_events_scrobbled",
+            "unique": false,
+            "columnNames": [
+              "scrobbled"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_scrobbled` ON `${TABLE_NAME}` (`scrobbled`)"
+          },
+          {
+            "name": "index_listening_events_yt_scrobbled",
+            "unique": false,
+            "columnNames": [
+              "yt_scrobbled"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_yt_scrobbled` ON `${TABLE_NAME}` (`yt_scrobbled`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "track_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`track_id` INTEGER NOT NULL, `tag` TEXT NOT NULL, `weight` REAL NOT NULL, `source` TEXT NOT NULL, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`track_id`, `tag`), FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "track_id",
+            "tag"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_tags_tag",
+            "unique": false,
+            "columnNames": [
+              "tag"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_tags_tag` ON `${TABLE_NAME}` (`tag`)"
+          },
+          {
+            "name": "index_track_tags_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_tags_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stash_mix_recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `include_tags_csv` TEXT NOT NULL, `exclude_tags_csv` TEXT NOT NULL, `era_start_year` INTEGER, `era_end_year` INTEGER, `affinity_bias` REAL NOT NULL, `discovery_ratio` REAL NOT NULL, `freshness_window_days` INTEGER NOT NULL, `target_length` INTEGER NOT NULL, `is_builtin` INTEGER NOT NULL, `is_active` INTEGER NOT NULL, `playlist_id` INTEGER, `created_at` INTEGER NOT NULL, `last_refreshed_at` INTEGER, `seed_strategy` TEXT NOT NULL DEFAULT 'ARTIST_SIMILAR', FOREIGN KEY(`playlist_id`) REFERENCES `playlists`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "includeTagsCsv",
+            "columnName": "include_tags_csv",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeTagsCsv",
+            "columnName": "exclude_tags_csv",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eraStartYear",
+            "columnName": "era_start_year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "eraEndYear",
+            "columnName": "era_end_year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "affinityBias",
+            "columnName": "affinity_bias",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discoveryRatio",
+            "columnName": "discovery_ratio",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "freshnessWindowDays",
+            "columnName": "freshness_window_days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetLength",
+            "columnName": "target_length",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBuiltin",
+            "columnName": "is_builtin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastRefreshedAt",
+            "columnName": "last_refreshed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seedStrategy",
+            "columnName": "seed_strategy",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ARTIST_SIMILAR'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stash_mix_recipes_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stash_mix_recipes_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          },
+          {
+            "name": "index_stash_mix_recipes_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stash_mix_recipes_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "discovery_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `recipe_id` INTEGER NOT NULL, `artist` TEXT NOT NULL, `title` TEXT NOT NULL, `seed_artist` TEXT NOT NULL, `status` TEXT NOT NULL, `track_id` INTEGER, `queued_at` INTEGER NOT NULL, `completed_at` INTEGER, `error_message` TEXT, FOREIGN KEY(`recipe_id`) REFERENCES `stash_mix_recipes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipe_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seedArtist",
+            "columnName": "seed_artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queued_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_discovery_queue_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_queue_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_discovery_queue_recipe_id",
+            "unique": false,
+            "columnNames": [
+              "recipe_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_queue_recipe_id` ON `${TABLE_NAME}` (`recipe_id`)"
+          },
+          {
+            "name": "index_discovery_queue_queued_at",
+            "unique": false,
+            "columnNames": [
+              "queued_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_queue_queued_at` ON `${TABLE_NAME}` (`queued_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stash_mix_recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipe_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "track_blocklist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`canonical_key` TEXT NOT NULL, `artist` TEXT NOT NULL, `title` TEXT NOT NULL, `spotify_uri` TEXT, `youtube_id` TEXT, `blocked_at` INTEGER NOT NULL, `blocked_from` TEXT NOT NULL, PRIMARY KEY(`canonical_key`))",
+        "fields": [
+          {
+            "fieldPath": "canonicalKey",
+            "columnName": "canonical_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotify_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeId",
+            "columnName": "youtube_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "blockedAt",
+            "columnName": "blocked_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockedFrom",
+            "columnName": "blocked_from",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "canonical_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_blocklist_spotify_uri",
+            "unique": false,
+            "columnNames": [
+              "spotify_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_blocklist_spotify_uri` ON `${TABLE_NAME}` (`spotify_uri`)"
+          },
+          {
+            "name": "index_track_blocklist_youtube_id",
+            "unique": false,
+            "columnNames": [
+              "youtube_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_blocklist_youtube_id` ON `${TABLE_NAME}` (`youtube_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "track_skip_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `track_id` INTEGER NOT NULL, `skipped_at` INTEGER NOT NULL, `position_ms` INTEGER NOT NULL, FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skippedAt",
+            "columnName": "skipped_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_skip_events_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_skip_events_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          },
+          {
+            "name": "index_track_skip_events_skipped_at",
+            "unique": false,
+            "columnNames": [
+              "skipped_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_skip_events_skipped_at` ON `${TABLE_NAME}` (`skipped_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b7bc2ae9758d13f8eb8092508def47d5')"
+    ]
+  }
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/db/StashDatabase.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/StashDatabase.kt
@@ -70,7 +70,7 @@ import com.stash.core.data.db.entity.TrackTagEntity
         TrackBlocklistEntity::class,
         TrackSkipEventEntity::class,
     ],
-    version = 22,
+    version = 23,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -636,6 +636,27 @@ abstract class StashDatabase : RoomDatabase() {
         val MIGRATION_21_22 = object : Migration(21, 22) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 // No-op DDL: TEXT columns accept new enum names natively.
+            }
+        }
+
+        /**
+         * v0.9.23 — track which playlist_tracks rows were added by the user
+         * (vs. by a sync run). Drives REFRESH-mode survival so a user's
+         * manual additions to an imported Spotify/YT Music playlist persist
+         * across re-syncs. See issue #42.
+         *
+         * Default 0 (FALSE) on existing rows is correct: every pre-fix row
+         * was either sync-added (CUSTOM playlists never go through REFRESH
+         * so the flag is moot for them) or added via the existing
+         * MusicRepositoryImpl.addTrackToPlaylist path which only targeted
+         * CUSTOM playlists — those don't hit clearPlaylistTracks anyway.
+         */
+        val MIGRATION_22_23 = object : Migration(22, 23) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE playlist_tracks " +
+                        "ADD COLUMN locally_added INTEGER NOT NULL DEFAULT 0",
+                )
             }
         }
     }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
@@ -239,14 +239,26 @@ interface PlaylistDao {
     suspend fun getActivePlaylistsBySource(source: MusicSource): List<PlaylistEntity>
 
     /**
-     * Hard-delete all track associations for a playlist. Called before
-     * re-inserting the current track set during sync. Without this,
-     * the playlist_tracks table accumulates entries from every sync run
-     * with overlapping position values (e.g., two tracks both at position 1),
-     * which scrambles the display order in the playlist detail view.
+     * Hard-delete all track associations for a playlist. Called by
+     * StashMixRefreshWorker on each refresh — the mix's tracks are
+     * regenerated from scratch every time, so wiping locally-added rows
+     * along with sync-added ones is intentional.
+     *
+     * **NOT used by DiffWorker (sync) anymore** — use
+     * [clearSyncedPlaylistTracks] instead so user-added tracks survive
+     * REFRESH-mode re-sync of an imported playlist.
      */
     @Query("DELETE FROM playlist_tracks WHERE playlist_id = :playlistId")
     suspend fun clearPlaylistTracks(playlistId: Long)
+
+    /**
+     * v0.9.23 — hard-delete only the SYNC-added playlist_tracks rows.
+     * User-added rows (locally_added = 1) are preserved across REFRESH
+     * so manual additions to imported Spotify/YT Music playlists persist.
+     * See issue #42.
+     */
+    @Query("DELETE FROM playlist_tracks WHERE playlist_id = :playlistId AND locally_added = 0")
+    suspend fun clearSyncedPlaylistTracks(playlistId: Long)
 
     /**
      * Remove a single track's membership from a specific playlist. Used by
@@ -396,6 +408,27 @@ interface PlaylistDao {
     /** All user-created custom playlists (source = BOTH means local). */
     @Query("SELECT * FROM playlists WHERE type = 'CUSTOM' AND source = 'BOTH' AND is_active = 1 ORDER BY name ASC")
     fun getUserCreatedPlaylists(): Flow<List<PlaylistEntity>>
+
+    /**
+     * v0.9.23 — playlists the user can pick as a destination for
+     * "Save to Playlist." Includes custom playlists AND imported
+     * Spotify / YT Music CUSTOM playlists (issue #42), excludes
+     * system surfaces the user shouldn't add tracks to directly
+     * (Stash Mix recipes, Downloads Mix, daily mixes/liked songs).
+     * LIKED_SONGS is intentionally not pickable here — Like is a
+     * separate first-class action.
+     */
+    @Query(
+        """
+        SELECT * FROM playlists
+        WHERE is_active = 1
+          AND type IN ('CUSTOM')
+        ORDER BY
+          CASE WHEN source = 'BOTH' THEN 0 ELSE 1 END,
+          name ASC
+        """
+    )
+    fun getPickablePlaylists(): Flow<List<PlaylistEntity>>
 
     /** Soft-delete a single track from a playlist. */
     @Query("UPDATE playlist_tracks SET removed_at = CURRENT_TIMESTAMP WHERE playlist_id = :playlistId AND track_id = :trackId AND removed_at IS NULL")

--- a/core/data/src/main/kotlin/com/stash/core/data/db/entity/PlaylistTrackCrossRef.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/entity/PlaylistTrackCrossRef.kt
@@ -47,4 +47,15 @@ data class PlaylistTrackCrossRef(
 
     @ColumnInfo(name = "removed_at")
     val removedAt: Instant? = null,
+
+    /**
+     * True when this membership was added by the user from within Stash
+     * (e.g. "Save to Playlist" on a downloaded track), false when added
+     * by a sync run from Spotify or YouTube Music. Drives REFRESH-mode
+     * survival: [com.stash.core.data.db.dao.PlaylistDao.clearSyncedPlaylistTracks]
+     * deletes only sync-added rows so user-added tracks persist across
+     * re-syncs. See issue #42.
+     */
+    @ColumnInfo(name = "locally_added", defaultValue = "0")
+    val locallyAdded: Boolean = false,
 )

--- a/core/data/src/main/kotlin/com/stash/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/di/DatabaseModule.kt
@@ -53,6 +53,7 @@ object DatabaseModule {
                 StashDatabase.MIGRATION_19_20,
                 StashDatabase.MIGRATION_20_21,
                 StashDatabase.MIGRATION_21_22,
+                StashDatabase.MIGRATION_22_23,
             )
             // No fallbackToDestructiveMigration() — if a migration is missing,
             // the app will crash on startup instead of silently wiping the

--- a/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepository.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepository.kt
@@ -203,6 +203,13 @@ interface MusicRepository {
     /** Get all user-created custom playlists. */
     fun getUserCreatedPlaylists(): Flow<List<Playlist>>
 
+    /**
+     * Playlists the user can pick as a "Save to Playlist" destination:
+     * custom playlists plus imported Spotify / YT Music playlists.
+     * Excludes Stash Mix / Downloads Mix / daily-mix surfaces.
+     */
+    fun getPickablePlaylists(): Flow<List<Playlist>>
+
     // ── Unmatched tracks ────────────────────────────────────────────────
 
     /** Unmatched tracks (matching failures, not dismissed). */

--- a/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
@@ -356,6 +356,10 @@ class MusicRepositoryImpl @Inject constructor(
                 playlistId = playlistId,
                 trackId = trackId,
                 position = position,
+                // v0.9.23: mark as user-added so REFRESH-mode sync of
+                // imported Spotify / YT Music playlists doesn't wipe it.
+                // See issue #42.
+                locallyAdded = true,
             )
         )
         val count = trackDao.getByPlaylist(playlistId).first().size
@@ -389,6 +393,9 @@ class MusicRepositoryImpl @Inject constructor(
 
     override fun getUserCreatedPlaylists(): Flow<List<com.stash.core.model.Playlist>> =
         playlistDao.getUserCreatedPlaylists().map { entities -> entities.map { it.toDomain() } }
+
+    override fun getPickablePlaylists(): Flow<List<com.stash.core.model.Playlist>> =
+        playlistDao.getPickablePlaylists().map { entities -> entities.map { it.toDomain() } }
 
     // ── Unmatched tracks ────────────────────────────────────────────────
 

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
@@ -300,8 +300,13 @@ class DiffWorker @AssistedInject constructor(
         // ensurePlaylistMembership stops user-removed tracks from coming
         // back, and duplicates fall out naturally since existing rows are
         // re-stamped by the same (playlistId, trackId) primary key.
+        //
+        // v0.9.23 — only wipe SYNC-added rows. User-added tracks
+        // (locally_added = 1) survive REFRESH so manual additions to
+        // imported Spotify / YT Music playlists persist across re-syncs.
+        // See issue #42.
         if (syncMode == SyncMode.REFRESH) {
-            playlistDao.clearPlaylistTracks(localPlaylist.id)
+            playlistDao.clearSyncedPlaylistTracks(localPlaylist.id)
         }
 
         var newTrackCount = 0

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
@@ -127,11 +127,15 @@ class NowPlayingViewModel @Inject constructor(
     }
 
     /**
-     * Observes user-created playlists and maps them to lightweight
-     * [PlaylistInfo] models for the "Save to Playlist" bottom sheet.
+     * Observes the "Save to Playlist" picker destination list — custom
+     * playlists AND imported Spotify / YT Music playlists.
+     * v0.9.23 (issue #42): manual addition of Stash-downloaded tracks
+     * to imported playlists is now supported. The new locally_added
+     * flag on the cross-ref makes the addition survive REFRESH-mode
+     * re-sync of the underlying Spotify / YT Music playlist.
      */
     private fun observeUserPlaylists() {
-        musicRepository.getUserCreatedPlaylists()
+        musicRepository.getPickablePlaylists()
             .onEach { playlists ->
                 _uiState.update { current ->
                     current.copy(


### PR DESCRIPTION
## Summary

Songs downloaded directly through Stash couldn't be added to Spotify- or YT-Music-imported playlists. The "Save to Playlist" picker filtered out everything except custom playlists, and even bypassing the picker would lose the addition on the next REFRESH-mode re-sync.

This PR adds a \`locally_added\` boolean to \`playlist_tracks\` so user-added rows survive REFRESH, and exposes imported playlists in the picker.

## Changes

- **Schema v22→v23**: \`ALTER TABLE playlist_tracks ADD COLUMN locally_added INTEGER NOT NULL DEFAULT 0\` (Migration_22_23, 23.json schema exported)
- **PlaylistDao**:
  - \`clearSyncedPlaylistTracks(playlistId)\` — preserves \`locally_added = 1\` rows
  - \`getPickablePlaylists()\` — active CUSTOM playlists across all sources (custom + imported Spotify + imported YT Music)
- **DiffWorker** REFRESH branch uses \`clearSyncedPlaylistTracks\` so user additions survive re-sync
- **StashMixRefreshWorker** continues to use the full clear (its tracks regenerate wholesale; no user-added concept)
- **MusicRepositoryImpl.addTrackToPlaylist** stamps \`locallyAdded = true\`
- **NowPlayingViewModel** picker reads from \`getPickablePlaylists\`

## Test plan
- [x] \`:core:data:compileDebugKotlin\` BUILD SUCCESSFUL (schema validation)
- [x] \`:app:assembleDebug\` BUILD SUCCESSFUL
- [ ] On-device: imported Spotify playlist appears in Save-to-Playlist picker
- [ ] On-device: addition persists across a Spotify re-sync

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)