### PR TITLE
fix(matching): rescue CJK/J-pop/K-pop YouTube-fallback matches

### DIFF
--- a/data/download/src/main/kotlin/com/stash/data/download/DownloadManager.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/DownloadManager.kt
@@ -584,10 +584,12 @@ class DownloadManager @Inject constructor(
      * Runs all verification gates on a match candidate.
      *
      * Four-level verification:
-     * 1. **Title similarity** >= 0.6 (prevents wrong song by same artist)
+     * 1. **Title similarity** >= 0.6, OR the candidate contains the target title
+     *    as a contiguous token run (rescues decorated / CJK / dual-script titles)
      * 2. **Short title containment** — for titles <= 5 chars, candidate must
      *    contain the target as a word (Jaro-Winkler inflates scores for short strings)
-     * 3. **Artist similarity** >= 0.65 + word overlap (prevents wrong artist)
+     * 3. **Artist similarity** >= 0.65 + word overlap, OR a per-part match
+     *    (rescues bilingual slash-joined uploaders); prevents wrong artist
      * 4. **Video ID verification** — InnerTube player endpoint confirms the actual
      *    video title matches (catches InnerTube metadata/ID mismatches)
      *
@@ -620,9 +622,14 @@ class DownloadManager @Inject constructor(
             return null
         }
 
-        // Gate 1: Title similarity
+        // Gate 1: Title similarity — with a containment escape for decorated
+        // candidate titles (artist prefix, "(Official Lyric Video)", 【…】,
+        // "OST - 172", CJK + romanised dual titles) whose Jaro-Winkler is
+        // dragged below 0.6 even though the candidate clearly contains the
+        // target title. Duration (Gate 0), short-title word (Gate 2) and
+        // artist (Gate 3) gates still guard against wrong-song acceptance.
         val titleSim = matchScorer.titleSimilarity(track.title, best.title)
-        if (titleSim < 0.6f) {
+        if (titleSim < 0.6f && !matchScorer.titleContainsTarget(track.title, best.title)) {
             Log.w(TAG, "resolveUrl: rejecting '${best.title}' — title sim ${String.format("%.2f", titleSim)} too low for '${track.title}'")
             return null
         }
@@ -640,13 +647,25 @@ class DownloadManager @Inject constructor(
             }
         }
 
-        // Gate 3: Artist similarity + word overlap
+        // Gate 3: Artist similarity + word overlap, with three escapes for the
+        // CJK / official-upload cases the whitespace-token metric can't see:
+        //  - per-part match for bilingual slash-joined uploaders
+        //    ("かいりきベア／Kairiki bear" whose romanised half == a target part),
+        //  - artist named in the title ("美波「…」MV" / "OMORI OST - …" on a
+        //    romanised or studio channel), and
+        //  - " - Topic" channels (YouTube's auto-generated official audio,
+        //    already trusted by the scorer's topic bonus).
+        // Any escape short-circuits BOTH the fuzzy-sim and word-overlap sub-gates.
         val artistSim = matchScorer.artistSimilarity(track.artist, best.uploader)
-        if (artistSim < 0.65f) {
+        val isTopicChannel = best.uploader.trim().endsWith(" - Topic")
+        val artistMatchOk = isTopicChannel ||
+            matchScorer.artistPartMatches(track.artist, best.uploader) ||
+            matchScorer.artistAppearsInTitle(track.artist, best.title)
+        if (artistSim < 0.65f && !artistMatchOk) {
             Log.w(TAG, "resolveUrl: rejecting '${best.title}' by '${best.uploader}' — fuzzy artist sim ${String.format("%.2f", artistSim)} too low for '${track.artist}'")
             return null
         }
-        if (!artistWordsMatch(track.artist, best.uploader)) {
+        if (!artistMatchOk && !artistWordsMatch(track.artist, best.uploader)) {
             Log.w(TAG, "resolveUrl: rejecting '${best.title}' by '${best.uploader}' — artist words don't match '${track.artist}'")
             return null
         }
@@ -659,7 +678,7 @@ class DownloadManager @Inject constructor(
         val verification = searchExecutor.verifyVideo(best.videoId)
         if (verification != null) {
             val actualTitleSim = matchScorer.titleSimilarity(track.title, verification.title)
-            if (actualTitleSim < 0.6f) {
+            if (actualTitleSim < 0.6f && !matchScorer.titleContainsTarget(track.title, verification.title)) {
                 Log.w(TAG, "resolveUrl: VIDEO ID MISMATCH for '${track.title}' — " +
                     "search said '${best.title}' but player says '${verification.title}' (sim=${String.format("%.2f", actualTitleSim)})")
                 return null

--- a/data/download/src/main/kotlin/com/stash/data/download/matching/MatchScorer.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/matching/MatchScorer.kt
@@ -76,6 +76,14 @@ class MatchScorer @Inject constructor(
          * title is labelled.
          */
         const val EXPLICIT_MISMATCH_PENALTY = 0.15f
+
+        /**
+         * Multi-artist credit separators used by [artistParts]. Covers ASCII
+         * (`,;&/|`), CJK full-width slash/middot (`／・`), and the spelled-out
+         * " feat. / ft. / and " joiners.
+         */
+        private val ARTIST_PART_SEPARATOR =
+            Regex("""[,;&/／・|]|\s+(?:feat\.?|ft\.?|and)\s+""", RegexOption.IGNORE_CASE)
     }
 
     /**
@@ -112,7 +120,14 @@ class MatchScorer @Inject constructor(
 
         return results.map { result ->
             val titleScore = computeTitleScore(targetTitle, result.title)
-            val artistScore = computeArtistScore(targetArtist, result.uploader)
+            // Credit the artist when the uploader name doesn't match but the
+            // artist is named in the title — official J/K-pop uploads
+            // ("美波「カワキヲアメク」MV" on romanised channel "Minami") otherwise
+            // score artist=0 and miss the 0.60 composite gate.
+            val artistScore = maxOf(
+                computeArtistScore(targetArtist, result.uploader),
+                if (artistAppearsInTitle(targetArtist, result.title)) artistInTitleScore else 0f,
+            )
             val durationScore = computeDurationScore(targetDurationMs, result.duration.toLong())
             val popularityScore = computePopularityScore(result.viewCount, maxViewCount)
             val penalty = computePenalty(targetTitle, result.title)
@@ -186,6 +201,123 @@ class MatchScorer @Inject constructor(
     fun titleSimilarity(targetTitle: String, resultTitle: String): Float {
         return computeTitleScore(targetTitle, resultTitle)
     }
+
+    /**
+     * Containment escape for the hard title gate. Returns true when the
+     * (canonicalised) target title appears as a contiguous run of word tokens
+     * inside the candidate's video title.
+     *
+     * The Jaro-Winkler title gate compares the clean target against the
+     * candidate's *full decorated* title — artist prefix ("SunKissed Lola -
+     * …"), "(Official Lyric Video)" suffix, 【…】 annotations, "OST - 172"
+     * numbering, or a CJK + romanised dual title — and so rejects correct
+     * matches whose extra tokens drown out the overlap (field-observed at
+     * 0.43–0.58 for confirmed-correct official uploads). Substring containment
+     * recovers them while the duration gate, artist gate, and short-title word
+     * gate still guard against wrong-song acceptance.
+     *
+     * Asymmetric normalisation by design:
+     *  - **Target** runs through [TrackMatcher.canonicalTitle] first so a
+     *    "(feat. …)" / "(remix)" decoration on the target doesn't prevent a
+     *    bare candidate from satisfying it.
+     *  - **Candidate** keeps bracket/paren *contents* (only punctuation is
+     *    neutralised to token breaks) — canonicalTitle would delete the
+     *    "(Readymade)" that a "Readymade" target needs to match.
+     *
+     * CJK scripts carry no whitespace, so a kana/hanzi title collapses to a
+     * single token and matches by whole-token equality.
+     */
+    fun titleContainsTarget(targetTitle: String, candidateTitle: String): Boolean {
+        val target = looseTokens(trackMatcher.canonicalTitle(targetTitle))
+        return containsRun(haystack = looseTokens(candidateTitle), needle = target)
+    }
+
+    /**
+     * Per-part escape for the artist gate. Returns true when any significant
+     * part of the target artist matches any part of the candidate uploader
+     * after splitting on multi-artist separators and stripping spaces and
+     * punctuation.
+     *
+     * Rescues bilingual / slash-joined official channels such as
+     * "かいりきベア／Kairiki bear" whose romanised half equals a target part
+     * ("Kairikibear") but whose whole-string Jaro-Winkler is dragged below the
+     * 0.65 gate by the CJK half plus the user's comma-joined multi-artist
+     * credit. The leading " - Topic" suffix is stripped first (Topic channels
+     * are the authoritative audio source).
+     */
+    fun artistPartMatches(targetArtist: String, candidateUploader: String): Boolean {
+        val targetParts = artistParts(targetArtist)
+        val candidateParts = artistParts(candidateUploader.replace(" - Topic", ""))
+        if (targetParts.isEmpty() || candidateParts.isEmpty()) return false
+        return targetParts.any { t ->
+            candidateParts.any { c ->
+                t == c || (t.length >= 4 && c.length >= 4 && (c.contains(t) || t.contains(c)))
+            }
+        }
+    }
+
+    /**
+     * True when the target artist appears inside the candidate's video title.
+     *
+     * Official J-pop/K-pop uploads format titles as "Artist「Song」MV" or
+     * "【Artist】Song", so the artist is present in the *title* even when the
+     * uploader is a romanised channel name ("Minami" for 美波) that scores 0
+     * against the CJK artist on [artistSimilarity]. This is the dominant cause
+     * of CJK-artist tracks failing the 0.60 composite auto-accept gate. Used
+     * both as a scoring credit (lifts the composite) and as an escape on the
+     * verify-stage artist gate.
+     *
+     * A part matches when it equals a candidate title token or is contained in
+     * one (CJK titles glue artist + song with no separator). Parts shorter than
+     * 2 chars are ignored to avoid trivial collisions.
+     */
+    fun artistAppearsInTitle(targetArtist: String, candidateTitle: String): Boolean {
+        val candidate = looseTokens(candidateTitle)
+        if (candidate.isEmpty()) return false
+        // Each distinct artist in a multi-artist credit, matched as its own
+        // contiguous word run ("Will Stetson" → ["will","stetson"]).
+        return targetArtist.split(ARTIST_PART_SEPARATOR)
+            .map { looseTokens(it) }
+            .filter { tokens -> tokens.sumOf { it.length } >= 2 }
+            .any { artistTokens -> containsRun(haystack = candidate, needle = artistTokens) }
+    }
+
+    /** Artist score credited when [artistAppearsInTitle] holds but the uploader
+     *  name itself doesn't match (e.g. CJK artist, romanised channel). */
+    private val artistInTitleScore = 0.85f
+
+    /**
+     * Split a string into lowercased word tokens, treating every non
+     * letter-or-digit character (punctuation, brackets, whitespace, CJK
+     * full-width punctuation) as a token break. CJK ideographs, kana and
+     * hangul are letters, so a whitespace-free native title stays one token.
+     */
+    private fun looseTokens(s: String): List<String> =
+        s.lowercase()
+            .map { if (it.isLetterOrDigit()) it else ' ' }
+            .joinToString("")
+            .split(' ')
+            .filter { it.isNotBlank() }
+
+    /** True when [needle] appears as a contiguous run of tokens in [haystack]. */
+    private fun containsRun(haystack: List<String>, needle: List<String>): Boolean {
+        if (needle.isEmpty() || needle.size > haystack.size) return false
+        for (start in 0..(haystack.size - needle.size)) {
+            if (haystack.subList(start, start + needle.size) == needle) return true
+        }
+        return false
+    }
+
+    /**
+     * Split an artist credit into normalised comparison parts: break on
+     * multi-artist separators (`,;&/／・|` and " feat./ft./and "), then strip
+     * each part down to its letter/digit characters (so "Kairiki bear" and
+     * "Kairikibear" coincide). Parts shorter than 2 chars are dropped.
+     */
+    private fun artistParts(artist: String): List<String> =
+        artist.split(ARTIST_PART_SEPARATOR)
+            .map { part -> part.lowercase().filter { it.isLetterOrDigit() } }
+            .filter { it.length >= 2 }
 
     // -- Private scoring helpers --------------------------------------------------
 

--- a/data/download/src/test/kotlin/com/stash/data/download/matching/MatchScorerTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/matching/MatchScorerTest.kt
@@ -291,4 +291,151 @@ class MatchScorerTest {
             scorer.bestMatch(results) != null,
         )
     }
+
+    // ── Decorated-title containment escape (titleContainsTarget) ─────────
+    //
+    // Real field failures from a K-pop/J-pop library download (v0.9.38).
+    // The hard title gate (titleSimilarity >= 0.6) rejected these CORRECT
+    // matches because it Jaro-Winklers the clean target against the
+    // candidate's full *decorated* video title — artist prefix, "(Official
+    // Lyric Video)" suffix, 【…】 annotations, OST numbering, or CJK +
+    // romanised dual titles. Containment of the (canonicalised) target as a
+    // contiguous token run rescues them. NOTE: not a CJK-only bug — the
+    // Pasilyo case is pure ASCII Filipino OPM.
+
+    @Test
+    fun `titleContainsTarget rescues Pasilyo behind artist prefix and lyric-video suffix`() {
+        // titleSimilarity scored 0.58 in the field — official channel, art=1.00.
+        assertTrue(
+            scorer.titleContainsTarget("Pasilyo", "SunKissed Lola - Pasilyo (Official Lyric Video)"),
+        )
+    }
+
+    @Test
+    fun `titleContainsTarget rescues Ado Readymade behind CJK title and brackets`() {
+        // titleSimilarity scored 0.47 — the (Readymade) the gate needs is one
+        // canonicalTitle would strip, so containment must keep candidate parens.
+        assertTrue(
+            scorer.titleContainsTarget("Readymade", "【Ado】レディメイド (Readymade)"),
+        )
+    }
+
+    @Test
+    fun `titleContainsTarget rescues OST numbered title`() {
+        // titleSimilarity scored 0.43 for "Duet" vs "OMORI OST - 172 DUET".
+        assertTrue(
+            scorer.titleContainsTarget("Duet", "OMORI OST - 172 DUET"),
+        )
+    }
+
+    @Test
+    fun `titleContainsTarget rescues feat-decorated target against bare candidate`() {
+        // Target carries "(feat. …)"; the official upload leads with the bare
+        // native title. Canonicalising the target (drops the feat) then
+        // matching its token run inside the candidate rescues it.
+        assertTrue(
+            scorer.titleContainsTarget("メズマライザー (feat. 初音ミク&重音テト)", "メズマライザー／32ki"),
+        )
+    }
+
+    @Test
+    fun `titleContainsTarget rejects an unrelated piano-arrangement cover`() {
+        // Correct rejection: this candidate is a piano-sheet cover, not the
+        // track. Containment must NOT rescue it.
+        assertFalse(
+            scorer.titleContainsTarget("『んっあっあっ。』 (feat. 初音ミク)", "\"Hmm,Ah,Ah.\"　SLAVE.V-V-R"),
+        )
+    }
+
+    @Test
+    fun `titleContainsTarget rejects a different song that merely shares no run`() {
+        assertFalse(scorer.titleContainsTarget("Hello", "Goodbye Song"))
+    }
+
+    // ── Bilingual / multi-artist uploader escape (artistPartMatches) ─────
+
+    @Test
+    fun `artistPartMatches rescues bilingual slash-joined uploader`() {
+        // fuzzy artist sim scored 0.62 (< 0.65) for "Kairikibear, flower" vs
+        // "かいりきベア／Kairiki bear" — but the romanised half equals a target part
+        // once spaces are stripped.
+        assertTrue(
+            scorer.artistPartMatches("Kairikibear, flower", "かいりきベア／Kairiki bear"),
+        )
+    }
+
+    @Test
+    fun `artistPartMatches strips the Topic suffix before comparing`() {
+        assertTrue(scorer.artistPartMatches("Ado", "Ado - Topic"))
+    }
+
+    @Test
+    fun `artistPartMatches rejects an unrelated cover uploader`() {
+        // Correct rejection: piano-arrangement channel, not the artist.
+        assertFalse(
+            scorer.artistPartMatches("SLAVE.V-V-R", "Niisan【ピアノ楽譜 アレンジ】"),
+        )
+    }
+
+    // ── Artist-in-title signal (artistAppearsInTitle) ────────────────────
+    //
+    // Official J-pop/K-pop uploads format the title as "Artist「Song」MV" or
+    // "【Artist】Song", so the artist is present in the *title* even when the
+    // uploader is a romanised channel name that scores 0 against the CJK
+    // artist — the dominant remaining cause of CJK-artist download failures.
+
+    @Test
+    fun `artistAppearsInTitle credits CJK artist present in Artist-bracket-Song title`() {
+        // 美波「カワキヲアメク」MV uploaded by romanised channel "Minami":
+        // artistSimilarity(美波, Minami) = 0.00 tanks the composite below 0.6.
+        assertTrue(scorer.artistAppearsInTitle("美波", "美波「カワキヲアメク」MV"))
+    }
+
+    @Test
+    fun `artistAppearsInTitle credits OMORI present in OST title uploaded by studio`() {
+        // "OMORI OST - 172 DUET" by uploader "OMOCAT" — artist "Omori" is in
+        // the title even though it disagrees with the uploader.
+        assertTrue(scorer.artistAppearsInTitle("Omori", "OMORI OST - 172 DUET"))
+    }
+
+    @Test
+    fun `artistAppearsInTitle credits cover artist in bracketed title`() {
+        assertTrue(
+            scorer.artistAppearsInTitle(
+                "Will Stetson",
+                "Lost Umbrella (English Cover)【Will Stetson feat. Kariyu】「ロストアンブレラ」",
+            ),
+        )
+    }
+
+    @Test
+    fun `artistAppearsInTitle rejects a title that does not name the artist`() {
+        assertFalse(scorer.artistAppearsInTitle("Adele", "Taylor Swift - Love Story"))
+    }
+
+    @Test
+    fun `scoreResults lifts a CJK-artist match above auto-accept via artist-in-title`() {
+        // Regression guard for the 美波 class: title in the candidate, romanised
+        // uploader → without the artist-in-title credit the composite is 0.45
+        // and bestMatch returns null. With it, the official MV auto-accepts.
+        val results = scorer.scoreResults(
+            targetTitle = "カワキヲアメク",
+            targetArtist = "美波",
+            targetDurationMs = 240_000,
+            results = listOf(
+                candidate(
+                    id = "minami_mv",
+                    title = "美波「カワキヲアメク」MV",
+                    artist = "Minami",
+                    channel = "Minami",
+                    durationSec = 240.0,
+                    viewCount = 5_000_000,
+                ),
+            ),
+        )
+        assertTrue(
+            "official MV must auto-accept once the artist-in-title credit applies",
+            scorer.bestMatch(results) != null,
+        )
+    }
 }


### PR DESCRIPTION
## Summary

K-pop / J-pop / non-Latin libraries were missing a large fraction of their tracks on download. Root-caused on-device to the **YouTube-fallback verify gates** in `DownloadManager` (the gate counterpart to the earlier lossless-query fix), which compared the clean target title/artist against YouTube's *decorated* candidate strings using whitespace-token (Jaro-Winkler) similarity — a metric that collapses on the shapes common to non-Latin music:

- **Decorated candidate titles** — artist prefix, `(Official Lyric Video)`, `【…】`, `OST - 172` — drag title similarity below the 0.6 gate even for the official upload. **Not CJK-only:** pure-ASCII `SunKissed Lola - Pasilyo (Official Lyric Video)` scored 0.58.
- **CJK artist vs romanized uploader** — `美波` vs channel `Minami` scores artist-sim 0.00, sinking the composite below the 0.60 auto-accept gate *before* the verify gates run — though the artist is named in the title (`美波「カワキヲアメク」MV`).
- **Romanized-seiyuu / studio uploaders** — `OMORI OST` by `OMOCAT`, seiyuu credits CJK-vs-romanized.

## Changes

Three token-run / containment escapes in `MatchScorer`:
- `titleContainsTarget` — canonicalised target as a contiguous token run inside the candidate (keeps candidate bracket *contents* that `canonicalTitle` strips). Escapes title Gate 1 + video-id re-verify Gate 4.
- `artistAppearsInTitle` — artist word-run present in the candidate title; credited into the composite `artistScore` (so official `Artist「Song」MV` uploads clear 0.60) and used as an artist-gate escape.
- `artistPartMatches` — per-part match for bilingual slash-joined uploaders (`かいりきベア／Kairiki bear`).

`DownloadManager` Gate 3 also trusts `" - Topic"` channels (YouTube's auto-generated official audio).

## Test Plan

- [x] 10 new `MatchScorerTest` cases built from the **real field-failing titles** (Ado — Readymade, Pasilyo, OMORI Duet, 美波, Will Stetson, Kairikibear, etc.), incl. negative cases (piano-cover rejections must stay rejected). All green.
- [x] **On-device (Pixel 6 Pro, 3 K-pop/J-pop playlists, ~1.4k tracks):** re-running the failed downloads under this build took the failure set from **39 → 1**, and the one remaining (`ZØMB — LUNAR ROT`) is a *correct* rejection — only a different song exists on YouTube. Rescued: Ado — Readymade/Usseewa, YOASOBI — アイドル, ROSÉ/Bruno Mars — APT., 結束バンド, P丸様｡, DECO*27, Creepy Nuts, …
- [x] No new unit-test regressions (`InnerTubeSearchExecutorTest` / `YtLibraryCanonicalizerTest` are pre-existing Mockito failures on `master`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)