### PR TITLE
Relocate SyncStatusCard from Home to top of Sync tab

### DIFF
--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -13,12 +13,15 @@ android {
     }
 }
 dependencies {
-    implementation(project(":core:auth"))
+    // :core:auth was used by HomeViewModel for TokenManager / AuthState
+    // to feed the SyncStatusCard's "Connect Spotify / YouTube" prompt.
+    // Both moved to :feature:sync along with the card.
     implementation(project(":core:data"))
     implementation(project(":core:media"))
-    // For FileOrganizer.getTotalStorageBytes / getLosslessStorageBytes —
-    // disk-truth Storage stats on the Home sync card (bypassing the
-    // unreliable DB `file_size_bytes` SUM for legacy libraries).
+    // Still required after the SyncStatusCard relocation: the lossless
+    // retry/backfill banners on Home read MetadataBackfillState,
+    // LosslessRetryWorker, KennyySource, QobuzSource, and the
+    // AggregatorRateLimiter from this module.
     implementation(project(":data:download"))
     // v0.9.36: LyricsBackfillState snapshot for the LyricsBackfillBanner
     // on Home — mirrors the :data:download dependency for the v0.9.35

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
@@ -1,6 +1,5 @@
 package com.stash.feature.home
 
-import android.text.format.DateUtils
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
@@ -102,8 +101,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stash.core.model.MusicSource
 import com.stash.core.model.Playlist
 import com.stash.core.model.PlaylistType
-import com.stash.core.model.SyncDisplayStatus
-import com.stash.core.model.SyncState
 import com.stash.core.model.Track
 import com.stash.core.ui.components.CreatePlaylistDialog
 import com.stash.core.ui.components.GlassCard
@@ -250,17 +247,6 @@ fun HomeScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 20.dp)
                     .padding(bottom = 12.dp),
-            )
-        }
-
-        // ── Sync status card ─────────────────────────────────────────
-        item {
-            SyncStatusCard(
-                syncStatus = uiState.syncStatus,
-                spotifyConnected = uiState.spotifyConnected,
-                youTubeConnected = uiState.youTubeConnected,
-                hasEverSynced = uiState.hasEverSynced,
-                modifier = Modifier.padding(horizontal = 16.dp),
             )
         }
 
@@ -775,196 +761,6 @@ fun HomeScreen(
             },
         )
     }
-}
-
-// ── Sync status card ─────────────────────────────────────────────────────
-
-@Composable
-private fun SyncStatusCard(
-    syncStatus: SyncStatusInfo,
-    spotifyConnected: Boolean,
-    youTubeConnected: Boolean,
-    hasEverSynced: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    val extendedColors = StashTheme.extendedColors
-    val anyServiceConnected = spotifyConnected || youTubeConnected
-
-    GlassCard(modifier = modifier) {
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            // -- Connection + sync status header --
-            // Uses SyncDisplayStatus so "Completed with some failures" and
-            // "Interrupted mid-run" don't both read as a generic failure.
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                PulseDot(color = syncStatusDotColor(syncStatus, anyServiceConnected, hasEverSynced))
-                Text(
-                    text = syncStatusLabel(syncStatus, anyServiceConnected, hasEverSynced),
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-            }
-
-            // Connected-services row removed 2026-04-21: the stats row
-            // below already labels Spotify/YouTube with their counts, so
-            // the dot+label row was pure duplication.
-
-            // -- Prompt or stats depending on sync state --
-            if (!anyServiceConnected) {
-                Text(
-                    text = "Connect Spotify or YouTube Music in Settings to start syncing your library.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            } else if (!hasEverSynced) {
-                Text(
-                    text = "Tap Sync Now to download your playlists and tracks.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            } else {
-                // Decoupled gating: show each FLAC sub-line whenever its
-                // own value is > 0. The previous AND-coupling
-                // (`flacTracks > 0 && flacStorageBytes > 0`) hid the
-                // sub-text for any user whose DB had FLAC rows but
-                // file_size_bytes still at 0 — turning the "defensive"
-                // check into a permanent display blocker. Per-stat
-                // gating is the design that v0.9.0 originally shipped
-                // with; the coupling was a regression introduced in
-                // c3c6529 and is now reverted.
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                ) {
-                    StatItem(
-                        label = "Tracks",
-                        value = syncStatus.totalTracks.toString(),
-                        subValue = if (syncStatus.flacTracks > 0) "${syncStatus.flacTracks} FLAC" else null,
-                    )
-                    StatItem(
-                        label = "Spotify",
-                        value = syncStatus.spotifyTracks.toString(),
-                    )
-                    StatItem(
-                        label = "YouTube",
-                        value = syncStatus.youTubeTracks.toString(),
-                    )
-                    StatItem(
-                        label = "Storage",
-                        value = formatBytes(syncStatus.storageUsedBytes),
-                        subValue = if (syncStatus.flacStorageBytes > 0) "${formatBytes(syncStatus.flacStorageBytes)} FLAC" else null,
-                    )
-                }
-                if (syncStatus.lastSyncTime != null) {
-                    Text(
-                        text = "Last sync ${formatRelativeTime(syncStatus.lastSyncTime)}",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-        }
-    }
-}
-
-/**
- * Label shown next to the pulse dot in [SyncStatusCard]. Interprets
- * [SyncStatusInfo.displayStatus] so partial / interrupted runs aren't
- * misreported as generic failures.
- */
-@Composable
-private fun syncStatusLabel(
-    syncStatus: SyncStatusInfo,
-    anyServiceConnected: Boolean,
-    hasEverSynced: Boolean,
-): String = when {
-    !anyServiceConnected -> "No services connected"
-    !hasEverSynced -> "Ready to sync"
-    else -> when (val s = syncStatus.displayStatus) {
-        SyncDisplayStatus.Idle -> "Ready to sync"
-        SyncDisplayStatus.Running -> "Syncing..."
-        SyncDisplayStatus.Success -> "Synced"
-        is SyncDisplayStatus.PartialSuccess ->
-            "Partially synced — ${s.downloaded} saved, ${s.failed} failed"
-        is SyncDisplayStatus.Interrupted ->
-            if (s.downloaded > 0) "Interrupted — ${s.downloaded} saved"
-            else "Interrupted"
-        is SyncDisplayStatus.Failed -> "Sync failed"
-    }
-}
-
-/**
- * Color for the pulse dot in [SyncStatusCard]. Green = success-ish,
- * amber = in-progress / warning, red = genuine failure, gray = idle.
- */
-@Composable
-private fun syncStatusDotColor(
-    syncStatus: SyncStatusInfo,
-    anyServiceConnected: Boolean,
-    hasEverSynced: Boolean,
-): Color {
-    val extendedColors = StashTheme.extendedColors
-    return when {
-        !anyServiceConnected -> MaterialTheme.colorScheme.onSurfaceVariant
-        !hasEverSynced -> extendedColors.warning
-        else -> when (syncStatus.displayStatus) {
-            SyncDisplayStatus.Idle -> extendedColors.warning
-            SyncDisplayStatus.Running -> extendedColors.warning
-            SyncDisplayStatus.Success -> extendedColors.success
-            is SyncDisplayStatus.PartialSuccess -> extendedColors.warning
-            is SyncDisplayStatus.Interrupted -> extendedColors.warning
-            is SyncDisplayStatus.Failed -> Color(0xFFEF4444)
-        }
-    }
-}
-
-@Composable
-private fun StatItem(label: String, value: String, subValue: String? = null) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(
-            text = value,
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.primary,
-        )
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        if (subValue != null) {
-            Text(
-                text = subValue,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.primary,
-            )
-        }
-    }
-}
-
-@Composable
-private fun PulseDot(color: Color, modifier: Modifier = Modifier) {
-    val infiniteTransition = rememberInfiniteTransition(label = "pulse")
-    val alpha by infiniteTransition.animateFloat(
-        initialValue = 1f,
-        targetValue = 0.3f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 1200, easing = LinearEasing),
-            repeatMode = RepeatMode.Reverse,
-        ),
-        label = "pulseAlpha",
-    )
-    Box(
-        modifier = modifier
-            .size(8.dp)
-            .alpha(alpha)
-            .clip(CircleShape)
-            .background(color),
-    )
 }
 
 // ── Daily mix card ───────────────────────────────────────────────────────
@@ -2024,26 +1820,3 @@ private fun PlaylistSortOrder.displayName(): String = when (this) {
     PlaylistSortOrder.MOST_PLAYED -> "Most Played"
 }
 
-// ── Utilities ────────────────────────────────────────────────────────────
-
-/**
- * Formats a byte count into a human-readable string (e.g. "45.2 MB").
- */
-private fun formatBytes(bytes: Long): String {
-    if (bytes <= 0) return "0 B"
-    val units = arrayOf("B", "KB", "MB", "GB", "TB")
-    val digitGroups = (Math.log10(bytes.toDouble()) / Math.log10(1024.0)).toInt()
-    val safeIndex = digitGroups.coerceIn(0, units.lastIndex)
-    return "%.1f %s".format(bytes / Math.pow(1024.0, safeIndex.toDouble()), units[safeIndex])
-}
-
-/**
- * Formats an epoch-millis timestamp into a relative time string (e.g. "2 hours ago").
- */
-private fun formatRelativeTime(epochMillis: Long): String {
-    return DateUtils.getRelativeTimeSpanString(
-        epochMillis,
-        System.currentTimeMillis(),
-        DateUtils.MINUTE_IN_MILLIS,
-    ).toString()
-}

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeUiState.kt
@@ -1,8 +1,6 @@
 package com.stash.feature.home
 
 import com.stash.core.model.Playlist
-import com.stash.core.model.SyncDisplayStatus
-import com.stash.core.model.SyncState
 import com.stash.core.model.Track
 import com.stash.feature.home.banner.LyricsBackfillBannerState
 import com.stash.feature.home.banner.MetadataBackfillBannerState
@@ -15,10 +13,13 @@ import com.stash.feature.home.banner.WaitingForLosslessBannerState
  * Liked songs and daily mixes are split by source (Spotify / YouTube) so
  * the UI can render them in source-grouped sections with smart collapse
  * when only one source is connected.
+ *
+ * Note: sync-status, per-source connection booleans, and `hasEverSynced`
+ * used to live here too — they powered the SyncStatusCard at the top of
+ * the Home screen. The card was relocated to the Sync tab; its data
+ * plumbing moved with it to `:feature:sync`'s SyncViewModel/SyncUiState.
  */
 data class HomeUiState(
-    val syncStatus: SyncStatusInfo = SyncStatusInfo(),
-
     /**
      * Recipe-generated Stash Mixes. Rotate daily via StashMixRefreshWorker.
      * Rendered in a dedicated Home section above Daily Mixes so users
@@ -47,9 +48,6 @@ data class HomeUiState(
     /** Combined YouTube liked-songs track count (sum of playlist metadata). */
     val youtubeLikedCount: Int = 0,
 
-    val totalTracks: Int = 0,
-    val totalStorageBytes: Long = 0,
-
     /** Custom (non-mix, non-liked) playlists shown in the grid. */
     val playlists: List<Playlist> = emptyList(),
 
@@ -57,8 +55,6 @@ data class HomeUiState(
     val playlistSortOrder: PlaylistSortOrder = PlaylistSortOrder.RECENT,
 
     val isLoading: Boolean = true,
-    val spotifyConnected: Boolean = false,
-    val youTubeConnected: Boolean = false,
     /**
      * Non-null when Last.fm creds are wired but the user hasn't
      * connected yet AND there are local plays queued waiting to be
@@ -74,7 +70,6 @@ data class HomeUiState(
      * fields like pendingCount); the banner copy is static.
      */
     val losslessPrompt: LosslessPromptState? = null,
-    val hasEverSynced: Boolean = false,
 
     /**
      * v0.9.13: live tip-jar state. Drives the Home pill (compact
@@ -164,23 +159,3 @@ data object LosslessPromptState
  * to a shared module rather than crossing the feature:library boundary.
  */
 enum class PlaylistSortOrder { RECENT, ALPHABETICAL, MOST_PLAYED }
-
-/**
- * Summarised sync status information displayed in the sync status card.
- */
-data class SyncStatusInfo(
-    val lastSyncTime: Long? = null,
-    val nextSyncTime: Long? = null,
-    val totalTracks: Int = 0,
-    val spotifyTracks: Int = 0,
-    val youTubeTracks: Int = 0,
-    val totalPlaylists: Int = 0,
-    val storageUsedBytes: Long = 0,
-    /** Count of downloaded FLAC tracks. Subset of [totalTracks]. */
-    val flacTracks: Int = 0,
-    /** Sum of file sizes for downloaded FLAC tracks. Subset of [storageUsedBytes]. */
-    val flacStorageBytes: Long = 0,
-    val state: SyncState = SyncState.IDLE,
-    /** Richer display-oriented summary of the latest sync outcome. */
-    val displayStatus: SyncDisplayStatus = SyncDisplayStatus.Idle,
-)

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.stash.core.auth.TokenManager
-import com.stash.core.auth.model.AuthState
 import com.stash.core.data.db.dao.DownloadQueueDao
 import com.stash.core.data.db.dao.ListeningEventDao
 import com.stash.core.data.db.dao.StashMixRecipeDao
@@ -14,17 +12,13 @@ import com.stash.core.data.lastfm.LastFmSessionPreference
 import com.stash.core.data.prefs.DownloadNetworkPreference
 import com.stash.core.data.prefs.StreamingPreference
 import com.stash.core.data.repository.MusicRepository
-import com.stash.core.data.sync.toDisplayStatus
 import com.stash.core.data.sync.workers.StashDiscoveryWorker
 import com.stash.core.data.sync.workers.StashMixRefreshWorker
 import com.stash.core.media.PlayerRepository
 import com.stash.core.model.MusicSource
 import com.stash.core.model.Playlist
 import com.stash.core.model.PlaylistType
-import com.stash.core.model.SyncDisplayStatus
 import com.stash.core.model.Track
-import com.stash.data.download.files.LibrarySizeBreakdown
-import com.stash.data.download.files.LibrarySizeHolder
 import com.stash.data.download.lossless.AggregatorRateLimiter
 import com.stash.data.download.lossless.LosslessRetryWorker
 import com.stash.data.download.lossless.LosslessSourcePreferences
@@ -72,24 +66,27 @@ import javax.inject.Inject
 private const val TAG = "HomeViewModel"
 
 /**
- * ViewModel for the Home screen. Collects playlist, track, sync data,
- * and authentication state from [MusicRepository] and [TokenManager],
- * combining them into a single reactive [HomeUiState].
+ * ViewModel for the Home screen. Collects playlist, track, recently-added,
+ * and prompt-banner data from [MusicRepository] and the Last.fm / lossless
+ * preference surfaces, combining them into a single reactive [HomeUiState].
  *
  * All data sources are Flow-based so the UI updates automatically when:
  * - New tracks/playlists are inserted after a sync
  * - A sync completes and a new history record appears
- * - Spotify or YouTube auth state changes (connect/disconnect)
+ *
+ * Note: the Sync status card (and its per-source connection booleans,
+ * library-size walk, and latest-sync stream) was relocated to
+ * `:feature:sync` in the SyncStatusCard relocation refactor — see
+ * SyncViewModel for the moved flow assembly. Home no longer observes
+ * TokenManager.spotifyAuthState / youTubeAuthState directly.
  */
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val musicRepository: MusicRepository,
     private val playerRepository: PlayerRepository,
-    private val tokenManager: TokenManager,
     private val lastFmSessionPreference: LastFmSessionPreference,
     private val lastFmCredentials: LastFmCredentials,
     private val listeningEventDao: ListeningEventDao,
-    private val librarySizeHolder: LibrarySizeHolder,
     private val losslessPrefs: LosslessSourcePreferences,
     private val settingsDeepLinkController: com.stash.core.data.navigation.SettingsDeepLinkController,
     private val tipJarRepository: com.stash.core.data.tipjar.TipJarRepository,
@@ -194,45 +191,17 @@ class HomeViewModel @Inject constructor(
     }
 
     /**
-     * Derives [SyncStatusInfo] reactively from the latest sync history record.
-     * Emits a default (empty) status when no sync has ever run.
-     */
-    private val syncStatusFlow = musicRepository.observeLatestSync().map { latestSync ->
-        if (latestSync != null) {
-            SyncStatusInfo(
-                lastSyncTime = latestSync.startedAt.toEpochMilli(),
-                nextSyncTime = latestSync.completedAt?.toEpochMilli()?.plus(6 * 3_600_000L),
-                state = latestSync.status,
-                displayStatus = latestSync.toDisplayStatus(),
-            )
-        } else {
-            SyncStatusInfo(displayStatus = SyncDisplayStatus.Idle)
-        }
-    }
-
-    /**
-     * Combines the Room-backed data flows + the disk-walked library size
-     * into a single intermediate holder. The DB column `file_size_bytes`
-     * is bypassed for the Storage display because legacy libraries have it
-     * stuck at 0 for thousands of rows. [librarySizeHolder] reflects disk
-     * truth via the shared [LibrarySizeHolder] singleton (storage-mode-aware:
-     * internal File walk OR SAF DocumentFile traversal). See that class for
-     * lifecycle and walk-failure semantics.
+     * Bundles the two Room-backed flows Home needs into a single
+     * intermediate holder. Track count + disk-walked library size used
+     * to live here too — both fed the SyncStatusCard at the top of
+     * Home; that card now lives in `:feature:sync` and its plumbing
+     * moved with it.
      */
     private val musicDataFlow = combine(
         musicRepository.getAllPlaylists(),
         musicRepository.getRecentlyAdded(20),
-        musicRepository.getTrackCount(),
-        librarySizeHolder.size,
-    ) { playlists, recentlyAdded, trackCount, librarySize ->
-        MusicData(playlists, recentlyAdded, trackCount, librarySize)
-    }
-
-    private val sourceCountsFlow = combine(
-        musicRepository.getSpotifyDownloadedCount(),
-        musicRepository.getYouTubeDownloadedCount(),
-    ) { spotify, youtube ->
-        SourceCounts(spotify = spotify, youtube = youtube)
+    ) { playlists, recentlyAdded ->
+        MusicData(playlists, recentlyAdded)
     }
 
     /**
@@ -371,20 +340,17 @@ class HomeViewModel @Inject constructor(
     ) { lossless, backfill, lyrics -> BannersInfo(lossless, backfill, lyrics) }
 
     /**
-     * Derives (spotifyConnected, youTubeConnected, lastFmPrompt,
-     * losslessPrompt) from TokenManager + Last.fm session state +
-     * lossless prefs. Bundled so the top-level combine stays at 5
-     * inputs (the non-vararg ceiling).
+     * Bundles the two prompt-banner flows so the top-level combine
+     * treats them as a single positional arg. Previously also carried
+     * Spotify / YouTube auth state for the SyncStatusCard's "Connect
+     * Spotify or YouTube Music" prompt — that responsibility moved
+     * to `:feature:sync` along with the card itself.
      */
-    private val authStateFlow = combine(
-        tokenManager.spotifyAuthState,
-        tokenManager.youTubeAuthState,
+    private val promptsFlow = combine(
         lastFmPromptFlow,
         losslessPromptFlow,
-    ) { spotify, youtube, lastFmPrompt, losslessPrompt ->
-        AuthInfo(
-            spotifyConnected = spotify is AuthState.Connected,
-            youTubeConnected = youtube is AuthState.Connected,
+    ) { lastFmPrompt, losslessPrompt ->
+        PromptsInfo(
             lastFmPrompt = lastFmPrompt,
             losslessPrompt = losslessPrompt,
         )
@@ -392,24 +358,11 @@ class HomeViewModel @Inject constructor(
 
     val uiState: StateFlow<HomeUiState> = combine(
         musicDataFlow,
-        syncStatusFlow,
-        authStateFlow,
-        sourceCountsFlow,
+        promptsFlow,
         _playlistSortOrder,
         tipJarRepository.state,
         bannersInfoFlow,
-    ) { args ->
-        @Suppress("UNCHECKED_CAST")
-        val musicData = args[0] as MusicData
-        @Suppress("UNCHECKED_CAST")
-        val syncStatus = args[1] as SyncStatusInfo
-        @Suppress("UNCHECKED_CAST")
-        val authInfo = args[2] as AuthInfo
-        @Suppress("UNCHECKED_CAST")
-        val sourceCounts = args[3] as SourceCounts
-        val playlistSortOrder = args[4] as PlaylistSortOrder
-        val tipJar = args[5] as com.stash.core.data.tipjar.TipJarState
-        val banners = args[6] as BannersInfo
+    ) { musicData, prompts, playlistSortOrder, tipJar, banners ->
         val bannerState = banners.waitingForLossless
         val metadataBackfillBanner = banners.metadataBackfill
         val lyricsBackfillBanner = banners.lyricsBackfill
@@ -442,15 +395,6 @@ class HomeViewModel @Inject constructor(
             }
 
         HomeUiState(
-            syncStatus = syncStatus.copy(
-                totalTracks = musicData.trackCount,
-                spotifyTracks = sourceCounts.spotify,
-                youTubeTracks = sourceCounts.youtube,
-                totalPlaylists = musicData.playlists.size,
-                storageUsedBytes = musicData.librarySize.totalBytes,
-                flacTracks = musicData.librarySize.losslessFileCount,
-                flacStorageBytes = musicData.librarySize.losslessBytes,
-            ),
             stashMixes = stashMixes,
             spotifyMixes = spotifyMixes,
             youtubeMixes = youtubeMixes,
@@ -459,16 +403,11 @@ class HomeViewModel @Inject constructor(
             youtubeLikedPlaylists = youtubeLikedPlaylists,
             spotifyLikedCount = spotifyLikedCount,
             youtubeLikedCount = youtubeLikedCount,
-            totalTracks = musicData.trackCount,
-            totalStorageBytes = musicData.librarySize.totalBytes,
             playlists = otherPlaylists,
             playlistSortOrder = playlistSortOrder,
             isLoading = false,
-            spotifyConnected = authInfo.spotifyConnected,
-            youTubeConnected = authInfo.youTubeConnected,
-            lastFmPrompt = authInfo.lastFmPrompt,
-            losslessPrompt = authInfo.losslessPrompt,
-            hasEverSynced = syncStatus.lastSyncTime != null,
+            lastFmPrompt = prompts.lastFmPrompt,
+            losslessPrompt = prompts.losslessPrompt,
             tipJar = tipJar,
             waitingForLosslessBanner = bannerState,
             metadataBackfillBanner = metadataBackfillBanner,
@@ -959,33 +898,23 @@ class HomeViewModel @Inject constructor(
 }
 
 /**
- * Internal holder for the four music-data Room flows so we can combine
- * them into a single upstream before the top-level combine.
+ * Internal holder for the Room-backed flows Home reads so the top-level
+ * combine treats them as a single positional arg. Track count + disk-
+ * walked library size used to live here too; both belonged to the
+ * relocated SyncStatusCard pipeline.
  */
 private data class MusicData(
     val playlists: List<Playlist>,
     val recentlyAdded: List<Track>,
-    val trackCount: Int,
-    val librarySize: LibrarySizeBreakdown,
 )
 
 /**
- * Bundled per-source counts that flow into [HomeUiState.syncStatus].
- * FLAC count + storage now come from disk via [MusicData.librarySize],
- * not from this struct — see KDoc on `musicDataFlow` for why.
+ * Internal holder for the two prompt-banner flows so the top-level
+ * combine treats them as a single positional arg. Previously also
+ * carried per-source connection booleans for the SyncStatusCard —
+ * those moved to `:feature:sync` along with the card.
  */
-private data class SourceCounts(
-    val spotify: Int,
-    val youtube: Int,
-)
-
-/**
- * Internal holder for auth state so it can participate in the combine
- * as a single flow emission.
- */
-private data class AuthInfo(
-    val spotifyConnected: Boolean,
-    val youTubeConnected: Boolean,
+private data class PromptsInfo(
     val lastFmPrompt: LastFmPromptState?,
     val losslessPrompt: LosslessPromptState?,
 )

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncScreen.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncScreen.kt
@@ -55,6 +55,7 @@ import com.stash.feature.sync.components.RecentSyncsCard
 import com.stash.feature.sync.components.SyncRowStatus
 import com.stash.feature.sync.components.SyncHeroCard
 import com.stash.feature.sync.components.SyncActionProgress
+import com.stash.feature.sync.components.SyncStatusCard
 import com.stash.feature.sync.components.StatusPill
 import com.stash.feature.sync.components.formatRelativeTime
 
@@ -80,6 +81,20 @@ fun SyncScreen(
             .padding(horizontal = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
+        // -- Sync status card (relocated from Home) ---------------------------
+        // Lives at the very top of the Sync tab so library-status info
+        // sits with the rest of the Sync surface (was previously the
+        // first content card on Home, directly under the supporter pill).
+        item {
+            Spacer(Modifier.height(8.dp))
+            SyncStatusCard(
+                syncStatus = uiState.syncStatus,
+                spotifyConnected = uiState.spotifyConnected,
+                youTubeConnected = uiState.youTubeConnected,
+                hasEverSynced = uiState.hasEverSynced,
+            )
+        }
+
         // -- Header -----------------------------------------------------------
         item {
             Spacer(Modifier.height(8.dp))

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncStatusInfo.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncStatusInfo.kt
@@ -1,0 +1,31 @@
+package com.stash.feature.sync
+
+import com.stash.core.model.SyncDisplayStatus
+import com.stash.core.model.SyncState
+
+/**
+ * Summarised sync status information displayed in the Sync tab's
+ * [com.stash.feature.sync.components.SyncStatusCard].
+ *
+ * Lives in `:feature:sync` (moved here from `:feature:home` in the
+ * SyncStatusCard relocation refactor). Carries everything the card
+ * needs to render: per-source counts, storage breakdown, latest
+ * sync timestamp, and a richer [SyncDisplayStatus] so partial /
+ * interrupted runs aren't reported as generic failures.
+ */
+data class SyncStatusInfo(
+    val lastSyncTime: Long? = null,
+    val nextSyncTime: Long? = null,
+    val totalTracks: Int = 0,
+    val spotifyTracks: Int = 0,
+    val youTubeTracks: Int = 0,
+    val totalPlaylists: Int = 0,
+    val storageUsedBytes: Long = 0,
+    /** Count of downloaded FLAC tracks. Subset of [totalTracks]. */
+    val flacTracks: Int = 0,
+    /** Sum of file sizes for downloaded FLAC tracks. Subset of [storageUsedBytes]. */
+    val flacStorageBytes: Long = 0,
+    val state: SyncState = SyncState.IDLE,
+    /** Richer display-oriented summary of the latest sync outcome. */
+    val displayStatus: SyncDisplayStatus = SyncDisplayStatus.Idle,
+)

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncViewModel.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncViewModel.kt
@@ -16,12 +16,14 @@ import com.stash.core.data.sync.SyncScheduler
 import com.stash.core.data.sync.SyncStateManager
 import com.stash.core.data.sync.toDisplayStatus
 import com.stash.core.model.SyncDisplayStatus
+import com.stash.data.download.files.LibrarySizeHolder
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -126,6 +128,23 @@ data class SyncUiState(
     val lastSyncHealthLabel: String = "",
     /** Tint colour for [lastSyncHealthLabel]. */
     val lastSyncHealthColor: androidx.compose.ui.graphics.Color = androidx.compose.ui.graphics.Color.Transparent,
+
+    // -- SyncStatusCard inputs (relocated from HomeUiState) -------------------
+    /**
+     * Aggregated stats + display status driving the
+     * [com.stash.feature.sync.components.SyncStatusCard] at the top of
+     * this screen. Assembled by [SyncViewModel.observeSyncStatusCard]
+     * from the latest sync history + Room track counts + disk-walked
+     * library size, mirroring the original HomeViewModel wiring verbatim.
+     */
+    val syncStatus: SyncStatusInfo = SyncStatusInfo(),
+    /**
+     * True after at least one sync has completed. Drives the
+     * "Tap Sync Now" prompt vs. the stats grid in [SyncStatusCard].
+     * Derived as `syncStatus.lastSyncTime != null` so it stays in lock-
+     * step with the displayed "Last sync …" line.
+     */
+    val hasEverSynced: Boolean = false,
 )
 
 /**
@@ -145,6 +164,14 @@ class SyncViewModel @Inject constructor(
     private val downloadQueueDao: com.stash.core.data.db.dao.DownloadQueueDao,
     private val musicRepository: com.stash.core.data.repository.MusicRepository,
     private val blocklistGuard: com.stash.core.data.blocklist.BlocklistGuard,
+    /**
+     * Disk-walked library size (storage-mode-aware: internal File walk
+     * OR SAF DocumentFile traversal). Drives the SyncStatusCard's
+     * Storage column. Mirrors HomeViewModel's injection — the Room
+     * `file_size_bytes` column is bypassed because legacy libraries
+     * have it stuck at 0 for thousands of rows.
+     */
+    private val librarySizeHolder: LibrarySizeHolder,
 ) : ViewModel() {
 
     /**
@@ -175,6 +202,7 @@ class SyncViewModel @Inject constructor(
         observeYouTubePlaylists()
         observeUnmatchedCount()
         observeFlaggedCount()
+        observeSyncStatusCard()
     }
 
     // -- Public actions -------------------------------------------------------
@@ -486,6 +514,63 @@ class SyncViewModel @Inject constructor(
         viewModelScope.launch {
             musicRepository.getFlaggedCount().collect { count ->
                 _uiState.update { it.copy(flaggedCount = count) }
+            }
+        }
+    }
+
+    /**
+     * Mirrors HomeViewModel's `syncStatusFlow` + `musicDataFlow` +
+     * `sourceCountsFlow` assembly that originally populated the
+     * SyncStatusCard at the top of the Home screen. The card now
+     * lives at the top of the Sync screen; this observer keeps it
+     * fed with the same flow shape so the relocation introduces no
+     * behavioural change.
+     *
+     * Inputs (all reactive):
+     *  - `observeLatestSync()` for last-sync timestamp + display status
+     *  - `getTrackCount()` for the "Tracks" stat
+     *  - `getSpotifyDownloadedCount()` / `getYouTubeDownloadedCount()`
+     *    for the per-source stats
+     *  - `librarySizeHolder.size` for storage (disk truth — the Room
+     *    `file_size_bytes` SUM is unreliable for legacy libraries)
+     */
+    private fun observeSyncStatusCard() {
+        val syncStatusFlow = musicRepository.observeLatestSync().map { latestSync ->
+            if (latestSync != null) {
+                SyncStatusInfo(
+                    lastSyncTime = latestSync.startedAt.toEpochMilli(),
+                    nextSyncTime = latestSync.completedAt?.toEpochMilli()?.plus(6 * 3_600_000L),
+                    state = latestSync.status,
+                    displayStatus = latestSync.toDisplayStatus(),
+                )
+            } else {
+                SyncStatusInfo(displayStatus = SyncDisplayStatus.Idle)
+            }
+        }
+
+        viewModelScope.launch {
+            combine(
+                syncStatusFlow,
+                musicRepository.getTrackCount(),
+                musicRepository.getSpotifyDownloadedCount(),
+                musicRepository.getYouTubeDownloadedCount(),
+                librarySizeHolder.size,
+            ) { base, trackCount, spotifyCount, youtubeCount, librarySize ->
+                base.copy(
+                    totalTracks = trackCount,
+                    spotifyTracks = spotifyCount,
+                    youTubeTracks = youtubeCount,
+                    storageUsedBytes = librarySize.totalBytes,
+                    flacTracks = librarySize.losslessFileCount,
+                    flacStorageBytes = librarySize.losslessBytes,
+                )
+            }.collect { status ->
+                _uiState.update {
+                    it.copy(
+                        syncStatus = status,
+                        hasEverSynced = status.lastSyncTime != null,
+                    )
+                }
             }
         }
     }

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/components/SyncStatusCard.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/components/SyncStatusCard.kt
@@ -1,0 +1,250 @@
+package com.stash.feature.sync.components
+
+import android.text.format.DateUtils
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.stash.core.model.SyncDisplayStatus
+import com.stash.core.ui.components.GlassCard
+import com.stash.core.ui.theme.StashTheme
+import com.stash.feature.sync.SyncStatusInfo
+
+/**
+ * Sync status card displayed at the top of the Sync tab.
+ *
+ * Shows a pulse-dot status indicator, the latest sync's display
+ * status, per-source track counts, FLAC subtotals, total storage,
+ * and a "Last sync …" relative-time line.
+ *
+ * Originally lived in `:feature:home` (HomeScreen.SyncStatusCard).
+ * Relocated to `:feature:sync` so library-status information lives
+ * with the rest of the Sync surface.
+ */
+@Composable
+fun SyncStatusCard(
+    syncStatus: SyncStatusInfo,
+    spotifyConnected: Boolean,
+    youTubeConnected: Boolean,
+    hasEverSynced: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val anyServiceConnected = spotifyConnected || youTubeConnected
+
+    GlassCard(modifier = modifier) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // -- Connection + sync status header --
+            // Uses SyncDisplayStatus so "Completed with some failures" and
+            // "Interrupted mid-run" don't both read as a generic failure.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                PulseDot(color = syncStatusDotColor(syncStatus, anyServiceConnected, hasEverSynced))
+                Text(
+                    text = syncStatusLabel(syncStatus, anyServiceConnected, hasEverSynced),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+            // -- Prompt or stats depending on sync state --
+            if (!anyServiceConnected) {
+                Text(
+                    text = "Connect Spotify or YouTube Music in Settings to start syncing your library.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else if (!hasEverSynced) {
+                Text(
+                    text = "Tap Sync Now to download your playlists and tracks.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                // Decoupled gating: show each FLAC sub-line whenever its
+                // own value is > 0. The previous AND-coupling
+                // (`flacTracks > 0 && flacStorageBytes > 0`) hid the
+                // sub-text for any user whose DB had FLAC rows but
+                // file_size_bytes still at 0 — turning the "defensive"
+                // check into a permanent display blocker. Per-stat
+                // gating is the design that v0.9.0 originally shipped
+                // with; the coupling was a regression introduced in
+                // c3c6529 and is now reverted.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    StatItem(
+                        label = "Tracks",
+                        value = syncStatus.totalTracks.toString(),
+                        subValue = if (syncStatus.flacTracks > 0) "${syncStatus.flacTracks} FLAC" else null,
+                    )
+                    StatItem(
+                        label = "Spotify",
+                        value = syncStatus.spotifyTracks.toString(),
+                    )
+                    StatItem(
+                        label = "YouTube",
+                        value = syncStatus.youTubeTracks.toString(),
+                    )
+                    StatItem(
+                        label = "Storage",
+                        value = formatBytes(syncStatus.storageUsedBytes),
+                        subValue = if (syncStatus.flacStorageBytes > 0) "${formatBytes(syncStatus.flacStorageBytes)} FLAC" else null,
+                    )
+                }
+                if (syncStatus.lastSyncTime != null) {
+                    Text(
+                        text = "Last sync ${formatRelativeTimeForCard(syncStatus.lastSyncTime)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Label shown next to the pulse dot in [SyncStatusCard]. Interprets
+ * [SyncStatusInfo.displayStatus] so partial / interrupted runs aren't
+ * misreported as generic failures.
+ */
+@Composable
+private fun syncStatusLabel(
+    syncStatus: SyncStatusInfo,
+    anyServiceConnected: Boolean,
+    hasEverSynced: Boolean,
+): String = when {
+    !anyServiceConnected -> "No services connected"
+    !hasEverSynced -> "Ready to sync"
+    else -> when (val s = syncStatus.displayStatus) {
+        SyncDisplayStatus.Idle -> "Ready to sync"
+        SyncDisplayStatus.Running -> "Syncing..."
+        SyncDisplayStatus.Success -> "Synced"
+        is SyncDisplayStatus.PartialSuccess ->
+            "Partially synced — ${s.downloaded} saved, ${s.failed} failed"
+        is SyncDisplayStatus.Interrupted ->
+            if (s.downloaded > 0) "Interrupted — ${s.downloaded} saved"
+            else "Interrupted"
+        is SyncDisplayStatus.Failed -> "Sync failed"
+    }
+}
+
+/**
+ * Color for the pulse dot in [SyncStatusCard]. Green = success-ish,
+ * amber = in-progress / warning, red = genuine failure, gray = idle.
+ */
+@Composable
+private fun syncStatusDotColor(
+    syncStatus: SyncStatusInfo,
+    anyServiceConnected: Boolean,
+    hasEverSynced: Boolean,
+): Color {
+    val extendedColors = StashTheme.extendedColors
+    return when {
+        !anyServiceConnected -> MaterialTheme.colorScheme.onSurfaceVariant
+        !hasEverSynced -> extendedColors.warning
+        else -> when (syncStatus.displayStatus) {
+            SyncDisplayStatus.Idle -> extendedColors.warning
+            SyncDisplayStatus.Running -> extendedColors.warning
+            SyncDisplayStatus.Success -> extendedColors.success
+            is SyncDisplayStatus.PartialSuccess -> extendedColors.warning
+            is SyncDisplayStatus.Interrupted -> extendedColors.warning
+            is SyncDisplayStatus.Failed -> Color(0xFFEF4444)
+        }
+    }
+}
+
+@Composable
+private fun StatItem(label: String, value: String, subValue: String? = null) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (subValue != null) {
+            Text(
+                text = subValue,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PulseDot(color: Color, modifier: Modifier = Modifier) {
+    val infiniteTransition = rememberInfiniteTransition(label = "pulse")
+    val alpha by infiniteTransition.animateFloat(
+        initialValue = 1f,
+        targetValue = 0.3f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1200, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "pulseAlpha",
+    )
+    Box(
+        modifier = modifier
+            .size(8.dp)
+            .alpha(alpha)
+            .clip(CircleShape)
+            .background(color),
+    )
+}
+
+/**
+ * Formats a byte count into a human-readable string (e.g. "45.2 MB").
+ */
+private fun formatBytes(bytes: Long): String {
+    if (bytes <= 0) return "0 B"
+    val units = arrayOf("B", "KB", "MB", "GB", "TB")
+    val digitGroups = (Math.log10(bytes.toDouble()) / Math.log10(1024.0)).toInt()
+    val safeIndex = digitGroups.coerceIn(0, units.lastIndex)
+    return "%.1f %s".format(bytes / Math.pow(1024.0, safeIndex.toDouble()), units[safeIndex])
+}
+
+/**
+ * Formats an epoch-millis timestamp into a relative time string (e.g. "2 hours ago").
+ *
+ * File-private and distinctly named (vs. the public `formatRelativeTime`
+ * exposed by [com.stash.feature.sync.components.RecentSyncsCard]) so the
+ * two helpers can evolve independently without import-ambiguity surprises.
+ */
+private fun formatRelativeTimeForCard(epochMillis: Long): String =
+    DateUtils.getRelativeTimeSpanString(
+        epochMillis,
+        System.currentTimeMillis(),
+        DateUtils.MINUTE_IN_MILLIS,
+    ).toString()


### PR DESCRIPTION
## Summary
Moves the at-a-glance sync stats card off the Home tab (where it was visually heavy under the supporter pill) to the very top of the Sync tab, where library-status info naturally lives.

## Behaviour
Pure relocation. The card renders identically. No new fields, no removed counts, no behavioural changes.

- **Home tab:** `SyncStatusCard` call site removed. Supporter pill is now directly above the Last.fm / Lossless connect nudges (or the empty area when those banners aren't rendering).
- **Sync tab:** card now renders as the first item in the `LazyColumn`, above the "Sync" title header / Sources section.

## Architecture
- `SyncStatusInfo` + `SyncDisplayStatus` moved from `feature/home/.../HomeUiState.kt` → `feature/sync/.../SyncStatusInfo.kt`
- `SyncStatusCard` composable + private helpers (`PulseDot`, `StatItem`, `syncStatusLabel`, `syncStatusDotColor`, `formatBytes`, `formatRelativeTime`) moved from `feature/home/.../HomeScreen.kt` → `feature/sync/.../components/SyncStatusCard.kt`. Composable visibility dropped from `private` to public.
- `SyncViewModel` gains `librarySizeHolder` injection; new `observeSyncStatusCard()` mirrors HomeViewModel's flow assembly verbatim. `SyncUiState` gains `syncStatus` + `hasEverSynced` + connection booleans.
- `HomeViewModel` pruned: dropped `tokenManager` + `librarySizeHolder` injections, dropped `syncStatusFlow` + `sourceCountsFlow`. Top-level `combine` shrank from 7 inputs to 5; still a real combine, not degenerate.
- Two previously-unused `HomeUiState` fields (`totalTracks`, `totalStorageBytes`) deleted as dead weight — confirmed via grep that nothing consumed them.

## Test plan
- [x] `:feature:home:compileDebugKotlin :feature:sync:compileDebugKotlin` — green
- [x] `:feature:home:testDebugUnitTest :feature:sync:testDebugUnitTest` — green
- [x] `:app:assembleDebug` — green
- [x] `:app:assembleRelease` — green (no Compose overload ambiguity surfaced)
- [x] `:app:installDebug` on Pixel 6 Pro — visual: Home clean, Sync renders card at top
- [ ] CI assemble passes

## Release
Bundled into v0.9.37 — no tag pushed from this PR. Will merge + tag with other v0.9.37 work when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)