### PR TITLE
fix(mix): cap + fairness + Last.fm hydration + streaming-mode drain gate

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
@@ -57,9 +57,50 @@ interface DiscoveryQueueDao {
     ): List<DiscoveryQueueEntity>
 
     /**
-     * Recipe ids currently over the weekly download cap. Mirrors
+     * Distinct recipe ids that currently have at least one PENDING row.
+     * Feeds the round-robin scheduler in [com.stash.core.data.sync.workers.StashDiscoveryWorker]:
+     * we ask which recipes are waiting for work, then pull a fair quota
+     * from each rather than letting one recipe's FIFO backlog monopolise
+     * the batch (conversation 2026-05-28).
+     */
+    @Query(
+        """
+        SELECT DISTINCT recipe_id FROM discovery_queue
+        WHERE status = 'PENDING'
+          AND recipe_id NOT IN (:cappedRecipeIds)
+        """
+    )
+    suspend fun getRecipesWithPending(cappedRecipeIds: List<Long>): List<Long>
+
+    /**
+     * PENDING rows for a single recipe, oldest first. Used by the
+     * round-robin scheduler to pull a bounded per-recipe quota out of the
+     * queue so no one recipe can starve the others — v0.9.38 fairness fix.
+     */
+    @Query(
+        """
+        SELECT * FROM discovery_queue
+        WHERE status = 'PENDING'
+          AND recipe_id = :recipeId
+        ORDER BY queued_at ASC
+        LIMIT :limit
+        """
+    )
+    suspend fun getPendingForRecipe(recipeId: Long, limit: Int): List<DiscoveryQueueEntity>
+
+    /**
+     * Recipe ids currently over the weekly cap. Mirrors
      * [countRecentCompletedForRecipe]'s join + filter exactly so the
      * pre-fetch and per-row checks agree.
+     *
+     * v0.9.38: counts both `is_downloaded = 1` AND `is_streamable = 1`
+     * rows. The v0.9.37 stream-only seam stopped writing
+     * `is_downloaded = 1` for discovery survivors — they land as
+     * streamable stubs only. The old downloaded-only count returned 0
+     * for every recipe and the cap never engaged, so a single recipe's
+     * FIFO PENDING backlog could monopolise the worker indefinitely
+     * (Daily Discover drained 60/day while Deep Cuts + First Listen
+     * stayed at 0 DONE — conversation 2026-05-28).
      */
     @Query(
         """
@@ -67,7 +108,7 @@ interface DiscoveryQueueDao {
         INNER JOIN tracks t ON t.id = dq.track_id
         WHERE dq.status = 'DONE'
           AND dq.completed_at >= :sinceMillis
-          AND t.is_downloaded = 1
+          AND (t.is_downloaded = 1 OR t.is_streamable = 1)
         GROUP BY dq.recipe_id
         HAVING COUNT(*) >= :cap
         """
@@ -76,15 +117,20 @@ interface DiscoveryQueueDao {
 
     /**
      * Count of discovery entries completed within [sinceMillis] for a
-     * specific recipe — enforces the per-recipe weekly cap so discovery
-     * doesn't spiral.
+     * specific recipe — enforces the per-recipe weekly cap so a single
+     * recipe doesn't monopolise the queue drainer.
      *
-     * v0.9.21: Aligned with [getDoneTrackIdsForRecipe] — only count DONE
-     * rows whose track actually landed on disk (`is_downloaded = 1`). The
-     * cap exists to bound real disk usage; counting unmaterialized stubs
-     * trapped recipes in a "100 intended but 0 downloaded" loop where
-     * fresh PENDING candidates could never drain. See conversation
-     * 2026-05-12: Deep Cuts had ~100 DONE rows but 0 in the mix.
+     * v0.9.21 narrowed this to `is_downloaded = 1` so unmaterialised stubs
+     * wouldn't "trap" a recipe at cap with 0 actually-downloaded tracks.
+     * v0.9.37 inverted that situation: the stream-only seam stopped writing
+     * downloads at all for discoveries, so this query returned 0 for every
+     * recipe and the cap stopped engaging — letting one recipe's FIFO
+     * PENDING backlog starve the others (conversation 2026-05-28).
+     *
+     * v0.9.38: count both `is_downloaded = 1` and `is_streamable = 1`. The
+     * cap now bounds real worker-output volume per recipe regardless of
+     * which delivery mode wins, which is the property the cap was always
+     * meant to express. Mirror [findRecipesAtWeeklyCap] exactly.
      */
     @Query(
         """
@@ -93,7 +139,7 @@ interface DiscoveryQueueDao {
         WHERE dq.recipe_id = :recipeId
           AND dq.status = 'DONE'
           AND dq.completed_at >= :sinceMillis
-          AND t.is_downloaded = 1
+          AND (t.is_downloaded = 1 OR t.is_streamable = 1)
         """
     )
     suspend fun countRecentCompletedForRecipe(recipeId: Long, sinceMillis: Long): Int

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -118,6 +118,19 @@ data class DurationBackfillRow(
 )
 
 /**
+ * Minimal row projection for the v0.9.38 stream-only metadata backfill —
+ * stubs that StashDiscoveryWorker created with bare title+artist, no art
+ * URL and no duration. A single Last.fm `track.getInfo` lookup yields
+ * both fields so this row carries just the identity needed to make the
+ * call.
+ */
+data class StreamableBackfillRow(
+    val id: Long,
+    val artist: String,
+    val title: String,
+)
+
+/**
  * Minimal projection for the startup file-integrity sweep — only needs id
  * and the stored path so we can verify the file actually exists on disk.
  * `file_path` is nullable in the schema; rows with `is_downloaded=1` and
@@ -1483,6 +1496,32 @@ interface TrackDao {
         """
     )
     suspend fun findArtBackfillCandidates(limit: Int): List<ArtBackfillRow>
+
+    /**
+     * Candidate projection for the v0.9.38 stream-only metadata backfill —
+     * tracks that StashDiscoveryWorker filed as `is_streamable = 1,
+     * is_downloaded = 0` stubs with no art and no duration. Returns rows
+     * where at least one of (art, duration) is still missing so a single
+     * Last.fm `track.getInfo` round-trip can fill both in one pass.
+     *
+     * Pre-fix: stream-only mix tracks rendered with empty thumbnails and
+     * "0:00" durations on first paint; metadata only filled in
+     * incidentally when the player resolved a queue window at play time
+     * (conversation 2026-05-28).
+     */
+    @Query(
+        """
+        SELECT id, artist, title
+        FROM tracks
+        WHERE is_streamable = 1
+          AND is_downloaded = 0
+          AND (album_art_url IS NULL OR album_art_url = '' OR duration_ms = 0)
+          AND artist != ''
+          AND title != ''
+        LIMIT :limit
+        """
+    )
+    suspend fun findStreamableMetadataBackfillCandidates(limit: Int): List<StreamableBackfillRow>
 
     /**
      * Atomically reverts a track to an undownloaded state so the download

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/ArtBackfillWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/ArtBackfillWorker.kt
@@ -69,6 +69,7 @@ class ArtBackfillWorker @AssistedInject constructor(
     companion object {
         private const val TAG = "ArtBackfill"
         private const val WORK_NAME = "stash_art_backfill"
+        private const val MIX_REFRESH_WORK_NAME = "stash_art_backfill_mix_refresh"
         private const val BATCH_SIZE = 500
         private const val REQUEST_INTERVAL_MS = 220L
 
@@ -90,11 +91,36 @@ class ArtBackfillWorker @AssistedInject constructor(
                 work,
             )
         }
+
+        /**
+         * v0.9.38 — re-fire the backfill after each
+         * [StashMixRefreshWorker] cycle so freshly-created stream-only
+         * stubs gain art + duration within one refresh. Distinct work
+         * name + `REPLACE` policy so the install-time one-shot
+         * ([enqueueOneTime]) keeps its KEEP semantics and the two never
+         * compete. Both pass paths are idempotent — every UPDATE guards
+         * on "still missing" — so concurrent runs would no-op cleanly
+         * anyway, but separate names keep the WorkManager log clear.
+         */
+        fun enqueueFromMixRefresh(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+            val work = OneTimeWorkRequestBuilder<ArtBackfillWorker>()
+                .setConstraints(constraints)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                MIX_REFRESH_WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                work,
+            )
+        }
     }
 
     override suspend fun doWork(): Result {
         runArtPass()
         runDurationPass()
+        runStreamableMetadataPass()
         return Result.success()
     }
 
@@ -163,6 +189,68 @@ class ArtBackfillWorker @AssistedInject constructor(
             }
         }
         Log.i(TAG, "duration backfill done: filled=$filled skipped=$skipped (unreadable or missing)")
+    }
+
+    /**
+     * Pass 3: hydrate v0.9.37 stream-only stubs. `StashDiscoveryWorker`
+     * lands those rows with only title + artist; album art and duration
+     * default to NULL / 0, so the mix list rendered with empty thumbnails
+     * and missing run-times until the player resolved a queue window at
+     * play time (conversation 2026-05-28).
+     *
+     * One Last.fm `track.getInfo` lookup per candidate yields both
+     * `bestImageUrl` and `durationMs`, so we issue a single network call
+     * and apply both UPDATEs guarded by their existing "only-if-blank"
+     * predicates. Rate-limited like [runArtPass] to respect Last.fm's
+     * 5 req/s ceiling. No-ops when Last.fm isn't configured (the user
+     * hasn't supplied an API key) — the play-time hydration path remains
+     * the fallback for those installs.
+     */
+    private suspend fun runStreamableMetadataPass() {
+        if (!credentials.isConfigured) {
+            Log.d(TAG, "Last.fm not configured — skipping stream-only metadata backfill")
+            return
+        }
+        val candidates = trackDao.findStreamableMetadataBackfillCandidates(BATCH_SIZE)
+        if (candidates.isEmpty()) {
+            Log.d(TAG, "no stream-only stubs need metadata backfill")
+            return
+        }
+        Log.i(TAG, "backfilling metadata for ${candidates.size} stream-only stubs")
+
+        var artFilled = 0
+        var durationFilled = 0
+        var skipped = 0
+        for (row in candidates) {
+            val info = runCatching {
+                lastFmApiClient.getTrackInfo(row.artist, row.title).getOrNull()
+            }.getOrNull()
+            if (info == null) {
+                skipped++
+                delay(REQUEST_INTERVAL_MS)
+                continue
+            }
+            info.bestImageUrl?.takeIf { it.isNotBlank() }?.let { artUrl ->
+                runCatching { trackDao.fillMissingAlbumArtUrl(row.id, artUrl) }
+                    .onSuccess { artFilled++ }
+                    .onFailure { e ->
+                        Log.w(TAG, "stream-only art fill failed for trackId=${row.id}", e)
+                    }
+            }
+            info.durationMs?.takeIf { it > 0 }?.let { ms ->
+                runCatching { trackDao.fillMissingDuration(row.id, ms) }
+                    .onSuccess { durationFilled++ }
+                    .onFailure { e ->
+                        Log.w(TAG, "stream-only duration fill failed for trackId=${row.id}", e)
+                    }
+            }
+            delay(REQUEST_INTERVAL_MS)
+        }
+        Log.i(
+            TAG,
+            "stream-only backfill done: art=$artFilled duration=$durationFilled " +
+                "skipped=$skipped (Last.fm miss)",
+        )
     }
 
     /**

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
@@ -139,19 +139,37 @@ class StashDiscoveryWorker @AssistedInject constructor(
 
         // v0.9.21: pre-filter the PENDING fetch by under-cap recipes so a
         // single recipe's deferred-at-cap backlog doesn't starve other
-        // recipes' fresh candidates out of the BATCH_SIZE window. See
-        // conversation 2026-05-12: First Listen had 100+ deferred-at-cap
-        // PENDING rows clogging the head of the queue so Deep Cuts'
-        // freshly-queued candidates never reached the worker.
+        // recipes' fresh candidates out of the BATCH_SIZE window.
+        //
+        // v0.9.38: combine the cap pre-filter with round-robin batching.
+        // Plain FIFO `getPending` lets one recipe with a deep PENDING
+        // backlog monopolise the BATCH_SIZE window even when it's *under*
+        // cap (conversation 2026-05-28: Daily Discover had 131 PENDING
+        // queued before Deep Cuts/First Listen's batches and consumed 57
+        // of every 60-row drain; Deep Cuts + First Listen never ran). The
+        // cap query was also dead in v0.9.37 — fixed in the DAO by
+        // counting both downloaded AND streamable DONE rows.
         val cappedRecipeIds = discoveryQueueDao.findRecipesAtWeeklyCap(
             sinceMillis = System.currentTimeMillis() - WEEK_MS,
             cap = PER_RECIPE_WEEKLY_CAP,
         )
-        val pending = if (cappedRecipeIds.isEmpty()) {
-            discoveryQueueDao.getPending(BATCH_SIZE)
-        } else {
+        if (cappedRecipeIds.isNotEmpty()) {
             Log.i(TAG, "recipes at cap (excluded from fetch): $cappedRecipeIds")
-            discoveryQueueDao.getPendingExcludingRecipes(cappedRecipeIds, BATCH_SIZE)
+        }
+        // Room rejects empty `IN ()` lists. -1L is safe as a sentinel —
+        // real recipe ids are autogen > 0.
+        val cappedSentinel = cappedRecipeIds.ifEmpty { listOf(-1L) }
+        val activeRecipes = discoveryQueueDao.getRecipesWithPending(cappedSentinel)
+        val pending = if (activeRecipes.isEmpty()) {
+            emptyList()
+        } else {
+            // Fair quota: ceil(BATCH_SIZE / activeRecipes). With the typical
+            // 3 builtin recipes that's 20/each; a single solo recipe still
+            // gets the full 60.
+            val perRecipeQuota = (BATCH_SIZE + activeRecipes.size - 1) / activeRecipes.size
+            activeRecipes.flatMap { rid ->
+                discoveryQueueDao.getPendingForRecipe(rid, perRecipeQuota)
+            }
         }
         if (pending.isEmpty()) {
             Log.d(TAG, "no pending discoveries")

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -322,6 +322,14 @@ class StashMixRefreshWorker @AssistedInject constructor(
                     .onFailure { Log.w(TAG, "discovery queueing failed for '${recipe.name}'", it) }
             }
         }
+
+        // v0.9.38 — hydrate fresh stream-only stubs with art + duration.
+        // StashDiscoveryWorker lands those rows bare; without this chain
+        // they'd render empty in the mix until the player resolves a
+        // queue window at play time (conversation 2026-05-28). Fire-and-
+        // forget — backfill failure must never block a successful refresh.
+        ArtBackfillWorker.enqueueFromMixRefresh(applicationContext)
+
         return Result.success()
     }
 

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/TrackDownloadWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/TrackDownloadWorker.kt
@@ -159,6 +159,27 @@ class TrackDownloadWorker @AssistedInject constructor(
                 Log.i(TAG, "Reset $resetInProgress stale IN_PROGRESS entries back to PENDING")
             }
 
+            // Streaming mode: do not drain ANY pending downloads — DiffWorker
+            // already skipped enqueueing fresh ones (see its v0.9.30 gate),
+            // but pre-toggle PENDING rows (queued while the user was in
+            // Offline mode) would otherwise drain on every Sync Now and the
+            // user sees "downloads happening" despite being in Online mode.
+            // Leave them PENDING so a future switch back to Offline naturally
+            // resumes them. Housekeeping above (orphan sweep, stale-IP reset)
+            // still ran so counters stay accurate. Fall through to finalize
+            // with downloaded=0 so the chain closes cleanly.
+            if (streamingPreference.current()) {
+                Log.i(TAG, "Streaming mode: skipping download drain (PENDING rows preserved)")
+                syncStateManager.onDownloading(downloaded = 0, total = 0)
+                return Result.success(
+                    workDataOf(
+                        KEY_SYNC_ID to syncId,
+                        KEY_DOWNLOADED to 0,
+                        KEY_FAILED to 0,
+                    )
+                )
+            }
+
             // Re-queue tracks that are undownloaded but have no active queue entry.
             // This catches tracks whose retries were all exhausted and entries cleaned up,
             // or tracks that somehow never got queued.

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoFairnessTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDaoFairnessTest.kt
@@ -1,0 +1,219 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.DiscoveryQueueEntity
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.db.entity.TrackEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Locks in the v0.9.38 fairness + cap-counting fixes for
+ * [DiscoveryQueueDao]. Two changes are under test here:
+ *
+ *  1. **Cap counts stream-only DONE rows.** The v0.9.37 stream-only seam
+ *     stopped writing `is_downloaded = 1` for discovery survivors, which
+ *     left [DiscoveryQueueDao.countRecentCompletedForRecipe] +
+ *     [DiscoveryQueueDao.findRecipesAtWeeklyCap] returning 0 for every
+ *     recipe. The per-recipe weekly cap stopped engaging entirely.
+ *
+ *  2. **Round-robin fetch helpers.** [DiscoveryQueueDao.getRecipesWithPending]
+ *     + [DiscoveryQueueDao.getPendingForRecipe] let the worker schedule
+ *     a fair quota per recipe instead of letting one recipe's FIFO
+ *     backlog monopolise the drain window.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DiscoveryQueueDaoFairnessTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: DiscoveryQueueDao
+    private var recipeA: Long = 0L
+    private var recipeB: Long = 0L
+    private var recipeC: Long = 0L
+
+    @Before fun setUp() = runTest {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.discoveryQueueDao()
+        recipeA = db.stashMixRecipeDao().insert(
+            StashMixRecipeEntity(name = "Recipe A", isBuiltin = false)
+        )
+        recipeB = db.stashMixRecipeDao().insert(
+            StashMixRecipeEntity(name = "Recipe B", isBuiltin = false)
+        )
+        recipeC = db.stashMixRecipeDao().insert(
+            StashMixRecipeEntity(name = "Recipe C", isBuiltin = false)
+        )
+    }
+
+    @After fun tearDown() { db.close() }
+
+    // ── cap-counts-streamonly (the v0.9.37 regression) ──────────────────
+
+    @Test fun `countRecent counts stream-only DONE rows post-v0937 seam`() = runTest {
+        // Three DONE survivors for recipeA — all stream-only stubs, as
+        // StashDiscoveryWorker creates them in v0.9.37+.
+        for (i in 1..3) {
+            db.trackDao().insert(
+                streamOnlyStub(id = i.toLong())
+            )
+            dao.insertIfNew(doneRow(recipeA, trackId = i.toLong(), completedAt = 1_000L * i))
+        }
+
+        val count = dao.countRecentCompletedForRecipe(recipeA, sinceMillis = 0L)
+
+        assertEquals(
+            "stream-only DONE rows must count toward the cap, otherwise " +
+                "one recipe monopolises the drain queue forever",
+            3, count,
+        )
+    }
+
+    @Test fun `countRecent still counts downloaded DONE rows`() = runTest {
+        // Regression guard: pre-v0.9.37 downloaded rows must still count.
+        db.trackDao().insert(downloadedTrack(id = 1L))
+        dao.insertIfNew(doneRow(recipeA, trackId = 1L, completedAt = 1_000L))
+
+        assertEquals(1, dao.countRecentCompletedForRecipe(recipeA, sinceMillis = 0L))
+    }
+
+    @Test fun `countRecent excludes DONE rows older than sinceMillis`() = runTest {
+        db.trackDao().insert(streamOnlyStub(id = 1L))
+        db.trackDao().insert(streamOnlyStub(id = 2L))
+        dao.insertIfNew(doneRow(recipeA, trackId = 1L, completedAt = 500L))   // before window
+        dao.insertIfNew(doneRow(recipeA, trackId = 2L, completedAt = 2_000L)) // inside window
+
+        assertEquals(1, dao.countRecentCompletedForRecipe(recipeA, sinceMillis = 1_000L))
+    }
+
+    @Test fun `findRecipesAtCap flags recipes whose stream-only DONE rows hit the cap`() = runTest {
+        // recipeA: 3 stream-only DONE — at-cap when cap = 3.
+        // recipeB: 1 stream-only DONE — not at cap.
+        for (i in 1..3) {
+            db.trackDao().insert(streamOnlyStub(id = i.toLong()))
+            dao.insertIfNew(doneRow(recipeA, trackId = i.toLong(), completedAt = 1_000L))
+        }
+        db.trackDao().insert(streamOnlyStub(id = 10L))
+        dao.insertIfNew(doneRow(recipeB, trackId = 10L, completedAt = 1_000L))
+
+        val capped = dao.findRecipesAtWeeklyCap(sinceMillis = 0L, cap = 3)
+
+        assertEquals(listOf(recipeA), capped)
+    }
+
+    // ── round-robin scheduling helpers ──────────────────────────────────
+
+    @Test fun `getRecipesWithPending returns distinct ids that have PENDING`() = runTest {
+        // recipeA: 2 pending, 1 done; recipeB: 1 pending; recipeC: 0 pending (only DONE).
+        db.trackDao().insert(streamOnlyStub(id = 1L))
+        db.trackDao().insert(streamOnlyStub(id = 2L))
+        dao.insertIfNew(pendingRow(recipeA, trackId = null, queuedAt = 100L))
+        dao.insertIfNew(pendingRow(recipeA, trackId = null, queuedAt = 200L))
+        dao.insertIfNew(doneRow(recipeA, trackId = 1L, completedAt = 50L))
+        dao.insertIfNew(pendingRow(recipeB, trackId = null, queuedAt = 100L))
+        dao.insertIfNew(doneRow(recipeC, trackId = 2L, completedAt = 50L))
+
+        // Empty `IN ()` is illegal SQL → caller must pass a sentinel.
+        val recipes = dao.getRecipesWithPending(listOf(-1L))
+
+        assertEquals(setOf(recipeA, recipeB), recipes.toSet())
+    }
+
+    @Test fun `getRecipesWithPending honours cappedRecipeIds`() = runTest {
+        dao.insertIfNew(pendingRow(recipeA, trackId = null, queuedAt = 100L))
+        dao.insertIfNew(pendingRow(recipeB, trackId = null, queuedAt = 100L))
+
+        // recipeA capped → excluded from the active set.
+        val recipes = dao.getRecipesWithPending(listOf(recipeA))
+
+        assertEquals(listOf(recipeB), recipes)
+    }
+
+    @Test fun `getPendingForRecipe returns up to limit oldest-first`() = runTest {
+        // 5 PENDING for recipeA across spread queued_at timestamps.
+        for (i in 1..5) {
+            dao.insertIfNew(pendingRow(recipeA, trackId = null, queuedAt = i * 100L))
+        }
+        // recipeB rows must not leak into recipeA's result.
+        dao.insertIfNew(pendingRow(recipeB, trackId = null, queuedAt = 1L))
+
+        val pending = dao.getPendingForRecipe(recipeA, limit = 3)
+
+        assertEquals(3, pending.size)
+        // FIFO within a recipe: oldest queued_at first.
+        assertTrue(pending[0].queuedAt < pending[1].queuedAt)
+        assertTrue(pending[1].queuedAt < pending[2].queuedAt)
+        assertEquals(recipeA, pending[0].recipeId)
+    }
+
+    @Test fun `getPendingForRecipe ignores non-PENDING rows`() = runTest {
+        db.trackDao().insert(streamOnlyStub(id = 1L))
+        dao.insertIfNew(doneRow(recipeA, trackId = 1L, completedAt = 1L))   // not PENDING
+        dao.insertIfNew(pendingRow(recipeA, trackId = null, queuedAt = 2L))
+
+        val pending = dao.getPendingForRecipe(recipeA, limit = 99)
+
+        assertEquals(1, pending.size)
+        assertEquals(DiscoveryQueueEntity.STATUS_PENDING, pending.single().status)
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private fun streamOnlyStub(id: Long) = TrackEntity(
+        id = id,
+        title = "Track $id",
+        artist = "Artist $id",
+        canonicalTitle = "track $id",
+        canonicalArtist = "artist $id",
+        isDownloaded = false,
+        isStreamable = true,
+    )
+
+    private fun downloadedTrack(id: Long) = TrackEntity(
+        id = id,
+        title = "Track $id",
+        artist = "Artist $id",
+        canonicalTitle = "track $id",
+        canonicalArtist = "artist $id",
+        isDownloaded = true,
+        isStreamable = false,
+    )
+
+    private fun doneRow(recipeId: Long, trackId: Long?, completedAt: Long?) = DiscoveryQueueEntity(
+        recipeId = recipeId,
+        artist = "Artist",
+        title = "Title $trackId",
+        seedArtist = "Seed",
+        status = DiscoveryQueueEntity.STATUS_DONE,
+        trackId = trackId,
+        queuedAt = 0L,
+        completedAt = completedAt,
+        errorMessage = null,
+    )
+
+    private fun pendingRow(recipeId: Long, trackId: Long?, queuedAt: Long) = DiscoveryQueueEntity(
+        recipeId = recipeId,
+        artist = "Artist",
+        title = "Title $trackId",
+        seedArtist = "Seed",
+        status = DiscoveryQueueEntity.STATUS_PENDING,
+        trackId = trackId,
+        queuedAt = queuedAt,
+        completedAt = null,
+        errorMessage = null,
+    )
+}


### PR DESCRIPTION
## Summary
Three follow-ups on the v0.9.37 mixes streaming work, all surfaced on a live device whose stash.db showed:
- Daily Discover: 60 DONE + 131 PENDING
- Deep Cuts: 0 DONE + 50 PENDING
- First Listen: 0 DONE + 715 PENDING
- 116 PENDING in `download_queue` from a pre-streaming-mode sync

### Fix 1 — Cap query was dead, FIFO starved Deep Cuts + First Listen
- `findRecipesAtWeeklyCap` and `countRecentCompletedForRecipe` filtered on `is_downloaded = 1`. v0.9.37 stubs land `is_downloaded = 0, is_streamable = 1`, so both queries counted 0 forever and the weekly cap never engaged.
- `getPending(BATCH_SIZE)` was plain FIFO, so whichever recipe queued its candidates first monopolised every drain — Daily Discover's 131-PENDING backlog locked Deep Cuts and First Listen out of the BATCH_SIZE=60 window.
- Cap queries now count both downloaded and streamable DONE rows. New `getRecipesWithPending` + `getPendingForRecipe` DAOs let `StashDiscoveryWorker` pull a fair quota (`ceil(BATCH_SIZE / N)`) per recipe.

### Fix 2 — Stream-only stubs never gained art or duration
- `StashDiscoveryWorker.handle()` filed stubs with bare title+artist, no art URL, durationMs=0. Metadata only filled in incidentally when the player resolved a queue window at play time.
- New `runStreamableMetadataPass()` in `ArtBackfillWorker` calls Last.fm `track.getInfo` once per candidate — yields both `bestImageUrl` and `durationMs` so one round-trip fills both columns.
- `StashMixRefreshWorker` chains this backfill on completion via a new `enqueueFromMixRefresh` (distinct work name, REPLACE policy), so freshly-created stubs gain metadata within one refresh cycle. The install-time one-shot (KEEP) is untouched.

### Fix 3 — Sync Now downloaded tracks in Online (streaming) mode
- `DiffWorker` and `TrackDownloadWorker`'s auto-requeue both gated on streaming mode (v0.9.30), but the actual drain loop did not. Pre-toggle PENDING rows (or any long-press "Download to library" rows) got drained on every Sync Now, contradicting the Online = no downloads model.
- Added an early-return after the housekeeping pass (orphan sweep, stale IN_PROGRESS revert) that skips the entire download phase when streaming mode is on. PENDING rows are preserved so flipping back to Offline naturally resumes them.

## Test plan
- [x] DAO unit tests: cap counts streamable DONE; round-robin returns expected sets; FIFO within recipe preserved
- [x] Live device verification: after the cap fix, Deep Cuts and First Listen went from 0 DONE to 20 DONE each per worker pass
- [x] Live device verification: Sync Now in Online mode no longer drains download_queue PENDING

🤖 Generated with [Claude Code](https://claude.com/claude-code)