### PR TITLE
feat(sync): re-enable Spotify auth probe via TokenManager (#117)

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/sync/auth/SpotifyAuthHealthProbe.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/auth/SpotifyAuthHealthProbe.kt
@@ -1,35 +1,50 @@
 package com.stash.core.data.sync.auth
 
-import com.stash.data.spotify.SpotifyApiClient
+import android.util.Log
+import com.stash.core.auth.TokenManager
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Real HTTP-based Spotify auth probe (issue #117).
+ *
+ * `TokenManager.getSpotifyAccessToken()` is the right signal: it returns the
+ * cached access token if still fresh (no network), otherwise refreshes via the
+ * stored sp_dc cookie. Refresh fails — and the call returns `null` — when the
+ * sp_dc is invalid or expired (Spotify returns an anonymous token, which
+ * [com.stash.core.auth.spotify.SpotifyAuthManager.getAccessToken] maps to
+ * `null`). A non-null result means auth is healthy.
+ *
+ * **Contract assumption:** the caller (`PlaylistFetchWorker.runAuthProbes`)
+ * only invokes this probe when `TokenManager.spotifyAuthState is Connected`,
+ * so `null` here cannot mean "not connected" — it can only mean
+ * "expired / invalid sp_dc". The connection-state guard lives at the worker.
+ *
+ * Side benefit: when the cached token is stale, the probe refreshes it and
+ * persists the new value via TokenManager. The about-to-run sync gets a
+ * pre-warmed token for free.
+ *
+ * Conservative on exceptions: a network failure (DNS, timeout, etc.) returns
+ * `false` so a flaky Wi-Fi connection doesn't false-positive the banner.
+ * Real auth failures still get caught mid-sync by `DownloadFailureClassifier`
+ * (Task 7) when individual track downloads return 401/403.
+ */
 @Singleton
 class SpotifyAuthHealthProbe @Inject constructor(
-    @Suppress("unused") private val api: SpotifyApiClient,
+    private val tokenManager: TokenManager,
 ) : AuthHealthProbe {
     override val source: AuthSource = AuthSource.SPOTIFY
 
-    /**
-     * Always reports healthy (false = not expired) until a proper HTTP-based
-     * Spotify auth probe is wired.
-     *
-     * Why: the original implementation used `api.getCurrentUserProfile() == null`
-     * as the expired signal, but `getCurrentUserProfile()` is a local cache
-     * lookup (`tokenManager.getSpotifyUsername()`), NOT an HTTP call. Users with
-     * incomplete stored metadata — legacy auth flows or migration drift —
-     * return null even with valid cookies, causing the probe to wrongly block
-     * sync. See issue (TODO: file follow-up) for the proper fix: add
-     * `SpotifyApiClient.isAuthHealthy()` that hits a cheap authenticated
-     * GraphQL endpoint and returns 3-state Valid/Invalid/Unknown.
-     *
-     * Real Spotify auth failures during a sync still get caught — the per-row
-     * `DownloadFailureClassifier` (Task 7) maps 401/403 responses to
-     * `AUTH_EXPIRED` and surfaces them in the Failed Downloads viewer.
-     */
-    override suspend fun isExpired(): Boolean {
-        // Keep `api` field referenced so Hilt doesn't strip the injection;
-        // the placeholder will go away when isAuthHealthy() is added.
-        return false
+    override suspend fun isExpired(): Boolean = try {
+        tokenManager.getSpotifyAccessToken() == null
+    } catch (ce: kotlinx.coroutines.CancellationException) {
+        throw ce
+    } catch (e: Throwable) {
+        Log.w(TAG, "probe failed conservatively", e)
+        false
+    }
+
+    private companion object {
+        const val TAG = "SpotifyAuthProbe"
     }
 }

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/auth/SpotifyAuthHealthProbeTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/auth/SpotifyAuthHealthProbeTest.kt
@@ -1,17 +1,40 @@
 package com.stash.core.data.sync.auth
 
-import com.stash.data.spotify.SpotifyApiClient
+import com.stash.core.auth.TokenManager
+import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SpotifyAuthHealthProbeTest {
 
-    private val api: SpotifyApiClient = mockk()
-    private val probe = SpotifyAuthHealthProbe(api)
+    private val tokenManager: TokenManager = mockk()
+    private val probe = SpotifyAuthHealthProbe(tokenManager)
 
-    @Test fun `always reports healthy until proper HTTP probe lands`() = runTest {
+    @Test fun `returns true when getSpotifyAccessToken returns null`() = runTest {
+        // null while the worker has already gated on Connected means the
+        // sp_dc refresh failed — Spotify returned anonymous, cookie is bad.
+        coEvery { tokenManager.getSpotifyAccessToken() } returns null
+        assertTrue(probe.isExpired())
+    }
+
+    @Test fun `returns false when getSpotifyAccessToken returns a token`() = runTest {
+        coEvery { tokenManager.getSpotifyAccessToken() } returns "BQA-real-looking-token"
         assertFalse(probe.isExpired())
+    }
+
+    @Test fun `returns false when network throws (conservative)`() = runTest {
+        coEvery { tokenManager.getSpotifyAccessToken() } throws RuntimeException("network down")
+        assertFalse(probe.isExpired())
+    }
+
+    @Test fun `propagates CancellationException for structured concurrency`() = runTest {
+        coEvery {
+            tokenManager.getSpotifyAccessToken()
+        } throws kotlinx.coroutines.CancellationException("cancelled")
+        val thrown = runCatching { probe.isExpired() }.exceptionOrNull()
+        assertTrue(thrown is kotlinx.coroutines.CancellationException)
     }
 }


### PR DESCRIPTION
## Summary

Closes #117. Stacked on top of #115 (the disabled-stub commit is `1e52a0a` there).

Replaces \`SpotifyAuthHealthProbe.isExpired()\`'s always-healthy stub with a real signal: \`TokenManager.getSpotifyAccessToken()\`. If the cached access token is still fresh it returns immediately with no network; if stale it refreshes via the stored \`sp_dc\` cookie. The refresh returns \`null\` specifically when Spotify responds with an anonymous token, which happens only when \`sp_dc\` has been invalidated.

  - \`null\` → \`sp_dc\` is bad → AUTH_EXPIRED, fire the banner
  - non-null → cookie is healthy
  - exception → network flake → conservative healthy

Contract relies on \`PlaylistFetchWorker.runAuthProbes\` already gating the probe behind \`is AuthState.Connected\`, so a \`null\` here can't mean "not connected" — it can only mean expired.

Side benefit: the probe pre-warms the access token. If sync is about to run and was going to refresh anyway, that refresh happens here instead. Net cost is zero in the healthy case.

## Test plan

- [x] Unit tests restored: 4 cases (null / token / network-exception / CancellationException) against a TokenManager mock
- [x] APK installs cleanly on Pixel 6 Pro
- [ ] Manual: revoke an sp_dc cookie externally → next sync should fire the AuthExpiredBanner with a single re-auth CTA

## Notes for reviewer

- Base branch is \`pr1-library-health\` so the diff stays scoped to the probe re-enable. Will rebase onto \`master\` automatically once #115 merges.
- The constructor signature changed from \`SpotifyApiClient\` to \`TokenManager\`. Both are \`@Singleton\` Hilt-provided so the graph rewires automatically; the only call site is \`PlaylistFetchWorker.runAuthProbes\` which is unaffected.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>