### PR TITLE
Backup and Restore internal database and settings.

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
@@ -1,0 +1,152 @@
+package com.stash.core.data.db
+
+import android.content.Context
+import android.net.Uri
+import androidx.sqlite.db.SimpleSQLiteQuery
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.io.FileInputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+import javax.inject.Inject
+import javax.inject.Singleton
+import androidx.core.net.toUri
+
+/**
+ * Handles exporting and importing the internal Room database, DataStore settings,
+ * and encrypted tokens. Bundles everything into a single ZIP archive.
+ *
+ * Exporting uses a checkpoint-then-zip approach to ensure WAL-mode
+ * consistency. Importing replaces the database and preferences files on disk
+ * and requires an app restart to take effect.
+ */
+@Singleton
+class DatabaseBackupManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val database: StashDatabase,
+) {
+
+    /**
+     * Exports the database and settings to the provided [targetUri] as a ZIP.
+     */
+    suspend fun exportDatabase(targetUri: Uri): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            // 1. Force a checkpoint to ensure the .db file is up to date
+            database.openHelper.writableDatabase.query(
+                SimpleSQLiteQuery("PRAGMA wal_checkpoint(FULL)")
+            ).use { it.moveToFirst() }
+
+            val dbFile = context.getDatabasePath(StashDatabase.DATABASE_NAME)
+            val datastoreDir = File(context.filesDir, "datastore")
+
+            context.contentResolver.openOutputStream(targetUri)?.use { outputStream ->
+                ZipOutputStream(outputStream).use { zipOut ->
+                    // Add DB
+                    if (dbFile.exists()) {
+                        addToZip(zipOut, dbFile, "stash.db")
+                    }
+
+                    // Add all DataStore files (settings, tokens, etc.)
+                    if (datastoreDir.exists()) {
+                        datastoreDir.listFiles()?.forEach { file ->
+                            if (file.isFile) {
+                                addToZip(zipOut, file, "datastore/${file.name}")
+                            }
+                        }
+                    }
+                }
+            } ?: throw IllegalStateException("Could not open output stream for URI: $targetUri")
+        }
+    }
+
+    private fun addToZip(zipOut: ZipOutputStream, file: File, zipPath: String) {
+        FileInputStream(file).use { input ->
+            zipOut.putNextEntry(ZipEntry(zipPath))
+            input.copyTo(zipOut)
+            zipOut.closeEntry()
+        }
+    }
+
+    /**
+     * Imports a ZIP backup from [sourceUri], replacing the current DB and settings.
+     * Returns the restored external storage URI if found in the preferences.
+     */
+    suspend fun importDatabase(sourceUri: Uri): Result<Uri?> = withContext(Dispatchers.IO) {
+        runCatching {
+            android.util.Log.i("BackupManager", "Starting import from $sourceUri")
+            // 1. Close the database to release file locks
+            database.close()
+
+            val dbFile = context.getDatabasePath(StashDatabase.DATABASE_NAME)
+            val walFile = File(dbFile.path + "-wal")
+            val shmFile = File(dbFile.path + "-shm")
+            val datastoreDir = File(context.filesDir, "datastore")
+
+            var restoredTreeUri: Uri? = null
+
+            context.contentResolver.openInputStream(sourceUri)?.use { inputStream ->
+                ZipInputStream(inputStream).use { zipIn ->
+                    var entry = zipIn.nextEntry
+                    while (entry != null) {
+                        if (entry.isDirectory) {
+                            entry = zipIn.nextEntry
+                            continue
+                        }
+
+                        val outFile = when {
+                            entry.name == "stash.db" -> {
+                                dbFile.parentFile?.mkdirs()
+                                dbFile
+                            }
+                            entry.name.startsWith("datastore/") -> {
+                                val file = File(datastoreDir, entry.name.substringAfter("datastore/"))
+                                file.parentFile?.mkdirs()
+                                file
+                            }
+                            else -> null
+                        }
+
+                        if (outFile != null) {
+                            android.util.Log.d("BackupManager", "Restoring ${entry.name} to ${outFile.absolutePath}")
+
+                            // If it's the storage preferences, try to peek at the tree URI
+                            if (entry.name.contains("storage_preferences")) {
+                                val bytes = zipIn.readBytes()
+                                val content = String(bytes, Charsets.UTF_8)
+                                // Look for SAF tree URI pattern
+                                val regex = Regex("content://[a-zA-Z0-9./%:]+/tree/[a-zA-Z0-9./%:]+")
+                                regex.find(content)?.value?.let { restoredTreeUri = it.toUri() }
+
+                                FileOutputStream(outFile).use { output ->
+                                    output.write(bytes)
+                                }
+                            } else {
+                                FileOutputStream(outFile).use { output ->
+                                    zipIn.copyTo(output)
+                                }
+                            }
+                        }
+                        zipIn.closeEntry()
+                        entry = zipIn.nextEntry
+                    }
+                }
+            } ?: throw IllegalStateException("Could not open input stream for URI: $sourceUri")
+
+            // 3. Delete WAL/SHM files so they don't conflict with the new DB
+            if (walFile.exists()) {
+                android.util.Log.d("BackupManager", "Deleting old WAL file")
+                walFile.delete()
+            }
+            if (shmFile.exists()) {
+                android.util.Log.d("BackupManager", "Deleting old SHM file")
+                shmFile.delete()
+            }
+            android.util.Log.i("BackupManager", "Import completed successfully. Restored URI: $restoredTreeUri")
+            restoredTreeUri
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsScreen.kt
@@ -1173,13 +1173,13 @@ private fun SettingsContent(
             Column(modifier = Modifier.fillMaxWidth()) {
                 // Database Backup -----------------------------------------
                 Text(
-                    text = "Internal Database",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    text = "Backup",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = "Export or import everything: metadata, playlists, settings, and service cookies.",
+                    text = "Export settings and database or import from a previous backup.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.RadioButton
@@ -68,6 +69,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
+import android.net.Uri
 import android.widget.Toast
 import com.stash.core.data.sync.workers.UpdateCheckWorker
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -175,6 +177,40 @@ fun SettingsScreen(
     // immediately so revisiting the screen doesn't re-scroll.
     val deepLinkFocus = remember { viewModel.consumeDeepLinkFocus() }
 
+    val storageContext = LocalContext.current
+    val contentResolver = storageContext.contentResolver
+    // Tracks what action the user intended when they tapped the folder
+    // picker. "SetOnly" = redirect new downloads; "SetAndMove" = also start the
+    // library migration to the picked folder as soon as it's granted.
+    var pendingPickerIntent by remember { mutableStateOf(PickerIntent.SetOnly) }
+    val treePicker = androidx.activity.compose.rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.OpenDocumentTree(),
+    ) { uri ->
+        if (uri != null) {
+            // Take a persistable permission BEFORE handing the URI to the
+            // VM — without this, the permission is revoked when the app
+            // is backgrounded and the persisted URI becomes useless.
+            runCatching {
+                contentResolver.takePersistableUriPermission(
+                    uri,
+                    android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                        android.content.Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+                )
+            }
+            viewModel.setExternalStorageUri(uri)
+            when (pendingPickerIntent) {
+                PickerIntent.SetAndMove -> viewModel.startMoveLibrary(uri)
+                PickerIntent.SetAndRestart -> {
+                    // Success: permission re-granted for the restored folder.
+                    // We can now safely restart the app.
+                    android.os.Process.killProcess(android.os.Process.myPid())
+                }
+                else -> Unit
+            }
+        }
+        pendingPickerIntent = PickerIntent.SetOnly
+    }
+
     SettingsContent(
         uiState = uiState,
         focusOnEntry = deepLinkFocus,
@@ -209,11 +245,23 @@ fun SettingsScreen(
         onHeartDefaultStashChanged = viewModel::onHeartDefaultStashChanged,
         onHeartDefaultSpotifyChanged = viewModel::onHeartDefaultSpotifyChanged,
         onHeartDefaultYtMusicChanged = viewModel::onHeartDefaultYtMusicChanged,
+        onExportDatabase = viewModel::onExportDatabase,
+        onImportDatabase = viewModel::onImportDatabase,
+        onConfirmImportDatabase = {
+            viewModel.onConfirmImportDatabase { restoredUri ->
+                pendingPickerIntent = PickerIntent.SetAndRestart
+                treePicker.launch(restoredUri)
+            }
+        },
+        onCancelImportDatabase = viewModel::onCancelImportDatabase,
+        onDismissDatabaseBackupStatus = viewModel::onDismissDatabaseBackupStatus,
         onNavigateToEqualizer = onNavigateToEqualizer,
         onNavigateToLibraryHealth = onNavigateToLibraryHealth,
         onNavigateToSquidWtfCaptcha = onNavigateToSquidWtfCaptcha,
         onShareLatestCrashReport = viewModel::latestCrashShareTarget,
         onDiagnosticsRefresh = viewModel::refreshDiagnostics,
+        treePicker = treePicker,
+        onSetPickerIntent = { pendingPickerIntent = it },
         modifier = modifier,
     )
 }
@@ -258,6 +306,11 @@ private fun SettingsContent(
     onHeartDefaultStashChanged: (Boolean) -> Unit,
     onHeartDefaultSpotifyChanged: (Boolean) -> Unit,
     onHeartDefaultYtMusicChanged: (Boolean) -> Unit,
+    onExportDatabase: (Uri) -> Unit,
+    onImportDatabase: (Uri) -> Unit,
+    onConfirmImportDatabase: () -> Unit,
+    onCancelImportDatabase: () -> Unit,
+    onDismissDatabaseBackupStatus: () -> Unit,
     onNavigateToEqualizer: () -> Unit,
     onNavigateToLibraryHealth: () -> Unit,
     onNavigateToSquidWtfCaptcha: () -> Unit,
@@ -273,6 +326,8 @@ private fun SettingsContent(
      * when the user navigates away and comes back.
      */
     onDiagnosticsRefresh: () -> Unit,
+    treePicker: androidx.activity.result.ActivityResultLauncher<android.net.Uri?>?,
+    onSetPickerIntent: (PickerIntent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val extendedColors = StashTheme.extendedColors
@@ -1007,6 +1062,155 @@ private fun SettingsContent(
             java.io.File(storageContext.filesDir, "music").absolutePath
         }
 
+        // Database backup -----------------------------------------------------
+        val exportLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
+            contract = androidx.activity.result.contract.ActivityResultContracts.CreateDocument("application/zip"),
+        ) { uri ->
+            if (uri != null) onExportDatabase(uri)
+        }
+        val importLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
+            contract = androidx.activity.result.contract.ActivityResultContracts.OpenDocument(),
+        ) { uri ->
+            if (uri != null) onImportDatabase(uri)
+        }
+
+        if (uiState.databaseBackupState !is DatabaseBackupState.Idle) {
+            AlertDialog(
+                onDismissRequest = {
+                    if (uiState.databaseBackupState !is DatabaseBackupState.Exporting &&
+                        uiState.databaseBackupState !is DatabaseBackupState.Importing) {
+                        onDismissDatabaseBackupStatus()
+                    }
+                },
+                containerColor = MaterialTheme.colorScheme.surface,
+                shape = MaterialTheme.shapes.large,
+                title = {
+                    Text(
+                        text = when (uiState.databaseBackupState) {
+                            DatabaseBackupState.Exporting -> "Exporting Database"
+                            DatabaseBackupState.Importing -> "Importing Database"
+                            is DatabaseBackupState.Success -> "Success"
+                            is DatabaseBackupState.Error -> "Error"
+                        },
+                        style = MaterialTheme.typography.titleLarge,
+                    )
+                },
+                text = {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        when (val state = uiState.databaseBackupState) {
+                            DatabaseBackupState.Exporting, DatabaseBackupState.Importing -> {
+                                androidx.compose.material3.LinearProgressIndicator(
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                                Text(
+                                    text = "Processing...",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                            }
+                            is DatabaseBackupState.Success -> {
+                                Text(
+                                    text = state.message,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                            }
+                            is DatabaseBackupState.Error -> {
+                                Text(
+                                    text = state.message,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.error,
+                                )
+                            }
+                        }
+                    }
+                },
+                confirmButton = {
+                    if (uiState.databaseBackupState is DatabaseBackupState.Success ||
+                        uiState.databaseBackupState is DatabaseBackupState.Error) {
+                        TextButton(onClick = onDismissDatabaseBackupStatus) {
+                            Text("OK")
+                        }
+                    }
+                },
+            )
+        }
+
+        if (uiState.showImportConfirmation) {
+            AlertDialog(
+                onDismissRequest = onCancelImportDatabase,
+                containerColor = MaterialTheme.colorScheme.surface,
+                shape = MaterialTheme.shapes.large,
+                title = {
+                    Text(
+                        text = "Overwrite Library & Settings?",
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                },
+                text = {
+                    Text(
+                        text = "This will completely replace your existing library metadata, playlists, settings, and account connections. This action cannot be undone.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = onConfirmImportDatabase,
+                        colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                    ) {
+                        Text("Overwrite")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = onCancelImportDatabase) {
+                        Text("Cancel")
+                    }
+                },
+            )
+        }
+
+        GlassCard {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                // Database Backup -----------------------------------------
+                Text(
+                    text = "Internal Database",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Export or import everything: metadata, playlists, settings, and service cookies.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    OutlinedButton(
+                        onClick = { exportLauncher.launch("stash-backup.zip") },
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = MaterialTheme.colorScheme.primary,
+                        ),
+                    ) {
+                        Text("Export Backup")
+                    }
+                    OutlinedButton(
+                        onClick = { importLauncher.launch(arrayOf("application/zip", "application/octet-stream", "*/*")) },
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = MaterialTheme.colorScheme.primary,
+                        ),
+                    ) {
+                        Text("Import Backup")
+                    }
+                }
+            }
+        }
+
         GlassCard {
             Column(modifier = Modifier.fillMaxWidth()) {
                 StorageRow(label = "Total tracks", value = "${uiState.totalTracks}")
@@ -1051,8 +1255,11 @@ private fun SettingsContent(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    androidx.compose.material3.OutlinedButton(
-                        onClick = { treePicker.launch(null) },
+                    OutlinedButton(
+                        onClick = {
+                            onSetPickerIntent(PickerIntent.SetOnly)
+                            treePicker.launch(null)
+                        },
                         modifier = Modifier.weight(1f),
                         colors = ButtonDefaults.outlinedButtonColors(
                             contentColor = MaterialTheme.colorScheme.primary,
@@ -1063,7 +1270,7 @@ private fun SettingsContent(
                         )
                     }
                     if (externalTree != null) {
-                        androidx.compose.material3.OutlinedButton(
+                        OutlinedButton(
                             onClick = { onSetExternalStorage(null) },
                             modifier = Modifier.weight(1f),
                             colors = ButtonDefaults.outlinedButtonColors(
@@ -1113,7 +1320,7 @@ private fun SettingsContent(
                             if (externalTree != null) {
                                 onStartMoveLibrary(externalTree)
                             } else {
-                                pendingPickerIntent = PickerIntent.SetAndMove
+                                onSetPickerIntent(PickerIntent.SetAndMove)
                                 treePicker.launch(null)
                             }
                         },
@@ -1399,7 +1606,7 @@ private fun LastFmSection(
  * [SetOnly] = redirect new downloads; [SetAndMove] = also start the
  * library migration to the picked folder as soon as it's granted.
  */
-private enum class PickerIntent { SetOnly, SetAndMove }
+private enum class PickerIntent { SetOnly, SetAndMove, SetAndRestart }
 
 /**
  * Renders the "Move existing library" action inside the Storage card.

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
@@ -143,7 +143,22 @@ data class SettingsUiState(
      * taps share, in case the file was deleted between init and tap.
      */
     val hasCrashReport: Boolean = false,
+    /** Current status of the database export/import operation. */
+    val databaseBackupState: DatabaseBackupState = DatabaseBackupState.Idle,
+    /** Whether the import confirmation dialog is showing. */
+    val showImportConfirmation: Boolean = false,
 )
+
+/**
+ * State of a database export or import operation in Settings.
+ */
+sealed interface DatabaseBackupState {
+    data object Idle : DatabaseBackupState
+    data object Exporting : DatabaseBackupState
+    data object Importing : DatabaseBackupState
+    data class Success(val message: String) : DatabaseBackupState
+    data class Error(val message: String) : DatabaseBackupState
+}
 
 /**
  * Connection state for the Last.fm scrobbler integration.

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -28,6 +28,7 @@ import com.stash.core.data.lastfm.LastFmCredentials
 import com.stash.core.data.lastfm.LastFmScrobbler
 import com.stash.core.data.lastfm.LastFmSession
 import com.stash.core.data.lastfm.LastFmSessionPreference
+import com.stash.core.data.db.DatabaseBackupManager
 import com.stash.core.data.db.dao.ListeningEventDao
 import com.stash.data.download.files.LibrarySizeBreakdown
 import com.stash.data.download.files.LibrarySizeHolder
@@ -94,6 +95,7 @@ class SettingsViewModel @Inject constructor(
     private val trackDao: TrackDao,
     private val settingsDeepLinkController: com.stash.core.data.navigation.SettingsDeepLinkController,
     private val crashFileStore: CrashFileStore,
+    private val databaseBackupManager: DatabaseBackupManager,
 ) : ViewModel() {
 
     /** Internal mutable UI state that is combined with token-manager flows. */
@@ -245,6 +247,8 @@ class SettingsViewModel @Inject constructor(
             autoSavedCountLast7Days = autoSavedCount7d,
             youtubeFallbackEnabled = youtubeFallbackEnabled,
             hasCrashReport = local.hasCrashReport,
+            databaseBackupState = local.databaseBackupState,
+            showImportConfirmation = local.showImportConfirmation,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -287,6 +291,106 @@ class SettingsViewModel @Inject constructor(
     /** Dismisses a terminal Done/Error state, returning to Idle. */
     fun dismissMoveLibrary() {
         moveLibraryCoordinator.dismiss()
+    }
+
+    /**
+     * Triggers a database export to the chosen URI.
+     */
+    fun onExportDatabase(uri: Uri) {
+        viewModelScope.launch {
+            _localState.update { it.copy(databaseBackupState = DatabaseBackupState.Exporting) }
+            val result = databaseBackupManager.exportDatabase(uri)
+            _localState.update {
+                it.copy(
+                    databaseBackupState = result.fold(
+                        onSuccess = { DatabaseBackupState.Success("Database exported successfully") },
+                        onFailure = { t -> DatabaseBackupState.Error(t.message ?: "Export failed") }
+                    )
+                )
+            }
+        }
+    }
+
+    /**
+     * Triggers a database import from the chosen URI. Closes the current
+     * database and overwrites it. Success triggers an app process kill
+     * to force a clean re-init.
+     */
+    fun onImportDatabase(uri: Uri) {
+        _localState.update { it.copy(showImportConfirmation = true, pendingImportUri = uri) }
+    }
+
+    /**
+     * Confirms the pending database import.
+     */
+    fun onConfirmImportDatabase(onExternalPermissionNeeded: (Uri) -> Unit) {
+        val uri = _localState.value.pendingImportUri ?: return
+        _localState.update { it.copy(showImportConfirmation = false, pendingImportUri = null) }
+
+        viewModelScope.launch {
+            _localState.update { it.copy(databaseBackupState = DatabaseBackupState.Importing) }
+            val result = databaseBackupManager.importDatabase(uri)
+
+            if (result.isSuccess) {
+                // v0.9.15: The import manager peeks at the restored preferences
+                // to detect if an external storage folder was configured.
+                val restoredTreeUri = result.getOrNull()
+
+                if (restoredTreeUri != null) {
+                    // Check if we ALREADY have the permission (maybe it's a restore over same install)
+                    val hasPermission = appContext.contentResolver.persistedUriPermissions.any {
+                        it.uri == restoredTreeUri && it.isReadPermission
+                    }
+
+                    if (hasPermission) {
+                        finishImportAndRestart()
+                    } else {
+                        // We need the user to re-grant permission for the restored folder
+                        // BEFORE we restart, so that the startup migrations can see the files.
+                        _localState.update { it.copy(databaseBackupState = DatabaseBackupState.Idle) }
+                        onExternalPermissionNeeded(restoredTreeUri)
+                    }
+                } else {
+                    finishImportAndRestart()
+                }
+            } else {
+                _localState.update {
+                    it.copy(
+                        databaseBackupState = DatabaseBackupState.Error(
+                            result.exceptionOrNull()?.message ?: "Import failed"
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun finishImportAndRestart() {
+        _localState.update {
+            it.copy(databaseBackupState = DatabaseBackupState.Success("Database imported. Restarting..."))
+        }
+        kotlinx.coroutines.delay(1500)
+
+        // Re-launch the activity and kill the current process to ensure all
+        // components (Room, DataStore, Tink) re-initialize with the restored data.
+        val intent = appContext.packageManager.getLaunchIntentForPackage(appContext.packageName)
+        if (intent != null) {
+            intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK or android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            appContext.startActivity(intent)
+        }
+        android.os.Process.killProcess(android.os.Process.myPid())
+    }
+
+    /**
+     * Cancels the pending database import.
+     */
+    fun onCancelImportDatabase() {
+        _localState.update { it.copy(showImportConfirmation = false, pendingImportUri = null) }
+    }
+
+    /** Dismisses the backup Success/Error overlay. */
+    fun onDismissDatabaseBackupStatus() {
+        _localState.update { it.copy(databaseBackupState = DatabaseBackupState.Idle) }
     }
 
     // -- Last.fm actions ------------------------------------------------------
@@ -837,6 +941,12 @@ class SettingsViewModel @Inject constructor(
          * (snackbar) and then cleared via [onClearScrobbleDrainResult].
          */
         val lastScrobbleDrainResult: LastFmScrobbler.DrainResult? = null,
+        /** Current status of the database backup operation. */
+        val databaseBackupState: DatabaseBackupState = DatabaseBackupState.Idle,
+        /** Whether the import confirmation dialog is showing. */
+        val showImportConfirmation: Boolean = false,
+        /** The URI of the database file chosen for import, while waiting for confirmation. */
+        val pendingImportUri: Uri? = null,
         /**
          * Last-known liveness of `cacheDir/crashes/`. Refreshed by
          * [refreshDiagnostics] on Settings entry and again after the user


### PR DESCRIPTION
Backup and restore system, allowing users to export their entire database and preferences into a single ZIP archive, ensuring data portability for reinstalling the application or switching phones.

When restoring a backup the user will be prompted to select the song library folder so that permissions will be granted again.

It is impossible to export youtube and spotify cookies as they're encrypted with a device-bound master key, so after restoring a backup the user has to log in again to the services.

- Implemented a checkpoint-then-zip approach. It forces a `wal_checkpoint(FULL)` to ensure the main `.db` file is fully synchronized before copying.
- Bundles the database file and all files within the `datastore/` directory into a ZIP.
- During import, it safely closes the database, replaces files, and cleans up stale `-wal` and `-shm` files to prevent corruption.
-  Added Backup section in settings page

it also closes #55 

I think ready to merge @rawnaldclark, lmk!