### PR TITLE
fix: match/resync reliability (#36, #19, #143)

### DIFF
--- a/data/download/src/main/kotlin/com/stash/data/download/files/SwapCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/SwapCoordinator.kt
@@ -85,58 +85,102 @@ class SwapCoordinator @Inject constructor(
         newVideoId: String,
     ) {
         scope.launch {
-            // v0.9.15: Reject blocklisted identities. A swap on a blocked
-            // track would re-mark it downloaded and resurrect the file.
-            if (blocklistGuard.isBlocked(
-                    artist = artist, title = title,
-                    spotifyUri = null, youtubeId = newVideoId,
-                )) {
-                Log.d(TAG, "Refused swap of blocked: $artist - $title")
-                return@launch
-            }
+            performSwap(trackId, oldFilePath, artist, title, newVideoId)
+        }
+    }
 
-            oldFilePath?.let { oldPath ->
-                try {
-                    val deleted = File(oldPath).delete()
-                    Log.d(TAG, "swap: old file delete path=$oldPath deleted=$deleted")
-                } catch (e: Exception) {
-                    Log.w(TAG, "swap: old file delete threw", e)
-                }
-            }
+    /**
+     * The actual swap body, exposed as a suspend function so it can be
+     * unit-tested directly without racing the fire-and-forget [scope].
+     */
+    internal suspend fun performSwap(
+        trackId: Long,
+        oldFilePath: String?,
+        artist: String,
+        title: String,
+        newVideoId: String,
+    ) {
+        // v0.9.15: Reject blocklisted identities. A swap on a blocked
+        // track would re-mark it downloaded and resurrect the file.
+        if (blocklistGuard.isBlocked(
+                artist = artist, title = title,
+                spotifyUri = null, youtubeId = newVideoId,
+            )) {
+            Log.d(TAG, "Refused swap of blocked: $artist - $title")
+            return
+        }
 
-            try {
-                val url = "https://www.youtube.com/watch?v=$newVideoId"
-                val qualityArgs = qualityPrefs.qualityTier.first().toYtDlpArgs()
-                val tempDir = fileOrganizer.getTempDir()
-                val tempFilename = "swap_$newVideoId"
+        try {
+            val url = "https://www.youtube.com/watch?v=$newVideoId"
+            val qualityArgs = qualityPrefs.qualityTier.first().toYtDlpArgs()
+            val tempDir = fileOrganizer.getTempDir()
+            val tempFilename = "swap_$newVideoId"
 
-                val result = downloadExecutor.download(
-                    url = url,
-                    outputDir = tempDir,
-                    filename = tempFilename,
-                    qualityArgs = qualityArgs,
+            // #36: download + commit the replacement BEFORE touching the old
+            // file. The previous order deleted the user's existing audio up
+            // front, so a failed download left them with nothing AND a row
+            // silently gone (the flag was already cleared in the VM).
+            val result = downloadExecutor.download(
+                url = url,
+                outputDir = tempDir,
+                filename = tempFilename,
+                qualityArgs = qualityArgs,
+            )
+
+            if (result is DownloadResult.Success) {
+                val committed = fileOrganizer.commitDownload(
+                    tempFile = result.file,
+                    artist = artist,
+                    album = null,
+                    title = title,
+                    format = result.file.extension,
                 )
+                trackDao.updateYoutubeId(trackId, newVideoId)
+                trackDao.markAsDownloaded(trackId, committed.filePath, committed.sizeBytes)
 
-                if (result is DownloadResult.Success) {
-                    val committed = fileOrganizer.commitDownload(
-                        tempFile = result.file,
-                        artist = artist,
-                        album = null,
-                        title = title,
-                        format = result.file.extension,
-                    )
-                    trackDao.updateYoutubeId(trackId, newVideoId)
-                    trackDao.markAsDownloaded(trackId, committed.filePath, committed.sizeBytes)
-                    Log.i(
-                        TAG,
-                        "swap: completed trackId=$trackId → videoId=$newVideoId path=${committed.filePath}",
-                    )
-                } else {
-                    Log.w(TAG, "swap: download failed for videoId=$newVideoId: $result")
+                // Only now is it safe to remove the old file — and only if it
+                // isn't the very path we just wrote (same artist/title can
+                // resolve to the same canonical file). A stray leftover is
+                // fine; the orphan cleanup pass eventually catches it.
+                oldFilePath?.let { oldPath ->
+                    if (oldPath != committed.filePath) {
+                        try {
+                            val deleted = File(oldPath).delete()
+                            Log.d(TAG, "swap: old file delete path=$oldPath deleted=$deleted")
+                        } catch (e: Exception) {
+                            Log.w(TAG, "swap: old file delete threw", e)
+                        }
+                    }
                 }
-            } catch (e: Exception) {
-                Log.w(TAG, "swap: unexpected error for videoId=$newVideoId", e)
+
+                Log.i(
+                    TAG,
+                    "swap: completed trackId=$trackId → videoId=$newVideoId path=${committed.filePath}",
+                )
+            } else {
+                // Download failed: the optimistic flag-clear in the VM made the
+                // row disappear. Re-flag so it reappears in Failed Matches and
+                // the user knows the swap didn't take, instead of silently
+                // losing the track (#36). The old file is untouched.
+                Log.w(TAG, "swap: download failed for videoId=$newVideoId: $result")
+                reFlagAfterFailure(trackId)
             }
+        } catch (e: Exception) {
+            Log.w(TAG, "swap: unexpected error for videoId=$newVideoId", e)
+            reFlagAfterFailure(trackId)
+        }
+    }
+
+    /**
+     * Restores the wrong-match flag after a failed swap so the row returns to
+     * the Failed Matches screen. Best-effort: a failure to re-flag is logged
+     * but not propagated (the swap already failed; nothing more to do here).
+     */
+    private suspend fun reFlagAfterFailure(trackId: Long) {
+        try {
+            trackDao.updateMatchFlagged(trackId, true)
+        } catch (e: Exception) {
+            Log.w(TAG, "swap: failed to re-flag trackId=$trackId after failure", e)
         }
     }
 }

--- a/data/download/src/test/kotlin/com/stash/data/download/files/SwapCoordinatorTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/files/SwapCoordinatorTest.kt
@@ -1,0 +1,115 @@
+package com.stash.data.download.files
+
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.model.QualityTier
+import com.stash.data.download.DownloadExecutor
+import com.stash.data.download.DownloadResult
+import com.stash.data.download.prefs.QualityPreferencesManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Regression tests for the wrong-match swap (#36): a failed swap must not
+ * destroy the user's existing file or silently vanish the flagged row, and
+ * a successful swap must commit the new audio before touching the old file.
+ */
+class SwapCoordinatorTest {
+
+    @get:Rule val tmp = TemporaryFolder()
+
+    private val downloadExecutor = mockk<DownloadExecutor>()
+    private val fileOrganizer = mockk<FileOrganizer>()
+    private val qualityPrefs = mockk<QualityPreferencesManager>()
+    private val trackDao = mockk<TrackDao>(relaxed = true)
+    private val blocklistGuard = mockk<BlocklistGuard>(relaxed = true)
+
+    private lateinit var coordinator: SwapCoordinator
+
+    @Before
+    fun setUp() {
+        every { qualityPrefs.qualityTier } returns flowOf(QualityTier.MAX)
+        every { fileOrganizer.getTempDir() } returns tmp.newFolder("temp")
+        coordinator = SwapCoordinator(
+            downloadExecutor = downloadExecutor,
+            fileOrganizer = fileOrganizer,
+            qualityPrefs = qualityPrefs,
+            trackDao = trackDao,
+            blocklistGuard = blocklistGuard,
+        )
+    }
+
+    @Test
+    fun `failed download keeps the old file on disk`() = runTest {
+        val oldFile = tmp.newFile("old.m4a").apply { writeText("original audio") }
+        coEvery {
+            downloadExecutor.download(any(), any(), any(), any(), any())
+        } returns DownloadResult.YtDlpError("boom")
+
+        coordinator.performSwap(
+            trackId = 7L,
+            oldFilePath = oldFile.absolutePath,
+            artist = "Artist",
+            title = "Title",
+            newVideoId = "vid123",
+        )
+
+        assertTrue("old file must survive a failed swap", oldFile.exists())
+        coVerify(exactly = 0) { trackDao.updateYoutubeId(any(), any()) }
+    }
+
+    @Test
+    fun `failed download re-flags the track so the row reappears`() = runTest {
+        val oldFile = tmp.newFile("old2.m4a")
+        coEvery {
+            downloadExecutor.download(any(), any(), any(), any(), any())
+        } returns DownloadResult.Error("network down")
+
+        coordinator.performSwap(
+            trackId = 7L,
+            oldFilePath = oldFile.absolutePath,
+            artist = "Artist",
+            title = "Title",
+            newVideoId = "vid123",
+        )
+
+        coVerify { trackDao.updateMatchFlagged(7L, true) }
+    }
+
+    @Test
+    fun `successful swap commits new audio, updates the track, then deletes the old file`() = runTest {
+        val oldFile = tmp.newFile("old3.m4a").apply { writeText("original") }
+        val newTemp = tmp.newFile("swap_vid123.m4a").apply { writeText("replacement") }
+        val committedPath = File(tmp.root, "Artist/Title.m4a").absolutePath
+        coEvery {
+            downloadExecutor.download(any(), any(), any(), any(), any())
+        } returns DownloadResult.Success(newTemp)
+        coEvery {
+            fileOrganizer.commitDownload(any(), any(), any(), any(), any())
+        } returns FileOrganizer.CommittedTrack(committedPath, 123L)
+
+        coordinator.performSwap(
+            trackId = 7L,
+            oldFilePath = oldFile.absolutePath,
+            artist = "Artist",
+            title = "Title",
+            newVideoId = "vid123",
+        )
+
+        coVerify { trackDao.updateYoutubeId(7L, "vid123") }
+        coVerify { trackDao.markAsDownloaded(7L, committedPath, 123L, any(), any(), any()) }
+        assertFalse("old file should be deleted only after a successful swap", oldFile.exists())
+        coVerify(exactly = 0) { trackDao.updateMatchFlagged(7L, true) }
+    }
+}

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
@@ -279,6 +279,18 @@ class FailedMatchesViewModel @Inject constructor(
 
             _isResyncing.value = false
 
+            // #143: a resync that surfaces no candidates is otherwise
+            // indistinguishable from a button that did nothing. Always report
+            // the outcome so the user knows the pass actually ran.
+            val found = _resyncCandidates.value.size
+            _userMessages.tryEmit(
+                when (found) {
+                    0 -> "No new matches found."
+                    1 -> "Found 1 replacement."
+                    else -> "Found $found replacements."
+                },
+            )
+
             // Pre-extract stream URLs for instant audio previews
             preExtractStreamUrls(_resyncCandidates.value)
         }

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
@@ -235,7 +235,12 @@ class FailedMatchesViewModel @Inject constructor(
             // Each row becomes a (trackId, searchQuery, rejectedVideoId?)
             // triple so the same semaphored search loop handles both kinds.
             val unmatched = uiState.value.tracks.map {
-                Triple(it.trackId, it.searchQuery, it.rejectedVideoId)
+                // Auto-requeued tracks (TrackDownloadWorker) get a blank
+                // download_queue.search_query. Fall back to "artist - title"
+                // — which we already have on the row — so resync can actually
+                // search instead of firing a blank query that finds nothing.
+                val query = it.searchQuery.ifBlank { "${it.artist} - ${it.title}" }
+                Triple(it.trackId, query, it.rejectedVideoId)
             }
             val flagged = uiState.value.flaggedTracks.map {
                 Triple(it.trackId, it.searchQuery, it.currentYoutubeId)

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
@@ -254,8 +254,26 @@ class FailedMatchesViewModel @Inject constructor(
                         // For flagged tracks, skip the currently-associated
                         // (wrong) video — surfacing it as the candidate would
                         // just swap the track with itself.
-                        val best = results.firstOrNull { excludeVideoId == null || it.id != excludeVideoId }
-                            ?: results.firstOrNull()
+                        var best = results.firstOrNull { excludeVideoId == null || it.id != excludeVideoId }
+
+                        // #19/#143: search() is InnerTube-first and only falls
+                        // back to yt-dlp when YT Music returns *zero* results.
+                        // When YT Music returns results but none are usable —
+                        // it's empty, or only the rejected/wrong video came back
+                        // — broaden to a full-YouTube yt-dlp search, which
+                        // surfaces tracks that exist on YouTube but not YouTube
+                        // Music (and genuine alternatives to a wrong match).
+                        if (best == null) {
+                            val direct = searchExecutor.searchYtDlpDirect(query, maxResults = 5)
+                            best = direct.firstOrNull { excludeVideoId == null || it.id != excludeVideoId }
+                        }
+
+                        // Last resort: surface the top result even if it's the
+                        // excluded one, so an unmatched track still gets *a*
+                        // candidate to preview rather than nothing.
+                        if (best == null) {
+                            best = results.firstOrNull()
+                        }
                         if (best != null) {
                             _resyncCandidates.update { current ->
                                 current + (trackId to ResyncCandidate(

--- a/feature/sync/src/test/kotlin/com/stash/feature/sync/FailedMatchesResyncFeedbackTest.kt
+++ b/feature/sync/src/test/kotlin/com/stash/feature/sync/FailedMatchesResyncFeedbackTest.kt
@@ -1,0 +1,106 @@
+package com.stash.feature.sync
+
+import com.stash.core.data.db.dao.UnmatchedTrackView
+import com.stash.core.data.repository.MusicRepository
+import com.stash.core.media.preview.PreviewPlayer
+import com.stash.data.download.DownloadExecutor
+import com.stash.data.download.files.FileOrganizer
+import com.stash.data.download.files.SwapCoordinator
+import com.stash.data.download.matching.HybridSearchExecutor
+import com.stash.data.download.prefs.QualityPreferencesManager
+import com.stash.data.download.preview.PreviewUrlExtractor
+import com.stash.data.download.ytdlp.YtDlpSearchResult
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * #143 — "resync button does nothing". A resync that finds no candidates is
+ * indistinguishable from a dead button unless it tells the user the pass
+ * completed. These tests pin the completion feedback.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FailedMatchesResyncFeedbackTest {
+
+    private val musicRepository: MusicRepository = mockk(relaxed = true)
+    private val previewPlayer: PreviewPlayer = mockk(relaxed = true)
+    private val previewUrlExtractor: PreviewUrlExtractor = mockk(relaxed = true)
+    private val searchExecutor: HybridSearchExecutor = mockk(relaxed = true)
+    private val downloadExecutor: DownloadExecutor = mockk(relaxed = true)
+    private val fileOrganizer: FileOrganizer = mockk(relaxed = true)
+    private val qualityPrefs: QualityPreferencesManager = mockk(relaxed = true)
+    private val trackDao = mockk<com.stash.core.data.db.dao.TrackDao>(relaxed = true)
+    private val downloadQueueDao = mockk<com.stash.core.data.db.dao.DownloadQueueDao>(relaxed = true)
+    private val swapCoordinator: SwapCoordinator = mockk(relaxed = true)
+    private val blocklistGuard = mockk<com.stash.core.data.blocklist.BlocklistGuard>(relaxed = true)
+
+    @Before fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun unmatched() = UnmatchedTrackView(
+        id = 1L, trackId = 1L, title = "Title", artist = "Artist",
+        albumArtUrl = null, createdAt = 0L, rejectedVideoId = null,
+        searchQuery = "Artist - Title",
+    )
+
+    private fun makeVm(): FailedMatchesViewModel {
+        every { musicRepository.getUnmatchedTracks() } returns flowOf(listOf(unmatched()))
+        every { musicRepository.getFlaggedTracks() } returns flowOf(emptyList())
+        return FailedMatchesViewModel(
+            musicRepository, previewPlayer, previewUrlExtractor, searchExecutor,
+            downloadExecutor, fileOrganizer, qualityPrefs, trackDao,
+            downloadQueueDao, swapCoordinator, blocklistGuard,
+        )
+    }
+
+    @Test fun `resync with zero results tells the user no matches were found`() = runTest {
+        coEvery { searchExecutor.search(any(), any()) } returns emptyList()
+        val vm = makeVm()
+        val messages = mutableListOf<String>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect {} }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.userMessages.collect { messages.add(it) } }
+
+        vm.resync()
+        advanceUntilIdle()
+
+        assertTrue(
+            "expected a 'no matches' completion message, got $messages",
+            messages.any { it.contains("no", ignoreCase = true) && it.contains("match", ignoreCase = true) },
+        )
+    }
+
+    @Test fun `resync that finds a candidate reports how many replacements it found`() = runTest {
+        coEvery { searchExecutor.search(any(), any()) } returns
+            listOf(YtDlpSearchResult(id = "vid1", title = "Title"))
+        val vm = makeVm()
+        val messages = mutableListOf<String>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect {} }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.userMessages.collect { messages.add(it) } }
+
+        vm.resync()
+        advanceUntilIdle()
+
+        assertTrue(
+            "expected a 'found N' completion message, got $messages",
+            messages.any { it.contains("1") && it.contains("replacement", ignoreCase = true) },
+        )
+    }
+}

--- a/feature/sync/src/test/kotlin/com/stash/feature/sync/FailedMatchesResyncFeedbackTest.kt
+++ b/feature/sync/src/test/kotlin/com/stash/feature/sync/FailedMatchesResyncFeedbackTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -101,6 +102,26 @@ class FailedMatchesResyncFeedbackTest {
         assertTrue(
             "expected a 'found N' completion message, got $messages",
             messages.any { it.contains("1") && it.contains("replacement", ignoreCase = true) },
+        )
+    }
+
+    @Test fun `resync falls through to full-YouTube search when YT Music has no usable match`() = runTest {
+        // #19/#143: some tracks exist on YouTube but not YouTube Music. When the
+        // InnerTube (YT Music) pass yields nothing usable, resync must broaden to
+        // a yt-dlp full-YouTube search instead of giving up.
+        coEvery { searchExecutor.search(any(), any()) } returns emptyList()
+        coEvery { searchExecutor.searchYtDlpDirect(any(), any()) } returns
+            listOf(YtDlpSearchResult(id = "ytOnly", title = "Title"))
+        val vm = makeVm()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect {} }
+
+        vm.resync()
+        advanceUntilIdle()
+
+        assertEquals(
+            "expected the full-YouTube result to become the candidate",
+            "ytOnly",
+            vm.uiState.value.resyncCandidates[1L]?.videoId,
         )
     }
 }

--- a/feature/sync/src/test/kotlin/com/stash/feature/sync/FailedMatchesResyncFeedbackTest.kt
+++ b/feature/sync/src/test/kotlin/com/stash/feature/sync/FailedMatchesResyncFeedbackTest.kt
@@ -62,8 +62,10 @@ class FailedMatchesResyncFeedbackTest {
         searchQuery = "Artist - Title",
     )
 
-    private fun makeVm(): FailedMatchesViewModel {
-        every { musicRepository.getUnmatchedTracks() } returns flowOf(listOf(unmatched()))
+    private fun makeVm(
+        tracks: List<UnmatchedTrackView> = listOf(unmatched()),
+    ): FailedMatchesViewModel {
+        every { musicRepository.getUnmatchedTracks() } returns flowOf(tracks)
         every { musicRepository.getFlaggedTracks() } returns flowOf(emptyList())
         return FailedMatchesViewModel(
             musicRepository, previewPlayer, previewUrlExtractor, searchExecutor,
@@ -122,6 +124,31 @@ class FailedMatchesResyncFeedbackTest {
             "expected the full-YouTube result to become the candidate",
             "ytOnly",
             vm.uiState.value.resyncCandidates[1L]?.videoId,
+        )
+    }
+
+    @Test fun `resync derives query from artist and title when the stored search query is blank`() = runTest {
+        // Real bug: auto-requeued tracks (TrackDownloadWorker) get an empty
+        // download_queue.search_query. Resync trusted that blank string and
+        // searched for "" -> InnerTube empty -> yt-dlp throws "must not be
+        // blank" -> "can't find a match", even though artist+title are known.
+        val blankQueryTrack = UnmatchedTrackView(
+            id = 1L, trackId = 1L, title = "In the Aeroplane Over the Sea",
+            artist = "Neutral Milk Hotel", albumArtUrl = null, createdAt = 0L,
+            rejectedVideoId = null, searchQuery = "",
+        )
+        val queries = mutableListOf<String>()
+        coEvery { searchExecutor.search(capture(queries), any()) } returns
+            listOf(YtDlpSearchResult(id = "vid1", title = "x"))
+        val vm = makeVm(listOf(blankQueryTrack))
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect {} }
+
+        vm.resync()
+        advanceUntilIdle()
+
+        assertTrue(
+            "resync must search by artist+title, not the blank stored query; queries=$queries",
+            queries.any { it == "Neutral Milk Hotel - In the Aeroplane Over the Sea" },
         )
     }
 }


### PR DESCRIPTION
Fixes the "fix a wrong/unmatched song" flow in Failed Matches / resync.

### #36 — wrong-match swap was unsafe
`SwapCoordinator` deleted the user's existing audio **before** downloading the replacement and swallowed download failures, so a failed swap left the row silently gone (flag already cleared in the VM) with the wrong `youtube_id` intact and the old file destroyed. Now it downloads + commits the replacement first, deletes the old file only on success (and only if it differs from the just-written path), and **re-flags the track on failure** so the row reappears.

### #143 — "resync does nothing"
- `resync()` now emits a completion message ("No new matches found." / "Found N replacement(s).") so an empty pass isn't mistaken for a dead button.
- Auto-requeued tracks get a blank `download_queue.search_query`; resync trusted it and fired an empty search. Now it derives `"artist - title"` (which the row already has) when the stored query is blank — retroactively fixes existing blank-query rows.

### #19 / #143 — tracks only on YouTube, not YT Music
`HybridSearchExecutor.search` only falls back to yt-dlp when InnerTube returns *zero*. Resync now falls through to a full-YouTube search when the YT-Music pass yields no usable candidate.

### Tests
`SwapCoordinatorTest` (3) + `FailedMatchesResyncFeedbackTest` (4), all green. Verified on-device (resync now finds previously-"unmatchable" tracks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
