### PR TITLE
Android Auto Support

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -646,6 +646,14 @@ interface TrackDao {
     suspend fun updateLastPlayed(trackId: Long, timestamp: Long)
 
     /**
+     * v0.9.27: Returns the most recently played track that is actually
+     * downloaded. Used by the playback service to fulfill the Android Auto
+     * Media Resumption contract (onPlaybackResumption).
+     */
+    @Query("SELECT * FROM tracks WHERE is_downloaded = 1 AND last_played IS NOT NULL ORDER BY last_played DESC LIMIT 1")
+    suspend fun getLastPlayedTrack(): TrackEntity?
+
+    /**
      * v0.9.13: Mark a track as saved to Spotify Liked Songs.
      * Called by [LikeDestinationDispatcher] after a successful
      * `PUT /v1/me/tracks` call. Forward-only; once set, never cleared
@@ -797,6 +805,24 @@ interface TrackDao {
         """
     )
     fun search(query: String): Flow<List<TrackEntity>>
+
+    /**
+     * Search only downloaded tracks by title, artist, or album using FTS4.
+     */
+    @Query(
+        """
+        SELECT tracks.* FROM tracks
+        JOIN tracks_fts ON tracks.rowid = tracks_fts.rowid
+        LEFT JOIN track_blocklist bl
+            ON bl.canonical_key = (tracks.canonical_artist || '|' || tracks.canonical_title)
+            OR (bl.spotify_uri IS NOT NULL AND bl.spotify_uri = tracks.spotify_uri)
+            OR (bl.youtube_id  IS NOT NULL AND bl.youtube_id  = tracks.youtube_id)
+        WHERE tracks_fts MATCH :query
+          AND bl.canonical_key IS NULL
+          AND tracks.is_downloaded = 1
+        """
+    )
+    fun searchDownloaded(query: String): Flow<List<TrackEntity>>
 
     // ── Count / storage queries ─────────────────────────────────────────
 

--- a/core/data/src/main/kotlin/com/stash/core/data/social/stash/StashLikedPlaylistRepository.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/social/stash/StashLikedPlaylistRepository.kt
@@ -39,7 +39,8 @@ class StashLikedPlaylistRepository @Inject constructor(
      */
     suspend fun add(trackId: Long) {
         val playlistId = ensureSeeded()
-        if (playlistDao.getCrossRef(playlistId, trackId) != null) return
+        val existing = playlistDao.getCrossRef(playlistId, trackId)
+        if (existing != null && existing.removedAt == null) return
         // Reuse existing helper for trackCount + position handling.
         // Mirrors linkTrackToDownloadsMix at MusicRepositoryImpl.kt:294.
         musicRepository.addTrackToPlaylist(trackId = trackId, playlistId = playlistId)

--- a/core/media/src/main/AndroidManifest.xml
+++ b/core/media/src/main/AndroidManifest.xml
@@ -6,13 +6,28 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application>
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
+
         <service
             android:name="com.stash.core.media.service.StashPlaybackService"
             android:exported="true"
             android:foregroundServiceType="mediaPlayback">
             <intent-filter>
                 <action android:name="androidx.media3.session.MediaSessionService" />
+                <action android:name="androidx.media3.session.MediaLibraryService" />
+                <action android:name="android.media.browse.MediaBrowserService" />
+                <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH" />
             </intent-filter>
         </service>
+
+        <receiver
+            android:name="androidx.media3.session.MediaButtonReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -429,7 +429,7 @@ class PlayerRepositoryImpl @Inject constructor(
         val track = currentItem?.toTrack()
         val queue = buildList {
             for (i in 0 until controller.mediaItemCount) {
-                controller.getMediaItemAt(i).toTrack()?.let { add(it) }
+                add(controller.getMediaItemAt(i).toTrack())
             }
         }
 
@@ -507,15 +507,21 @@ class PlayerRepositoryImpl @Inject constructor(
      * Best-effort reconstruction of a [Track] from a [MediaItem]'s metadata.
      * Only the fields carried through Media3 metadata are populated.
      */
-    private fun MediaItem.toTrack(): Track? {
+    private fun MediaItem.toTrack(): Track {
         val meta = mediaMetadata
-        val trackId = meta.extras?.getLong(EXTRA_TRACK_ID) ?: mediaId.toLongOrNull() ?: return null
+        // v0.9.27: allow id=0 fallback for non-library tracks (e.g. search
+        // previews with videoId strings). This makes the Like button and
+        // other actions visible in Now Playing for non-library content.
+        val trackId = meta.extras?.getLong(EXTRA_TRACK_ID) ?: mediaId.toLongOrNull() ?: 0L
         return Track(
             id = trackId,
             title = meta.title?.toString() ?: "",
             artist = meta.artist?.toString() ?: "",
             album = meta.albumTitle?.toString() ?: "",
             albumArtUrl = meta.artworkUri?.toString(),
+            // For non-library tracks, the mediaId is the YouTube videoId.
+            youtubeId = if (trackId == 0L) mediaId else null,
+            source = if (trackId == 0L) com.stash.core.model.MusicSource.YOUTUBE else com.stash.core.model.MusicSource.SPOTIFY
         )
     }
 }

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -17,6 +17,7 @@ import com.stash.core.media.service.StashPlaybackService
 import com.stash.core.model.PlayerState
 import com.stash.core.model.RepeatMode
 import com.stash.core.model.Track
+import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_TRACK_ID
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -33,6 +34,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
+import androidx.core.net.toUri
 
 /**
  * [PlayerRepository] implementation backed by a [MediaController] that connects
@@ -51,6 +53,13 @@ class PlayerRepositoryImpl @Inject constructor(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     init {
+        // v0.9.27: Connect the controller immediately on init so we can
+        // provide live state even if the app was cold-started while
+        // music was already playing (e.g. via Android Auto).
+        scope.launch {
+            ensureController()
+        }
+
         // Evict deleted tracks from the live queue. Without this, ExoPlayer's
         // open file handle keeps audio playing after the user deletes the
         // song (correct Unix semantics, wrong UX) — see Reddit report from
@@ -453,7 +462,6 @@ class PlayerRepositoryImpl @Inject constructor(
     companion object {
         private const val TAG = "StashPlayer"
         private const val POSITION_UPDATE_INTERVAL_MS = 250L
-        private const val EXTRA_TRACK_ID = "stash_track_id"
 
         /** Auto-grow fires once the remaining queue tail drops below this many tracks. */
         private const val LIBRARY_SHUFFLE_GROW_THRESHOLD = 5
@@ -473,14 +481,14 @@ class PlayerRepositoryImpl @Inject constructor(
             .setArtist(artist)
             .setAlbumTitle(album)
             .setArtworkUri(
-                (albumArtPath ?: albumArtUrl)?.let { Uri.parse(it) }
+                (albumArtPath ?: albumArtUrl)?.toUri()
             )
             .setExtras(Bundle().apply { putLong(EXTRA_TRACK_ID, id) })
             .build()
 
         // Ensure file:// scheme so StashPlaybackService's URI validation passes.
         val fileUri = filePath?.let { path ->
-            if (path.startsWith("/")) Uri.parse("file://$path") else Uri.parse(path)
+            if (path.startsWith("/")) "file://$path".toUri() else path.toUri()
         }
 
         val requestMetadata = MediaItem.RequestMetadata.Builder()

--- a/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
@@ -318,7 +318,7 @@ class StashPlaybackService : MediaLibraryService() {
                     val playlistId = mediaItems[0].mediaId.removePrefix(SHUFFLE_PLAY_PREFIX).toLongOrNull()
                     if (playlistId != null) {
                         val tracks = playlistDao.getTracksForPlaylist(playlistId)
-                        val items = tracks.map { track ->
+                        val items = tracks.filter{track -> track.isDownloaded}.map { track ->
                             MediaItem.Builder()
                                 .setMediaId(track.id.toString())
                                 .setUri(track.filePath ?: "")
@@ -563,7 +563,7 @@ class StashPlaybackService : MediaLibraryService() {
                                     )
                                     .build()
 
-                                val tracks = playlistDao.getTracksForPlaylist(playlistId).map { track ->
+                                val tracks = playlistDao.getTracksForPlaylist(playlistId).filter{track -> track.isDownloaded}.map { track ->
                                     MediaItem.Builder()
                                         .setMediaId(track.id.toString())
                                         .setUri(track.filePath ?: "")

--- a/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.guava.future
 import javax.inject.Inject
@@ -162,11 +161,19 @@ class StashPlaybackService : MediaLibraryService() {
         //      state and ramps to the new target via LoudnessGainProcessor.
         player.addListener(object : Player.Listener {
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-                refreshLikeButton()
+                updateCustomLayout()
                 onTrackTransitionForLoudness(mediaItem)
             }
+
+            override fun onRepeatModeChanged(repeatMode: Int) {
+                updateCustomLayout()
+            }
+
+            override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
+                updateCustomLayout()
+            }
         })
-        refreshLikeButton()
+        updateCustomLayout()
     }
 
     /**
@@ -189,28 +196,82 @@ class StashPlaybackService : MediaLibraryService() {
         }
     }
 
+    private var lastTrackId: Long? = null
+    private var lastIsLiked: Boolean = false
+
     /**
-     * Cancels any existing like-state observer and starts a new one for
-     * the player's current media item. Each emission rebuilds the
-     * MediaSession's custom layout with the appropriate heart icon.
-     * When there's no current track the custom layout is cleared so the
-     * notification doesn't render a stale heart.
+     * Updates the MediaSession custom layout with the heart, shuffle, and repeat icons.
+     * Starts a database observer for the current track's like state. For player-state
+     * changes (repeat/shuffle) on the same track, it refreshes the layout using the
+     * last known like state to avoid redundant DB observer restarts.
      */
     @OptIn(UnstableApi::class)
-    private fun refreshLikeButton() {
-        likeObserverJob?.cancel()
+    private fun updateCustomLayout() {
         val session = mediaSession ?: return
-        val trackId = session.player.currentMediaItem?.mediaId?.toLongOrNull()
+        val player = session.player
+        val trackId = player.currentMediaItem?.mediaId?.toLongOrNull()
+
         if (trackId == null) {
+            likeObserverJob?.cancel()
+            lastTrackId = null
+            lastIsLiked = false
             session.setCustomLayout(ImmutableList.of())
             return
         }
-        likeObserverJob = serviceScope.launch {
-            trackDao.observeLikeState(trackId).collect { state ->
-                val isLiked = state?.stashLikedAt != null
-                session.setCustomLayout(ImmutableList.of(buildLikeButton(isLiked)))
+
+        if (trackId != lastTrackId) {
+            likeObserverJob?.cancel()
+            lastTrackId = trackId
+            // Reset liked state and push an initial layout immediately for the new track.
+            // This prevents the previous track's heart state from lingering until the
+            // DB observer emits for the first time.
+            lastIsLiked = false
+            pushLayout(session, player, false)
+
+            likeObserverJob = serviceScope.launch {
+                trackDao.observeLikeState(trackId).collect { state ->
+                    val isLiked = state?.stashLikedAt != null
+                    // Update if the state actually changed, or if we haven't pushed for this track yet.
+                    if (isLiked != lastIsLiked) {
+                        lastIsLiked = isLiked
+                        pushLayout(session, player, lastIsLiked)
+                    }
+                }
             }
+        } else {
+            pushLayout(session, player, lastIsLiked)
         }
+    }
+
+    @OptIn(UnstableApi::class)
+    private fun pushLayout(session: MediaSession, player: Player, isLiked: Boolean) {
+        val layout = ImmutableList.of(
+            buildLikeButton(isLiked),
+            buildRepeatButton(player.repeatMode)
+        )
+        session.setCustomLayout(layout)
+    }
+
+    @OptIn(UnstableApi::class)
+    private fun buildRepeatButton(repeatMode: Int): CommandButton {
+        val iconRes = when (repeatMode) {
+            Player.REPEAT_MODE_OFF -> R.drawable.ic_repeat_off
+            Player.REPEAT_MODE_ONE -> R.drawable.ic_repeat_one
+            else -> R.drawable.ic_repeat
+        }
+        val displayNameRes = when (repeatMode) {
+            Player.REPEAT_MODE_OFF -> R.string.notification_action_repeat_off
+            Player.REPEAT_MODE_ALL -> R.string.notification_action_repeat_all
+            Player.REPEAT_MODE_ONE -> R.string.notification_action_repeat_one
+            else -> R.string.notification_action_repeat_off
+        }
+        return CommandButton.Builder()
+            .setDisplayName(getString(displayNameRes))
+            .setIconResId(iconRes)
+            .setSessionCommand(
+                SessionCommand(COMMAND_CYCLE_REPEAT, android.os.Bundle.EMPTY),
+            )
+            .build()
     }
 
     @OptIn(UnstableApi::class)
@@ -678,17 +739,19 @@ class StashPlaybackService : MediaLibraryService() {
                     }
                 }
                 COMMAND_TOGGLE_LIKE -> {
-                    // Read the mediaId on the caller thread (Player APIs are
-                    // main-thread-only) but do the DAO/repo work in the
-                    // service scope so the callback returns immediately.
                     val trackId = session.player.currentMediaItem?.mediaId?.toLongOrNull()
                     if (trackId != null) {
+                        // Optimistic update: toggle the local state and push the layout
+                        // immediately so the UI feels snappy and avoids race conditions
+                        // where multiple clicks see the same stale DB state.
+                        lastIsLiked = !lastIsLiked
+                        pushLayout(session, session.player, lastIsLiked)
+
                         serviceScope.launch {
-                            val current = trackDao.observeLikeState(trackId).firstOrNull()
-                            if (current?.stashLikedAt != null) {
-                                stashLikedRepository.remove(trackId)
-                            } else {
+                            if (lastIsLiked) {
                                 stashLikedRepository.add(trackId)
+                            } else {
+                                stashLikedRepository.remove(trackId)
                             }
                         }
                     }

--- a/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
@@ -10,13 +10,17 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.CommandButton
+import androidx.media3.session.LibraryResult
+import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
-import androidx.media3.session.MediaSessionService
 import androidx.media3.session.SessionCommand
+import androidx.media3.session.SessionError
 import androidx.media3.session.SessionResult
+import androidx.media3.common.MediaMetadata
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import com.stash.core.data.db.dao.PlaylistDao
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.social.stash.StashLikedPlaylistRepository
 import com.stash.core.media.R
@@ -30,9 +34,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.guava.future
 import javax.inject.Inject
+import androidx.core.net.toUri
+import com.stash.core.data.db.entity.TrackEntity
 
 /**
  * Background playback service that hosts an [ExoPlayer] and exposes a [MediaSession]
@@ -47,11 +55,12 @@ import javax.inject.Inject
  *   lockscreen without opening Now Playing.
  */
 @AndroidEntryPoint
-class StashPlaybackService : MediaSessionService() {
+class StashPlaybackService : MediaLibraryService() {
 
     @Inject lateinit var eqController: EqController
     @Inject lateinit var loudnessController: LoudnessController
     @Inject lateinit var trackDao: TrackDao
+    @Inject lateinit var playlistDao: PlaylistDao
     @Inject lateinit var stashLikedRepository: StashLikedPlaylistRepository
 
     companion object {
@@ -63,9 +72,17 @@ class StashPlaybackService : MediaSessionService() {
 
         /** Custom command action for toggling Stash Liked on the current track. */
         const val COMMAND_TOGGLE_LIKE = "com.stash.TOGGLE_LIKE"
+
+        /** Extra key for the track ID in MediaMetadata extras. */
+        const val EXTRA_TRACK_ID = "stash_track_id"
+
+        private const val ROOT_ID = "ROOT"
+        private const val PLAYLISTS_ID = "PLAYLISTS"
+        private const val RECENTLY_ADDED_ID = "RECENTLY_ADDED"
+        private const val PLAYLIST_PREFIX = "PLAYLIST_"
     }
 
-    private var mediaSession: MediaSession? = null
+    private var mediaSession: MediaLibrarySession? = null
 
     // Service-scoped CoroutineScope for the like-state observer + toggle
     // suspending calls. Cancelled in onDestroy so the observer doesn't leak
@@ -124,8 +141,7 @@ class StashPlaybackService : MediaSessionService() {
             )
         } else null
 
-        val sessionBuilder = MediaSession.Builder(this, player)
-            .setCallback(StashSessionCallback())
+        val sessionBuilder = MediaLibrarySession.Builder(this, player, StashSessionCallback())
         if (sessionActivity != null) {
             sessionBuilder.setSessionActivity(sessionActivity)
         }
@@ -161,7 +177,7 @@ class StashPlaybackService : MediaSessionService() {
      * those cases [computeGain] returns 0 dB which is the safe bypass.
      *
      * Visibility is `internal` so unit tests can invoke the hook directly
-     * without booting a full [MediaSessionService] / [ExoPlayer].
+     * without booting a full [MediaLibraryService] / [ExoPlayer].
      */
     internal fun onTrackTransitionForLoudness(mediaItem: MediaItem?) {
         val trackId = mediaItem?.mediaId?.toLongOrNull() ?: return
@@ -217,7 +233,7 @@ class StashPlaybackService : MediaSessionService() {
             .build()
     }
 
-    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? {
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? {
         return mediaSession
     }
 
@@ -240,35 +256,300 @@ class StashPlaybackService : MediaSessionService() {
         super.onDestroy()
     }
 
-    // ---- MediaSession.Callback ----
+    // ---- MediaLibrarySession.Callback ----
 
-    private inner class StashSessionCallback : MediaSession.Callback {
+    private inner class StashSessionCallback : MediaLibrarySession.Callback {
 
-        /**
-         * Resolve media items from request metadata URIs so that the controller
-         * can set items by URI rather than providing fully-resolved [MediaItem]s.
-         *
-         * Only allows file://, android.resource://, and content:// URI schemes
-         * to prevent external controllers from injecting arbitrary network URIs.
-         */
+        fun TrackEntity.toMediaMetadata(): MediaMetadata {
+            return MediaMetadata.Builder()
+                .setTitle(this.title)
+                .setArtist(this.artist)
+                .setAlbumTitle(this.album)
+                .setArtworkUri(this.albumArtUrl?.toUri() ?: this.albumArtPath?.toUri())
+                .setIsPlayable(true)
+                .setIsBrowsable(false)
+                .setExtras(android.os.Bundle().apply {
+                    putLong(EXTRA_TRACK_ID, id)
+                })
+                .build()
+        }
+
+        private suspend fun resolveMediaItem(item: MediaItem): MediaItem {
+            // 1. If it's already a fully resolved item (has URI), use it
+            if (item.localConfiguration?.uri != null) {
+                return item
+            }
+
+            // 2. If it's a library item (has mediaId), resolve it from DB
+            val trackId = item.mediaId.toLongOrNull()
+            if (trackId != null) {
+                val track = trackDao.getById(trackId)
+                if (track != null) {
+                    return item.buildUpon()
+                        .setUri(track.filePath ?: "")
+                        .setMediaMetadata(track.toMediaMetadata())
+                        .build()
+                }
+            }
+
+            // 3. Fallback to request metadata URI (with security check)
+            val uri = item.requestMetadata.mediaUri
+            if (uri != null) {
+                val scheme = uri.scheme
+                if (scheme == "file" || scheme == "android.resource" || scheme == "content") {
+                    return item.buildUpon().setUri(uri).build()
+                }
+            }
+
+            return item
+        }
+
+        @OptIn(UnstableApi::class)
+        override fun onSetMediaItems(
+            mediaSession: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            mediaItems: List<MediaItem>,
+            startIndex: Int,
+            startPositionMs: Long,
+        ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> {
+            return serviceScope.future {
+                val resolvedItems = mediaItems.map { resolveMediaItem(it) }
+                MediaSession.MediaItemsWithStartPosition(resolvedItems, startIndex, startPositionMs)
+            }
+        }
+
+        @OptIn(UnstableApi::class)
         override fun onAddMediaItems(
             mediaSession: MediaSession,
             controller: MediaSession.ControllerInfo,
             mediaItems: List<MediaItem>,
         ): ListenableFuture<List<MediaItem>> {
-            val resolved = mediaItems.mapNotNull { item ->
-                val uri = item.requestMetadata.mediaUri ?: return@mapNotNull null
-                val scheme = uri.scheme
-                if (scheme != "file" && scheme != "android.resource" && scheme != "content") {
-                    return@mapNotNull null
-                }
-                item.buildUpon()
-                    .setUri(uri)
-                    .build()
+            return serviceScope.future {
+                mediaItems.map { resolveMediaItem(it) }
             }
-            return Futures.immediateFuture(resolved)
         }
 
+        @OptIn(UnstableApi::class)
+        override fun onGetItem(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            mediaId: String,
+        ): ListenableFuture<LibraryResult<MediaItem>> {
+            android.util.Log.d("StashPlayback", "onGetItem: id=$mediaId client=${browser.packageName}")
+            return when (mediaId) {
+                ROOT_ID -> {
+                    val rootItem = MediaItem.Builder()
+                        .setMediaId(ROOT_ID)
+                        .setMediaMetadata(
+                            MediaMetadata.Builder()
+                                .setTitle("Stash Root")
+                                .setIsBrowsable(true)
+                                .setIsPlayable(false)
+                                .build(),
+                        )
+                        .build()
+                    Futures.immediateFuture(LibraryResult.ofItem(rootItem, null))
+                }
+                PLAYLISTS_ID -> {
+                    val playlistsItem = MediaItem.Builder()
+                        .setMediaId(PLAYLISTS_ID)
+                        .setMediaMetadata(
+                            MediaMetadata.Builder()
+                                .setTitle("Playlists")
+                                .setIsBrowsable(true)
+                                .setIsPlayable(false)
+                                .build(),
+                        )
+                        .build()
+                    Futures.immediateFuture(LibraryResult.ofItem(playlistsItem, null))
+                }
+                else -> {
+                    // Try to resolve track or playlist
+                    serviceScope.future {
+                        val trackId = mediaId.toLongOrNull()
+                        if (trackId != null) {
+                            val track = trackDao.getById(trackId)
+                            if (track != null) {
+                                return@future LibraryResult.ofItem(
+                                    MediaItem.Builder()
+                                        .setMediaId(track.id.toString())
+                                        .setUri(track.filePath ?: "")
+                                        .setMediaMetadata(
+                                            track.toMediaMetadata(),
+                                        )
+                                        .build(),
+                                    null,
+                                )
+                            }
+                        }
+                        if (mediaId.startsWith(PLAYLIST_PREFIX)) {
+                            val playlistId = mediaId.removePrefix(PLAYLIST_PREFIX).toLongOrNull()
+                            if (playlistId != null) {
+                                val playlist = playlistDao.getById(playlistId)
+                                if (playlist != null) {
+                                    return@future LibraryResult.ofItem(
+                                        MediaItem.Builder()
+                                            .setMediaId(mediaId)
+                                            .setMediaMetadata(
+                                                MediaMetadata.Builder()
+                                                    .setTitle(playlist.name)
+                                                    .setIsBrowsable(true)
+                                                    .setIsPlayable(false)
+                                                    .build(),
+                                            )
+                                            .build(),
+                                        null,
+                                    )
+                                }
+                            }
+                        }
+                        LibraryResult.ofError(SessionError.ERROR_BAD_VALUE)
+                    }
+                }
+            }
+        }
+
+        override fun onGetLibraryRoot(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            params: LibraryParams?,
+        ): ListenableFuture<LibraryResult<MediaItem>> {
+            val rootItem = MediaItem.Builder()
+                .setMediaId(ROOT_ID)
+                .setMediaMetadata(
+                    MediaMetadata.Builder()
+                        .setTitle("Stash Root")
+                        .setIsBrowsable(true)
+                        .setIsPlayable(false)
+                        .build(),
+                )
+                .build()
+            return Futures.immediateFuture(LibraryResult.ofItem(rootItem, params))
+        }
+
+        @OptIn(UnstableApi::class)
+        override fun onGetChildren(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            parentId: String,
+            page: Int,
+            pageSize: Int,
+            params: LibraryParams?,
+        ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
+            return serviceScope.future {
+                val items = when (parentId) {
+                    ROOT_ID -> {
+                        listOf(
+                            MediaItem.Builder()
+                                .setMediaId(PLAYLISTS_ID)
+                                .setMediaMetadata(
+                                    MediaMetadata.Builder()
+                                        .setTitle("Playlists")
+                                        .setIsBrowsable(true)
+                                        .setIsPlayable(false)
+                                        .build(),
+                                )
+                                .build(),
+                            MediaItem.Builder()
+                                .setMediaId(RECENTLY_ADDED_ID)
+                                .setMediaMetadata(
+                                    MediaMetadata.Builder()
+                                        .setTitle("Recently Added")
+                                        .setIsBrowsable(true)
+                                        .setIsPlayable(false)
+                                        .build(),
+                                )
+                                .build(),
+                        )
+                    }
+                    PLAYLISTS_ID -> {
+                        playlistDao.getAllVisible().first().map { playlist ->
+                            MediaItem.Builder()
+                                .setMediaId("$PLAYLIST_PREFIX${playlist.id}")
+                                .setMediaMetadata(
+                                    MediaMetadata.Builder()
+                                        .setTitle(playlist.name)
+                                        .setSubtitle("${playlist.trackCount} tracks")
+                                        .setArtworkUri(playlist.artUrl?.toUri())
+                                        .setIsBrowsable(true)
+                                        .setIsPlayable(false)
+                                        .build(),
+                                )
+                                .build()
+                        }
+                    }
+                    RECENTLY_ADDED_ID -> {
+                        trackDao.getRecentlyAdded(20).first().map { track ->
+                            MediaItem.Builder()
+                                .setMediaId(track.id.toString())
+                                .setUri(track.filePath ?: "")
+                                .setMediaMetadata(
+                                    track.toMediaMetadata(),
+                                )
+                                .build()
+                        }
+                    }
+                    else -> {
+                        if (parentId.startsWith(PLAYLIST_PREFIX)) {
+                            val playlistId = parentId.removePrefix(PLAYLIST_PREFIX).toLongOrNull()
+                            if (playlistId != null) {
+                                playlistDao.getTracksForPlaylist(playlistId).map { track ->
+                                    MediaItem.Builder()
+                                        .setMediaId(track.id.toString())
+                                        .setUri(track.filePath ?: "")
+                                        .setMediaMetadata(
+                                            track.toMediaMetadata(),
+                                        )
+                                        .build()
+                                }
+                            } else emptyList()
+                        } else emptyList()
+                    }
+                }
+                LibraryResult.ofItemList(ImmutableList.copyOf(items), params)
+            }
+        }
+
+        override fun onSearch(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            query: String,
+            params: LibraryParams?,
+        ): ListenableFuture<LibraryResult<Void>> {
+            session.notifySearchResultChanged(browser, query, 0, params)
+            return Futures.immediateFuture(LibraryResult.ofVoid())
+        }
+
+        @OptIn(UnstableApi::class)
+        override fun onGetSearchResult(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            query: String,
+            page: Int,
+            pageSize: Int,
+            params: LibraryParams?,
+        ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
+            return serviceScope.future {
+                // Sanitize for FTS (append * to each term for prefix matching)
+                val sanitized = query.split(" ")
+                    .filter { it.isNotBlank() }
+                    .joinToString(" ") { "$it*" }
+
+                val tracks = trackDao.searchDownloaded(sanitized).first()
+                val items = tracks.map { track ->
+                    MediaItem.Builder()
+                        .setMediaId(track.id.toString())
+                        .setUri(track.filePath ?: "")
+                        .setMediaMetadata(
+                            track.toMediaMetadata(),
+                        )
+                        .build()
+                }
+                LibraryResult.ofItemList(ImmutableList.copyOf(items), params)
+            }
+        }
+
+        @OptIn(UnstableApi::class)
         override fun onConnect(
             session: MediaSession,
             controller: MediaSession.ControllerInfo,
@@ -280,6 +561,13 @@ class StashPlaybackService : MediaSessionService() {
             )
             val sessionCommands = MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS.buildUpon()
             customCommands.forEach { sessionCommands.add(it) }
+
+            //Android auto commands
+            sessionCommands.add(SessionCommand.COMMAND_CODE_LIBRARY_GET_LIBRARY_ROOT)
+            sessionCommands.add(SessionCommand.COMMAND_CODE_LIBRARY_GET_CHILDREN)
+            sessionCommands.add(SessionCommand.COMMAND_CODE_LIBRARY_GET_ITEM)
+            sessionCommands.add(SessionCommand.COMMAND_CODE_LIBRARY_SUBSCRIBE)
+            sessionCommands.add(SessionCommand.COMMAND_CODE_LIBRARY_SEARCH)
 
             // Default availablePlayerCommands omits COMMAND_CHANGE_MEDIA_ITEMS,
             // which is what addMediaItem / removeMediaItem / moveMediaItem
@@ -336,6 +624,43 @@ class StashPlaybackService : MediaSessionService() {
                 }
             }
             return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+        }
+
+        @OptIn(UnstableApi::class)
+        override fun onPlaybackResumption(
+            session: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            isForPlayback: Boolean,
+        ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> {
+            return serviceScope.future {
+                val track = trackDao.getLastPlayedTrack()
+                val item = if (track != null) {
+                    MediaItem.Builder()
+                        .setMediaId(track.id.toString())
+                        .setUri(track.filePath ?: "")
+                        .setMediaMetadata(track.toMediaMetadata())
+                        .build()
+                } else {
+                    // Fallback to most recently added if no last-played record exists
+                    trackDao.getRecentlyAdded(1).first().firstOrNull()?.let { recentlyAdded ->
+                        MediaItem.Builder()
+                            .setMediaId(recentlyAdded.id.toString())
+                            .setUri(recentlyAdded.filePath ?: "")
+                            .setMediaMetadata(recentlyAdded.toMediaMetadata())
+                            .build()
+                    }
+                }
+
+                if (item != null) {
+                    MediaSession.MediaItemsWithStartPosition(
+                        ImmutableList.of(item),
+                        /* startIndex= */ 0,
+                        /* startPositionMs= */ C.TIME_UNSET,
+                    )
+                } else {
+                    throw UnsupportedOperationException()
+                }
+            }
         }
     }
 }

--- a/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
@@ -80,6 +80,7 @@ class StashPlaybackService : MediaLibraryService() {
         private const val PLAYLISTS_ID = "PLAYLISTS"
         private const val RECENTLY_ADDED_ID = "RECENTLY_ADDED"
         private const val PLAYLIST_PREFIX = "PLAYLIST_"
+        private const val SHUFFLE_PLAY_PREFIX = "SHUFFLE_PLAY_"
     }
 
     private var mediaSession: MediaLibrarySession? = null
@@ -313,6 +314,29 @@ class StashPlaybackService : MediaLibraryService() {
             startPositionMs: Long,
         ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> {
             return serviceScope.future {
+                if (mediaItems.size == 1 && mediaItems[0].mediaId.startsWith(SHUFFLE_PLAY_PREFIX)) {
+                    val playlistId = mediaItems[0].mediaId.removePrefix(SHUFFLE_PLAY_PREFIX).toLongOrNull()
+                    if (playlistId != null) {
+                        val tracks = playlistDao.getTracksForPlaylist(playlistId)
+                        val items = tracks.map { track ->
+                            MediaItem.Builder()
+                                .setMediaId(track.id.toString())
+                                .setUri(track.filePath ?: "")
+                                .setMediaMetadata(track.toMediaMetadata())
+                                .build()
+                        }.shuffled()
+
+                        kotlinx.coroutines.withContext(Dispatchers.Main) {
+                            mediaSession.player.shuffleModeEnabled = true
+                        }
+
+                        return@future MediaSession.MediaItemsWithStartPosition(
+                            items,
+                            0,
+                            C.TIME_UNSET
+                        )
+                    }
+                }
                 val resolvedItems = mediaItems.map { resolveMediaItem(it) }
                 MediaSession.MediaItemsWithStartPosition(resolvedItems, startIndex, startPositionMs)
             }
@@ -325,6 +349,18 @@ class StashPlaybackService : MediaLibraryService() {
             mediaItems: List<MediaItem>,
         ): ListenableFuture<List<MediaItem>> {
             return serviceScope.future {
+                if (mediaItems.size == 1 && mediaItems[0].mediaId.startsWith(SHUFFLE_PLAY_PREFIX)) {
+                    val playlistId = mediaItems[0].mediaId.removePrefix(SHUFFLE_PLAY_PREFIX).toLongOrNull()
+                    if (playlistId != null) {
+                        return@future playlistDao.getTracksForPlaylist(playlistId).map { track ->
+                            MediaItem.Builder()
+                                .setMediaId(track.id.toString())
+                                .setUri(track.filePath ?: "")
+                                .setMediaMetadata(track.toMediaMetadata())
+                                .build()
+                        }.shuffled()
+                    }
+                }
                 mediaItems.map { resolveMediaItem(it) }
             }
         }
@@ -395,6 +431,28 @@ class StashPlaybackService : MediaLibraryService() {
                                                     .setTitle(playlist.name)
                                                     .setIsBrowsable(true)
                                                     .setIsPlayable(false)
+                                                    .build(),
+                                            )
+                                            .build(),
+                                        null,
+                                    )
+                                }
+                            }
+                        }
+                        if (mediaId.startsWith(SHUFFLE_PLAY_PREFIX)) {
+                            val playlistId = mediaId.removePrefix(SHUFFLE_PLAY_PREFIX).toLongOrNull()
+                            if (playlistId != null) {
+                                val playlist = playlistDao.getById(playlistId)
+                                if (playlist != null) {
+                                    return@future LibraryResult.ofItem(
+                                        MediaItem.Builder()
+                                            .setMediaId(mediaId)
+                                            .setMediaMetadata(
+                                                MediaMetadata.Builder()
+                                                    .setTitle(getString(R.string.shuffle_play))
+                                                    .setArtworkUri("android.resource://$packageName/drawable/ic_shuffle".toUri())
+                                                    .setIsBrowsable(false)
+                                                    .setIsPlayable(true)
                                                     .build(),
                                             )
                                             .build(),
@@ -493,7 +551,19 @@ class StashPlaybackService : MediaLibraryService() {
                         if (parentId.startsWith(PLAYLIST_PREFIX)) {
                             val playlistId = parentId.removePrefix(PLAYLIST_PREFIX).toLongOrNull()
                             if (playlistId != null) {
-                                playlistDao.getTracksForPlaylist(playlistId).map { track ->
+                                val shuffleItem = MediaItem.Builder()
+                                    .setMediaId("$SHUFFLE_PLAY_PREFIX$playlistId")
+                                    .setMediaMetadata(
+                                        MediaMetadata.Builder()
+                                            .setTitle(getString(R.string.shuffle_play))
+                                            .setArtworkUri("android.resource://$packageName/drawable/ic_shuffle".toUri())
+                                            .setIsBrowsable(false)
+                                            .setIsPlayable(true)
+                                            .build(),
+                                    )
+                                    .build()
+
+                                val tracks = playlistDao.getTracksForPlaylist(playlistId).map { track ->
                                     MediaItem.Builder()
                                         .setMediaId(track.id.toString())
                                         .setUri(track.filePath ?: "")
@@ -502,6 +572,7 @@ class StashPlaybackService : MediaLibraryService() {
                                         )
                                         .build()
                                 }
+                                listOf(shuffleItem) + tracks
                             } else emptyList()
                         } else emptyList()
                     }

--- a/core/media/src/main/res/drawable/ic_repeat.xml
+++ b/core/media/src/main/res/drawable/ic_repeat.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,7h10v3l4,-4l-4,-4v3h-12v6h2v-4zM17,17h-10v-3l-4,4l4,4v-3h12v-6h-2v4z"/>
+</vector>

--- a/core/media/src/main/res/drawable/ic_repeat_off.xml
+++ b/core/media/src/main/res/drawable/ic_repeat_off.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,7h10v3l4,-4l-4,-4v3h-12v6h2v-4zM17,17h-10v-3l-4,4l4,4v-3h12v-6h-2v4z"/>
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M4.22,2.1L21.9,19.78l-1.41,1.41L2.81,3.51L4.22,2.1z"/>
+</vector>

--- a/core/media/src/main/res/drawable/ic_repeat_one.xml
+++ b/core/media/src/main/res/drawable/ic_repeat_one.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,7h10v3l4,-4l-4,-4v3h-12v6h2v-4zM17,17h-10v-3l-4,4l4,4v-3h12v-6h-2v4zM13,15V9h-1l-2,1v1h1.7V15H13z"/>
+</vector>

--- a/core/media/src/main/res/drawable/ic_shuffle.xml
+++ b/core/media/src/main/res/drawable/ic_shuffle.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10.59,9.17L5.41,4L4,5.41l5.17,5.17L10.59,9.17z M14.5,4l2.04,2.04L4,18.59L5.41,20L17.96,7.46L20,9.5V4H14.5z M14.83,13.41l-1.41,1.41l3.13,3.13L14.5,20H20v-5.5l-2.04,2.04L14.83,13.41z"/>
+</vector>

--- a/core/media/src/main/res/values/strings.xml
+++ b/core/media/src/main/res/values/strings.xml
@@ -2,5 +2,10 @@
 <resources>
     <string name="notification_action_like">Add to Liked Songs</string>
     <string name="notification_action_unlike">Remove from Liked Songs</string>
+    <string name="notification_action_repeat_off">Repeat Off</string>
+    <string name="notification_action_repeat_all">Repeat All</string>
+    <string name="notification_action_repeat_one">Repeat One</string>
+    <string name="notification_action_shuffle_on">Shuffle On</string>
+    <string name="notification_action_shuffle_off">Shuffle Off</string>
     <string name="shuffle_play">Shuffle Play</string>
 </resources>

--- a/core/media/src/main/res/values/strings.xml
+++ b/core/media/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="notification_action_like">Add to Liked Songs</string>
     <string name="notification_action_unlike">Remove from Liked Songs</string>
+    <string name="shuffle_play">Shuffle Play</string>
 </resources>

--- a/core/media/src/main/res/xml/automotive_app_desc.xml
+++ b/core/media/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<automotiveApp>
+    <uses name="media"/>
+</automotiveApp>

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
@@ -66,6 +66,11 @@ class NowPlayingViewModel @Inject constructor(
     /** One-shot snackbar messages (e.g. "Track flagged as wrong match"). */
     val userMessages: SharedFlow<String> = _userMessages.asSharedFlow()
 
+    /**
+     * v0.9.27: holds optimistic heart-toggle states to prevent flickering.
+     */
+    private val optimisticLikeState = MutableStateFlow<Map<Long, Boolean>>(emptyMap())
+
     init {
         observePlayerStateLive()
         observeUserPlaylists()
@@ -92,6 +97,9 @@ class NowPlayingViewModel @Inject constructor(
      * `flatMapLatest` into Room for the full row. Fall back to the
      * player's snapshot only when Room has no row (e.g., streamed/preview
      * content with synthetic id) so search-tab playback still works.
+     *
+     * v0.9.27 (fix): merges [optimisticLikeState] so the heart icon doesn't
+     * flicker when the 250ms position ticks race with the DB write.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun observePlayerStateLive() {
@@ -107,12 +115,22 @@ class NowPlayingViewModel @Inject constructor(
             playerRepository.playerState,
             playerRepository.currentPosition,
             liveTrackFlow,
-        ) { state, positionMs, liveTrack ->
+            optimisticLikeState,
+        ) { state, positionMs, liveTrack, optimistic ->
             _uiState.update { current ->
+                val track = liveTrack ?: state.currentTrack
+                val trackKey = if (track?.id == 0L) track.youtubeId.hashCode().toLong() else track?.id
+                val finalTrack = if (track != null && trackKey != null && optimistic.containsKey(trackKey)) {
+                    val optLiked = optimistic[trackKey]!!
+                    track.copy(stashLikedAt = if (optLiked) System.currentTimeMillis() else null)
+                } else {
+                    track
+                }
+
                 current.copy(
                     // Prefer Room's live row; fall back to player's MediaItem
                     // snapshot for non-library content (streams, search previews).
-                    currentTrack = liveTrack ?: state.currentTrack,
+                    currentTrack = finalTrack,
                     isPlaying = state.isPlaying,
                     currentPositionMs = positionMs,
                     durationMs = state.durationMs,
@@ -333,36 +351,40 @@ class NowPlayingViewModel @Inject constructor(
     fun onLikeTap() {
         val track = _uiState.value.currentTrack ?: return
         val wasLiked = track.stashLikedAt != null
-        // Optimistic UI: flip the timestamp BEFORE the DB write so the
-        // icon updates within one frame. The smart-merge in
-        // observePlayerState keeps this from being stomped by position
-        // ticks; observeLikeStateForCurrentTrack converges to the
-        // canonical value when Room emits.
-        val now = System.currentTimeMillis()
-        _uiState.update { current ->
-            val t = current.currentTrack ?: return@update current
-            if (t.id != track.id) return@update current
-            current.copy(currentTrack = t.copy(stashLikedAt = if (wasLiked) null else now))
-        }
+
+        // Optimistic UI: flip the state in our local map immediately.
+        // The combine() block in observePlayerStateLive merges this so
+        // the heart icon updates within one frame and stays updated.
+        // We use a temporary key for non-library tracks (id=0) using their videoId.
+        val trackKey = if (track.id == 0L) track.youtubeId.hashCode().toLong() else track.id
+        optimisticLikeState.update { it + (trackKey to !wasLiked) }
+
         viewModelScope.launch {
             runCatching {
-                if (wasLiked) {
-                    stashLikedRepository.remove(track.id)
-                } else {
-                    stashLikedRepository.add(track.id)
+                var finalTrackId = track.id
+                if (finalTrackId == 0L) {
+                    // Not in library yet (search preview). Insert it first.
+                    // This creates a stub TrackEntity in the DB so the
+                    // Liked Songs cross-ref has a parent to point to.
+                    finalTrackId = musicRepository.insertTrack(track)
                 }
+
+                if (wasLiked) {
+                    stashLikedRepository.remove(finalTrackId)
+                } else {
+                    stashLikedRepository.add(finalTrackId)
+                }
+                // Once the DB write is confirmed, we can clear the optimistic
+                // override; Room's own emission will carry the truth.
+                optimisticLikeState.update { it - trackKey }
             }.onFailure { e ->
                 android.util.Log.w("NowPlayingViewModel", "stash like toggle failed", e)
                 _userMessages.tryEmit(
                     if (wasLiked) "Couldn't remove from Liked Songs"
                     else "Couldn't add to Liked Songs"
                 )
-                // Roll back the optimistic flip so UI reflects truth.
-                _uiState.update { current ->
-                    val t = current.currentTrack ?: return@update current
-                    if (t.id != track.id) return@update current
-                    current.copy(currentTrack = t.copy(stashLikedAt = track.stashLikedAt))
-                }
+                // Roll back: clear the optimistic flip so UI reflects truth.
+                optimisticLikeState.update { it - trackKey }
             }
         }
     }


### PR DESCRIPTION
## Add Initial Android Auto support

### Overview

This PR introduces basic Android Auto support to stash, allowing users to browse and control playback directly from compatible car infotainment systems.

### Changes included

* Added Android Auto integration using the Media Browser Service architecture
* Implemented media playback controls for Android Auto
* Added support for browsing playlists and recently added songs
* Added support for searching songs in your local library while driving
* Integrated metadata and album artwork display
* Synchronized application and Android Auto playback display
* Updated AndroidManifest and required automotive permissions

### Testing

* Tested on Android Auto Desktop Head Unit (DHU)
* Verified playback controls and media browsing
* Confirmed compatibility with existing playback functionality

### Issues
This pull request closes #18 
