### PR TITLE
Stash Mixes: stream-only for new discoveries (v0.9.37)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,8 +72,8 @@ android {
         applicationId = "com.stash.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 73
-        versionName = "0.9.36"
+        versionCode = 74
+        versionName = "0.9.37"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // AppAuth redirect scheme removed -- Spotify now uses sp_dc cookie auth
         // Last.fm API credentials exposed via BuildConfig for the app-level

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
@@ -493,4 +493,32 @@ interface PlaylistDao {
      */
     @Query("SELECT DISTINCT track_id FROM playlist_tracks WHERE playlist_id IN (:playlistIds)")
     suspend fun getTrackIdsForPlaylists(playlistIds: List<Long>): List<Long>
+
+    /**
+     * Like [DiscoveryQueueDao.getDoneTrackIdsForRecipe] but also returns
+     * ids whose track row is stream-only (`is_streamable = 1`, no
+     * `is_downloaded`). The Stash Mix streaming-first rollout (v0.9.37)
+     * inserts stream-only stubs from `StashDiscoveryWorker`;
+     * [com.stash.core.data.sync.workers.StashMixRefreshWorker.materializeMix]
+     * must surface both downloaded and streamable tracks when assembling
+     * the Mix, so the rotating playlists keep filling even when new
+     * discoveries never land on disk.
+     *
+     * Mirrors the existing query's INNER JOIN + status / track_id filters
+     * exactly — the only difference is the OR-relaxed track predicate
+     * (`is_downloaded = 1 OR is_streamable = 1`). The original method is
+     * preserved for non-Mix callers; this one is materializer-only.
+     */
+    @Query(
+        """
+        SELECT dq.track_id FROM discovery_queue dq
+        INNER JOIN tracks t ON t.id = dq.track_id
+        WHERE dq.recipe_id = :recipeId
+          AND dq.status = 'DONE'
+          AND dq.track_id IS NOT NULL
+          AND (t.is_downloaded = 1 OR t.is_streamable = 1)
+        ORDER BY dq.completed_at DESC
+        """
+    )
+    suspend fun getStreamableOrDoneTrackIdsForRecipe(recipeId: Long): List<Long>
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -991,6 +991,16 @@ interface TrackDao {
     fun observeLikeState(trackId: Long): Flow<TrackLikeState?>
 
     /**
+     * v0.9.37: youtube_id-keyed equivalent of [observeLikeState]. The
+     * notification mini-player and Now Playing both fall back to this
+     * when the active MediaItem's mediaId is a streaming-engine
+     * synthetic `videoId.hashCode().toLong()` that doesn't match any
+     * `tracks.id` (issue #105 follow-up).
+     */
+    @Query("SELECT id, stash_liked_at, spotify_saved_at, ytmusic_saved_at FROM tracks WHERE youtube_id = :youtubeId LIMIT 1")
+    fun observeLikeStateByYoutubeId(youtubeId: String): Flow<TrackLikeState?>
+
+    /**
      * v0.9.13: Live-observe a full track row by id. Now Playing uses
      * this as the canonical source for currentTrack — the Player only
      * provides id+title+artist+album+art via MediaItem extras, but
@@ -1002,6 +1012,18 @@ interface TrackDao {
      */
     @Query("SELECT * FROM tracks WHERE id = :trackId")
     fun observeById(trackId: Long): Flow<TrackEntity?>
+
+    /**
+     * Live-observe a track by its `youtube_id`. Needed by Now Playing so
+     * streaming-engine tracks (whose `currentTrack.id` is a synthetic
+     * `videoId.hashCode().toLong()`) can find the real Room row that
+     * `MusicRepository.ensureTrackPersisted` writes under a fresh autogen
+     * PK. Without this fallback the heart icon never reflects the post-
+     * persist `stashLikedAt` because `observeById(syntheticId)` returns
+     * null forever (issue #105 follow-up).
+     */
+    @Query("SELECT * FROM tracks WHERE youtube_id = :youtubeId LIMIT 1")
+    fun observeByYoutubeId(youtubeId: String): Flow<TrackEntity?>
 
     /**
      * v0.9.13: Count of tracks marked as auto-saved to Spotify since
@@ -1250,6 +1272,15 @@ interface TrackDao {
     /** Set the YouTube video ID for a track so future syncs don't re-queue it. */
     @Query("UPDATE tracks SET youtube_id = :youtubeId WHERE id = :trackId")
     suspend fun updateYoutubeId(trackId: Long, youtubeId: String)
+
+    /**
+     * Backfill duration_ms when the existing row has 0 (no duration yet —
+     * usually because the row was inserted by `ensureTrackPersisted` from
+     * a streaming-engine Track whose `durationMs` wasn't yet known at
+     * insert time). Issue #105 follow-up.
+     */
+    @Query("UPDATE tracks SET duration_ms = :durationMs WHERE id = :trackId AND duration_ms <= 0")
+    suspend fun backfillDurationIfMissing(trackId: Long, durationMs: Long)
 
     /**
      * Set the cached canonical ATV/OMV video id for this track. Called once

--- a/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepository.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepository.kt
@@ -149,6 +149,14 @@ interface MusicRepository {
      */
     fun observeTrackById(trackId: Long): Flow<Track?>
 
+    /**
+     * Live-observe a Track by its `youtubeId`. Now Playing falls back to
+     * this when `observeTrackById` returns null for a v0.9.30 streaming-
+     * engine synthetic id, so the heart icon picks up the row inserted
+     * by [ensureTrackPersisted] (issue #105 follow-up).
+     */
+    fun observeTrackByYoutubeId(youtubeId: String): Flow<Track?>
+
     // ── Mutations ───────────────────────────────────────────────────────
 
     /** Record a play event: increments play count and updates last-played. */
@@ -156,6 +164,24 @@ interface MusicRepository {
 
     /** Insert or replace a track. Returns the row ID. */
     suspend fun insertTrack(track: Track): Long
+
+    /**
+     * Ensures a Track row exists in Room for [track], returning its real
+     * Room PK. If [track.id] is non-zero and the row exists, returns it
+     * unchanged. Otherwise looks up by `youtube_id` (then canonical
+     * identity); if none match, inserts a fresh stub and returns the
+     * autogen id.
+     *
+     * Necessary because the v0.9.30 streaming engine synthesises a
+     * `videoId.hashCode().toLong()` for transient stream-only tracks
+     * (`PlayerRepositoryImpl:805-812`). That id is **not** a real
+     * `tracks.id`, so any FK-bearing write keyed on it
+     * (Liked-Songs cross-ref, download_queue) FK-violates. Call this
+     * first to resolve to a real id.
+     *
+     * Idempotent. Mirrors `SearchDownloadCoordinator.upsertSearchTrack`.
+     */
+    suspend fun ensureTrackPersisted(track: Track): Long
 
     /**
      * Delete a track from the database and remove its audio file from disk.
@@ -169,9 +195,17 @@ interface MusicRepository {
      * Queue [trackId] for a user-initiated download. Inserts a row into
      * `download_queue` with `sync_id = null` (distinguishing it from
      * sync-time downloads) and kicks the discovery download worker.
-     * No-op if the track is already downloaded or is missing.
+     *
+     * Returns true when a row was inserted and the worker enqueued;
+     * false when the track row is missing, already downloaded, or
+     * already has a non-terminal queue entry. Callers should base
+     * "Queued for download." toasts on this return — emitting the
+     * toast unconditionally lies to the user when the track id is a
+     * v0.9.30 streaming-engine synthetic and the row doesn't exist
+     * (issue #105). Use [ensureTrackPersisted] beforehand to convert
+     * a synthetic id to a real one.
      */
-    suspend fun queueDownload(trackId: Long)
+    suspend fun queueDownload(trackId: Long): Boolean
 
     /**
      * Remove the on-disk file for [trackId] and clear its download flags.

--- a/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
@@ -372,6 +372,9 @@ class MusicRepositoryImpl @Inject constructor(
     override fun observeTrackById(trackId: Long): Flow<Track?> =
         trackDao.observeById(trackId).map { it?.toDomain() }
 
+    override fun observeTrackByYoutubeId(youtubeId: String): Flow<Track?> =
+        trackDao.observeByYoutubeId(youtubeId).map { it?.toDomain() }
+
     override suspend fun getPlaylistWithTracks(id: Long): Playlist? {
         val result = playlistDao.getPlaylistWithTracks(id) ?: return null
         return result.playlist.toDomain().copy(
@@ -388,6 +391,58 @@ class MusicRepositoryImpl @Inject constructor(
 
     override suspend fun insertTrack(track: Track): Long =
         trackDao.insert(track.toEntity())
+
+    override suspend fun ensureTrackPersisted(track: Track): Long {
+        // Quick exit: real DB row already.
+        if (track.id > 0L) {
+            val existing = trackDao.getById(track.id)
+            if (existing != null) {
+                backfillDurationIfBetter(existing.id, existing.durationMs, track.durationMs)
+                return track.id
+            }
+        }
+
+        // Upsert by youtube_id, then canonical identity.
+        val youtubeId = track.youtubeId
+        if (!youtubeId.isNullOrBlank()) {
+            trackDao.findByYoutubeId(youtubeId)?.let { existing ->
+                backfillDurationIfBetter(existing.id, existing.durationMs, track.durationMs)
+                return existing.id
+            }
+        }
+        val cTitle = canonicalizeIdentity(track.title)
+        val cArtist = canonicalizeIdentity(track.artist)
+        if (cTitle.isNotBlank() && cArtist.isNotBlank()) {
+            trackDao.findByCanonicalIdentity(cTitle, cArtist)?.let { existing ->
+                backfillDurationIfBetter(existing.id, existing.durationMs, track.durationMs)
+                return existing.id
+            }
+        }
+
+        // Insert a fresh stub — id = 0 so Room autogens.
+        return trackDao.insert(
+            track.toEntity().copy(
+                id = 0L,
+                canonicalTitle = cTitle,
+                canonicalArtist = cArtist,
+                isStreamable = true,
+            )
+        )
+    }
+
+    private suspend fun backfillDurationIfBetter(trackId: Long, existing: Long, incoming: Long) {
+        if (existing <= 0L && incoming > 0L) {
+            trackDao.backfillDurationIfMissing(trackId, incoming)
+        }
+    }
+
+    /** Same normalization as [SearchDownloadCoordinator.canonicalize] — kept
+     *  local to avoid leaking that private helper out of `:data:download`. */
+    private fun canonicalizeIdentity(s: String): String =
+        s.lowercase()
+            .replace(Regex("[^\\p{L}\\p{N}\\s]"), " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
 
     override suspend fun deleteTrack(track: Track): Boolean {
         // Best-effort file deletion -- the file may already be gone.
@@ -408,12 +463,12 @@ class MusicRepositoryImpl @Inject constructor(
     // discovery-worker partition. Removal nulls the file_path / flags
     // but keeps the row so the track remains streamable (Path A).
 
-    override suspend fun queueDownload(trackId: Long) {
-        val entity = trackDao.getById(trackId) ?: return
-        if (entity.isDownloaded) return
+    override suspend fun queueDownload(trackId: Long): Boolean {
+        val entity = trackDao.getById(trackId) ?: return false
+        if (entity.isDownloaded) return false
 
         val existing = downloadQueueDao.getByTrackId(trackId)
-        if (existing != null && existing.status in NON_TERMINAL_QUEUE_STATES) return
+        if (existing != null && existing.status in NON_TERMINAL_QUEUE_STATES) return false
 
         downloadQueueDao.insert(
             com.stash.core.data.db.entity.DownloadQueueEntity(
@@ -429,6 +484,7 @@ class MusicRepositoryImpl @Inject constructor(
             context = context,
             constraints = com.stash.core.data.sync.workers.constraintsForManualTrigger(mode),
         )
+        return true
     }
 
     override suspend fun removeDownload(trackId: Long) {
@@ -523,9 +579,12 @@ class MusicRepositoryImpl @Inject constructor(
                 locallyAdded = true,
             )
         )
-        // v0.9.27 — count downloaded-only here; stream-only tracks don't
-        // affect the persisted track_count metric used for UI badges.
-        val count = trackDao.getByPlaylist(playlistId, includeStreamable = false).first().size
+        // v0.9.37 — count downloaded + streamable. Stream-only tracks
+        // (e.g. Liked Songs added from the Now Playing heart on a
+        // streaming track) are first-class playlist members under the
+        // streaming-engine model and must be reflected in the badge,
+        // or the Library card lies ("1 tracks" but the detail shows 4).
+        val count = trackDao.getByPlaylist(playlistId, includeStreamable = true).first().size
         playlistDao.updateTrackCount(playlistId, count)
     }
 
@@ -550,9 +609,12 @@ class MusicRepositoryImpl @Inject constructor(
 
     override suspend fun removeTrackFromPlaylist(trackId: Long, playlistId: Long) {
         playlistDao.softDeleteTrackFromPlaylist(playlistId, trackId)
-        // v0.9.27 — count downloaded-only here; stream-only tracks don't
-        // affect the persisted track_count metric used for UI badges.
-        val count = trackDao.getByPlaylist(playlistId, includeStreamable = false).first().size
+        // v0.9.37 — count downloaded + streamable. Stream-only tracks
+        // (e.g. Liked Songs added from the Now Playing heart on a
+        // streaming track) are first-class playlist members under the
+        // streaming-engine model and must be reflected in the badge,
+        // or the Library card lies ("1 tracks" but the detail shows 4).
+        val count = trackDao.getByPlaylist(playlistId, includeStreamable = true).first().size
         playlistDao.updateTrackCount(playlistId, count)
     }
 

--- a/core/data/src/main/kotlin/com/stash/core/data/social/stash/StashLikedPlaylistRepository.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/social/stash/StashLikedPlaylistRepository.kt
@@ -41,10 +41,17 @@ class StashLikedPlaylistRepository @Inject constructor(
         val playlistId = ensureSeeded()
         val existing = playlistDao.getCrossRef(playlistId, trackId)
         if (existing != null && existing.removedAt == null) return
+        // Order matters: mark the timestamp FIRST so the Room observation
+        // that fires after `insertCrossRef` already sees `stashLikedAt`
+        // set. Without this, the observer emits the row twice — once with
+        // stashLikedAt = null (right after the cross-ref insert), then
+        // again after `markStashLiked` — and the heart visual flickers
+        // un-red between the two emissions. The recount inside
+        // `addTrackToPlaylist` widens that gap noticeably (issue #105 follow-up).
+        trackDao.markStashLiked(trackId, System.currentTimeMillis())
         // Reuse existing helper for trackCount + position handling.
         // Mirrors linkTrackToDownloadsMix at MusicRepositoryImpl.kt:294.
         musicRepository.addTrackToPlaylist(trackId = trackId, playlistId = playlistId)
-        trackDao.markStashLiked(trackId, System.currentTimeMillis())
     }
 
     /**
@@ -64,8 +71,11 @@ class StashLikedPlaylistRepository @Inject constructor(
             trackDao.clearStashLiked(trackId)
             return
         }
-        musicRepository.removeTrackFromPlaylist(trackId = trackId, playlistId = playlistId)
+        // Clear FIRST for the same Room-emission-ordering reason as `add` —
+        // observers see one update with stashLikedAt = null, not a brief
+        // un-red→red flicker if cross-ref removal is observed first.
         trackDao.clearStashLiked(trackId)
+        musicRepository.removeTrackFromPlaylist(trackId = trackId, playlistId = playlistId)
     }
 
     /**

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
@@ -13,11 +13,9 @@ import androidx.work.WorkerParameters
 import com.stash.core.data.db.dao.DiscoveryQueueDao
 import com.stash.core.model.DownloadNetworkMode
 import com.stash.core.data.prefs.DownloadNetworkPreference
-import com.stash.core.data.db.dao.DownloadQueueDao
 import com.stash.core.data.db.dao.StashMixRecipeDao
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.db.entity.DiscoveryQueueEntity
-import com.stash.core.data.db.entity.DownloadQueueEntity
 import com.stash.core.data.db.entity.TrackEntity
 import com.stash.core.data.sync.TrackMatcher
 import com.stash.core.model.MusicSource
@@ -35,7 +33,7 @@ import java.util.concurrent.TimeUnit
  *     recipe's playlist.
  *  2. Otherwise create a stub [TrackEntity] with `isStreamable = true,
  *     isDownloaded = false`. v0.9.37 stream-only seam: no
- *     [DownloadQueueEntity] is filed. The v0.9.30 streaming engine
+ *     `download_queue` row is filed. The v0.9.30 streaming engine
  *     (`PlayerRepositoryImpl.buildMediaItemForTrack` → Qobuz/Kennyy +
  *     YouTube fallback) plays the stub on demand without ever writing
  *     a file to disk. Saves data + storage for what is, by recipe
@@ -46,9 +44,11 @@ import java.util.concurrent.TimeUnit
  *     pass can link it into the recipe's playlist via
  *     `PlaylistDao.getStreamableOrDoneTrackIdsForRecipe`.
  *
- * [downloadQueueDao] is retained for legacy / leftover rows the chained
- * [DiscoveryDownloadWorker] still drains — this worker itself no longer
- * inserts new rows there.
+ * v0.9.37 also dropped the `DownloadQueueDao` constructor injection —
+ * this worker no longer files download rows. The chained
+ * [DiscoveryDownloadWorker] still drains legacy / leftover rows in
+ * `download_queue` (orphan PENDING, retry-eligible FAILED from prior
+ * runs); see `doWork()`'s tail chain.
  *
  * Caps per-recipe throughput at 100 new discoveries per rolling 7 days
  * (a hold-over from the download-era storage cap; storage cost is gone
@@ -60,7 +60,6 @@ class StashDiscoveryWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted params: WorkerParameters,
     private val discoveryQueueDao: DiscoveryQueueDao,
-    private val downloadQueueDao: DownloadQueueDao,
     private val trackDao: TrackDao,
     private val recipeDao: StashMixRecipeDao,
     private val trackMatcher: TrackMatcher,
@@ -230,10 +229,18 @@ class StashDiscoveryWorker @AssistedInject constructor(
     )
 
     /**
-     * Processes a single pending discovery row. Reuses the existing
-     * "create track + enqueue download" pattern that DiffWorker uses for
-     * unmatched Spotify tracks, so downloads run through the same queue
-     * the sync pipeline already drains.
+     * Processes a single pending discovery row. v0.9.37 stream-only
+     * contract: creates (or reuses) a streamable stub [TrackEntity] for
+     * the row. The v0.9.30 streaming engine plays the stub on demand via
+     * the Qobuz/Kennyy + YouTube fallback chain; no file is downloaded.
+     * [StashMixRefreshWorker.materializeMix] picks the stubs up via
+     * `PlaylistDao.getStreamableOrDoneTrackIdsForRecipe` (v0.9.37) on the
+     * next refresh pass to link them into the recipe's playlist.
+     *
+     * Guards: blocklist-rejects the candidate before any insert, and
+     * skips recipes whose materialized playlist doesn't exist yet (the
+     * very first refresh hasn't run — materializer owns playlist
+     * creation, not this worker).
      */
     private suspend fun handle(
         entry: DiscoveryQueueEntity,
@@ -245,7 +252,12 @@ class StashDiscoveryWorker @AssistedInject constructor(
                 null,
                 "recipe ${entry.recipeId} missing",
             )
-        val playlistId = recipe.playlistId
+        // Don't process discoveries for un-materialized recipes — the
+        // first StashMixRefreshWorker pass creates the playlist row, and
+        // until that's run there's nothing for materializeMix to link
+        // this stub into. Leave the row PENDING-failed; next refresh
+        // cycle will re-queue.
+        recipe.playlistId
             ?: return HandledResult(
                 DiscoveryQueueEntity.STATUS_FAILED,
                 null,

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
@@ -30,22 +30,30 @@ import java.util.concurrent.TimeUnit
  * [StashMixRefreshWorker]. For each one:
  *
  *  1. Check whether a track with the same canonical identity already
- *     exists in the library — if so, skip the download and just link the
- *     existing track into the recipe's playlist.
- *  2. Otherwise create a stub [TrackEntity] (is_downloaded = false) and
- *     file a [DownloadQueueEntity] row. The existing
- *     [TrackDownloadWorker] picks that up and performs the actual YT
- *     search + download, reusing every bit of matching infra we already
- *     ship. No duplicate code paths.
- *  3. Link the new (or found) track into the recipe's playlist so it
- *     appears in the mix as soon as its audio is downloaded.
- *  4. Mark the discovery row DONE with a reference to the created track
- *     so diagnostics can trace the seed → candidate → download chain.
+ *     exists (downloaded) in the library — if so, skip and just reuse
+ *     the existing track row when the materializer later links the
+ *     recipe's playlist.
+ *  2. Otherwise create a stub [TrackEntity] with `isStreamable = true,
+ *     isDownloaded = false`. v0.9.37 stream-only seam: no
+ *     [DownloadQueueEntity] is filed. The v0.9.30 streaming engine
+ *     (`PlayerRepositoryImpl.buildMediaItemForTrack` → Qobuz/Kennyy +
+ *     YouTube fallback) plays the stub on demand without ever writing
+ *     a file to disk. Saves data + storage for what is, by recipe
+ *     design, ephemeral discovery content. Existing downloaded Mix
+ *     tracks remain on disk; no purge.
+ *  3. Mark the discovery row DONE with a reference to the created (or
+ *     reused) track so the next [StashMixRefreshWorker.materializeMix]
+ *     pass can link it into the recipe's playlist via
+ *     `PlaylistDao.getStreamableOrDoneTrackIdsForRecipe`.
  *
- * Caps per-recipe throughput at 10 new discoveries per rolling 7 days so
- * a mix with many pending candidates doesn't blow up the user's disk
- * overnight. Requires unmetered network + charging to be polite about
- * data and battery.
+ * [downloadQueueDao] is retained for legacy / leftover rows the chained
+ * [DiscoveryDownloadWorker] still drains — this worker itself no longer
+ * inserts new rows there.
+ *
+ * Caps per-recipe throughput at 100 new discoveries per rolling 7 days
+ * (a hold-over from the download-era storage cap; storage cost is gone
+ * now, raising the cap is tracked as separate future work). Requires
+ * unmetered network + charging to be polite about data and battery.
  */
 @HiltWorker
 class StashDiscoveryWorker @AssistedInject constructor(
@@ -274,7 +282,30 @@ class StashDiscoveryWorker @AssistedInject constructor(
             // Nothing to download — just link.
             existing.id
         } else {
-            // Create stub + enqueue.
+            // v0.9.37: stream-only seam. Every recipe in `stash_mix_recipes`
+            // is materialized as PlaylistType.STASH_MIX (see
+            // StashMixRefreshWorker.materializeMix), so every PENDING row
+            // this worker drains belongs to a Stash Mix. Per the v0.9.37
+            // spec we no longer file a `download_queue` row for these —
+            // instead the stub lands with `isStreamable = true` and the
+            // v0.9.30 streaming engine plays it on-demand via the
+            // Qobuz/Kennyy + YouTube fallback chain. Existing downloaded
+            // Mix tracks remain on disk and are untouched.
+            //
+            // Note: no `findByYoutubeId` upsert defense needed at this
+            // call site because the stub is inserted with `youtubeId =
+            // null` (the videoId is resolved later by
+            // StashDiscoveryWorker's chain into the streaming engine /
+            // player path, never by THIS row's insert). With both
+            // `spotifyUri` and `youtubeId` NULL the UNIQUE indexes can't
+            // collide; the canonical-identity dedup above already absorbs
+            // the only realistic cross-source race (streaming engine
+            // inserting a row with matching canonical title+artist first,
+            // which `findDownloadedByCanonical` won't catch because
+            // streaming inserts aren't `is_downloaded = 1`). Broadening
+            // that lookup is a separate refactor — out of scope for the
+            // stream-only seam; the worst-case here is a duplicate stub,
+            // not a constraint violation.
             val stub = TrackEntity(
                 title = entry.title,
                 artist = entry.artist,
@@ -282,17 +313,9 @@ class StashDiscoveryWorker @AssistedInject constructor(
                 canonicalTitle = canonicalTitle,
                 canonicalArtist = canonicalArtist,
                 isDownloaded = false,
+                isStreamable = true,
             )
-            val newId = trackDao.insert(stub)
-            downloadQueueDao.insert(
-                DownloadQueueEntity(
-                    trackId = newId,
-                    syncId = null,
-                    searchQuery = "${entry.artist} - ${entry.title}",
-                    youtubeUrl = null,
-                )
-            )
-            newId
+            trackDao.insert(stub)
         }
 
         // v0.9.21: Do NOT insert into playlist_tracks here. Earlier versions

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -449,8 +449,19 @@ class StashMixRefreshWorker @AssistedInject constructor(
         // wider taste graph) the older limit could exhaust before we found
         // discoveryCap survivors. Headroom is bounded by the total recipe
         // backlog — DAO query has its own LIMIT clause.
-        val rawCandidateIds = discoveryQueueDao
-            .getDoneTrackIdsForRecipe(recipe.id, limit = discoveryCap * 2 + excludeIds.size)
+        //
+        // v0.9.37: swap to playlistDao.getStreamableOrDoneTrackIdsForRecipe
+        // so stream-only DONE rows (is_downloaded=0, is_streamable=1) also
+        // make it into the Mix playlist. The new DAO method has NO limit
+        // parameter (kept the query simple — the spec's Section 8 still
+        // owns the per-recipe cap revisit). We trim post-fetch with .take
+        // to preserve the over-fetch headroom semantics from above. ORDER
+        // BY completed_at DESC inside the query means .take still slides
+        // newest-first.
+        val fetchLimit = discoveryCap * 2 + excludeIds.size
+        val rawCandidateIds = playlistDao
+            .getStreamableOrDoneTrackIdsForRecipe(recipe.id)
+            .take(fetchLimit)
         val nonLibraryCandidates = rawCandidateIds.filter { it !in librarySet }
         // v0.9.21: soft cross-mix dedup. Prefer survivors not already claimed
         // by an earlier-ordered mix; if dedup leaves us below the cap, backfill

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoStreamableOrDoneTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoStreamableOrDoneTest.kt
@@ -1,0 +1,95 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.DiscoveryQueueEntity
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.db.entity.TrackEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [PlaylistDao.getStreamableOrDoneTrackIdsForRecipe] — the
+ * v0.9.37 Stash-Mixes stream-only addition. Mirrors
+ * [DiscoveryQueueDao.getDoneTrackIdsForRecipe]'s query shape but relaxes
+ * the predicate so stream-only stubs (`is_streamable = 1` without
+ * `is_downloaded = 1`) also surface; `StashMixRefreshWorker.materializeMix`
+ * uses this method so the Mix playlist includes both downloaded and
+ * stream-only discovered tracks.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PlaylistDaoStreamableOrDoneTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: PlaylistDao
+    private var recipeId: Long = 0L
+
+    @Before fun setUp() = runTest {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.playlistDao()
+        // FK: discovery_queue.recipe_id -> stash_mix_recipes.id (CASCADE).
+        recipeId = db.stashMixRecipeDao().insert(
+            StashMixRecipeEntity(name = "Test Recipe", isBuiltin = false)
+        )
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `returns downloaded and streamable but not neither`() = runTest {
+        // Three tracks, all linked to the same recipe via DONE discovery rows.
+        // Downloaded only — must appear.
+        db.trackDao().insert(track(id = 1L, isDownloaded = true, isStreamable = false))
+        // Stream-only stub (the new v0.9.37 path) — must appear.
+        db.trackDao().insert(track(id = 2L, isDownloaded = false, isStreamable = true))
+        // Neither — must NOT appear (legacy stub or pending availability check).
+        db.trackDao().insert(track(id = 3L, isDownloaded = false, isStreamable = false))
+
+        db.discoveryQueueDao().insertIfNew(doneRow(recipeId, trackId = 1L, completedAt = 1000L))
+        db.discoveryQueueDao().insertIfNew(doneRow(recipeId, trackId = 2L, completedAt = 2000L))
+        db.discoveryQueueDao().insertIfNew(doneRow(recipeId, trackId = 3L, completedAt = 3000L))
+
+        val result = dao.getStreamableOrDoneTrackIdsForRecipe(recipeId)
+
+        assertEquals(setOf(1L, 2L), result.toSet())
+        assertEquals("expected exactly two ids", 2, result.size)
+    }
+
+    private fun track(
+        id: Long,
+        isDownloaded: Boolean,
+        isStreamable: Boolean,
+    ) = TrackEntity(
+        id = id,
+        title = "Track $id",
+        artist = "Artist $id",
+        canonicalTitle = "track $id",
+        canonicalArtist = "artist $id",
+        isDownloaded = isDownloaded,
+        isStreamable = isStreamable,
+    )
+
+    private fun doneRow(recipeId: Long, trackId: Long?, completedAt: Long?) = DiscoveryQueueEntity(
+        recipeId = recipeId,
+        artist = "Artist",
+        title = "Title $trackId",
+        seedArtist = "Seed",
+        status = DiscoveryQueueEntity.STATUS_DONE,
+        trackId = trackId,
+        queuedAt = 0L,
+        completedAt = completedAt,
+        errorMessage = null,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorkerStreamOnlyTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorkerStreamOnlyTest.kt
@@ -4,11 +4,9 @@ import android.content.Context
 import androidx.work.WorkerParameters
 import com.stash.core.data.blocklist.BlocklistGuard
 import com.stash.core.data.db.dao.DiscoveryQueueDao
-import com.stash.core.data.db.dao.DownloadQueueDao
 import com.stash.core.data.db.dao.StashMixRecipeDao
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.db.entity.DiscoveryQueueEntity
-import com.stash.core.data.db.entity.DownloadQueueEntity
 import com.stash.core.data.db.entity.StashMixRecipeEntity
 import com.stash.core.data.db.entity.TrackEntity
 import com.stash.core.data.prefs.DownloadNetworkPreference
@@ -31,16 +29,21 @@ import org.junit.Test
  * MockK end-to-end test for [StashDiscoveryWorker]'s v0.9.37 stream-only
  * seam. Every recipe in `stash_mix_recipes` is materialized as
  * `PlaylistType.STASH_MIX`, so this worker — whose only job is to drain
- * PENDING discoveries for those recipes — must:
- *   1. Create the stub [TrackEntity] with `isStreamable = true`,
- *      `isDownloaded = false`.
- *   2. **Skip** the `downloadQueueDao.insert(...)` call that the pre-v0.9.37
- *      flow used to file every discovery against [DiscoveryDownloadWorker].
+ * PENDING discoveries for those recipes — must create the stub
+ * [TrackEntity] with `isStreamable = true`, `isDownloaded = false`.
  *
  * The downstream `StashMixRefreshWorker.materializeMix` (Task 3) then picks
  * the stream-only stub up via the new
  * `PlaylistDao.getStreamableOrDoneTrackIdsForRecipe` query so the new track
  * surfaces in the Mix playlist without ever touching the download pipeline.
+ *
+ * Note on the "skip download_queue" guarantee: pre-cleanup, this test held
+ * a `coVerify(exactly = 0) { downloadQueueDao.insert(...) }` assertion. The
+ * cleanup removed the `DownloadQueueDao` injection from
+ * [StashDiscoveryWorker] entirely, so the runtime check is now a stronger
+ * compile-time guarantee — there is no DAO reference for the worker to
+ * call. If a future change re-adds the DAO, the constructor signature
+ * shift will force this test to be updated, restoring the assertion.
  *
  * `DiscoveryDownloadWorker.enqueueOneTime` is mocked because the production
  * `doWork()` chains a manual-trigger download sweep at the end — irrelevant
@@ -50,7 +53,6 @@ class StashDiscoveryWorkerStreamOnlyTest {
 
     private val appContext: Context = mockk(relaxed = true)
     private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
-    private val downloadQueueDao: DownloadQueueDao = mockk(relaxed = true)
     private val trackDao: TrackDao = mockk(relaxed = true)
     private val recipeDao: StashMixRecipeDao = mockk(relaxed = true)
     // TrackMatcher is a final @Singleton class with no Android deps — use the
@@ -80,7 +82,7 @@ class StashDiscoveryWorkerStreamOnlyTest {
         val params: WorkerParameters = mockk(relaxed = true)
         return StashDiscoveryWorker(
             appContext, params,
-            discoveryQueueDao, downloadQueueDao, trackDao, recipeDao,
+            discoveryQueueDao, trackDao, recipeDao,
             trackMatcher, blocklistGuard, downloadNetworkPreference,
         )
     }
@@ -135,10 +137,9 @@ class StashDiscoveryWorkerStreamOnlyTest {
             insertedTrack.captured.isDownloaded,
         )
 
-        // Critical assertion: no download_queue row for the new stub. This is
-        // what diverts the new discovery from the v0.9.20 download pipeline
-        // onto the v0.9.30 streaming engine.
-        coVerify(exactly = 0) { downloadQueueDao.insert(any<DownloadQueueEntity>()) }
+        // Critical "no download_queue insert" guarantee is now structural
+        // (see class KDoc): the worker no longer holds a DownloadQueueDao
+        // reference, so there is nothing to call. Compile-time-enforced.
 
         // Discovery row was still marked DONE with the new trackId so the
         // materializer can re-link it on the next mix refresh.
@@ -196,7 +197,7 @@ class StashDiscoveryWorkerStreamOnlyTest {
         newWorker().doWork()
 
         coVerify(exactly = 0) { trackDao.insert(any<TrackEntity>()) }
-        coVerify(exactly = 0) { downloadQueueDao.insert(any<DownloadQueueEntity>()) }
+        // "no download_queue insert" — structural; see class KDoc.
         coVerify(exactly = 1) {
             discoveryQueueDao.updateStatus(
                 id = 7L,

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorkerStreamOnlyTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorkerStreamOnlyTest.kt
@@ -1,0 +1,211 @@
+package com.stash.core.data.sync.workers
+
+import android.content.Context
+import androidx.work.WorkerParameters
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.DownloadQueueDao
+import com.stash.core.data.db.dao.StashMixRecipeDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.DiscoveryQueueEntity
+import com.stash.core.data.db.entity.DownloadQueueEntity
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.prefs.DownloadNetworkPreference
+import com.stash.core.data.sync.TrackMatcher
+import com.stash.core.model.DownloadNetworkMode
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * MockK end-to-end test for [StashDiscoveryWorker]'s v0.9.37 stream-only
+ * seam. Every recipe in `stash_mix_recipes` is materialized as
+ * `PlaylistType.STASH_MIX`, so this worker — whose only job is to drain
+ * PENDING discoveries for those recipes — must:
+ *   1. Create the stub [TrackEntity] with `isStreamable = true`,
+ *      `isDownloaded = false`.
+ *   2. **Skip** the `downloadQueueDao.insert(...)` call that the pre-v0.9.37
+ *      flow used to file every discovery against [DiscoveryDownloadWorker].
+ *
+ * The downstream `StashMixRefreshWorker.materializeMix` (Task 3) then picks
+ * the stream-only stub up via the new
+ * `PlaylistDao.getStreamableOrDoneTrackIdsForRecipe` query so the new track
+ * surfaces in the Mix playlist without ever touching the download pipeline.
+ *
+ * `DiscoveryDownloadWorker.enqueueOneTime` is mocked because the production
+ * `doWork()` chains a manual-trigger download sweep at the end — irrelevant
+ * here, and unsafe to call from a unit test without a real WorkManager.
+ */
+class StashDiscoveryWorkerStreamOnlyTest {
+
+    private val appContext: Context = mockk(relaxed = true)
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val downloadQueueDao: DownloadQueueDao = mockk(relaxed = true)
+    private val trackDao: TrackDao = mockk(relaxed = true)
+    private val recipeDao: StashMixRecipeDao = mockk(relaxed = true)
+    // TrackMatcher is a final @Singleton class with no Android deps — use the
+    // real implementation so canonical title/artist normalisation flows
+    // through end-to-end (mirrors how the worker uses it).
+    private val trackMatcher: TrackMatcher = TrackMatcher()
+    private val blocklistGuard: BlocklistGuard = mockk {
+        coEvery { isBlocked(any(), any(), any(), any()) } returns false
+    }
+    private val downloadNetworkPreference: DownloadNetworkPreference = mockk {
+        coEvery { current() } returns DownloadNetworkMode.WIFI_AND_CHARGING
+    }
+
+    @Before fun setUp() {
+        // `doWork()` chains DiscoveryDownloadWorker.enqueueOneTime → WorkManager
+        // .getInstance. Stubbing the companion object here keeps the test pure
+        // (no Robolectric WorkManager bring-up needed).
+        mockkObject(DiscoveryDownloadWorker.Companion)
+        coEvery { DiscoveryDownloadWorker.enqueueOneTime(any(), any()) } returns Unit
+    }
+
+    @After fun tearDown() {
+        unmockkObject(DiscoveryDownloadWorker.Companion)
+    }
+
+    private fun newWorker(): StashDiscoveryWorker {
+        val params: WorkerParameters = mockk(relaxed = true)
+        return StashDiscoveryWorker(
+            appContext, params,
+            discoveryQueueDao, downloadQueueDao, trackDao, recipeDao,
+            trackMatcher, blocklistGuard, downloadNetworkPreference,
+        )
+    }
+
+    @Test fun `mix recipe discovery inserts streamable stub and skips download_queue`() = runTest {
+        val recipe = StashMixRecipeEntity(
+            id = 1L,
+            name = "Daily Discover",
+            playlistId = 100L,  // recipe is materialized: PlaylistType.STASH_MIX
+            isBuiltin = true,
+            isActive = true,
+        )
+        // Recipe.playlistId points at the materialized STASH_MIX playlist;
+        // mock it so callers that look up the playlist's type can resolve.
+        val pending = DiscoveryQueueEntity(
+            id = 42L,
+            recipeId = 1L,
+            artist = "Test Artist",
+            title = "Test Track",
+            seedArtist = "Some Seed",
+            status = DiscoveryQueueEntity.STATUS_PENDING,
+        )
+
+        coEvery { discoveryQueueDao.deleteStalePending(any()) } returns 0
+        coEvery {
+            discoveryQueueDao.findRecipesAtWeeklyCap(any(), any())
+        } returns emptyList()
+        coEvery { discoveryQueueDao.getPending(any()) } returns listOf(pending)
+        coEvery {
+            discoveryQueueDao.countRecentCompletedForRecipe(1L, any())
+        } returns 0
+        coEvery { recipeDao.getById(1L) } returns recipe
+        // No existing track collision — forces the new-stub branch.
+        coEvery {
+            trackDao.findDownloadedByCanonical(any(), any())
+        } returns null
+
+        val insertedTrack = slot<TrackEntity>()
+        coEvery { trackDao.insert(capture(insertedTrack)) } returns 999L
+
+        newWorker().doWork()
+
+        // The stub MUST land as a streamable, non-downloaded row so the new
+        // PlaylistDao.getStreamableOrDoneTrackIdsForRecipe query picks it up
+        // for the Mix playlist on the next materializeMix pass.
+        assertTrue(
+            "stub track must be flagged isStreamable=true",
+            insertedTrack.captured.isStreamable,
+        )
+        assertFalse(
+            "stub track must NOT be flagged isDownloaded=true at insert time",
+            insertedTrack.captured.isDownloaded,
+        )
+
+        // Critical assertion: no download_queue row for the new stub. This is
+        // what diverts the new discovery from the v0.9.20 download pipeline
+        // onto the v0.9.30 streaming engine.
+        coVerify(exactly = 0) { downloadQueueDao.insert(any<DownloadQueueEntity>()) }
+
+        // Discovery row was still marked DONE with the new trackId so the
+        // materializer can re-link it on the next mix refresh.
+        coVerify(exactly = 1) {
+            discoveryQueueDao.updateStatus(
+                id = 42L,
+                status = DiscoveryQueueEntity.STATUS_DONE,
+                trackId = 999L,
+                completedAt = any(),
+                errorMessage = null,
+            )
+        }
+    }
+
+    @Test fun `existing downloaded track is reused without re-insert or enqueue`() = runTest {
+        // Sanity guard: the dedup branch (matched a track already on disk) must
+        // continue to skip BOTH the stub-insert AND the download-queue insert.
+        // No regression from the stream-only seam.
+        val recipe = StashMixRecipeEntity(
+            id = 1L,
+            name = "Daily Discover",
+            playlistId = 100L,
+            isBuiltin = true,
+            isActive = true,
+        )
+        val pending = DiscoveryQueueEntity(
+            id = 7L,
+            recipeId = 1L,
+            artist = "Library Artist",
+            title = "Library Track",
+            seedArtist = "Some Seed",
+        )
+        val existing = TrackEntity(
+            id = 555L,
+            title = "Library Track",
+            artist = "Library Artist",
+            canonicalTitle = "library track",
+            canonicalArtist = "library artist",
+            isDownloaded = true,
+        )
+
+        coEvery { discoveryQueueDao.deleteStalePending(any()) } returns 0
+        coEvery {
+            discoveryQueueDao.findRecipesAtWeeklyCap(any(), any())
+        } returns emptyList()
+        coEvery { discoveryQueueDao.getPending(any()) } returns listOf(pending)
+        coEvery {
+            discoveryQueueDao.countRecentCompletedForRecipe(1L, any())
+        } returns 0
+        coEvery { recipeDao.getById(1L) } returns recipe
+        coEvery {
+            trackDao.findDownloadedByCanonical(any(), any())
+        } returns existing
+
+        newWorker().doWork()
+
+        coVerify(exactly = 0) { trackDao.insert(any<TrackEntity>()) }
+        coVerify(exactly = 0) { downloadQueueDao.insert(any<DownloadQueueEntity>()) }
+        coVerify(exactly = 1) {
+            discoveryQueueDao.updateStatus(
+                id = 7L,
+                status = DiscoveryQueueEntity.STATUS_DONE,
+                trackId = 555L,
+                completedAt = any(),
+                errorMessage = null,
+            )
+        }
+    }
+
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerDedupTest.kt
@@ -79,9 +79,11 @@ class StashMixRefreshWorkerDedupTest {
         coEvery { mixGenerator.generate(dailyDiscover, capture(excludeCaptureDailyDiscover)) } returns listOf(track(20L), track(21L))
 
         // First Listen brings 5 discovery survivors; Deep Cuts brings 6 (10, 11 are also library); Daily Discover 7 (1 is in First Listen).
-        coEvery { discoveryQueueDao.getDoneTrackIdsForRecipe(firstListen.id, any()) } returns listOf(1L, 2L, 3L, 4L, 5L)
-        coEvery { discoveryQueueDao.getDoneTrackIdsForRecipe(deepCuts.id, any()) } returns listOf(6L, 7L, 8L, 9L, 10L, 11L)
-        coEvery { discoveryQueueDao.getDoneTrackIdsForRecipe(dailyDiscover.id, any()) } returns listOf(1L, 12L, 13L, 14L, 15L, 16L, 17L)
+        // v0.9.37: materializeMix now pulls survivors via PlaylistDao.getStreamableOrDoneTrackIdsForRecipe
+        // (downloaded OR streamable), so the stub moves from DiscoveryQueueDao to PlaylistDao.
+        coEvery { playlistDao.getStreamableOrDoneTrackIdsForRecipe(firstListen.id) } returns listOf(1L, 2L, 3L, 4L, 5L)
+        coEvery { playlistDao.getStreamableOrDoneTrackIdsForRecipe(deepCuts.id) } returns listOf(6L, 7L, 8L, 9L, 10L, 11L)
+        coEvery { playlistDao.getStreamableOrDoneTrackIdsForRecipe(dailyDiscover.id) } returns listOf(1L, 12L, 13L, 14L, 15L, 16L, 17L)
 
         coEvery { playlistDao.getById(any()) } returns null
         coEvery { playlistDao.insert(any()) } returnsMany listOf(100L, 200L, 300L)

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerPerRecipeDedupTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerPerRecipeDedupTest.kt
@@ -88,7 +88,7 @@ class StashMixRefreshWorkerPerRecipeDedupTest {
         val excludeCapture = slot<Set<Long>>()
         coEvery { mixGenerator.generate(targetRecipe, capture(excludeCapture)) } returns emptyList()
         coEvery {
-            discoveryQueueDao.getDoneTrackIdsForRecipe(any(), any())
+            playlistDao.getStreamableOrDoneTrackIdsForRecipe(any())
         } returns emptyList()
 
         newWorker(recipeId = 1L).doWork()
@@ -112,7 +112,7 @@ class StashMixRefreshWorkerPerRecipeDedupTest {
         val excludeCapture = slot<Set<Long>>()
         coEvery { mixGenerator.generate(targetRecipe, capture(excludeCapture)) } returns emptyList()
         coEvery {
-            discoveryQueueDao.getDoneTrackIdsForRecipe(any(), any())
+            playlistDao.getStreamableOrDoneTrackIdsForRecipe(any())
         } returns emptyList()
 
         newWorker(recipeId = 1L).doWork()

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerStreamOnlyMaterializeTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerStreamOnlyMaterializeTest.kt
@@ -1,0 +1,155 @@
+package com.stash.core.data.sync.workers
+
+import android.content.Context
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DiscoveryQueueDao
+import com.stash.core.data.db.dao.ListeningEventDao
+import com.stash.core.data.db.dao.PlaylistDao
+import com.stash.core.data.db.dao.StashMixRecipeDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.dao.TrackSkipEventDao
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.PlaylistTrackCrossRef
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.lastfm.LastFmApiClient
+import com.stash.core.data.lastfm.LastFmCredentials
+import com.stash.core.data.lastfm.LastFmSessionPreference
+import com.stash.core.data.mix.MixGenerator
+import com.stash.core.data.mix.MixSeedGenerator
+import com.stash.core.data.sync.TrackMatcher
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * MockK end-to-end test for the v0.9.37 Stash Mix streaming-first rollout
+ * (Task 3). `StashMixRefreshWorker.materializeMix` now sources discovery
+ * survivors via `PlaylistDao.getStreamableOrDoneTrackIdsForRecipe` instead
+ * of `DiscoveryQueueDao.getDoneTrackIdsForRecipe`, so DONE rows whose track
+ * stub is stream-only (is_streamable = 1, is_downloaded = 0) are linked
+ * into the materialized Mix playlist alongside downloaded survivors.
+ *
+ * The DAO query itself is unit-tested in `PlaylistDaoStreamableOrDoneTest`
+ * — this test verifies the WORKER calls the streaming-aware query (not the
+ * legacy downloaded-only one) and inserts the returned ids as
+ * [PlaylistTrackCrossRef] rows on the Mix playlist.
+ */
+class StashMixRefreshWorkerStreamOnlyMaterializeTest {
+
+    private val appContext: Context = mockk(relaxed = true)
+    private val recipeDao: StashMixRecipeDao = mockk(relaxed = true)
+    private val playlistDao: PlaylistDao = mockk(relaxed = true)
+    private val discoveryQueueDao: DiscoveryQueueDao = mockk(relaxed = true)
+    private val listeningEventDao: ListeningEventDao = mockk(relaxed = true)
+    private val trackDao: TrackDao = mockk(relaxed = true)
+    private val mixGenerator: MixGenerator = mockk()
+    private val seedGenerator: MixSeedGenerator = mockk(relaxed = true)
+    private val lastFmApiClient: LastFmApiClient = mockk(relaxed = true)
+    private val lastFmCredentials: LastFmCredentials = mockk {
+        // Skip the discovery/Last.fm queueing branch entirely — irrelevant to
+        // the materializeMix swap under test.
+        coEvery { isConfigured } returns false
+    }
+    private val sessionPreference: LastFmSessionPreference = mockk {
+        coEvery { session } returns flowOf(null)
+    }
+    private val blocklistGuard: BlocklistGuard = mockk {
+        coEvery { isBlockedByTrackId(any()) } returns false
+    }
+    private val trackSkipEventDao: TrackSkipEventDao = mockk(relaxed = true)
+    private val trackMatcher: TrackMatcher = mockk(relaxed = true)
+
+    private fun newWorker(recipeId: Long): StashMixRefreshWorker {
+        val params: WorkerParameters = mockk(relaxed = true) {
+            coEvery { inputData } returns workDataOf(
+                StashMixRefreshWorker.KEY_RECIPE_ID to recipeId,
+            )
+        }
+        return StashMixRefreshWorker(
+            appContext, params,
+            recipeDao, playlistDao, discoveryQueueDao, listeningEventDao,
+            trackDao, mixGenerator, seedGenerator, lastFmApiClient,
+            lastFmCredentials, sessionPreference, blocklistGuard,
+            trackSkipEventDao, trackMatcher,
+        )
+    }
+
+    @Test fun `materializeMix links downloaded AND stream-only discovery survivors`() = runTest {
+        val recipe = recipe(id = 1L, name = "Daily Discover", playlistId = 100L)
+
+        coEvery { recipeDao.getById(1L) } returns recipe
+        coEvery { recipeDao.getActive() } returns listOf(recipe)
+
+        // Library section empty — focus the assertion on the discovery
+        // survivors pulled in via the new DAO query.
+        coEvery { mixGenerator.generate(recipe, any()) } returns emptyList()
+
+        // Existing playlist found (skips the create branch).
+        coEvery { playlistDao.getById(100L) } returns PlaylistEntity(
+            id = 100L,
+            name = "Daily Discover",
+            source = MusicSource.BOTH,
+            sourceId = "stash_mix_1",
+            type = PlaylistType.STASH_MIX,
+            trackCount = 0,
+            syncEnabled = true,
+            isActive = true,
+        )
+
+        // The new query returns BOTH the downloaded survivor AND the
+        // stream-only one. The legacy DAO would have filtered out the
+        // stream-only id by `is_downloaded = 1` — this is the swap's
+        // whole point.
+        val downloadedTrackId = 555L
+        val streamOnlyTrackId = 777L
+        coEvery {
+            playlistDao.getStreamableOrDoneTrackIdsForRecipe(1L)
+        } returns listOf(downloadedTrackId, streamOnlyTrackId)
+
+        val insertedCrossRefs = mutableListOf<PlaylistTrackCrossRef>()
+        coEvery { playlistDao.insertCrossRef(capture(insertedCrossRefs)) } returns Unit
+
+        newWorker(recipeId = 1L).doWork()
+
+        // BOTH ids must have been linked to the Mix playlist (id=100L).
+        val linkedTrackIds = insertedCrossRefs
+            .filter { it.playlistId == 100L }
+            .map { it.trackId }
+            .toSet()
+        assertEquals(
+            "materializeMix must link both downloaded and stream-only DONE survivors",
+            setOf(downloadedTrackId, streamOnlyTrackId),
+            linkedTrackIds,
+        )
+        assertTrue(
+            "every linked row must point at the materialized Mix playlist",
+            insertedCrossRefs.all { it.playlistId == 100L },
+        )
+
+        // Legacy DAO method MUST NOT be used as the survivor source — if it
+        // is, stream-only stubs disappear from the Mix again. (This is the
+        // core regression we'd silently introduce by reverting the swap.)
+        coVerify(exactly = 0) {
+            discoveryQueueDao.getDoneTrackIdsForRecipe(any(), any())
+        }
+    }
+
+    private fun recipe(id: Long, name: String, playlistId: Long?) = StashMixRecipeEntity(
+        id = id,
+        name = name,
+        discoveryRatio = 0.85f,
+        targetLength = 40,
+        playlistId = playlistId,
+        isBuiltin = true,
+        isActive = true,
+    )
+}

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepository.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepository.kt
@@ -82,6 +82,22 @@ interface PlayerRepository {
      */
     val streamingHaltedEvents: kotlinx.coroutines.flow.SharedFlow<StreamingHaltedEvent>
 
+    /**
+     * Snackbar-targeted one-shot messages from playback flow. Used for
+     * conditions the player layer surfaces directly to the user:
+     *
+     *  - "Couldn't play this track right now." — `setQueue` couldn't
+     *    resolve the tapped track via any source.
+     *  - "End of offline Mix" — auto-advance silent-skip exhausted the
+     *    queue trying to find a playable item while offline (v0.9.37).
+     *
+     * Collected by NowPlayingViewModel and forwarded into its own
+     * `userMessages` SharedFlow so the Snackbar/Toast surfaces while the
+     * user is on Now Playing or anywhere else the global player UI is
+     * visible.
+     */
+    val userMessages: kotlinx.coroutines.flow.SharedFlow<String>
+
     /** Start or resume playback. */
     suspend fun play()
 

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -1054,7 +1054,16 @@ class PlayerRepositoryImpl @Inject constructor(
             // or `hasNextMediaItem()` returns false (handled in
             // `maybeSkipOfflineStreamOnly`). No manual loop needed; this
             // matches the existing `recoverOrStop` re-entrancy pattern.
-            mediaItem?.let { maybeSkipOfflineStreamOnly(controller, it) }
+            //
+            // Gate on REASON_AUTO so only natural queue advancement triggers
+            // the silent-skip. Explicit user skips (REASON_SEEK), repeat-one
+            // wraparounds (REASON_REPEAT), and code-driven queue changes
+            // (REASON_PLAYLIST_CHANGED) bypass it — those surfaces have
+            // their own gating (tap-time guard in Task 5, user intent for
+            // repeat, consumer choice for queue mutations).
+            if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
+                mediaItem?.let { maybeSkipOfflineStreamOnly(controller, it) }
+            }
             updateState(controller)
         }
 

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -31,6 +31,7 @@ import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_STREAM_
 import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_STREAM_SAMPLE_RATE
 import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_TRACK_DURATION_MS
 import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_TRACK_ID
+import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_TRACK_IS_STREAMABLE
 import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_TRACK_YOUTUBE_ID
 import com.stash.core.model.TrackItem
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -240,13 +241,17 @@ class PlayerRepositoryImpl @Inject constructor(
         onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST,
     )
     /**
-     * Snackbar-targeted messages from playback flow ("Couldn't play this
-     * track right now."). Surfaced when [setQueue]'s tapped track can't
-     * be resolved by any source so the user knows the tap was received
-     * but the track is genuinely unavailable. Collected by Now Playing
-     * + playlist detail screens.
+     * Snackbar-targeted messages from playback flow:
+     *   - "Couldn't play this track right now." — [setQueue]'s tapped
+     *     track failed every resolver, surfaced so the user knows the
+     *     tap was received but the track is genuinely unavailable.
+     *   - "End of offline Mix" — the auto-advance silent-skip walked off
+     *     the end of the queue trying to find a playable item while the
+     *     device was offline (v0.9.37).
+     * Collected by Now Playing (forwarded into its own user-messages
+     * SharedFlow for Toast display) and the playlist detail screen.
      */
-    val userMessages: kotlinx.coroutines.flow.SharedFlow<String> =
+    override val userMessages: kotlinx.coroutines.flow.SharedFlow<String> =
         _userMessages.asSharedFlow()
 
     private val cascadeGuard = StreamErrorCascadeGuard()
@@ -878,6 +883,7 @@ class PlayerRepositoryImpl @Inject constructor(
                                 putLong(EXTRA_TRACK_ID, track.id)
                                 track.youtubeId?.let { putString(EXTRA_TRACK_YOUTUBE_ID, it) }
                                 if (track.durationMs > 0) putLong(EXTRA_TRACK_DURATION_MS, track.durationMs)
+                                putBoolean(EXTRA_TRACK_IS_STREAMABLE, track.isStreamable)
                             })
                             .build()
                     )
@@ -932,6 +938,7 @@ class PlayerRepositoryImpl @Inject constructor(
                             putLong(EXTRA_TRACK_ID, track.id)
                             track.youtubeId?.let { putString(EXTRA_TRACK_YOUTUBE_ID, it) }
                             if (track.durationMs > 0) putLong(EXTRA_TRACK_DURATION_MS, track.durationMs)
+                            putBoolean(EXTRA_TRACK_IS_STREAMABLE, track.isStreamable)
                             // Surface the actual format Qobuz served so Now Playing
                             // shows "FLAC · 24-bit/96 kHz" instead of the stale Room
                             // default ("opus") that streaming-only rows carry forever.
@@ -1035,6 +1042,19 @@ class PlayerRepositoryImpl @Inject constructor(
                 Log.w(TAG, "onMediaItemTransition landed in STATE_IDLE — defensive prepare()")
                 controller.prepare()
             }
+            // v0.9.37 (Mixes Stream-Only Task 6): silent-skip stream-only
+            // tracks while offline. Connectivity is dynamic — the user may
+            // toggle airplane mid-playback — so we can't filter the queue
+            // at build time; instead we observe each transition and skip
+            // forward when the now-current item is stream-only but the
+            // device can no longer reach it. Naturally tail-recursive
+            // through the listener: a single `seekToNextMediaItem` call
+            // re-fires `onMediaItemTransition` with the next item, which
+            // re-runs this guard until either a playable item is reached
+            // or `hasNextMediaItem()` returns false (handled in
+            // `maybeSkipOfflineStreamOnly`). No manual loop needed; this
+            // matches the existing `recoverOrStop` re-entrancy pattern.
+            mediaItem?.let { maybeSkipOfflineStreamOnly(controller, it) }
             updateState(controller)
         }
 
@@ -1141,6 +1161,51 @@ class PlayerRepositoryImpl @Inject constructor(
     }
 
     /**
+     * v0.9.37: silent-skip stream-only tracks that the queue would play
+     * but the user can't reach because the device is offline. Invoked
+     * from [Player.Listener.onMediaItemTransition] for every queue
+     * advance (whether driven by auto-advance, user skip, or a previous
+     * silent-skip).
+     *
+     * **Re-entrancy:** uses Media3's natural tail-recursion through the
+     * listener — a single [MediaController.seekToNextMediaItem] call
+     * re-fires `onMediaItemTransition`, which re-invokes this function
+     * with the new current item. No manual loop, no re-entrancy flag.
+     * Mirrors the existing [recoverOrStop] pattern used by `onPlayerError`.
+     *
+     * **Default safety:** when [EXTRA_TRACK_IS_STREAMABLE] is absent
+     * (legacy items, downloaded tracks, items built outside
+     * [buildMediaItemForTrack]), `getBoolean(..., false)` returns false
+     * and we treat the item as not-streamable → don't skip, let it play.
+     * Downloaded items always play regardless of network state.
+     *
+     * **End of queue:** when no next item exists, the player is paused
+     * (rather than [MediaController.stop]ed — pause preserves the queue
+     * for when connectivity returns) and a Snackbar is emitted via
+     * [_userMessages] so the user understands why the music stopped.
+     */
+    private fun maybeSkipOfflineStreamOnly(controller: MediaController, item: MediaItem) {
+        if (connectivity.isConnected()) return
+        val isStreamable = item.mediaMetadata.extras?.getBoolean(EXTRA_TRACK_IS_STREAMABLE, false) == true
+        if (!isStreamable) return
+        val failingTitle = item.mediaMetadata.title?.toString()
+        if (controller.hasNextMediaItem()) {
+            Log.i(
+                TAG,
+                "silent-skip: offline + stream-only '$failingTitle' — advancing to next item",
+            )
+            controller.seekToNextMediaItem()
+        } else {
+            Log.i(
+                TAG,
+                "silent-skip: offline + stream-only '$failingTitle' — end of queue, pausing",
+            )
+            controller.pause()
+            _userMessages.tryEmit("End of offline Mix")
+        }
+    }
+
+    /**
      * Reads the current state from the [MediaController] and publishes it to
      * [_playerState]. Also persists the current position via [PlaybackStateStore].
      */
@@ -1237,6 +1302,7 @@ class PlayerRepositoryImpl @Inject constructor(
                 putLong(EXTRA_TRACK_ID, id)
                 youtubeId?.let { putString(EXTRA_TRACK_YOUTUBE_ID, it) }
                 if (durationMs > 0) putLong(EXTRA_TRACK_DURATION_MS, durationMs)
+                putBoolean(EXTRA_TRACK_IS_STREAMABLE, isStreamable)
             })
             .build()
 

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -29,7 +29,9 @@ import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_STREAM_
 import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_STREAM_CODEC
 import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_STREAM_ORIGIN
 import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_STREAM_SAMPLE_RATE
+import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_TRACK_DURATION_MS
 import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_TRACK_ID
+import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_TRACK_YOUTUBE_ID
 import com.stash.core.model.TrackItem
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
@@ -872,7 +874,11 @@ class PlayerRepositoryImpl @Inject constructor(
                             .setArtworkUri(
                                 (track.albumArtPath ?: track.albumArtUrl)?.let { Uri.parse(it) }
                             )
-                            .setExtras(Bundle().apply { putLong(EXTRA_TRACK_ID, track.id) })
+                            .setExtras(Bundle().apply {
+                                putLong(EXTRA_TRACK_ID, track.id)
+                                track.youtubeId?.let { putString(EXTRA_TRACK_YOUTUBE_ID, it) }
+                                if (track.durationMs > 0) putLong(EXTRA_TRACK_DURATION_MS, track.durationMs)
+                            })
                             .build()
                     )
                     .build()
@@ -924,6 +930,8 @@ class PlayerRepositoryImpl @Inject constructor(
                         )
                         .setExtras(Bundle().apply {
                             putLong(EXTRA_TRACK_ID, track.id)
+                            track.youtubeId?.let { putString(EXTRA_TRACK_YOUTUBE_ID, it) }
+                            if (track.durationMs > 0) putLong(EXTRA_TRACK_DURATION_MS, track.durationMs)
                             // Surface the actual format Qobuz served so Now Playing
                             // shows "FLAC · 24-bit/96 kHz" instead of the stale Room
                             // default ("opus") that streaming-only rows carry forever.
@@ -1225,7 +1233,11 @@ class PlayerRepositoryImpl @Inject constructor(
             .setArtworkUri(
                 (albumArtPath ?: albumArtUrl)?.toUri()
             )
-            .setExtras(Bundle().apply { putLong(EXTRA_TRACK_ID, id) })
+            .setExtras(Bundle().apply {
+                putLong(EXTRA_TRACK_ID, id)
+                youtubeId?.let { putString(EXTRA_TRACK_YOUTUBE_ID, it) }
+                if (durationMs > 0) putLong(EXTRA_TRACK_DURATION_MS, durationMs)
+            })
             .build()
 
         // Ensure file:// scheme so StashPlaybackService's URI validation passes.
@@ -1273,8 +1285,15 @@ class PlayerRepositoryImpl @Inject constructor(
             artist = meta.artist?.toString() ?: "",
             album = meta.albumTitle?.toString() ?: "",
             albumArtUrl = meta.artworkUri?.toString(),
-            // For non-library tracks, the mediaId is the YouTube videoId.
-            youtubeId = if (trackId == 0L) mediaId else null,
+            durationMs = extras?.getLong(EXTRA_TRACK_DURATION_MS, 0L) ?: 0L,
+            // For non-library tracks (id=0L), the mediaId is the YouTube
+            // videoId. For streaming-engine tracks (synthetic non-zero id),
+            // the videoId is carried explicitly in extras so downstream
+            // code (Now Playing's like-state observation, ensure-persisted
+            // upsert) can resolve identity without a real DB row
+            // (issue #105 follow-up).
+            youtubeId = extras?.getString(EXTRA_TRACK_YOUTUBE_ID)
+                ?: if (trackId == 0L) mediaId else null,
             source = if (trackId == 0L) com.stash.core.model.MusicSource.YOUTUBE else com.stash.core.model.MusicSource.SPOTIFY,
             fileFormat = streamCodec ?: "opus",
             bitsPerSample = streamBitDepth,

--- a/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
@@ -592,7 +592,9 @@ class StashPlaybackService : MediaLibraryService() {
                     val playlistId = mediaItems[0].mediaId.removePrefix(SHUFFLE_PLAY_PREFIX).toLongOrNull()
                     if (playlistId != null) {
                         val tracks = playlistDao.getTracksForPlaylist(playlistId)
-                        val items = tracks.filter{track -> track.isDownloaded}.map { track ->
+                        // v0.9.37: include streamable tracks so stream-only Mix entries are
+                        // playable. Downloaded-only filter would silently drop them.
+                        val items = tracks.filter{track -> track.isDownloaded || track.isStreamable}.map { track ->
                             MediaItem.Builder()
                                 .setMediaId(track.id.toString())
                                 .setUri(track.filePath ?: "")
@@ -841,7 +843,9 @@ class StashPlaybackService : MediaLibraryService() {
                                     )
                                     .build()
 
-                                val tracks = playlistDao.getTracksForPlaylist(playlistId).filter{track -> track.isDownloaded}.map { track ->
+                                // v0.9.37: include streamable tracks so stream-only Mix entries are
+                                // playable. Downloaded-only filter would silently drop them.
+                                val tracks = playlistDao.getTracksForPlaylist(playlistId).filter{track -> track.isDownloaded || track.isStreamable}.map { track ->
                                     MediaItem.Builder()
                                         .setMediaId(track.id.toString())
                                         .setUri(track.filePath ?: "")

--- a/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
@@ -100,6 +100,14 @@ class StashPlaybackService : MediaLibraryService() {
          */
         const val EXTRA_TRACK_DURATION_MS = "stash_track_duration_ms"
 
+        /**
+         * Extra key for the track's `isStreamable` flag. Carried alongside
+         * [EXTRA_TRACK_ID] so the auto-advance listener can decide whether
+         * to silent-skip a track that the queue would play but the user
+         * can't reach (stream-only + offline). v0.9.37.
+         */
+        const val EXTRA_TRACK_IS_STREAMABLE = "stash_track_is_streamable"
+
         // ── Streaming-format extras ───────────────────────────────────
         // Written into MediaMetadata.extras when a streaming-only track
         // gets its URL resolved (PlayerRepositoryImpl.buildMediaItemForTrack).

--- a/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
@@ -36,8 +36,11 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.guava.future
@@ -79,6 +82,23 @@ class StashPlaybackService : MediaLibraryService() {
 
         /** Extra key for the track ID in MediaMetadata extras. */
         const val EXTRA_TRACK_ID = "stash_track_id"
+
+        /**
+         * Extra key for the track's YouTube video id. Carried alongside
+         * [EXTRA_TRACK_ID] so the notification heart can resolve a
+         * v0.9.30 streaming-engine synthetic id to a real DB row via
+         * `TrackDao.findByYoutubeId` (issue #105 fix).
+         */
+        const val EXTRA_TRACK_YOUTUBE_ID = "stash_track_youtube_id"
+
+        /**
+         * Extra key for the track's duration in milliseconds. Without
+         * this, `MediaItem.toTrack` rehydrates streaming tracks with
+         * `durationMs = 0` (the domain default), and `ensureTrackPersisted`
+         * then inserts a Liked-Songs row with duration 0:00 (issue #105
+         * follow-up: Liked Songs detail showed 0:00 for stream-only tracks).
+         */
+        const val EXTRA_TRACK_DURATION_MS = "stash_track_duration_ms"
 
         // ── Streaming-format extras ───────────────────────────────────
         // Written into MediaMetadata.extras when a streaming-only track
@@ -311,7 +331,9 @@ class StashPlaybackService : MediaLibraryService() {
     private fun updateCustomLayout() {
         val session = mediaSession ?: return
         val player = session.player
-        val trackId = player.currentMediaItem?.mediaId?.toLongOrNull()
+        val mediaItem = player.currentMediaItem
+        val trackId = mediaItem?.mediaId?.toLongOrNull()
+        val youtubeId = mediaItem?.mediaMetadata?.extras?.getString(EXTRA_TRACK_YOUTUBE_ID)
 
         if (trackId == null) {
             likeObserverJob?.cancel()
@@ -331,9 +353,19 @@ class StashPlaybackService : MediaLibraryService() {
             pushLayout(session, player, false)
 
             likeObserverJob = serviceScope.launch {
-                trackDao.observeLikeState(trackId).collect { state ->
+                // The id-keyed observer doesn't match streaming-engine
+                // synthetic ids; fall back to youtube_id so the heart
+                // tracks Room's truth even for stream-only tracks. The
+                // service stays in sync with Now Playing's optimistic
+                // flip because `MusicRepository.ensureTrackPersisted`
+                // writes a row with the same `youtube_id` on like.
+                val likeFlow = trackDao.observeLikeState(trackId)
+                    .flatMapLatest { state ->
+                        if (state != null || youtubeId.isNullOrBlank()) flowOf(state)
+                        else trackDao.observeLikeStateByYoutubeId(youtubeId)
+                    }
+                likeFlow.collect { state ->
                     val isLiked = state?.stashLikedAt != null
-                    // Update if the state actually changed, or if we haven't pushed for this track yet.
                     if (isLiked != lastIsLiked) {
                         lastIsLiked = isLiked
                         pushLayout(session, player, lastIsLiked)
@@ -420,6 +452,69 @@ class StashPlaybackService : MediaLibraryService() {
         mediaSession = null
         super.onDestroy()
     }
+
+    /**
+     * Resolves the Room PK for a Like-toggle from MediaSession state. The
+     * `mediaId` may be a v0.9.30 streaming-engine synthetic id
+     * (`videoId.hashCode().toLong()`) that doesn't exist in `tracks` —
+     * passing it to a FK-bearing write crashes the service. Mirrors the
+     * upsert pattern in `MusicRepositoryImpl.ensureTrackPersisted` /
+     * `SearchDownloadCoordinator.upsertSearchTrack`.
+     *
+     * @return the real `tracks.id` to use; never returns a synthetic id.
+     * @throws IllegalStateException when no identity info is recoverable
+     *   from the MediaItem (i.e. neither a real candidate id nor a
+     *   youtubeId / title / artist that maps to one).
+     */
+    private suspend fun resolveTrackIdForLike(
+        candidateId: Long,
+        youtubeId: String?,
+        metadata: MediaMetadata,
+    ): Long {
+        // Real Room PK already? Cheap exit.
+        if (candidateId > 0L && trackDao.getById(candidateId) != null) return candidateId
+
+        // YouTube id is the most reliable secondary identity.
+        if (!youtubeId.isNullOrBlank()) {
+            trackDao.findByYoutubeId(youtubeId)?.let { return it.id }
+        }
+
+        val title = metadata.title?.toString().orEmpty()
+        val artist = metadata.artist?.toString().orEmpty()
+        val album = metadata.albumTitle?.toString().orEmpty()
+        val albumArtist = metadata.albumArtist?.toString().orEmpty()
+        val cTitle = canonicalizeIdentity(title)
+        val cArtist = canonicalizeIdentity(artist)
+
+        if (cTitle.isNotBlank() && cArtist.isNotBlank()) {
+            trackDao.findByCanonicalIdentity(cTitle, cArtist)?.let { return it.id }
+        }
+
+        check(title.isNotBlank() && artist.isNotBlank()) {
+            "Cannot resolve track id for like: no youtubeId and no title/artist metadata"
+        }
+
+        return trackDao.insert(
+            TrackEntity(
+                title = title,
+                artist = artist,
+                album = album,
+                albumArtist = albumArtist,
+                youtubeId = youtubeId,
+                canonicalTitle = cTitle,
+                canonicalArtist = cArtist,
+                source = com.stash.core.model.MusicSource.YOUTUBE,
+                isStreamable = true,
+                isDownloaded = false,
+            )
+        )
+    }
+
+    private fun canonicalizeIdentity(s: String): String =
+        s.lowercase()
+            .replace(Regex("[^\\p{L}\\p{N}\\s]"), " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
 
     // ---- MediaLibrarySession.Callback ----
 
@@ -861,19 +956,44 @@ class StashPlaybackService : MediaLibraryService() {
                     }
                 }
                 COMMAND_TOGGLE_LIKE -> {
-                    val trackId = session.player.currentMediaItem?.mediaId?.toLongOrNull()
-                    if (trackId != null) {
+                    val mediaItem = session.player.currentMediaItem
+                    val mediaMetadata = mediaItem?.mediaMetadata
+                    val candidateId = mediaItem?.mediaId?.toLongOrNull()
+                    val youtubeId = mediaMetadata?.extras?.getString(EXTRA_TRACK_YOUTUBE_ID)
+
+                    if (candidateId != null && mediaMetadata != null) {
                         // Optimistic update: toggle the local state and push the layout
                         // immediately so the UI feels snappy and avoids race conditions
                         // where multiple clicks see the same stale DB state.
-                        lastIsLiked = !lastIsLiked
-                        pushLayout(session, session.player, lastIsLiked)
+                        val newLikeState = !lastIsLiked
+                        lastIsLiked = newLikeState
+                        pushLayout(session, session.player, newLikeState)
 
                         serviceScope.launch {
-                            if (lastIsLiked) {
-                                stashLikedRepository.add(trackId)
-                            } else {
-                                stashLikedRepository.remove(trackId)
+                            runCatching {
+                                // Resolve the real Room PK. The mediaId may be a
+                                // v0.9.30 streaming-engine synthetic id
+                                // (`videoId.hashCode().toLong()`); without this
+                                // resolve the next call FK-violates on
+                                // `tracks.id` and crashes the service process
+                                // (issue #105).
+                                val realId = resolveTrackIdForLike(
+                                    candidateId = candidateId,
+                                    youtubeId = youtubeId,
+                                    metadata = mediaMetadata,
+                                )
+
+                                if (newLikeState) stashLikedRepository.add(realId)
+                                else              stashLikedRepository.remove(realId)
+                            }.onFailure { e ->
+                                android.util.Log.w(
+                                    "StashPlayback",
+                                    "notification like toggle failed for candidateId=$candidateId yt=$youtubeId",
+                                    e,
+                                )
+                                // Roll back the optimistic flip so the UI reflects truth.
+                                lastIsLiked = !newLikeState
+                                pushLayout(session, session.player, !newLikeState)
                             }
                         }
                     }

--- a/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
@@ -44,6 +44,8 @@ class ListeningRecorderSkipTest {
         override val currentPosition: Flow<Long> get() = throw UnsupportedOperationException()
         override val streamingHaltedEvents: SharedFlow<StreamingHaltedEvent> =
             MutableSharedFlow<StreamingHaltedEvent>().asSharedFlow()
+        override val userMessages: SharedFlow<String> =
+            MutableSharedFlow<String>().asSharedFlow()
         fun set(state: PlayerState) {
             flow.value = state
         }

--- a/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/InnerTubeClient.kt
+++ b/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/InnerTubeClient.kt
@@ -281,15 +281,21 @@ class InnerTubeClient @Inject constructor(
      * @param query The search query string.
      * @return The parsed JSON response, or null on failure.
      */
-    suspend fun search(query: String): JsonObject? = withContext(Dispatchers.IO) {
+    suspend fun search(query: String, params: String? = null): JsonObject? = withContext(Dispatchers.IO) {
         val cookie = tokenManager.getYouTubeCookie()
         val variant = InnerTubeVariant.WEB_REMIX
         val body = buildJsonObject {
             put("context", buildContext(variant))
             put("query", query)
+            if (params != null) put("params", params)
         }
         executeRequest("$BASE_URL/search", body, cookie, variant)
     }
+
+    /** ytmusicapi-derived filter selector that constrains search results to the
+     *  "Songs" shelf only. With this set, the response reverts to the legacy
+     *  `musicShelfRenderer` shape that downstream parsers expect. */
+    private val songsFilterParams = "EgWKAQIIAWoKEAoQAxAJEAQQBQ%3D%3D"
 
     /**
      * Calls the InnerTube `player` action to get actual video metadata.
@@ -406,16 +412,30 @@ class InnerTubeClient @Inject constructor(
         withContext(Dispatchers.IO) {
             val cookie = tokenManager.getYouTubeCookie()
             val variant = InnerTubeVariant.WEB_REMIX
+            // YT's anti-bot challenge for /player rejects requests missing
+            // playbackContext.contentPlaybackContext.signatureTimestamp with
+            // a RELOAD_PAGE error. signatureTimestamp is the day number
+            // (days since epoch) and tells YouTube which JS player build the
+            // client is on; sending today's value passes the freshness check.
+            val signatureTimestamp = (System.currentTimeMillis() / 86_400_000L).toInt() - 1
             val body = buildJsonObject {
                 put("context", buildContext(variant))
                 put("videoId", videoId)
+                putJsonObject("playbackContext") {
+                    putJsonObject("contentPlaybackContext") {
+                        put("signatureTimestamp", signatureTimestamp)
+                    }
+                }
             }
             val response = executeRequest("$BASE_URL/player", body, cookie, variant)
                 ?: return@withContext null
             PlaybackTrackingParser().extract(response)
                 .also { url ->
                     if (url == null) {
-                        Log.w(TAG, "getPlaybackTracking: no playbackTracking block for $videoId")
+                        val playStatus = response["playabilityStatus"]?.jsonObject
+                            ?.get("status")?.jsonPrimitive?.content
+                        Log.w(TAG, "getPlaybackTracking: no playbackTracking block for " +
+                            "$videoId (playabilityStatus=$playStatus)")
                     }
                 }
         }
@@ -444,7 +464,7 @@ class InnerTubeClient @Inject constructor(
     suspend fun searchCanonical(artist: String, title: String): String? =
         withContext(Dispatchers.IO) {
             val query = "$artist $title"
-            val response = search(query) ?: return@withContext null
+            val response = search(query, params = songsFilterParams) ?: return@withContext null
 
             // Walk the Songs shelf(ves) inside the search response. Each row is a
             // musicResponsiveListItemRenderer; we extract videoId and musicVideoType

--- a/docs/superpowers/plans/2026-05-25-stash-mixes-stream-only.md
+++ b/docs/superpowers/plans/2026-05-25-stash-mixes-stream-only.md
@@ -1,0 +1,487 @@
+# Stash Mixes — Stream-Only for New Discoveries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Divert new Stash Mix discoveries from the download pipeline to the existing v0.9.30 streaming engine. Existing downloaded Mix tracks remain on disk and unchanged.
+
+**Architecture:** Single decision point ("Seam A") in `StashDiscoveryWorker.handle()` skips `download_queue` insertion for Mix-recipe items and stamps the new `TrackEntity` with `isStreamable = true, isDownloaded = false`. Downstream consumers (`StashMixRefreshWorker.materializeMix`, `StashPlaybackService` queue filter, Mix tap-handlers) are updated to recognize stream-only tracks as first-class Mix members. Offline UX: Snackbar on tap, silent-skip on auto-advance.
+
+**Tech Stack:** Kotlin coroutines, Room (DAOs + entities), Hilt (DI), Media3 (ExoPlayer/MediaSession), Compose (UI), JUnit + Turbine (tests).
+
+**Spec:** `docs/superpowers/specs/2026-05-25-stash-mixes-stream-only-design.md`
+
+---
+
+## Pre-flight
+
+Before starting Task 1, ensure the working tree is clean. The current `master` carries uncommitted Track B (scrobbler) and Track C (heart/download) fixes — those must be committed first so this plan's commits stay scoped to Track A. The recommended sequence is:
+
+1. Commit Track B (scrobbler) — `feat(scrobbler): restore YT Music history sync (Songs filter + playbackContext)`
+2. Commit Track C (heart/download/Liked-Songs count) — `fix(nowplaying): resolve streaming-track id mismatch for heart, download, count`
+3. **Then** create a worktree for this Track A work: `git worktree add .worktrees/mixes-stream-only -b feat/mixes-stream-only master`. Copy `local.properties` into the worktree per `feedback_worktree_local_properties.md`.
+
+All file paths below are relative to the worktree root.
+
+## File map
+
+| File | Action | Why |
+|---|---|---|
+| `core/data/.../db/dao/PlaylistDao.kt` | Modify | Add `getStreamableOrDoneTrackIdsForRecipe(recipeId)` query |
+| `core/data/.../db/dao/PlaylistDao.kt` | Modify test | Cover the new query |
+| `core/data/.../sync/workers/StashDiscoveryWorker.kt` | Modify | Seam A: skip `download_queue.insert` for STASH_MIX recipes; flag stub `isStreamable = true` |
+| `core/data/.../sync/workers/StashMixRefreshWorker.kt` | Modify | Swap `getDoneTrackIdsForRecipe` → new DAO method in `materializeMix` |
+| `core/media/.../service/StashPlaybackService.kt` | Modify (Task 4) | Two filter sites: `it.isDownloaded` → `it.isDownloaded \|\| it.isStreamable` |
+| `core/media/.../service/StashPlaybackService.kt` | Modify (Task 6) | Add `EXTRA_TRACK_IS_STREAMABLE` companion constant + populate in `buildMediaItemForTrack` |
+| `core/media/.../PlayerRepositoryImpl.kt` | Modify | Auto-advance silent-skip past stream-only tracks while offline |
+| `feature/library/.../PlaylistDetailViewModel.kt` | Modify | Tap-time `MixOfflineTapGuard` (emit Snackbar when offline) |
+| `feature/library/.../PlaylistDetailScreen.kt` | Modify | Wire SnackbarHost + collect events from VM |
+| `feature/home/.../HomeViewModel.kt` (Mix shortcuts) | Modify (if Mix cards launch playback from Home) | Same tap-time guard pattern |
+
+Test files:
+- `core/data/src/test/.../db/dao/PlaylistDaoStreamableOrDoneTest.kt` (new)
+- `core/data/src/test/.../sync/workers/StashDiscoveryWorkerStreamOnlyTest.kt` (new)
+- `core/data/src/test/.../sync/workers/StashMixRefreshWorkerStreamOnlyMaterializeTest.kt` (new)
+- `feature/library/src/test/.../MixOfflineTapGuardTest.kt` (new)
+
+On-device verification (per `feedback_install_after_fix.md`):
+- After every task that ships code into the worker pipeline, run `./gradlew :app:installDebug` and exercise the Mix path manually.
+
+---
+
+## Task 1: New DAO query — `getStreamableOrDoneTrackIdsForRecipe`
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt`
+- Test: `core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoStreamableOrDoneTest.kt` (new)
+
+- [ ] **Step 1: Write the failing test.** Test fixture: insert one `StashMixRecipeEntity`, three `TrackEntity` (one `isDownloaded=true, isStreamable=false`, one `isDownloaded=false, isStreamable=true`, one `isDownloaded=false, isStreamable=false`), link all three via `DiscoveryQueueEntity(status=DONE, recipeId=<recipe>)` to the recipe. Call `dao.getStreamableOrDoneTrackIdsForRecipe(recipeId)`. Expect the returned list to contain the first two ids only.
+
+```kotlin
+@Test
+fun getStreamableOrDoneTrackIdsForRecipe_returnsDownloadedAndStreamable_skipsNeither() = runTest {
+    val recipeId = recipeDao.insert(buildRecipe(name = "Test Mix"))
+    val downloadedId = trackDao.insert(buildTrack(isDownloaded = true, isStreamable = false))
+    val streamableId = trackDao.insert(buildTrack(isDownloaded = false, isStreamable = true))
+    val neitherId = trackDao.insert(buildTrack(isDownloaded = false, isStreamable = false))
+    listOf(downloadedId, streamableId, neitherId).forEach { trackId ->
+        discoveryQueueDao.insert(buildDiscovery(recipeId = recipeId, trackId = trackId, status = DiscoveryQueueStatus.DONE))
+    }
+
+    val result = playlistDao.getStreamableOrDoneTrackIdsForRecipe(recipeId)
+
+    assertThat(result).containsExactlyInAnyOrder(downloadedId, streamableId)
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails.**
+
+```
+./gradlew :core:data:testDebugUnitTest --tests "*PlaylistDaoStreamableOrDoneTest*"
+```
+
+Expected: FAIL with "unresolved reference: getStreamableOrDoneTrackIdsForRecipe".
+
+- [ ] **Step 3: Implement the DAO method.** Mirror the existing `getDoneTrackIdsForRecipe` query (find it via `grep -n "getDoneTrackIdsForRecipe" core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt`) and relax the predicate:
+
+```kotlin
+/**
+ * Like [getDoneTrackIdsForRecipe] but also returns ids whose track row is
+ * stream-only (`is_streamable = 1`, no `is_downloaded`). The Stash Mix
+ * streaming-first rollout (v0.9.37) inserts stream-only stubs from
+ * `StashDiscoveryWorker`; `StashMixRefreshWorker.materializeMix` must
+ * surface both downloaded and streamable tracks when assembling the Mix.
+ */
+@Query("""
+    SELECT t.id FROM tracks t
+    INNER JOIN discovery_queue d ON d.track_id = t.id
+    WHERE d.recipe_id = :recipeId
+      AND d.status = 'DONE'
+      AND (t.is_downloaded = 1 OR t.is_streamable = 1)
+""")
+suspend fun getStreamableOrDoneTrackIdsForRecipe(recipeId: Long): List<Long>
+```
+
+(Adjust column names to match the existing schema. Read `core/data/src/main/kotlin/com/stash/core/data/db/entity/DiscoveryQueueEntity.kt` for the exact column names.)
+
+- [ ] **Step 4: Run the test, verify it passes.**
+
+```
+./gradlew :core:data:testDebugUnitTest --tests "*PlaylistDaoStreamableOrDoneTest*"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```
+git add core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
+git add core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoStreamableOrDoneTest.kt
+git commit -m "feat(playlist): PlaylistDao.getStreamableOrDoneTrackIdsForRecipe"
+```
+
+---
+
+## Task 2: `StashDiscoveryWorker.handle` — skip download enqueue for Mix recipes
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt` (line ~278)
+- Test: `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorkerStreamOnlyTest.kt` (new)
+
+- [ ] **Step 1: Read context.** Open `StashDiscoveryWorker.kt:200-310`. Identify the exact `handle()` flow: how `recipeId` is reached, where the `TrackEntity` stub is built (around line 278-296), where `downloadQueueDao.insert(...)` fires. Confirm a recipe-type check is feasible (the recipe row has `type: PlaylistType` or similar — verify by reading `StashMixRecipeEntity.kt`).
+
+- [ ] **Step 2: Write the failing test.**
+
+```kotlin
+@Test
+fun handle_streamOnlyForStashMixRecipe_skipsDownloadQueueInsert() = runTest {
+    val recipeId = recipeDao.insert(buildStashMixRecipe())
+    val pendingId = discoveryQueueDao.insert(buildPending(recipeId = recipeId, /* artist+title */))
+
+    worker.doWork()
+
+    val track = trackDao.findByCanonicalIdentity(...)!!
+    assertThat(track.isStreamable).isTrue()
+    assertThat(track.isDownloaded).isFalse()
+
+    val queueRows = downloadQueueDao.getAll()
+    assertThat(queueRows).noneMatch { it.trackId == track.id }
+}
+```
+
+- [ ] **Step 3: Run the test, verify it fails.**
+
+```
+./gradlew :core:data:testDebugUnitTest --tests "*StashDiscoveryWorkerStreamOnlyTest*"
+```
+
+Expected: FAIL with downloadQueueDao having an entry for the new track.
+
+- [ ] **Step 4: Implement.** In `StashDiscoveryWorker.handle()` (line ~278), branch on the recipe's type:
+
+```kotlin
+val isMixRecipe = recipe.type == PlaylistType.STASH_MIX  // or however the recipe-type is exposed
+val trackId = trackDao.insert(
+    buildStubTrack().copy(
+        isDownloaded = false,
+        isStreamable = isMixRecipe,
+        // ... rest unchanged
+    )
+)
+if (!isMixRecipe) {
+    downloadQueueDao.insert(buildDownloadQueueEntry(trackId, ...))
+}
+```
+
+**Critical:** apply the same upsert-by-youtubeId discipline as `SearchDownloadCoordinator.upsertSearchTrack` (cited in spec risk #5). The streaming engine may race-insert a row with the same `youtubeId`; collisions on the UNIQUE index must be handled. Use `trackDao.findByYoutubeId(...)` first, fall back to insert.
+
+- [ ] **Step 5: Run the test, verify it passes.**
+
+```
+./gradlew :core:data:testDebugUnitTest --tests "*StashDiscoveryWorkerStreamOnlyTest*"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full module test suite to catch regressions.**
+
+```
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: PASS (no other discovery-worker tests broken).
+
+- [ ] **Step 7: Commit.**
+
+```
+git add core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+git add core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorkerStreamOnlyTest.kt
+git commit -m "feat(mix): skip download enqueue for Stash Mix discoveries (stream-only)"
+```
+
+---
+
+## Task 3: `StashMixRefreshWorker.materializeMix` — use new DAO method
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt` (line ~452)
+- Test: `core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerStreamOnlyMaterializeTest.kt` (new)
+
+- [ ] **Step 1: Write the failing test.** Recipe with two `DONE` discovery rows: one whose track is downloaded, one whose track is stream-only. After `materializeMix`, both should appear as `PlaylistTrackCrossRef` rows linked to the Mix playlist.
+
+```kotlin
+@Test
+fun materializeMix_includesStreamOnlyDiscoverySurvivors() = runTest {
+    val recipe = buildRecipe()
+    val downloadedTrackId = trackDao.insert(buildTrack(isDownloaded = true))
+    val streamOnlyTrackId = trackDao.insert(buildTrack(isStreamable = true, isDownloaded = false))
+    discoveryQueueDao.insert(buildDoneEntry(recipe.id, downloadedTrackId))
+    discoveryQueueDao.insert(buildDoneEntry(recipe.id, streamOnlyTrackId))
+
+    worker.doWork()
+
+    val mixPlaylist = playlistDao.findBySourceId("stash_mix_${recipe.id}")
+    val members = playlistDao.getTracksByPlaylistId(mixPlaylist!!.id)
+    assertThat(members.map { it.id }).containsExactlyInAnyOrder(downloadedTrackId, streamOnlyTrackId)
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails.**
+
+```
+./gradlew :core:data:testDebugUnitTest --tests "*StashMixRefreshWorkerStreamOnlyMaterializeTest*"
+```
+
+Expected: FAIL — only `downloadedTrackId` is in the playlist.
+
+- [ ] **Step 3: Swap the DAO call** in `StashMixRefreshWorker.materializeMix` at line ~452:
+
+```kotlin
+- val doneIds = playlistDao.getDoneTrackIdsForRecipe(recipe.id)
++ val doneIds = playlistDao.getStreamableOrDoneTrackIdsForRecipe(recipe.id)
+```
+
+- [ ] **Step 4: Run the test, verify it passes.**
+
+```
+./gradlew :core:data:testDebugUnitTest --tests "*StashMixRefreshWorkerStreamOnlyMaterializeTest*"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the broader test suite for the module to catch regressions in `StashMixRefreshWorkerSeedFilterTest`, `StashMixRefreshWorkerPerRecipeDedupTest`, etc.**
+
+```
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```
+git add core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+git add core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerStreamOnlyMaterializeTest.kt
+git commit -m "feat(mix): materializeMix links stream-only discoveries into the Mix playlist"
+```
+
+---
+
+## Task 4: `StashPlaybackService` queue filter — include streamable tracks
+
+**Files:**
+- Modify: `core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt` (lines ~500 and ~749 per spec)
+
+There are no isolated unit tests for these sites — they live deep in the MediaSession callback chain. This task is a small mechanical change verified on-device.
+
+- [ ] **Step 1: Find both filter sites.**
+
+```
+grep -n "filter.*isDownloaded\|filter { .*isDownloaded }" core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
+```
+
+Confirm there are exactly two `filter { it.isDownloaded }` calls (around lines 500 and 749).
+
+- [ ] **Step 2: Replace both with `filter { it.isDownloaded || it.isStreamable }`.** Each instance:
+
+```kotlin
+- val playable = tracks.filter { it.isDownloaded }
++ val playable = tracks.filter { it.isDownloaded || it.isStreamable }
+```
+
+- [ ] **Step 3: Build to verify compilation.**
+
+```
+./gradlew :core:media:compileDebugKotlin
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Install + manually verify.**
+
+```
+./gradlew :app:installDebug
+```
+
+On device: open a Mix playlist with at least one stream-only track. Tap the stream-only track. It should play (previously it would have been filtered out).
+
+- [ ] **Step 5: Commit.**
+
+```
+git add core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
+git commit -m "feat(player): include streamable tracks in playable-queue filter"
+```
+
+---
+
+## Task 5: `MixOfflineTapGuard` — Snackbar on offline tap
+
+**Files:**
+- Modify: `feature/library/src/main/kotlin/com/stash/feature/library/PlaylistDetailViewModel.kt`
+- Modify: `feature/library/src/main/kotlin/com/stash/feature/library/PlaylistDetailScreen.kt`
+- Test: `feature/library/src/test/kotlin/com/stash/feature/library/MixOfflineTapGuardTest.kt` (new)
+
+- [ ] **Step 1: Read context.** Open `PlaylistDetailViewModel.kt`. Identify the existing `playTrack(track)` / `onTrackTap(track)` flow. Locate the existing `_userMessages: SharedFlow<String>` or similar event channel (or grep for `userMessages` — the file likely already emits Snackbar events for other features per the codebase pattern).
+
+- [ ] **Step 2: Write the failing test.**
+
+```kotlin
+@Test
+fun playTrack_offlineAndStreamOnly_emitsSnackbarAndAborts() = runTest {
+    val track = Track(id = 42, isStreamable = true, isDownloaded = false, ...)
+    coEvery { connectivityMonitor.isConnected() } returns false
+    val playerSpy = mockk<PlayerRepository>(relaxed = true)
+    val vm = PlaylistDetailViewModel(..., playerRepository = playerSpy, connectivityMonitor = connectivityMonitor)
+
+    val messages = mutableListOf<String>()
+    val job = launch { vm.userMessages.toList(messages) }
+
+    vm.onTrackTap(track)
+
+    coVerify(exactly = 0) { playerSpy.setQueue(any(), any()) }
+    assertThat(messages).contains("Online only — connect to play this track")
+    job.cancel()
+}
+```
+
+- [ ] **Step 3: Run the test, verify it fails.**
+
+```
+./gradlew :feature:library:testDebugUnitTest --tests "*MixOfflineTapGuardTest*"
+```
+
+Expected: FAIL — play call was made, no Snackbar emitted.
+
+- [ ] **Step 4: Implement.** In `PlaylistDetailViewModel`, inject `ConnectivityMonitor` if not already injected. Modify the tap handler:
+
+```kotlin
+fun onTrackTap(track: Track) {
+    if (track.isStreamable && !track.isDownloaded && !connectivityMonitor.isConnected()) {
+        _userMessages.tryEmit("Online only — connect to play this track")
+        return
+    }
+    // ... existing play logic
+}
+```
+
+If `PlaylistDetailViewModel` doesn't already have `_userMessages`, add it (mirror the pattern in `HomeViewModel` / `NowPlayingViewModel`).
+
+- [ ] **Step 5: Run the test, verify it passes.**
+
+```
+./gradlew :feature:library:testDebugUnitTest --tests "*MixOfflineTapGuardTest*"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Wire SnackbarHost in `PlaylistDetailScreen`.** Look at `feature/search/SearchScreen.kt` for the established `SnackbarHost { ... } + LaunchedEffect { userMessages.collect { ... showSnackbar } }` pattern; mirror it. If `PlaylistDetailScreen` already wires Snackbar for other events, route the offline-only message through the same channel.
+
+- [ ] **Step 7: Install + manually verify.**
+
+```
+./gradlew :app:installDebug
+```
+
+On device: airplane-mode on, open a Mix playlist, tap a stream-only track. Snackbar appears reading "Online only — connect to play this track". Play does NOT start.
+
+- [ ] **Step 8: Commit.**
+
+```
+git add feature/library/src/main/kotlin/com/stash/feature/library/PlaylistDetailViewModel.kt
+git add feature/library/src/main/kotlin/com/stash/feature/library/PlaylistDetailScreen.kt
+git add feature/library/src/test/kotlin/com/stash/feature/library/MixOfflineTapGuardTest.kt
+git commit -m "feat(mix): offline tap-guard with Snackbar for stream-only Mix tracks"
+```
+
+---
+
+## Task 6: Player auto-advance silent-skip for offline stream-only tracks
+
+**Files:**
+- Modify: `core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt`
+
+There is no clean unit-test seam here (deep ExoPlayer interaction); on-device verification is the gate.
+
+- [ ] **Step 1: Identify the auto-advance hook.** Open `PlayerRepositoryImpl.kt` and find the `Player.Listener` block (look for `onMediaItemTransition` or `addListener` registrations). Determine which method fires when the queue advances to the next track.
+
+- [ ] **Step 2: Implement strategy (b): listener-based skip.** Decision locked: pre-filtering at queue-build time is wrong because connectivity is dynamic (user toggles airplane mid-playback). The listener observes `Player.Listener.onMediaItemTransition` (or `onPositionDiscontinuity` with reason `MEDIA_ITEM_TRANSITION`); when the new current MediaItem corresponds to a stream-only track AND `connectivityMonitor.isConnected()` is false, call `player.seekToNextMediaItem()` until either a playable item is reached or the queue is exhausted. Spec risk #2 already accepts the linear-scan cost.
+
+- [ ] **Step 3: Implement the listener-based skip.** Use the `MediaItem.mediaMetadata.extras` to read `isStreamable` flag (note: the existing extras don't carry this directly — you'll need to add `EXTRA_TRACK_IS_STREAMABLE` to `StashPlaybackService.Companion` and populate it from `buildMediaItemForTrack`, following the pattern used by `EXTRA_TRACK_DURATION_MS` added in Track C). Wrap the skip in a small loop that bounds itself to at most `queue.size` iterations to avoid runaway when nothing is playable.
+
+When the entire queue is exhausted of playable tracks, stop playback and emit a single Snackbar event ("End of offline Mix") through the existing player event channel (if one exists; otherwise add a SharedFlow on `PlayerRepository` that the UI layer can subscribe to).
+
+- [ ] **Step 4: Manual verification.** On device:
+  - Queue a Mix with mixed downloaded + stream-only tracks. Toggle airplane mode mid-playback. When the current downloaded track ends and the queue would advance to a stream-only track, the player should silently skip to the next downloaded one.
+  - Queue a Mix that's entirely stream-only. Toggle airplane mode. Playback stops with the "End of offline Mix" Snackbar.
+
+- [ ] **Step 5: Commit.**
+
+```
+git add core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+git add core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt  # for EXTRA_TRACK_IS_STREAMABLE
+git commit -m "feat(player): silent-skip stream-only Mix tracks while offline"
+```
+
+---
+
+## Task 7: Cross-cutting on-device QA
+
+**Files:** none (manual verification)
+
+- [ ] **Step 1: Install the final build.**
+
+```
+./gradlew :app:installDebug
+```
+
+- [ ] **Step 2: Smoke test the existing Mix flow.** Open a Mix that has only downloaded tracks. Verify it still plays exactly as before (no regression).
+
+- [ ] **Step 3: Smoke test new discovery.** Trigger a Mix refresh (Home long-press "Refresh this mix" or the periodic worker). Wait for `StashDiscoveryWorker` to run. Verify in the device DB (`adb exec-out run-as com.stash.app.debug cat databases/stash.db > /tmp/stash.db` then `sqlite3 /tmp/stash.db "SELECT id, title, is_downloaded, is_streamable FROM tracks ORDER BY id DESC LIMIT 5"`) that new discoveries land with `is_streamable=1, is_downloaded=0`, and that `download_queue` has NO new rows for those track ids.
+
+- [ ] **Step 4: Smoke test playback.** Open the refreshed Mix. Tap a freshly-discovered (stream-only) track. Verify it plays via the streaming engine.
+
+- [ ] **Step 5: Smoke test lyrics on streaming Mix (spec risk).** While a stream-only Mix track plays, open the Lyrics sheet. Verify lyrics render via the v0.9.36 streaming lyrics fetch path.
+
+- [ ] **Step 6: Smoke test offline tap.** Airplane mode on. Tap a stream-only Mix track. Snackbar appears, no play starts. Disable airplane mode, tap again, plays normally.
+
+- [ ] **Step 7: Smoke test offline auto-advance.** Mix with mixed tracks playing → airplane mode on mid-playback → queue advances → stream-only tracks silently skipped → downloaded tracks play through → exhausted-queue Snackbar at end.
+
+- [ ] **Step 8: Smoke test existing downloaded Mix tracks are untouched.** Per the spec's explicit non-goal, no existing downloaded Mix tracks should be deleted. Confirm by listing `tracks` table before and after the refresh — pre-existing rows with `is_downloaded=1` remain on disk.
+
+- [ ] **Step 9: Commit any QA-induced fixes.** If anything surfaces, fix-then-commit per the same pattern.
+
+---
+
+## Task 8: Version bump + final commit prep
+
+**Files:**
+- Modify: `app/build.gradle.kts` (versionCode + versionName)
+
+- [ ] **Step 1: Read current version.**
+
+```
+grep -nE "versionCode|versionName" app/build.gradle.kts
+```
+
+- [ ] **Step 2: Bump to v0.9.37.** Increment versionCode by 1; set versionName to `"0.9.37"`. **Coordination note:** Tracks B + C and the merged sync-card relocation (PR #103) all ship under v0.9.37. Do this version bump **once**, in this plan, as the final commit before the human tags the release — not separately in any of those tracks. If you find the version was already bumped to 0.9.37, skip this step.
+
+- [ ] **Step 3: Commit version bump.**
+
+```
+git add app/build.gradle.kts
+git commit -m "chore(release): bump versionCode + versionName to 0.9.37"
+```
+
+- [ ] **Step 4: Hand off to the human for the bundled v0.9.37 release commit.** Per `feedback_ship_terminology.md`, "ship" means tag + push, not local install. The human will compose the release commit message (per `feedback_release_notes.md`, the release body comes from the tagged-commit message body), tag, and push.
+
+---
+
+## Out of scope (separate work)
+
+Per the spec — do NOT do any of these as part of this plan:
+- Raise the 100/week discovery cap.
+- "Refresh when online" CTA on empty-offline-Mix Snackbar.
+- Per-track "Save offline" button on Mix tracks.
+- Search-tab `musicShelfRenderer` parser fix (separate issue, same root cause as Track B's first regression).
+- Custom playlist covers for stream-only Mixes.
+- Purging existing downloaded Mix tracks (explicit non-goal per user).
+- Lyrics on streaming Mix — assumed working via `118a9b3`; will smoke-test in Task 7 step 5.

--- a/docs/superpowers/specs/2026-05-25-stash-mixes-stream-only-design.md
+++ b/docs/superpowers/specs/2026-05-25-stash-mixes-stream-only-design.md
@@ -1,0 +1,122 @@
+# v0.9.37 — Stash Mixes: stream-only for new discoveries
+
+**Date:** 2026-05-25
+**Status:** Design
+**Branch:** `feat/mixes-stream-only` (to be created)
+**Follows:** v0.9.36 (`19fc52f`) — lyrics integration
+**Bundled with:** Track B (YT scrobbler 2-layer fix), Track C (Now Playing favorites/download fix)
+
+## Problem
+
+Stash Mixes (Daily Discover, Deep Cuts, and other recipe-driven rotating playlists) currently **download** every discovered track to device. The discovery pipeline at `StashDiscoveryWorker.handle()` (`core/data/.../sync/workers/StashDiscoveryWorker.kt:278`) enqueues a `DownloadQueueEntity` for every PENDING `DiscoveryQueueEntity` row that survives the filter passes. The download worker then writes the file to disk and stamps `isDownloaded = true`.
+
+This burns user data (each FLAC is 30-50 MB) and storage. The weekly cap of 100 discoveries per recipe (`StashDiscoveryWorker.kt:74`) was sized to bound the cost — but the cost is still meaningful for users on cellular plans or low-storage devices.
+
+The v0.9.30 **online streaming engine** (`022e98a`) makes downloads unnecessary for this use case. The player at `PlayerRepositoryImpl.buildMediaItemForTrack` (`core/media/.../PlayerRepositoryImpl.kt:856`) already plays any track with `isStreamable = true, isDownloaded = false, youtubeId = ...` via Qobuz/Kennyy + YouTube fallback. The infrastructure is in place; the discovery worker just doesn't use it yet.
+
+## Goals
+
+- **New** Mix discoveries are stream-only. The discovery worker creates a `TrackEntity(isStreamable = true, isDownloaded = false)` and **does not** insert a `DownloadQueueEntity`.
+- **Existing** downloaded Mix tracks remain on disk. They continue to play from local file. They rotate out of the Mix recipe naturally as `excludeSnapshot` cycles them; they stay in Library indefinitely (no purge).
+- The Mix playlist remains visible in Library and Home even when offline. Tapping a stream-only track while offline shows a **Snackbar** ("Online only — connect to play this track") and aborts the play.
+- When the queue auto-advances to a stream-only track while offline, **silently skip** to the next playable (downloaded) track in the queue. The Snackbar fires only on **explicit user tap**, never on auto-advance.
+- Search-tab downloads, Spotify-sync downloads, Liked-songs downloads — **unchanged**. The behavior change is scoped to the discovery worker's Mix path only.
+
+## Non-goals
+
+- **No migration / purge of already-downloaded Mix tracks.** User explicitly chose "leave the downloads as is in the stash mixes. future songs that appear there from last.fm will be stream only." No one-shot cleanup; no file deletion; no `download_queue` cancellation.
+- **No discovery-cap change.** Weekly cap stays at 100/recipe. Now that the storage cost is gone, raising it is reasonable future work — out of scope for this commit.
+- **No "Save offline" per-track button** on Mix tracks. Users who want a Mix track on disk can tap the Now Playing download button (after Track C fixes that path); fully-fledged "save this Mix" bulk action is out of scope.
+- **No "Refresh when online" CTA** when offline and the entire Mix queue is stream-only. Snackbar says end-of-queue; user reconnects manually.
+- **No Search-tab parser fix.** A parallel regression (same root cause as Track B) has the Search tab's "Songs / Artists / Albums" sections coming back empty; the Top-result card still works. That's a separate issue (#TBD) and a separate fix.
+- **No new lyrics-on-streaming-Mix work.** The streaming lyrics fetch shipped in `118a9b3` should cover this via the shared player path; verify in manual QA.
+- **No UI redesign.** Mix tiles, Mix detail screen, and Home Mix cards render exactly as today. Per `feedback_preserve_existing_design.md`.
+
+## Design
+
+### 1. Seam choice
+
+**Seam A** — divert at `StashDiscoveryWorker.handle()` line 278. Lowest blast radius; the change is confined to the discovery worker plus one new DAO method. Alternatives considered:
+
+- **Seam B** — branch in `DiscoveryDownloadWorker.doWork()` to mark Mix items COMPLETED without downloading. Rejected: leaves spurious `download_queue` rows; spends a DAO read per item; muddles two concerns.
+- **Seam C** — branch in `TrackDownloader.downloadTrack` / `DownloadCoordinator`. Rejected: this interface is shared with Search and Spotify-sync downloads; risk of bleeding into "other pipelines unchanged."
+
+### 2. Components
+
+| Component | Change | Why |
+|---|---|---|
+| `StashDiscoveryWorker.handle()` (`core/data/.../sync/workers/StashDiscoveryWorker.kt:278`) | Skip `downloadQueueDao.insert(...)` for Mix-recipe items; create the stub `TrackEntity` with `isStreamable = true, isDownloaded = false`. | Diverts new Mix discoveries from the download pipeline. |
+| `PlaylistDao` (new method) | `getStreamableOrDoneTrackIdsForRecipe(recipeId: Long): List<Long>` — selects tracks for a recipe whose status is `isDownloaded = 1` **OR** `isStreamable = 1`. | MixRefresh needs to link both downloaded and stream-only stubs into the Mix playlist. |
+| `StashMixRefreshWorker.materializeMix` (`core/data/.../sync/workers/StashMixRefreshWorker.kt:452`) | Call the new DAO method instead of `getDoneTrackIdsForRecipe`. | Stream-only stubs become Mix members. |
+| `StashPlaybackService` filter (`core/media/.../service/StashPlaybackService.kt:500, 749`) | Replace `tracks.filter { it.isDownloaded }` with `tracks.filter { it.isDownloaded \|\| it.isStreamable }` at both sites. | Stream-only tracks become playable in the queue. |
+| **New:** `MixOfflineTapGuard` in `PlaylistDetailViewModel` (and Home + Library Mix tap handlers) | Before `playTrack(track)`, check `track.isStreamable && !track.isDownloaded && !networkMonitor.isOnline.value`. If true → emit `SnackbarEvent("Online only — connect to play this track")`, abort. | Tap-time offline UX. |
+| `PlayerRepositoryImpl` queue advancement | When the next-up track is stream-only AND offline, advance silently to the next playable track. If the queue is exhausted of playable tracks, stop and emit a Snackbar event ("End of offline Mix"). | Auto-advance silent-skip. |
+
+**No database migration. No file deletion. No purge.**
+
+### 3. Data flow
+
+#### New-discovery path
+
+1. `MixSeedGenerator` queries Last.fm → `DiscoveryQueueEntity(status = PENDING)` row inserted. *(Unchanged.)*
+2. `StashDiscoveryWorker.handle()` drains PENDING rows:
+   - Creates `TrackEntity(isDownloaded = false, **isStreamable = true**, youtubeId = <resolved>, ...)`.
+   - **Does NOT** insert into `download_queue`.
+   - Marks the `DiscoveryQueueEntity` as `DONE`.
+3. `StashMixRefreshWorker.materializeMix` (next worker tick, daily cadence):
+   - Calls `playlistDao.getStreamableOrDoneTrackIdsForRecipe(recipeId)` — returns downloaded + streamable track ids.
+   - Inserts `PlaylistTrackCrossRef` rows linking them into the Mix playlist.
+4. User opens the Mix → taps a track:
+   - **Online:** plays via streaming engine (Qobuz/Kennyy + YouTube fallback). Already wired.
+   - **Offline:** `MixOfflineTapGuard` emits Snackbar; play aborts.
+   - **Auto-advance offline:** queue advances silently past stream-only tracks; stops with Snackbar when no playable track remains.
+
+#### Existing-track path
+
+Untouched. Already-downloaded Mix tracks continue to play from local file via `PlayerRepositoryImpl.resolveTrackToMediaItem` (which always prefers local file when `track.filePath` is non-null). They rotate out of the Mix recipe naturally as `excludeSnapshot` cycles them and remain in Library indefinitely.
+
+### 4. Error handling
+
+- **Resolver fails to find `youtubeId` for a new seed:** `StashDiscoveryWorker` already skips such tracks. No new code.
+- **Streaming engine returns 0 sources at playback time:** existing "Source unavailable" handling in `PlayerRepositoryImpl`. No new code.
+- **Network drops mid-playback (downloaded track playing, next track is stream-only):** auto-advance silent-skip handles it.
+- **Entire Mix queue is stream-only and user is offline:** Snackbar "End of offline Mix"; playback stops. Future enhancement: "Refresh when online" CTA — out of scope.
+- **Existing `getDoneTrackIdsForRecipe` query** is preserved for non-Mix callers (if any). The new method is materializer-only.
+
+### 5. Testing
+
+| Layer | Test |
+|---|---|
+| Unit (`StashDiscoveryWorkerTest`) | Mix recipe + PENDING discovery → asserts no `download_queue` insert; the `TrackEntity` row has `isStreamable = true, isDownloaded = false`. |
+| Unit (`PlaylistDaoTest`) | New `getStreamableOrDoneTrackIdsForRecipe` query returns downloaded + streamable track ids for a recipe. |
+| Unit (`MixOfflineTapGuardTest`) | Offline + stream-only Mix track → Snackbar event emitted; play call aborted. |
+| Unit (`PlayerRepositoryImplTest`) | Stream-only next-up + offline → skip to next downloaded track; queue exhausted of playable → Snackbar event. |
+| Integration (`StashMixRefreshWorkerIntegrationTest`) | Recipe with mixed downloaded + stream-only stubs materializes correctly into the Mix playlist. |
+| **On-device manual** (per `feedback_install_after_fix`) | Airplane-mode + tap Mix track → Snackbar appears; play through Mix mid-queue → silent skip past stream-only; restore connectivity + tap → streams normally. |
+
+### 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| `NetworkMonitor` (or equivalent) may not be reachable from `PlaylistDetailViewModel` / `PlayerRepositoryImpl` with the existing DI graph. | Verify before implementation; if not present, introduce one (`ConnectivityManager` callback wrapped in a `StateFlow<Boolean>` Singleton). |
+| Lookup of "next playable track in queue" for silent-skip could be expensive if the queue is large. | Linear scan over the in-memory MediaSession queue is O(n) and n ≤ ~100. Acceptable. |
+| Snackbar host scoping — the global `SnackbarHostState` must be reachable from the abort point. | Confirm `MainScaffold` exposes a global host; if not, route through an event channel observed by `MainScreen`. |
+| Lyrics for stream-only Mix tracks — assumed working via `118a9b3` streaming lyrics fetch. A silent regression here would mean new Mix tracks show no lyrics until refresh. | Smoke-test in manual QA; flag as a follow-up if broken. |
+| Same recipe touched by a v0.9.30 streaming-engine `TrackEntity` insert race could collide with the discovery worker's insert (both keyed on the same `youtubeId`). | Both paths must use the same upsert primitive (`findByYoutubeId` then insert with `id = 0` for autogen). Mirror the `SearchDownloadCoordinator.upsertSearchTrack` pattern. |
+
+### 7. Implementation order
+
+1. New DAO method `PlaylistDao.getStreamableOrDoneTrackIdsForRecipe` + unit test.
+2. `StashDiscoveryWorker.handle` — gate the download enqueue on recipe type (Mix vs not-Mix).
+3. `StashMixRefreshWorker.materializeMix` — switch to the new DAO method.
+4. `StashPlaybackService` queue filter — include `isStreamable` tracks.
+5. `MixOfflineTapGuard` + Snackbar wiring + auto-advance silent-skip in `PlayerRepositoryImpl`.
+6. Manual on-device QA: tap online, tap offline, queue mid-play with mixed Mix tracks, airplane-mode toggle mid-Mix.
+
+### 8. Out of scope (separate work)
+
+- Raise the 100/week discovery cap now that storage cost is gone.
+- "Refresh when online" CTA on empty-offline-Mix Snackbar.
+- Per-track "Save offline" button on Mix tracks (download a stream-only Mix track on demand).
+- Search-tab `musicShelfRenderer` parser fix (same root cause as Track B, separate surface).
+- Custom playlist covers for stream-only Mixes (already tracked in `memory/project_next_session_playlist_images.md`).

--- a/feature/library/src/main/kotlin/com/stash/feature/library/PlaylistDetailViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/PlaylistDetailViewModel.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.BulkPlayAction
 import com.stash.core.media.PlayerRepository
+import com.stash.core.media.streaming.ConnectivityMonitor
 import com.stash.core.model.Playlist
 import com.stash.core.model.PlaylistType
 import com.stash.core.model.Track
@@ -58,6 +59,7 @@ class PlaylistDetailViewModel @Inject constructor(
     private val playerRepository: PlayerRepository,
     private val playlistImageHelper: PlaylistImageHelper,
     private val streamingPreference: com.stash.core.data.prefs.StreamingPreference,
+    private val connectivityMonitor: ConnectivityMonitor,
 ) : ViewModel() {
 
     /** The playlist ID extracted from the navigation route arguments. */
@@ -144,6 +146,22 @@ class PlaylistDetailViewModel @Inject constructor(
      * filtered out.
      */
     fun playTrack(trackId: Long) {
+        // ── Stream-only offline guard (Task 5: Mixes Stream-Only) ──
+        // Stream-only Mix tracks (isStreamable + !isDownloaded) have no
+        // local audio and require network. When the device has no validated
+        // internet path, tapping them would either fail or burn time inside
+        // ExoPlayer's read. Bail out early with a Snackbar so the user knows
+        // *why* nothing happened. Downloaded tracks always play (local file
+        // works offline). Stream-only tracks online go through normal play.
+        val tapped = uiState.value.tracks.firstOrNull { it.id == trackId }
+        if (tapped != null &&
+            tapped.isStreamable && !tapped.isDownloaded &&
+            !connectivityMonitor.isConnected()
+        ) {
+            _userMessages.tryEmit("Online only — connect to play this track")
+            return
+        }
+
         viewModelScope.launch {
             _tappedTrackId.value = trackId
             try {

--- a/feature/library/src/test/kotlin/com/stash/feature/library/MixOfflineTapGuardTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/MixOfflineTapGuardTest.kt
@@ -1,0 +1,209 @@
+package com.stash.feature.library
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.data.prefs.StreamingPreference
+import com.stash.core.data.repository.MusicRepository
+import com.stash.core.media.PlayerRepository
+import com.stash.core.media.streaming.ConnectivityMonitor
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlayerState
+import com.stash.core.model.Playlist
+import com.stash.core.model.PlaylistType
+import com.stash.core.model.Track
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verifyBlocking
+
+/**
+ * Task 5 of the Stash Mixes Stream-Only plan: tap-time offline guard.
+ *
+ * Stream-only Mix tracks (isStreamable=true, isDownloaded=false) must NOT
+ * enqueue when the device has no validated internet. Instead the VM emits a
+ * "Online only — connect to play this track" message on [userMessages] so
+ * the screen shows a Snackbar. Downloaded tracks play normally even offline;
+ * stream-only tracks play normally when online.
+ *
+ * Mirrors the harness in [LikedSongsDetailViewModelTest] — mockito-kotlin,
+ * StandardTestDispatcher, mock collaborators.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MixOfflineTapGuardTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before fun setUp() { Dispatchers.setMain(dispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    @Test
+    fun `playTrack offline + stream-only emits Snackbar and skips setQueue`() = runTest {
+        val streamOnly = Track(
+            id = 42L,
+            title = "Cloud Track",
+            artist = "A",
+            isStreamable = true,
+            isDownloaded = false,
+            filePath = null,
+        )
+        val playlist = playlist(id = 7L)
+        val playerRepo = mock<PlayerRepository> {
+            on { playerState } doReturn MutableStateFlow(PlayerState())
+        }
+        val connectivity = mock<ConnectivityMonitor> {
+            on { isConnected() } doReturn false
+        }
+        val vm = buildVm(
+            playlistId = playlist.id,
+            tracks = listOf(streamOnly),
+            playlist = playlist,
+            playerRepository = playerRepo,
+            connectivityMonitor = connectivity,
+        )
+
+        val messages = mutableListOf<String>()
+        val msgJob = backgroundScope.launch { vm.userMessages.collect { messages.add(it) } }
+        val uiJob = backgroundScope.launch { vm.uiState.collect {} }
+        runCurrent()
+
+        vm.playTrack(trackId = 42L)
+        runCurrent()
+
+        verifyBlocking(playerRepo, never()) { setQueue(any(), any()) }
+        assertThat(messages).contains("Online only — connect to play this track")
+
+        msgJob.cancel()
+        uiJob.cancel()
+    }
+
+    @Test
+    fun `playTrack offline + downloaded does NOT trigger guard and plays`() = runTest {
+        val downloaded = Track(
+            id = 99L,
+            title = "Local Track",
+            artist = "A",
+            isStreamable = true,
+            isDownloaded = true,
+            filePath = "/storage/emulated/0/Music/local.opus",
+        )
+        val playlist = playlist(id = 7L)
+        val playerRepo = mock<PlayerRepository> {
+            on { playerState } doReturn MutableStateFlow(PlayerState())
+        }
+        val connectivity = mock<ConnectivityMonitor> {
+            on { isConnected() } doReturn false
+        }
+        val vm = buildVm(
+            playlistId = playlist.id,
+            tracks = listOf(downloaded),
+            playlist = playlist,
+            playerRepository = playerRepo,
+            connectivityMonitor = connectivity,
+        )
+
+        val messages = mutableListOf<String>()
+        val msgJob = backgroundScope.launch { vm.userMessages.collect { messages.add(it) } }
+        val uiJob = backgroundScope.launch { vm.uiState.collect {} }
+        runCurrent()
+
+        vm.playTrack(trackId = 99L)
+        runCurrent()
+
+        verifyBlocking(playerRepo) { setQueue(any(), any()) }
+        assertThat(messages).doesNotContain("Online only — connect to play this track")
+
+        msgJob.cancel()
+        uiJob.cancel()
+    }
+
+    @Test
+    fun `playTrack online + stream-only does NOT trigger guard and plays`() = runTest {
+        val streamOnly = Track(
+            id = 42L,
+            title = "Cloud Track",
+            artist = "A",
+            isStreamable = true,
+            isDownloaded = false,
+            filePath = null,
+        )
+        val playlist = playlist(id = 7L)
+        val playerRepo = mock<PlayerRepository> {
+            on { playerState } doReturn MutableStateFlow(PlayerState())
+        }
+        val connectivity = mock<ConnectivityMonitor> {
+            on { isConnected() } doReturn true
+        }
+        val vm = buildVm(
+            playlistId = playlist.id,
+            tracks = listOf(streamOnly),
+            playlist = playlist,
+            playerRepository = playerRepo,
+            connectivityMonitor = connectivity,
+        )
+
+        val messages = mutableListOf<String>()
+        val msgJob = backgroundScope.launch { vm.userMessages.collect { messages.add(it) } }
+        val uiJob = backgroundScope.launch { vm.uiState.collect {} }
+        runCurrent()
+
+        vm.playTrack(trackId = 42L)
+        runCurrent()
+
+        verifyBlocking(playerRepo) { setQueue(any(), any()) }
+        assertThat(messages).doesNotContain("Online only — connect to play this track")
+
+        msgJob.cancel()
+        uiJob.cancel()
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private fun playlist(id: Long) = Playlist(
+        id = id,
+        name = "Mix",
+        source = MusicSource.SPOTIFY,
+        type = PlaylistType.STASH_MIX,
+    )
+
+    private fun buildVm(
+        playlistId: Long,
+        tracks: List<Track>,
+        playlist: Playlist,
+        playerRepository: PlayerRepository,
+        connectivityMonitor: ConnectivityMonitor,
+        streamingPreference: StreamingPreference = mock {
+            onBlocking { current() } doReturn true
+        },
+    ): PlaylistDetailViewModel {
+        val musicRepo = mock<MusicRepository> {
+            on { getTracksByPlaylist(playlistId) } doReturn flowOf(tracks)
+            onBlocking { getPlaylistWithTracks(playlistId) } doReturn playlist
+            on { getUserCreatedPlaylists() } doReturn flowOf(emptyList())
+        }
+        val savedStateHandle = SavedStateHandle(mapOf("playlistId" to playlistId))
+        return PlaylistDetailViewModel(
+            savedStateHandle = savedStateHandle,
+            musicRepository = musicRepo,
+            playerRepository = playerRepository,
+            playlistImageHelper = mock(),
+            streamingPreference = streamingPreference,
+            connectivityMonitor = connectivityMonitor,
+        )
+    }
+}

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
@@ -221,11 +221,23 @@ class NowPlayingViewModel @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun observePlayerStateLive() {
         val liveTrackFlow = playerRepository.playerState
-            .map { it.currentTrack?.id }
+            .map { it.currentTrack?.let { t -> t.id to t.youtubeId } }
             .distinctUntilChanged()
-            .flatMapLatest { id ->
-                if (id == null) flowOf<com.stash.core.model.Track?>(null)
-                else musicRepository.observeTrackById(id)
+            .flatMapLatest { key ->
+                if (key == null) flowOf<com.stash.core.model.Track?>(null)
+                else {
+                    val (id, ytId) = key
+                    // Falls back to a youtube_id lookup so the heart icon
+                    // (and other Room-driven fields) update for v0.9.30
+                    // streaming-engine tracks whose `id` is a synthetic
+                    // `videoId.hashCode().toLong()` that doesn't exist in
+                    // `tracks` until `ensureTrackPersisted` writes one
+                    // under a real autogen PK (issue #105 follow-up).
+                    musicRepository.observeTrackById(id).flatMapLatest { row ->
+                        if (row != null || ytId.isNullOrBlank()) flowOf(row)
+                        else musicRepository.observeTrackByYoutubeId(ytId)
+                    }
+                }
             }
 
         combine(
@@ -247,7 +259,12 @@ class NowPlayingViewModel @Inject constructor(
                     state.isStreaming &&
                     baseTrack != null &&
                     streamFormat != null &&
-                    streamFormat.id == baseTrack.id &&
+                    // ids diverge once `ensureTrackPersisted` writes a real
+                    // Room row for a streaming-engine synthetic id, so match
+                    // on youtube_id as a fallback to keep the codec badge alive.
+                    (streamFormat.id == baseTrack.id ||
+                        (!streamFormat.youtubeId.isNullOrBlank() &&
+                            streamFormat.youtubeId == baseTrack.youtubeId)) &&
                     streamFormat.fileFormat.isNotBlank() &&
                     streamFormat.fileFormat != "opus"
                 ) {
@@ -261,12 +278,24 @@ class NowPlayingViewModel @Inject constructor(
                         streamOrigin = streamFormat.streamOrigin,
                     )
                 } else baseTrack
-                val trackKey = if (track?.id == 0L) track.youtubeId.hashCode().toLong() else track?.id
-                val finalTrack = if (track != null && trackKey != null && optimistic.containsKey(trackKey)) {
+                // ExoPlayer always knows the real duration once the
+                // stream loads; the Track-domain durationMs may still be
+                // 0 for streaming-engine tracks whose search-result
+                // metadata didn't carry one. Prefer the player's truth
+                // so `ensureTrackPersisted` writes the right value when
+                // the user likes/downloads the currently-playing track
+                // (issue #105 follow-up: stream-only Liked Songs were
+                // landing with 0:00 duration).
+                val durationOverlaid = track?.let {
+                    if (it.durationMs <= 0L && state.durationMs > 0L) it.copy(durationMs = state.durationMs)
+                    else it
+                }
+                val trackKey = if (durationOverlaid?.id == 0L) durationOverlaid.youtubeId.hashCode().toLong() else durationOverlaid?.id
+                val finalTrack = if (durationOverlaid != null && trackKey != null && optimistic.containsKey(trackKey)) {
                     val optLiked = optimistic[trackKey]!!
-                    track.copy(stashLikedAt = if (optLiked) System.currentTimeMillis() else null)
+                    durationOverlaid.copy(stashLikedAt = if (optLiked) System.currentTimeMillis() else null)
                 } else {
-                    track
+                    durationOverlaid
                 }
 
                 current.copy(
@@ -475,8 +504,21 @@ class NowPlayingViewModel @Inject constructor(
                 musicRepository.removeDownload(track.id)
                 _userMessages.tryEmit("Download removed.")
             } else {
-                musicRepository.queueDownload(track.id)
-                _userMessages.tryEmit("Queued for download.")
+                // Resolve a synthetic streaming-engine id to a real DB row
+                // before queuing — otherwise `getById` returns null and the
+                // queue insert silently no-ops while the toast still fires
+                // (issue #105).
+                val realId = runCatching { musicRepository.ensureTrackPersisted(track) }
+                    .getOrElse { e ->
+                        android.util.Log.w("NowPlayingViewModel", "ensureTrackPersisted failed", e)
+                        _userMessages.tryEmit("Couldn't queue download.")
+                        return@launch
+                    }
+                val queued = musicRepository.queueDownload(realId)
+                _userMessages.tryEmit(
+                    if (queued) "Queued for download."
+                    else "Couldn't queue download."
+                )
             }
         }
     }
@@ -652,13 +694,13 @@ class NowPlayingViewModel @Inject constructor(
 
         viewModelScope.launch {
             runCatching {
-                var finalTrackId = track.id
-                if (finalTrackId == 0L) {
-                    // Not in library yet (search preview). Insert it first.
-                    // This creates a stub TrackEntity in the DB so the
-                    // Liked Songs cross-ref has a parent to point to.
-                    finalTrackId = musicRepository.insertTrack(track)
-                }
+                // Handles all three id shapes: real Room PK, search-preview
+                // id=0 (legacy), and v0.9.30 streaming-engine synthetic
+                // `videoId.hashCode().toLong()`. Without this, streaming-only
+                // tracks (e.g. Liked Songs played from network with no local
+                // file) FK-violate at the cross-ref insert and surface as
+                // "Couldn't add to Liked Songs" (issue #105).
+                val finalTrackId = musicRepository.ensureTrackPersisted(track)
 
                 if (wasLiked) {
                     stashLikedRepository.remove(finalTrackId)

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
@@ -191,6 +191,7 @@ class NowPlayingViewModel @Inject constructor(
         observePlayerStateLive()
         observeUserPlaylists()
         observeStreamingHaltedEvents()
+        observePlayerUserMessages()
     }
 
     // ------------------------------------------------------------------
@@ -361,6 +362,21 @@ class NowPlayingViewModel @Inject constructor(
                     "Streaming is failing \u2014 try a downloaded track or check your connection"
                 )
             }
+            .launchIn(viewModelScope)
+    }
+
+    /**
+     * Forwards [PlayerRepository.userMessages] emissions into the screen's
+     * Toast channel. Source examples:
+     *  - "Couldn't play this track right now." (setQueue tap failure)
+     *  - "End of offline Mix" (v0.9.37 auto-advance silent-skip exhausted
+     *    the queue while offline)
+     * The player layer already paused playback when relevant; this
+     * observer is purely informational.
+     */
+    private fun observePlayerUserMessages() {
+        playerRepository.userMessages
+            .onEach { msg -> _userMessages.emit(msg) }
             .launchIn(viewModelScope)
     }
 


### PR DESCRIPTION
## Summary

Diverts new Stash Mix discoveries from the download pipeline to the v0.9.30 streaming engine. Existing downloaded Mix tracks remain untouched. Bundled with the v0.9.37 release alongside the YT scrobbler fix, Now Playing favorites/download fix (#105), and the already-merged SyncStatusCard relocation (#103).

## Behaviour

**New behaviour**
- `StashDiscoveryWorker.handle()` no longer inserts into `download_queue` for Stash Mix recipes. The worker creates a `TrackEntity` stamped `isStreamable = true, isDownloaded = false` and lets the streaming engine handle playback on demand.
- `StashMixRefreshWorker.materializeMix` swaps `getDoneTrackIdsForRecipe` → new `PlaylistDao.getStreamableOrDoneTrackIdsForRecipe` so stream-only stubs become first-class Mix members.
- `StashPlaybackService` playable-queue filter now includes streamable tracks so they actually play through MediaSession.
- Tap-time offline guard in `PlaylistDetailViewModel.playTrack`: stream-only Mix track + offline → Snackbar `"Online only — connect to play this track"`, abort play. Downloaded tracks always play (even offline).
- Auto-advance silent-skip in `PlayerRepositoryImpl.onMediaItemTransition` (gated on `REASON_AUTO` only): when the queue advances onto a stream-only track while offline, `seekToNextMediaItem` until a playable item is reached. Queue exhausted → `pause()` + Snackbar `"End of offline Mix"`.

**Preserved behaviour**
- Existing downloaded Mix tracks remain on disk and play from local file — no purge, no migration, no in-flight download cancellation.
- Search-tab downloads, Spotify-sync downloads, Liked Songs downloads — unchanged.
- Per-recipe weekly cap of 100 untouched (spec §8 defers raising/removing it).

## Architecture

- New DAO query mirrors `DiscoveryQueueDao.getDoneTrackIdsForRecipe` exactly except for the relaxed `is_downloaded = 1 OR is_streamable = 1` predicate.
- Re-entrancy in the auto-advance listener is handled by tail-recursion via Media3 re-firing `onMediaItemTransition` for the new item (single `seekToNextMediaItem` per invocation; bounded by `hasNextMediaItem()`).
- New extras keys on MediaMetadata: `EXTRA_TRACK_IS_STREAMABLE`. The existing `EXTRA_TRACK_YOUTUBE_ID` + `EXTRA_TRACK_DURATION_MS` (added in v0.9.37 Track C) are also populated at every \`setExtras\` site.
- `PlayerRepository` interface gains a public \`userMessages: SharedFlow<String>\` so player-emitted Snackbar events (existing "Couldn't play this track" + new "End of offline Mix") can be forwarded by \`NowPlayingViewModel\`.

## Spec + plan

- Spec: \`docs/superpowers/specs/2026-05-25-stash-mixes-stream-only-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-25-stash-mixes-stream-only.md\` — 8 tasks, all complete; spec + code-quality reviewers approved each.

## Test plan

- [x] \`:core:data:testDebugUnitTest\` green (231 tests, only the 2 known pre-existing failures unrelated to this work)
- [x] \`:feature:library:testDebugUnitTest\` green (\`MixOfflineTapGuardTest\` 3 cases)
- [x] \`:app:assembleDebug\` green
- [x] On-device: full 12-step QA pass on Pixel 6 Pro — existing downloaded Mix plays unchanged; new discoveries land stream-only; tap-time offline Snackbar appears; auto-advance silent-skip works; end-of-queue Snackbar appears; lyrics on streaming Mix renders; no existing downloads deleted.

## Release

Bundled into v0.9.37 — version bump committed as part of this branch (\`2ad37b0\`). Release commit + tag handled after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)