### PR TITLE
fix: Last.fm rate-limit resilience — breaker + cache + multi-key pool

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,12 @@ val lastFmApiKey: String =
     localProperties.getProperty("lastfm.apiKey") ?: System.getenv("LASTFM_API_KEY").orEmpty()
 val lastFmApiSecret: String =
     localProperties.getProperty("lastfm.apiSecret") ?: System.getenv("LASTFM_API_SECRET").orEmpty()
+// Optional comma-separated pool of EXTRA api keys used only for unsigned read
+// endpoints (tag/similar/etc.) to spread load and raise the shared-key rate
+// ceiling. No secret needed — reads are unsigned. Auth/scrobble always use the
+// primary key above. Empty by default.
+val lastFmExtraApiKeys: String =
+    localProperties.getProperty("lastfm.extraApiKeys") ?: System.getenv("LASTFM_EXTRA_API_KEYS").orEmpty()
 
 android {
     namespace = "com.stash.app"
@@ -81,6 +87,7 @@ android {
         // valid — the Settings UI just disables the connect button.
         buildConfigField("String", "LASTFM_API_KEY", "\"$lastFmApiKey\"")
         buildConfigField("String", "LASTFM_API_SECRET", "\"$lastFmApiSecret\"")
+        buildConfigField("String", "LASTFM_EXTRA_API_KEYS", "\"$lastFmExtraApiKeys\"")
         // v0.9.13: TipJarRepository fetches the public supporters JSON from
         // this URL on Home foreground (cache-aware, ~15 min refresh). Edit
         // the JSON and push to update the supporter list without an APK

--- a/app/src/main/kotlin/com/stash/app/di/LastFmCredentialsModule.kt
+++ b/app/src/main/kotlin/com/stash/app/di/LastFmCredentialsModule.kt
@@ -25,5 +25,12 @@ object LastFmCredentialsModule {
     fun provideLastFmCredentials(): LastFmCredentials = LastFmCredentials(
         apiKey = BuildConfig.LASTFM_API_KEY,
         apiSecret = BuildConfig.LASTFM_API_SECRET,
+        // Comma-separated read-only key pool (optional). Spreads unsigned read
+        // traffic across keys to raise the rate ceiling; blanks are dropped by
+        // LastFmCredentials.readApiKeys.
+        extraReadApiKeys = BuildConfig.LASTFM_EXTRA_API_KEYS
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotBlank() },
     )
 }

--- a/core/data/schemas/com.stash.core.data.db.StashDatabase/31.json
+++ b/core/data/schemas/com.stash.core.data.db.StashDatabase/31.json
@@ -1,0 +1,1788 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 31,
+    "identityHash": "db872c79fcff68f9c3a796f8bdabb315",
+    "entities": [
+      {
+        "tableName": "tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_artist` TEXT NOT NULL DEFAULT '', `duration_ms` INTEGER NOT NULL, `file_path` TEXT, `file_format` TEXT NOT NULL, `quality_kbps` INTEGER NOT NULL, `file_size_bytes` INTEGER NOT NULL, `source` TEXT NOT NULL, `spotify_uri` TEXT, `youtube_id` TEXT, `album_art_url` TEXT, `album_art_path` TEXT, `date_added` INTEGER NOT NULL, `last_played` INTEGER, `play_count` INTEGER NOT NULL, `is_downloaded` INTEGER NOT NULL, `canonical_title` TEXT NOT NULL, `canonical_artist` TEXT NOT NULL, `match_confidence` REAL NOT NULL, `match_dismissed` INTEGER NOT NULL, `match_flagged` INTEGER NOT NULL DEFAULT 0, `isrc` TEXT, `explicit` INTEGER, `music_video_type` TEXT, `yt_canonical_video_id` TEXT, `bits_per_sample` INTEGER, `sample_rate_hz` INTEGER, `spotify_saved_at` INTEGER, `ytmusic_saved_at` INTEGER, `stash_liked_at` INTEGER, `mbid` TEXT, `lastfm_user_playcount` INTEGER, `lastfm_listeners` INTEGER, `lastfm_user_loved` INTEGER NOT NULL DEFAULT 0, `loudness_lufs` REAL, `true_peak_dbfs` REAL, `loudness_measured_at` INTEGER, `is_streamable` INTEGER NOT NULL DEFAULT 0, `is_streamable_checked_at` INTEGER, `metadata_embedded_at` INTEGER, `lyrics_fetched_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileFormat",
+            "columnName": "file_format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "qualityKbps",
+            "columnName": "quality_kbps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "file_size_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotify_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeId",
+            "columnName": "youtube_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtUrl",
+            "columnName": "album_art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtPath",
+            "columnName": "album_art_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayed",
+            "columnName": "last_played",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDownloaded",
+            "columnName": "is_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalTitle",
+            "columnName": "canonical_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalArtist",
+            "columnName": "canonical_artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchConfidence",
+            "columnName": "match_confidence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchDismissed",
+            "columnName": "match_dismissed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchFlagged",
+            "columnName": "match_flagged",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "musicVideoType",
+            "columnName": "music_video_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ytCanonicalVideoId",
+            "columnName": "yt_canonical_video_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitsPerSample",
+            "columnName": "bits_per_sample",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRateHz",
+            "columnName": "sample_rate_hz",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "spotifySavedAt",
+            "columnName": "spotify_saved_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "ytMusicSavedAt",
+            "columnName": "ytmusic_saved_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "stashLikedAt",
+            "columnName": "stash_liked_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mbid",
+            "columnName": "mbid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastfmUserPlaycount",
+            "columnName": "lastfm_user_playcount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastfmListeners",
+            "columnName": "lastfm_listeners",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastfmUserLoved",
+            "columnName": "lastfm_user_loved",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "loudnessLufs",
+            "columnName": "loudness_lufs",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "truePeakDbfs",
+            "columnName": "true_peak_dbfs",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "loudnessMeasuredAt",
+            "columnName": "loudness_measured_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isStreamable",
+            "columnName": "is_streamable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isStreamableCheckedAt",
+            "columnName": "is_streamable_checked_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "metadataEmbeddedAt",
+            "columnName": "metadata_embedded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lyricsFetchedAt",
+            "columnName": "lyrics_fetched_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tracks_spotify_uri",
+            "unique": true,
+            "columnNames": [
+              "spotify_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tracks_spotify_uri` ON `${TABLE_NAME}` (`spotify_uri`)"
+          },
+          {
+            "name": "index_tracks_youtube_id",
+            "unique": true,
+            "columnNames": [
+              "youtube_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tracks_youtube_id` ON `${TABLE_NAME}` (`youtube_id`)"
+          },
+          {
+            "name": "index_tracks_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_artist` ON `${TABLE_NAME}` (`artist`)"
+          },
+          {
+            "name": "index_tracks_album",
+            "unique": false,
+            "columnNames": [
+              "album"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_album` ON `${TABLE_NAME}` (`album`)"
+          },
+          {
+            "name": "index_tracks_date_added",
+            "unique": false,
+            "columnNames": [
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_date_added` ON `${TABLE_NAME}` (`date_added`)"
+          },
+          {
+            "name": "index_tracks_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_last_played` ON `${TABLE_NAME}` (`last_played`)"
+          },
+          {
+            "name": "index_tracks_play_count",
+            "unique": false,
+            "columnNames": [
+              "play_count"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_play_count` ON `${TABLE_NAME}` (`play_count`)"
+          },
+          {
+            "name": "index_tracks_title_artist",
+            "unique": false,
+            "columnNames": [
+              "title",
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_title_artist` ON `${TABLE_NAME}` (`title`, `artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `source` TEXT NOT NULL, `source_id` TEXT NOT NULL, `type` TEXT NOT NULL, `mix_number` INTEGER, `last_synced` INTEGER, `track_count` INTEGER NOT NULL, `is_active` INTEGER NOT NULL, `art_url` TEXT, `snapshot_id` TEXT, `sync_enabled` INTEGER NOT NULL DEFAULT 1, `date_added` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mixNumber",
+            "columnName": "mix_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastSynced",
+            "columnName": "last_synced",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artUrl",
+            "columnName": "art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snapshotId",
+            "columnName": "snapshot_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncEnabled",
+            "columnName": "sync_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_source_id",
+            "unique": true,
+            "columnNames": [
+              "source_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playlists_source_id` ON `${TABLE_NAME}` (`source_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `track_id` INTEGER NOT NULL, `position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `removed_at` INTEGER, `locally_added` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`playlist_id`, `track_id`), FOREIGN KEY(`playlist_id`) REFERENCES `playlists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "removedAt",
+            "columnName": "removed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "locallyAdded",
+            "columnName": "locally_added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "track_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_tracks_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_tracks_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `started_at` INTEGER NOT NULL, `completed_at` INTEGER, `status` TEXT NOT NULL, `playlists_checked` INTEGER NOT NULL, `new_tracks_found` INTEGER NOT NULL, `tracks_downloaded` INTEGER NOT NULL, `tracks_failed` INTEGER NOT NULL, `bytes_downloaded` INTEGER NOT NULL, `error_message` TEXT, `diagnostics` TEXT, `trigger` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistsChecked",
+            "columnName": "playlists_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newTracksFound",
+            "columnName": "new_tracks_found",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tracksDownloaded",
+            "columnName": "tracks_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tracksFailed",
+            "columnName": "tracks_failed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bytesDownloaded",
+            "columnName": "bytes_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "diagnostics",
+            "columnName": "diagnostics",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trigger",
+            "columnName": "trigger",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "download_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `track_id` INTEGER NOT NULL, `sync_id` INTEGER, `status` TEXT NOT NULL, `search_query` TEXT NOT NULL, `youtube_url` TEXT, `retry_count` INTEGER NOT NULL, `error_message` TEXT, `failure_type` TEXT NOT NULL, `rejected_video_id` TEXT, `created_at` INTEGER NOT NULL, `completed_at` INTEGER, FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`sync_id`) REFERENCES `sync_history`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchQuery",
+            "columnName": "search_query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeUrl",
+            "columnName": "youtube_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retry_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "failureType",
+            "columnName": "failure_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rejectedVideoId",
+            "columnName": "rejected_video_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_queue_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          },
+          {
+            "name": "index_download_queue_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          },
+          {
+            "name": "index_download_queue_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sync_history",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sync_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "source_accounts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `source` TEXT NOT NULL, `display_name` TEXT NOT NULL, `email` TEXT NOT NULL, `avatar_url` TEXT, `is_connected` INTEGER NOT NULL, `connected_at` INTEGER, `last_sync_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatar_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isConnected",
+            "columnName": "is_connected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connectedAt",
+            "columnName": "connected_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastSyncAt",
+            "columnName": "last_sync_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_source_accounts_source",
+            "unique": true,
+            "columnNames": [
+              "source"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_source_accounts_source` ON `${TABLE_NAME}` (`source`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tracks_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, tokenize=unicode61, content=`tracks`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "tracks",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_BEFORE_UPDATE BEFORE UPDATE ON `tracks` BEGIN DELETE FROM `tracks_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_BEFORE_DELETE BEFORE DELETE ON `tracks` BEGIN DELETE FROM `tracks_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_AFTER_UPDATE AFTER UPDATE ON `tracks` BEGIN INSERT INTO `tracks_fts`(`docid`, `title`, `artist`, `album`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`artist`, NEW.`album`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_AFTER_INSERT AFTER INSERT ON `tracks` BEGIN INSERT INTO `tracks_fts`(`docid`, `title`, `artist`, `album`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`artist`, NEW.`album`); END"
+        ]
+      },
+      {
+        "tableName": "remote_playlist_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `source_playlist_id` TEXT NOT NULL, `playlist_name` TEXT NOT NULL, `playlist_type` TEXT NOT NULL, `mix_number` INTEGER, `snapshot_id` TEXT, `track_count` INTEGER NOT NULL, `art_url` TEXT, `fetched_at` INTEGER NOT NULL, `partial` INTEGER NOT NULL, `expected_count` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePlaylistId",
+            "columnName": "source_playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistName",
+            "columnName": "playlist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistType",
+            "columnName": "playlist_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mixNumber",
+            "columnName": "mix_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "snapshotId",
+            "columnName": "snapshot_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artUrl",
+            "columnName": "art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partial",
+            "columnName": "partial",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedCount",
+            "columnName": "expected_count",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_playlist_snapshots_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_playlist_snapshots_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          },
+          {
+            "name": "index_remote_playlist_snapshots_sync_id_source_playlist_id",
+            "unique": true,
+            "columnNames": [
+              "sync_id",
+              "source_playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_remote_playlist_snapshots_sync_id_source_playlist_id` ON `${TABLE_NAME}` (`sync_id`, `source_playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "remote_track_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_id` INTEGER NOT NULL, `snapshot_playlist_id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT, `duration_ms` INTEGER NOT NULL, `spotify_uri` TEXT, `youtube_id` TEXT, `album_art_url` TEXT, `position` INTEGER NOT NULL, `isrc` TEXT, `explicit` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snapshotPlaylistId",
+            "columnName": "snapshot_playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotify_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeId",
+            "columnName": "youtube_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtUrl",
+            "columnName": "album_art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_track_snapshots_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_track_snapshots_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          },
+          {
+            "name": "index_remote_track_snapshots_snapshot_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "snapshot_playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_track_snapshots_snapshot_playlist_id` ON `${TABLE_NAME}` (`snapshot_playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist_profile_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artist_id` TEXT NOT NULL, `json` TEXT NOT NULL, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`artist_id`))",
+        "fields": [
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artist_id"
+          ]
+        }
+      },
+      {
+        "tableName": "listening_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `track_id` INTEGER NOT NULL, `started_at` INTEGER NOT NULL, `scrobbled` INTEGER NOT NULL, `yt_scrobbled` INTEGER NOT NULL DEFAULT 0, `completed_at` INTEGER, FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrobbled",
+            "columnName": "scrobbled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ytScrobbled",
+            "columnName": "yt_scrobbled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_listening_events_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          },
+          {
+            "name": "index_listening_events_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          },
+          {
+            "name": "index_listening_events_scrobbled",
+            "unique": false,
+            "columnNames": [
+              "scrobbled"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_scrobbled` ON `${TABLE_NAME}` (`scrobbled`)"
+          },
+          {
+            "name": "index_listening_events_yt_scrobbled",
+            "unique": false,
+            "columnNames": [
+              "yt_scrobbled"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_yt_scrobbled` ON `${TABLE_NAME}` (`yt_scrobbled`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "track_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`track_id` INTEGER NOT NULL, `tag` TEXT NOT NULL, `weight` REAL NOT NULL, `source` TEXT NOT NULL, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`track_id`, `tag`), FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "track_id",
+            "tag"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_tags_tag",
+            "unique": false,
+            "columnNames": [
+              "tag"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_tags_tag` ON `${TABLE_NAME}` (`tag`)"
+          },
+          {
+            "name": "index_track_tags_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_tags_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stash_mix_recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `include_tags_csv` TEXT NOT NULL, `exclude_tags_csv` TEXT NOT NULL, `era_start_year` INTEGER, `era_end_year` INTEGER, `affinity_bias` REAL NOT NULL, `discovery_ratio` REAL NOT NULL, `freshness_window_days` INTEGER NOT NULL, `target_length` INTEGER NOT NULL, `is_builtin` INTEGER NOT NULL, `is_active` INTEGER NOT NULL, `playlist_id` INTEGER, `created_at` INTEGER NOT NULL, `last_refreshed_at` INTEGER, `seed_strategy` TEXT NOT NULL DEFAULT 'ARTIST_SIMILAR', `mood_keys_csv` TEXT NOT NULL DEFAULT '', `tag_sample_depth` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`playlist_id`) REFERENCES `playlists`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "includeTagsCsv",
+            "columnName": "include_tags_csv",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeTagsCsv",
+            "columnName": "exclude_tags_csv",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eraStartYear",
+            "columnName": "era_start_year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "eraEndYear",
+            "columnName": "era_end_year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "affinityBias",
+            "columnName": "affinity_bias",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discoveryRatio",
+            "columnName": "discovery_ratio",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "freshnessWindowDays",
+            "columnName": "freshness_window_days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetLength",
+            "columnName": "target_length",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBuiltin",
+            "columnName": "is_builtin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastRefreshedAt",
+            "columnName": "last_refreshed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seedStrategy",
+            "columnName": "seed_strategy",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ARTIST_SIMILAR'"
+          },
+          {
+            "fieldPath": "moodKeysCsv",
+            "columnName": "mood_keys_csv",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "tagSampleDepth",
+            "columnName": "tag_sample_depth",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stash_mix_recipes_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stash_mix_recipes_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          },
+          {
+            "name": "index_stash_mix_recipes_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stash_mix_recipes_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "discovery_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `recipe_id` INTEGER NOT NULL, `artist` TEXT NOT NULL, `title` TEXT NOT NULL, `seed_artist` TEXT NOT NULL, `status` TEXT NOT NULL, `track_id` INTEGER, `queued_at` INTEGER NOT NULL, `completed_at` INTEGER, `error_message` TEXT, FOREIGN KEY(`recipe_id`) REFERENCES `stash_mix_recipes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipe_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seedArtist",
+            "columnName": "seed_artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queued_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_discovery_queue_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_queue_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_discovery_queue_recipe_id",
+            "unique": false,
+            "columnNames": [
+              "recipe_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_queue_recipe_id` ON `${TABLE_NAME}` (`recipe_id`)"
+          },
+          {
+            "name": "index_discovery_queue_queued_at",
+            "unique": false,
+            "columnNames": [
+              "queued_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_queue_queued_at` ON `${TABLE_NAME}` (`queued_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stash_mix_recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipe_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "track_blocklist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`canonical_key` TEXT NOT NULL, `artist` TEXT NOT NULL, `title` TEXT NOT NULL, `spotify_uri` TEXT, `youtube_id` TEXT, `blocked_at` INTEGER NOT NULL, `blocked_from` TEXT NOT NULL, PRIMARY KEY(`canonical_key`))",
+        "fields": [
+          {
+            "fieldPath": "canonicalKey",
+            "columnName": "canonical_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotify_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeId",
+            "columnName": "youtube_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "blockedAt",
+            "columnName": "blocked_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockedFrom",
+            "columnName": "blocked_from",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "canonical_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_blocklist_spotify_uri",
+            "unique": false,
+            "columnNames": [
+              "spotify_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_blocklist_spotify_uri` ON `${TABLE_NAME}` (`spotify_uri`)"
+          },
+          {
+            "name": "index_track_blocklist_youtube_id",
+            "unique": false,
+            "columnNames": [
+              "youtube_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_blocklist_youtube_id` ON `${TABLE_NAME}` (`youtube_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "track_skip_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `track_id` INTEGER NOT NULL, `skipped_at` INTEGER NOT NULL, `position_ms` INTEGER NOT NULL, FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skippedAt",
+            "columnName": "skipped_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_skip_events_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_skip_events_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          },
+          {
+            "name": "index_track_skip_events_skipped_at",
+            "unique": false,
+            "columnNames": [
+              "skipped_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_skip_events_skipped_at` ON `${TABLE_NAME}` (`skipped_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lyrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`track_id` INTEGER NOT NULL, `plain_text` TEXT, `synced_lrc` TEXT, `instrumental` INTEGER NOT NULL, `language` TEXT, `source` TEXT NOT NULL, `source_lyrics_id` TEXT, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`track_id`), FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plainText",
+            "columnName": "plain_text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedLrc",
+            "columnName": "synced_lrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "instrumental",
+            "columnName": "instrumental",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceLyricsId",
+            "columnName": "source_lyrics_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "track_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lyrics_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lyrics_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lastfm_response_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cache_key` TEXT NOT NULL, `json` TEXT NOT NULL, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`cache_key`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cache_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cache_key"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'db872c79fcff68f9c3a796f8bdabb315')"
+    ]
+  }
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/db/StashDatabase.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/StashDatabase.kt
@@ -9,6 +9,7 @@ import com.stash.core.data.db.converter.Converters
 import com.stash.core.data.db.dao.ArtistProfileCacheDao
 import com.stash.core.data.db.dao.DiscoveryQueueDao
 import com.stash.core.data.db.dao.DownloadQueueDao
+import com.stash.core.data.db.dao.LastFmCacheDao
 import com.stash.core.data.db.dao.ListeningEventDao
 import com.stash.core.data.db.dao.LyricsDao
 import com.stash.core.data.db.dao.PlaylistDao
@@ -23,6 +24,7 @@ import com.stash.core.data.db.dao.TrackTagDao
 import com.stash.core.data.db.entity.ArtistProfileCacheEntity
 import com.stash.core.data.db.entity.DiscoveryQueueEntity
 import com.stash.core.data.db.entity.DownloadQueueEntity
+import com.stash.core.data.db.entity.LastFmCacheEntity
 import com.stash.core.data.db.entity.ListeningEventEntity
 import com.stash.core.data.db.entity.LyricsEntity
 import com.stash.core.data.db.entity.PlaylistEntity
@@ -72,8 +74,9 @@ import com.stash.core.data.db.entity.TrackTagEntity
         TrackBlocklistEntity::class,
         TrackSkipEventEntity::class,
         LyricsEntity::class,
+        LastFmCacheEntity::class,
     ],
-    version = 30,
+    version = 31,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -106,6 +109,8 @@ abstract class StashDatabase : RoomDatabase() {
     abstract fun trackSkipEventDao(): TrackSkipEventDao
 
     abstract fun lyricsDao(): LyricsDao
+
+    abstract fun lastFmCacheDao(): LastFmCacheDao
 
 
     companion object {
@@ -804,6 +809,21 @@ abstract class StashDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE stash_mix_recipes ADD COLUMN mood_keys_csv TEXT NOT NULL DEFAULT ''")
                 db.execSQL("ALTER TABLE stash_mix_recipes ADD COLUMN tag_sample_depth INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
+        /** v30 → v31: add lastfm_response_cache for generic Last.fm lookups. */
+        val MIGRATION_30_31 = object : Migration(30, 31) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS lastfm_response_cache (
+                        cache_key TEXT NOT NULL PRIMARY KEY,
+                        json TEXT NOT NULL,
+                        fetched_at INTEGER NOT NULL
+                    )
+                    """.trimIndent()
+                )
             }
         }
     }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/LastFmCacheDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/LastFmCacheDao.kt
@@ -1,0 +1,31 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.stash.core.data.db.entity.LastFmCacheEntity
+
+/**
+ * Read/write access to the [LastFmCacheEntity] table. TTL/staleness is the
+ * caller's concern — this DAO just stores and returns rows by key.
+ */
+@Dao
+interface LastFmCacheDao {
+
+    /** Insert or overwrite the cached body for a request key. */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: LastFmCacheEntity)
+
+    /** Cached row for [key], or null if never fetched. */
+    @Query("SELECT * FROM lastfm_response_cache WHERE cache_key = :key")
+    suspend fun get(key: String): LastFmCacheEntity?
+
+    /** Drop entries older than [olderThanMs] (epoch-millis). */
+    @Query("DELETE FROM lastfm_response_cache WHERE fetched_at < :olderThanMs")
+    suspend fun prune(olderThanMs: Long)
+
+    /** Wipe the entire cache (e.g. on sign-out / manual reset). */
+    @Query("DELETE FROM lastfm_response_cache")
+    suspend fun clear()
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/db/entity/LastFmCacheEntity.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/entity/LastFmCacheEntity.kt
@@ -1,0 +1,25 @@
+package com.stash.core.data.db.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * On-device cache for Last.fm read responses that are identical across every
+ * user (tag→tracks, artist→similar, etc.). Caching these collapses the bulk
+ * of the app's Last.fm traffic — the same generic lookups were otherwise
+ * re-fetched by every install on every refresh, which is what throttled the
+ * shared API key.
+ *
+ * - [cacheKey] is [com.stash.core.data.lastfm.lastFmCacheKey] of the request
+ *   params, deliberately excluding `api_key` so the entry survives key
+ *   rotation/pooling.
+ * - [json] is the raw successful response body (errors are never cached).
+ * - [fetchedAt] is epoch-millis; staleness is checked against the read TTL.
+ */
+@Entity(tableName = "lastfm_response_cache")
+data class LastFmCacheEntity(
+    @PrimaryKey @ColumnInfo(name = "cache_key") val cacheKey: String,
+    @ColumnInfo(name = "json") val json: String,
+    @ColumnInfo(name = "fetched_at") val fetchedAt: Long,
+)

--- a/core/data/src/main/kotlin/com/stash/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/di/DatabaseModule.kt
@@ -61,6 +61,7 @@ object DatabaseModule {
                 StashDatabase.MIGRATION_27_28,
                 StashDatabase.MIGRATION_28_29,
                 StashDatabase.MIGRATION_29_30,
+                StashDatabase.MIGRATION_30_31,
             )
             // No fallbackToDestructiveMigration() — if a migration is missing,
             // the app will crash on startup instead of silently wiping the
@@ -118,4 +119,8 @@ object DatabaseModule {
     @Provides
     fun provideLyricsDao(db: StashDatabase): com.stash.core.data.db.dao.LyricsDao =
         db.lyricsDao()
+
+    @Provides
+    fun provideLastFmCacheDao(db: StashDatabase): com.stash.core.data.db.dao.LastFmCacheDao =
+        db.lastFmCacheDao()
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmApiClient.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmApiClient.kt
@@ -42,6 +42,7 @@ class LastFmApiClient @Inject constructor(
     private val okHttpClient: OkHttpClient,
     private val credentials: LastFmCredentials,
     private val rateLimitGate: LastFmRateLimitGate,
+    private val cacheDao: com.stash.core.data.db.dao.LastFmCacheDao,
 ) {
     /** Step 1 of web-auth: request a token. User then authorises in browser. */
     suspend fun getAuthToken(): Result<String> = runCatching {
@@ -116,7 +117,7 @@ class LastFmApiClient @Inject constructor(
             "track" to track,
             "autocorrect" to "1",
         )
-        val response = unsignedGet(params)
+        val response = unsignedGet(params, cacheable = true)
         parseTopTags(response["toptags"]?.jsonObject)
     }
 
@@ -128,7 +129,7 @@ class LastFmApiClient @Inject constructor(
             "artist" to artist,
             "autocorrect" to "1",
         )
-        val response = unsignedGet(params)
+        val response = unsignedGet(params, cacheable = true)
         parseTopTags(response["toptags"]?.jsonObject)
     }
 
@@ -149,7 +150,7 @@ class LastFmApiClient @Inject constructor(
             "autocorrect" to "1",
             "limit" to limit.toString(),
         )
-        val response = unsignedGet(params)
+        val response = unsignedGet(params, cacheable = true)
         parseSimilarArtists(response["similarartists"]?.jsonObject)
     }
 
@@ -172,7 +173,7 @@ class LastFmApiClient @Inject constructor(
             "limit" to limit.toString(),
             "autocorrect" to "1",
         )
-        val response = unsignedGet(params)
+        val response = unsignedGet(params, cacheable = true)
         parseSimilarTracks(response["similartracks"]?.jsonObject)
     }
 
@@ -188,7 +189,7 @@ class LastFmApiClient @Inject constructor(
             "autocorrect" to "1",
             "limit" to limit.toString(),
         )
-        val response = unsignedGet(params)
+        val response = unsignedGet(params, cacheable = true)
         parseTopTracks(response["toptracks"]?.jsonObject)
     }
 
@@ -257,7 +258,7 @@ class LastFmApiClient @Inject constructor(
             "tag" to tag,
             "limit" to limit.toString(),
         )
-        val response = unsignedGet(params)
+        val response = unsignedGet(params, cacheable = true)
         parseTopArtists(response["topartists"]?.jsonObject)
     }
 
@@ -275,7 +276,7 @@ class LastFmApiClient @Inject constructor(
             "tag" to tag,
             "limit" to limit.toString(),
         )
-        val response = unsignedGet(params)
+        val response = unsignedGet(params, cacheable = true)
         parseTopTracks(response["tracks"]?.jsonObject)
     }
 
@@ -303,7 +304,9 @@ class LastFmApiClient @Inject constructor(
             "autocorrect" to "1",
         )
         if (!username.isNullOrBlank()) params["username"] = username
-        val response = unsignedGet(params)
+        // Cacheable only without a username — with one, the response carries
+        // that user's personal playcount/loved flags and must stay per-user.
+        val response = unsignedGet(params, cacheable = username.isNullOrBlank())
         LastFmTrackInfo.parse(response)
     }
 
@@ -385,8 +388,25 @@ class LastFmApiClient @Inject constructor(
      * key, no signature, just an API key. Returns the parsed root JSON
      * object (callers drill into the response-specific subtree).
      */
-    private suspend fun unsignedGet(params: Map<String, String>): JsonObject =
+    private suspend fun unsignedGet(
+        params: Map<String, String>,
+        cacheable: Boolean = false,
+    ): JsonObject =
         withContext(Dispatchers.IO) {
+            val cacheKey = if (cacheable) lastFmCacheKey(params) else null
+
+            // Cache hit comes BEFORE the breaker on purpose: cached generic
+            // lookups keep custom mixes working even while the shared key is
+            // throttled. Only fresh (within-TTL) entries are served.
+            if (cacheKey != null) {
+                val cached = cacheDao.get(cacheKey)
+                if (cached != null &&
+                    System.currentTimeMillis() - cached.fetchedAt < CACHE_TTL_MS
+                ) {
+                    return@withContext json.parseToJsonElement(cached.json).jsonObject
+                }
+            }
+
             // Circuit breaker: if the shared key is currently throttled, fail
             // fast without touching the network. Continuing to fire requests
             // at a rate-limited key only prolongs the block (Last.fm error 29).
@@ -425,6 +445,18 @@ class LastFmApiClient @Inject constructor(
 
             // A clean response means the key isn't throttled — close the breaker.
             rateLimitGate.recordSuccess()
+
+            // Cache only successful (non-error) bodies, keyed independently of
+            // api_key so the entry is shared across key rotation/pooling.
+            if (cacheKey != null) {
+                cacheDao.upsert(
+                    com.stash.core.data.db.entity.LastFmCacheEntity(
+                        cacheKey = cacheKey,
+                        json = bodyStr,
+                        fetchedAt = System.currentTimeMillis(),
+                    ),
+                )
+            }
             root
         }
 
@@ -515,6 +547,13 @@ class LastFmApiClient @Inject constructor(
     companion object {
         private const val API_URL = "https://ws.audioscrobbler.com/2.0/"
         private val json = Json { ignoreUnknownKeys = true }
+
+        /**
+         * TTL for cached generic lookups (tag→tracks, artist→similar, …).
+         * These change slowly, so a week keeps mixes fresh while collapsing
+         * the repeated cross-user traffic that throttled the shared key.
+         */
+        private const val CACHE_TTL_MS = 7L * 24 * 60 * 60 * 1000
     }
 }
 

--- a/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmApiClient.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmApiClient.kt
@@ -44,6 +44,9 @@ class LastFmApiClient @Inject constructor(
     private val rateLimitGate: LastFmRateLimitGate,
     private val cacheDao: com.stash.core.data.db.dao.LastFmCacheDao,
 ) {
+    /** Round-robin cursor for spreading reads across [LastFmCredentials.readApiKeys]. */
+    private val readKeyCounter = java.util.concurrent.atomic.AtomicInteger(0)
+
     /** Step 1 of web-auth: request a token. User then authorises in browser. */
     suspend fun getAuthToken(): Result<String> = runCatching {
         val params = sortedMapOf(
@@ -407,14 +410,18 @@ class LastFmApiClient @Inject constructor(
                 }
             }
 
-            // Circuit breaker: if the shared key is currently throttled, fail
-            // fast without touching the network. Continuing to fire requests
-            // at a rate-limited key only prolongs the block (Last.fm error 29).
-            if (rateLimitGate.isOpen(System.currentTimeMillis())) {
-                error("Last.fm rate-limited; skipping request (circuit open)")
-            }
+            // Pick a read key from the pool, round-robin, skipping any key
+            // whose breaker is open. null = every key throttled → fail fast
+            // without touching the network (continuing only prolongs the block).
+            val now = System.currentTimeMillis()
+            val readKey = selectReadKey(
+                keys = credentials.readApiKeys,
+                startIndex = readKeyCounter.getAndIncrement(),
+                isOpen = { rateLimitGate.isOpen(it, now) },
+            ) ?: error("Last.fm rate-limited; skipping request (all keys throttled)")
 
-            val paramsWithFormat = params + ("format" to "json")
+            // Swap the primary key baked into `params` for the rotated read key.
+            val paramsWithFormat = params + ("api_key" to readKey) + ("format" to "json")
             val url = API_URL.toHttpUrl().newBuilder().apply {
                 paramsWithFormat.forEach { (k, v) -> addQueryParameter(k, v) }
             }.build()
@@ -423,9 +430,9 @@ class LastFmApiClient @Inject constructor(
                 it.code to it.body?.string()
             }
 
-            // HTTP 429 — hard rate limit. Trip the breaker, then fail.
+            // HTTP 429 — hard rate limit. Trip this key's breaker, then fail.
             if (code == 429) {
-                rateLimitGate.recordRateLimited(System.currentTimeMillis())
+                rateLimitGate.recordRateLimited(readKey, System.currentTimeMillis())
                 error("Last.fm GET failed: HTTP 429 (rate limited)")
             }
             check(code in 200..299) { "Last.fm GET failed: HTTP $code" }
@@ -437,14 +444,14 @@ class LastFmApiClient @Inject constructor(
             // Surface those so callers don't treat garbage as success.
             root["error"]?.jsonPrimitive?.content?.let { err ->
                 val msg = root["message"]?.jsonPrimitive?.content ?: "unknown"
-                // error 29 == "Rate Limit Exceeded" → trip the breaker so the
-                // next calls short-circuit instead of piling on.
-                if (err == "29") rateLimitGate.recordRateLimited(System.currentTimeMillis())
+                // error 29 == "Rate Limit Exceeded" → trip this key's breaker
+                // so the next calls rotate past it instead of piling on.
+                if (err == "29") rateLimitGate.recordRateLimited(readKey, System.currentTimeMillis())
                 error("Last.fm API error $err: $msg")
             }
 
-            // A clean response means the key isn't throttled — close the breaker.
-            rateLimitGate.recordSuccess()
+            // A clean response means this key isn't throttled — close its breaker.
+            rateLimitGate.recordSuccess(readKey)
 
             // Cache only successful (non-error) bodies, keyed independently of
             // api_key so the entry is shared across key rotation/pooling.
@@ -584,6 +591,22 @@ data class LastFmTopArtist(val name: String, val playcount: Int)
 data class LastFmCredentials(
     val apiKey: String,
     val apiSecret: String,
+    /**
+     * Optional extra API keys used ONLY for unsigned read endpoints
+     * (tag/similar/etc.). They need no secret. Auth + scrobbling always use
+     * [apiKey] because Last.fm session keys are bound to the key that created
+     * them — rotating those would break scrobbling.
+     */
+    val extraReadApiKeys: List<String> = emptyList(),
 ) {
     val isConfigured: Boolean get() = apiKey.isNotBlank() && apiSecret.isNotBlank()
+
+    /**
+     * Keys eligible for unsigned READ requests: the primary plus any extras,
+     * blanks dropped and de-duplicated, primary first.
+     */
+    val readApiKeys: List<String>
+        get() = (listOf(apiKey) + extraReadApiKeys)
+            .filter { it.isNotBlank() }
+            .distinct()
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmApiClient.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmApiClient.kt
@@ -41,6 +41,7 @@ import javax.inject.Singleton
 class LastFmApiClient @Inject constructor(
     private val okHttpClient: OkHttpClient,
     private val credentials: LastFmCredentials,
+    private val rateLimitGate: LastFmRateLimitGate,
 ) {
     /** Step 1 of web-auth: request a token. User then authorises in browser. */
     suspend fun getAuthToken(): Result<String> = runCatching {
@@ -386,23 +387,44 @@ class LastFmApiClient @Inject constructor(
      */
     private suspend fun unsignedGet(params: Map<String, String>): JsonObject =
         withContext(Dispatchers.IO) {
+            // Circuit breaker: if the shared key is currently throttled, fail
+            // fast without touching the network. Continuing to fire requests
+            // at a rate-limited key only prolongs the block (Last.fm error 29).
+            if (rateLimitGate.isOpen(System.currentTimeMillis())) {
+                error("Last.fm rate-limited; skipping request (circuit open)")
+            }
+
             val paramsWithFormat = params + ("format" to "json")
             val url = API_URL.toHttpUrl().newBuilder().apply {
                 paramsWithFormat.forEach { (k, v) -> addQueryParameter(k, v) }
             }.build()
             val request = Request.Builder().url(url).get().build()
-            val body = okHttpClient.newCall(request).execute().use {
-                check(it.isSuccessful) { "Last.fm GET failed: HTTP ${it.code}" }
-                it.body?.string() ?: error("Empty Last.fm response")
+            val (code, body) = okHttpClient.newCall(request).execute().use {
+                it.code to it.body?.string()
             }
-            val root = json.parseToJsonElement(body).jsonObject
+
+            // HTTP 429 — hard rate limit. Trip the breaker, then fail.
+            if (code == 429) {
+                rateLimitGate.recordRateLimited(System.currentTimeMillis())
+                error("Last.fm GET failed: HTTP 429 (rate limited)")
+            }
+            check(code in 200..299) { "Last.fm GET failed: HTTP $code" }
+            val bodyStr = body ?: error("Empty Last.fm response")
+
+            val root = json.parseToJsonElement(bodyStr).jsonObject
             // Last.fm returns HTTP 200 with { error, message } on some
             // kinds of failures (invalid artist, rate-limited, etc).
             // Surface those so callers don't treat garbage as success.
             root["error"]?.jsonPrimitive?.content?.let { err ->
                 val msg = root["message"]?.jsonPrimitive?.content ?: "unknown"
+                // error 29 == "Rate Limit Exceeded" → trip the breaker so the
+                // next calls short-circuit instead of piling on.
+                if (err == "29") rateLimitGate.recordRateLimited(System.currentTimeMillis())
                 error("Last.fm API error $err: $msg")
             }
+
+            // A clean response means the key isn't throttled — close the breaker.
+            rateLimitGate.recordSuccess()
             root
         }
 

--- a/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmCacheKey.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmCacheKey.kt
@@ -1,0 +1,14 @@
+package com.stash.core.data.lastfm
+
+/**
+ * Builds the cache key for a Last.fm read request. Deliberately excludes
+ * `api_key` (and `format`) so the cached entry is shared across key rotation
+ * and multi-key pooling — the response for "top techno tracks" is identical no
+ * matter which key fetched it. Order-independent (sorted) so equal param sets
+ * always collide.
+ */
+internal fun lastFmCacheKey(params: Map<String, String>): String =
+    params.asSequence()
+        .filter { it.key != "api_key" && it.key != "format" }
+        .sortedBy { it.key }
+        .joinToString("&") { "${it.key}=${it.value}" }

--- a/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmRateLimitGate.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmRateLimitGate.kt
@@ -1,0 +1,58 @@
+package com.stash.core.data.lastfm
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.pow
+
+/**
+ * Process-wide circuit breaker for Last.fm rate-limit responses (error 29 /
+ * HTTP 429). The Last.fm API key is shared across every install, so when it
+ * gets throttled, continuing to fire requests only prolongs the block. This
+ * gate makes the client fail fast — skipping the network entirely — for an
+ * exponentially-growing cooldown after each rate-limit hit, then reopens
+ * automatically once the cooldown elapses. A successful response resets it.
+ *
+ * Time is passed in (`nowMs`) rather than read from the clock so the logic is
+ * deterministic and unit-testable.
+ */
+@Singleton
+class LastFmRateLimitGate @Inject constructor() {
+
+    @Volatile
+    private var openUntilMs: Long = 0L
+
+    @Volatile
+    private var consecutiveHits: Int = 0
+
+    /** True while the breaker is open — callers should skip the network. */
+    fun isOpen(nowMs: Long): Boolean = nowMs < openUntilMs
+
+    /**
+     * Record a rate-limit response. Opens the breaker for a cooldown that
+     * doubles with each consecutive hit (base, 2×, 4×, …), capped at
+     * [MAX_COOLDOWN_MS].
+     */
+    @Synchronized
+    fun recordRateLimited(nowMs: Long) {
+        consecutiveHits++
+        val cooldown = (BASE_COOLDOWN_MS.toDouble() * 2.0.pow(consecutiveHits - 1))
+            .toLong()
+            .coerceIn(BASE_COOLDOWN_MS, MAX_COOLDOWN_MS)
+        openUntilMs = nowMs + cooldown
+    }
+
+    /** Record a successful response: closes the breaker and resets backoff. */
+    @Synchronized
+    fun recordSuccess() {
+        consecutiveHits = 0
+        openUntilMs = 0L
+    }
+
+    companion object {
+        /** Cooldown after the first rate-limit hit. */
+        const val BASE_COOLDOWN_MS = 60_000L
+
+        /** Upper bound on the exponential backoff. */
+        const val MAX_COOLDOWN_MS = 60L * 60_000L
+    }
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmRateLimitGate.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmRateLimitGate.kt
@@ -1,16 +1,18 @@
 package com.stash.core.data.lastfm
 
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.pow
 
 /**
- * Process-wide circuit breaker for Last.fm rate-limit responses (error 29 /
- * HTTP 429). The Last.fm API key is shared across every install, so when it
- * gets throttled, continuing to fire requests only prolongs the block. This
- * gate makes the client fail fast — skipping the network entirely — for an
- * exponentially-growing cooldown after each rate-limit hit, then reopens
- * automatically once the cooldown elapses. A successful response resets it.
+ * Per-key circuit breaker for Last.fm rate-limit responses (error 29 / HTTP
+ * 429). The app spreads read traffic across a pool of API keys; when one key
+ * gets throttled, continuing to fire requests at it only prolongs the block,
+ * so this breaker fails that key fast — skipping the network — for an
+ * exponentially-growing cooldown, while the rest of the pool keeps serving.
+ * Each key reopens automatically once its cooldown elapses; a successful
+ * response on a key resets its backoff.
  *
  * Time is passed in (`nowMs`) rather than read from the clock so the logic is
  * deterministic and unit-testable.
@@ -18,38 +20,43 @@ import kotlin.math.pow
 @Singleton
 class LastFmRateLimitGate @Inject constructor() {
 
-    @Volatile
-    private var openUntilMs: Long = 0L
-
-    @Volatile
-    private var consecutiveHits: Int = 0
-
-    /** True while the breaker is open — callers should skip the network. */
-    fun isOpen(nowMs: Long): Boolean = nowMs < openUntilMs
-
-    /**
-     * Record a rate-limit response. Opens the breaker for a cooldown that
-     * doubles with each consecutive hit (base, 2×, 4×, …), capped at
-     * [MAX_COOLDOWN_MS].
-     */
-    @Synchronized
-    fun recordRateLimited(nowMs: Long) {
-        consecutiveHits++
-        val cooldown = (BASE_COOLDOWN_MS.toDouble() * 2.0.pow(consecutiveHits - 1))
-            .toLong()
-            .coerceIn(BASE_COOLDOWN_MS, MAX_COOLDOWN_MS)
-        openUntilMs = nowMs + cooldown
+    private class KeyState {
+        @Volatile var openUntilMs: Long = 0L
+        @Volatile var consecutiveHits: Int = 0
     }
 
-    /** Record a successful response: closes the breaker and resets backoff. */
+    private val states = ConcurrentHashMap<String, KeyState>()
+
+    /** True while [key] is throttled — callers should skip it. */
+    fun isOpen(key: String, nowMs: Long): Boolean =
+        (states[key]?.openUntilMs ?: 0L) > nowMs
+
+    /**
+     * Record a rate-limit response for [key]. Opens that key for a cooldown
+     * that doubles with each consecutive hit (base, 2×, 4×, …), capped at
+     * [MAX_COOLDOWN_MS]. Other keys are unaffected.
+     */
     @Synchronized
-    fun recordSuccess() {
-        consecutiveHits = 0
-        openUntilMs = 0L
+    fun recordRateLimited(key: String, nowMs: Long) {
+        val state = states.getOrPut(key) { KeyState() }
+        state.consecutiveHits++
+        val cooldown = (BASE_COOLDOWN_MS.toDouble() * 2.0.pow(state.consecutiveHits - 1))
+            .toLong()
+            .coerceIn(BASE_COOLDOWN_MS, MAX_COOLDOWN_MS)
+        state.openUntilMs = nowMs + cooldown
+    }
+
+    /** Record a successful response for [key]: closes it and resets backoff. */
+    @Synchronized
+    fun recordSuccess(key: String) {
+        states[key]?.let {
+            it.consecutiveHits = 0
+            it.openUntilMs = 0L
+        }
     }
 
     companion object {
-        /** Cooldown after the first rate-limit hit. */
+        /** Cooldown after the first rate-limit hit on a key. */
         const val BASE_COOLDOWN_MS = 60_000L
 
         /** Upper bound on the exponential backoff. */

--- a/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmReadKeySelector.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmReadKeySelector.kt
@@ -1,0 +1,26 @@
+package com.stash.core.data.lastfm
+
+/**
+ * Picks which API key to use for an unsigned READ request, spreading load
+ * round-robin across the pool while skipping any key currently throttled
+ * (its breaker is open). Returns null when the pool is empty or every key is
+ * throttled — the caller then fails fast without touching the network.
+ *
+ * Pure function so the rotation logic is unit-testable; the caller supplies a
+ * monotonically-increasing [startIndex] (a request counter) and the
+ * per-key open check.
+ */
+internal fun selectReadKey(
+    keys: List<String>,
+    startIndex: Int,
+    isOpen: (String) -> Boolean,
+): String? {
+    if (keys.isEmpty()) return null
+    for (offset in keys.indices) {
+        // Double-mod guards against a negative startIndex (counter overflow).
+        val idx = (((startIndex + offset) % keys.size) + keys.size) % keys.size
+        val key = keys[idx]
+        if (!isOpen(key)) return key
+    }
+    return null
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/lastfm/LastFmCacheKeyTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/lastfm/LastFmCacheKeyTest.kt
@@ -1,0 +1,43 @@
+package com.stash.core.data.lastfm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class LastFmCacheKeyTest {
+
+    @Test
+    fun `key excludes api_key and format so it survives key rotation and pooling`() {
+        val withKey1 = lastFmCacheKey(
+            mapOf(
+                "method" to "tag.gettoptracks", "tag" to "techno",
+                "limit" to "50", "api_key" to "KEY_ONE", "format" to "json",
+            ),
+        )
+        val withKey2 = lastFmCacheKey(
+            mapOf(
+                "method" to "tag.gettoptracks", "tag" to "techno",
+                "limit" to "50", "api_key" to "KEY_TWO",
+            ),
+        )
+        // Same logical request → same cache entry regardless of which API key
+        // (or whether `format` was set) served it.
+        assertEquals(withKey1, withKey2)
+    }
+
+    @Test
+    fun `different request params produce different keys`() {
+        assertNotEquals(
+            lastFmCacheKey(mapOf("method" to "tag.gettoptracks", "tag" to "techno")),
+            lastFmCacheKey(mapOf("method" to "tag.gettoptracks", "tag" to "house")),
+        )
+    }
+
+    @Test
+    fun `key is independent of param insertion order`() {
+        assertEquals(
+            lastFmCacheKey(linkedMapOf("a" to "1", "b" to "2", "method" to "x")),
+            lastFmCacheKey(linkedMapOf("method" to "x", "b" to "2", "a" to "1")),
+        )
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/lastfm/LastFmRateLimitGateTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/lastfm/LastFmRateLimitGateTest.kt
@@ -1,0 +1,71 @@
+package com.stash.core.data.lastfm
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The breaker that stops the app from hammering a Last.fm key that has
+ * already returned error 29. Once throttled, more requests only prolong the
+ * block, so we fail fast for an exponentially-growing cooldown and reopen
+ * automatically once it elapses.
+ */
+class LastFmRateLimitGateTest {
+
+    private val base = LastFmRateLimitGate.BASE_COOLDOWN_MS
+    private val max = LastFmRateLimitGate.MAX_COOLDOWN_MS
+
+    @Test
+    fun `a fresh gate is closed`() {
+        val gate = LastFmRateLimitGate()
+        assertFalse(gate.isOpen(nowMs = 0L))
+    }
+
+    @Test
+    fun `a rate-limit hit opens the gate for the base cooldown`() {
+        val gate = LastFmRateLimitGate()
+        gate.recordRateLimited(nowMs = 1_000L)
+
+        assertTrue(gate.isOpen(nowMs = 1_000L))
+        assertTrue(gate.isOpen(nowMs = 1_000L + base - 1))
+        // Cooldown elapsed -> reopen automatically.
+        assertFalse(gate.isOpen(nowMs = 1_000L + base))
+    }
+
+    @Test
+    fun `consecutive hits back off exponentially`() {
+        val gate = LastFmRateLimitGate()
+        gate.recordRateLimited(nowMs = 0L) // 1st -> base
+        gate.recordRateLimited(nowMs = 0L) // 2nd -> base*2
+        assertTrue(gate.isOpen(nowMs = base * 2 - 1))
+        assertFalse(gate.isOpen(nowMs = base * 2))
+
+        gate.recordRateLimited(nowMs = 0L) // 3rd -> base*4
+        assertTrue(gate.isOpen(nowMs = base * 4 - 1))
+        assertFalse(gate.isOpen(nowMs = base * 4))
+    }
+
+    @Test
+    fun `backoff is capped at the maximum cooldown`() {
+        val gate = LastFmRateLimitGate()
+        repeat(20) { gate.recordRateLimited(nowMs = 0L) }
+        assertTrue(gate.isOpen(nowMs = max - 1))
+        assertFalse(gate.isOpen(nowMs = max))
+    }
+
+    @Test
+    fun `a success closes the gate and resets the backoff`() {
+        val gate = LastFmRateLimitGate()
+        gate.recordRateLimited(nowMs = 0L)
+        gate.recordRateLimited(nowMs = 0L) // escalate to base*2
+
+        gate.recordSuccess()
+        assertFalse(gate.isOpen(nowMs = 0L))
+
+        // After reset, the next single hit is back to the base cooldown,
+        // not the escalated value.
+        gate.recordRateLimited(nowMs = 0L)
+        assertTrue(gate.isOpen(nowMs = base - 1))
+        assertFalse(gate.isOpen(nowMs = base))
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/lastfm/LastFmRateLimitGateTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/lastfm/LastFmRateLimitGateTest.kt
@@ -5,10 +5,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * The breaker that stops the app from hammering a Last.fm key that has
- * already returned error 29. Once throttled, more requests only prolong the
- * block, so we fail fast for an exponentially-growing cooldown and reopen
- * automatically once it elapses.
+ * The per-key breaker that stops the app from hammering a Last.fm key that has
+ * already returned error 29. Each key has its own cooldown so a throttled key
+ * can be skipped while the rest of the pool keeps serving. Once a key's
+ * cooldown elapses it reopens automatically; a success resets its backoff.
  */
 class LastFmRateLimitGateTest {
 
@@ -16,56 +16,57 @@ class LastFmRateLimitGateTest {
     private val max = LastFmRateLimitGate.MAX_COOLDOWN_MS
 
     @Test
-    fun `a fresh gate is closed`() {
+    fun `a fresh gate is closed for any key`() {
         val gate = LastFmRateLimitGate()
-        assertFalse(gate.isOpen(nowMs = 0L))
+        assertFalse(gate.isOpen(key = "A", nowMs = 0L))
     }
 
     @Test
-    fun `a rate-limit hit opens the gate for the base cooldown`() {
+    fun `a rate-limit hit opens only that key for the base cooldown`() {
         val gate = LastFmRateLimitGate()
-        gate.recordRateLimited(nowMs = 1_000L)
+        gate.recordRateLimited(key = "A", nowMs = 1_000L)
 
-        assertTrue(gate.isOpen(nowMs = 1_000L))
-        assertTrue(gate.isOpen(nowMs = 1_000L + base - 1))
-        // Cooldown elapsed -> reopen automatically.
-        assertFalse(gate.isOpen(nowMs = 1_000L + base))
+        assertTrue(gate.isOpen(key = "A", nowMs = 1_000L))
+        assertTrue(gate.isOpen(key = "A", nowMs = 1_000L + base - 1))
+        assertFalse(gate.isOpen(key = "A", nowMs = 1_000L + base))
+        // A different key in the pool is unaffected.
+        assertFalse(gate.isOpen(key = "B", nowMs = 1_000L))
     }
 
     @Test
-    fun `consecutive hits back off exponentially`() {
+    fun `consecutive hits on a key back off exponentially, independently per key`() {
         val gate = LastFmRateLimitGate()
-        gate.recordRateLimited(nowMs = 0L) // 1st -> base
-        gate.recordRateLimited(nowMs = 0L) // 2nd -> base*2
-        assertTrue(gate.isOpen(nowMs = base * 2 - 1))
-        assertFalse(gate.isOpen(nowMs = base * 2))
+        gate.recordRateLimited(key = "A", nowMs = 0L) // A -> base
+        gate.recordRateLimited(key = "A", nowMs = 0L) // A -> base*2
+        assertTrue(gate.isOpen(key = "A", nowMs = base * 2 - 1))
+        assertFalse(gate.isOpen(key = "A", nowMs = base * 2))
 
-        gate.recordRateLimited(nowMs = 0L) // 3rd -> base*4
-        assertTrue(gate.isOpen(nowMs = base * 4 - 1))
-        assertFalse(gate.isOpen(nowMs = base * 4))
+        // B's first hit is still only the base cooldown — backoff is per-key.
+        gate.recordRateLimited(key = "B", nowMs = 0L)
+        assertTrue(gate.isOpen(key = "B", nowMs = base - 1))
+        assertFalse(gate.isOpen(key = "B", nowMs = base))
     }
 
     @Test
     fun `backoff is capped at the maximum cooldown`() {
         val gate = LastFmRateLimitGate()
-        repeat(20) { gate.recordRateLimited(nowMs = 0L) }
-        assertTrue(gate.isOpen(nowMs = max - 1))
-        assertFalse(gate.isOpen(nowMs = max))
+        repeat(20) { gate.recordRateLimited(key = "A", nowMs = 0L) }
+        assertTrue(gate.isOpen(key = "A", nowMs = max - 1))
+        assertFalse(gate.isOpen(key = "A", nowMs = max))
     }
 
     @Test
-    fun `a success closes the gate and resets the backoff`() {
+    fun `a success closes that key and resets its backoff`() {
         val gate = LastFmRateLimitGate()
-        gate.recordRateLimited(nowMs = 0L)
-        gate.recordRateLimited(nowMs = 0L) // escalate to base*2
+        gate.recordRateLimited(key = "A", nowMs = 0L)
+        gate.recordRateLimited(key = "A", nowMs = 0L) // escalate to base*2
 
-        gate.recordSuccess()
-        assertFalse(gate.isOpen(nowMs = 0L))
+        gate.recordSuccess(key = "A")
+        assertFalse(gate.isOpen(key = "A", nowMs = 0L))
 
-        // After reset, the next single hit is back to the base cooldown,
-        // not the escalated value.
-        gate.recordRateLimited(nowMs = 0L)
-        assertTrue(gate.isOpen(nowMs = base - 1))
-        assertFalse(gate.isOpen(nowMs = base))
+        // Reset: next single hit is back to the base cooldown.
+        gate.recordRateLimited(key = "A", nowMs = 0L)
+        assertTrue(gate.isOpen(key = "A", nowMs = base - 1))
+        assertFalse(gate.isOpen(key = "A", nowMs = base))
     }
 }

--- a/core/data/src/test/kotlin/com/stash/core/data/lastfm/LastFmReadKeySelectorTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/lastfm/LastFmReadKeySelectorTest.kt
@@ -1,0 +1,39 @@
+package com.stash.core.data.lastfm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LastFmReadKeySelectorTest {
+
+    @Test
+    fun `picks the key at the round-robin start index`() {
+        assertEquals("B", selectReadKey(listOf("A", "B", "C"), startIndex = 1) { false })
+    }
+
+    @Test
+    fun `wraps around the pool with modulo`() {
+        assertEquals("A", selectReadKey(listOf("A", "B", "C"), startIndex = 3) { false })
+    }
+
+    @Test
+    fun `skips throttled keys and returns the next available one`() {
+        val open = setOf("A", "B")
+        assertEquals("C", selectReadKey(listOf("A", "B", "C"), startIndex = 0) { it in open })
+    }
+
+    @Test
+    fun `returns null when every key is throttled`() {
+        assertNull(selectReadKey(listOf("A", "B"), startIndex = 0) { true })
+    }
+
+    @Test
+    fun `returns null for an empty pool`() {
+        assertNull(selectReadKey(emptyList(), startIndex = 0) { false })
+    }
+
+    @Test
+    fun `single-key pool returns that key when it is available`() {
+        assertEquals("A", selectReadKey(listOf("A"), startIndex = 5) { false })
+    }
+}

--- a/docs/superpowers/specs/2026-05-31-lastfm-worker-proxy-design.md
+++ b/docs/superpowers/specs/2026-05-31-lastfm-worker-proxy-design.md
@@ -1,0 +1,131 @@
+# Last.fm Worker Proxy + Shared Cache — Design
+
+**Status:** Proposed (2026-05-31)
+**Problem owner:** mixes/discovery rely on Last.fm; the single shared API key
+gets globally rate-limited (error 29) as the user base grows, breaking custom
+Stash Mixes for everyone at once.
+
+## Goal
+
+**Decouple Last.fm request volume from user count.** The generic read lookups
+that dominate traffic (`tag.getTopTracks`, `artist.getSimilar`,
+`artist.getTopTracks`, `track.getSimilar`, `track.getTopTags`,
+`artist.getTopTags`, `track.getInfo` w/o username) return the *same* answer for
+every user. Today each install fetches them independently; at N users that is
+~N× the calls on one key. A server-side proxy with a shared cache collapses
+that to "fetch each unique query once, serve everyone" — so Last.fm sees a
+bounded number of queries regardless of whether there are 10 users or 100k.
+
+This is the durable layer beneath the two app-side mitigations already shipped
+(per-device cache + per-key breaker + optional multi-key read pool). Those
+reduce the slope; the proxy removes the dependency on user count entirely.
+
+## Non-goals / what stays on the device
+
+- **Auth + scrobbling** (`auth.getSession`, `track.scrobble`): signed with the
+  shared secret and bound to a user's session. These stay **direct from the
+  app** using the primary key — the secret never goes to the Worker.
+- **Per-user reads** (`user.getTopArtists/getTopTracks/getLovedTracks`,
+  `track.getInfo` *with* username): personal, low-volume. Keep direct from the
+  app (or proxy with a per-user cache key later — not needed initially).
+- **Personalization**: unchanged. The proxy only serves the generic *candidate
+  pool*; seed selection, scoring, filtering all remain on-device per user
+  (see MixGenerator). Same ingredients for everyone, different dish each.
+
+## Architecture
+
+```
+app  ──(generic reads, no api_key)──►  Cloudflare Worker  ──(1 server key)──►  ws.audioscrobbler.com
+                                          │
+                                          └─ Cache API / KV  (keyed by normalized method+params)
+app  ──(auth + scrobble, signed w/ primary key)────────────────────────────►  ws.audioscrobbler.com  (direct, unchanged)
+app  ──(user.* reads)──────────────────────────────────────────────────────►  ws.audioscrobbler.com  (direct, unchanged)
+```
+
+### Worker endpoint
+
+Single generic passthrough, method-allowlisted:
+
+```
+GET https://<worker-host>/lastfm?method=<m>&<params...>
+```
+
+Worker behavior:
+1. Reject any `method` not in the **read allowlist** (the generic methods
+   above). No `api_key`, `sk`, `api_sig`, `user`, or `username` accepted —
+   reads only, no per-user, no signed.
+2. Build the canonical cache key = sorted (method + allowed params), excluding
+   anything client-supplied that isn't part of the allowlist. (Mirrors the
+   app's existing `lastFmCacheKey`.)
+3. Cache lookup (Cloudflare **Cache API** for simplicity, or **KV** for
+   cross-colo sharing). On hit within TTL → return cached JSON.
+4. On miss → call Last.fm with the **Worker's own server-side api_key**, store
+   the body with `Cache-Control: public, max-age=<TTL>`, return it.
+5. On Last.fm error 29 at the Worker → return a 429 with `Retry-After`; the app
+   already has a per-key breaker + on-device cache to ride it out. (At steady
+   state this should be rare: the Worker makes at most one call per unique
+   query per TTL window.)
+
+TTL: 7–30 days (these charts move slowly). Start at 14d; tune later.
+
+### Why this scales
+
+Total Last.fm calls ≈ (number of *distinct* tag/artist/track queries across all
+users) ÷ (TTL windows), **independent of user count**. A few thousand popular
+tags/artists cached centrally covers the long tail. The Worker's single key
+stays well under the limit permanently.
+
+## App-side change (small)
+
+Add an optional proxy base URL, plumbed exactly like the existing Last.fm
+config:
+
+- `local.properties`: `lastfm.proxyUrl=https://<worker-host>/lastfm`
+  → `BuildConfig.LASTFM_PROXY_URL` → injected into `LastFmApiClient`.
+- In `LastFmApiClient.unsignedGet`, when `cacheable == true` **and** a proxy URL
+  is set: target the Worker (omit `api_key`) instead of `ws.audioscrobbler.com`.
+  Everything else — the on-device cache check, the per-key breaker, response
+  parsing — stays as-is and acts as a second-layer fallback.
+- When no proxy URL is set: current behavior (direct + multi-key pool). So this
+  is a drop-in, reversible toggle.
+
+Net app diff: ~1 new BuildConfig field + a base-URL branch in `unsignedGet`.
+The on-device cache becomes a fast L1 in front of the Worker's L2.
+
+## Security & ops
+
+- **Secret stays server-side.** The Worker holds one Last.fm api_key (+ secret
+  if ever needed); the APK no longer needs to ship a read key once the proxy is
+  the default. (Keep the on-device key as a fallback during rollout.)
+- **Abuse protection** on the Worker: per-IP rate limit + method allowlist so it
+  can't be turned into an open Last.fm proxy. Optional shared bearer/header the
+  app sends (low-value, since it ships in the APK, but raises the bar).
+- **Cost:** Cloudflare Workers free tier (100k req/day) + Cache API/KV is almost
+  certainly free at current scale, since cache hits don't count as Last.fm calls
+  and the Worker is hit at most once per unique query per TTL. Reuses the same
+  Cloudflare account already running the tip-jar Worker.
+
+## Rollout
+
+1. Deploy the Worker (allowlist + cache + server key). Verify a few queries
+   return cached on the second hit.
+2. Set `lastfm.proxyUrl` in debug, route reads through it, confirm mixes still
+   populate and Last.fm direct-traffic drops to ~0 for generic reads.
+3. Ship with the proxy URL set; keep the on-device key as fallback if the
+   Worker is unreachable (the breaker/cache already degrade gracefully).
+4. Once stable, the app no longer needs a bundled read key at all.
+
+## Relationship to shipped work
+
+- On-device cache (`lastfm_response_cache`) → becomes L1 in front of the Worker.
+- Per-key breaker + multi-key read pool → still useful for any direct reads and
+  as fallback when the proxy is unset/unreachable.
+- `lastFmCacheKey` (api_key-independent) → the Worker's cache key mirrors it.
+
+## Open questions
+
+- Cache API vs KV: Cache API is per-colo (simpler, free); KV is global
+  (consistent hit rate across regions, tiny cost). Start with Cache API.
+- Stale-while-revalidate to hide the occasional cold-miss latency? Optional.
+- Should `user.*` eventually be proxied with per-user TTL'd cache to cut the
+  ~10 persona calls/refresh too? Low priority; revisit if those become a factor.


### PR DESCRIPTION
Makes Stash Mixes survive the shared Last.fm API key being rate-limited (error 29). Root cause: every install funnels generic read lookups (`tag.getTopTracks`, `artist.getSimilar`, …) through one key, so as the user base grew the aggregate crossed Last.fm's per-application ceiling and the key got globally throttled — breaking custom mixes for everyone on all builds.

Three layers, none of which change personalization (only the generic candidate *pool* is shared; seed/scoring/filtering stay per-user):

### 1. Error-29 circuit breaker (`f96a8859`)
`LastFmRateLimitGate` — opens on error 29 / HTTP 429 with exponential backoff (1 min → … → 1 hr cap), reopens automatically, resets on success. Stops the app from hammering an already-throttled key.

### 2. On-device cache (`ed94f95f`)
`lastfm_response_cache` table (DB v30→v31, migration verified on-device). Generic lookups are cached for 7 days and served **before** the breaker, so cached pools keep mixes working even during a throttle. Cache key excludes `api_key` so it's shared across key rotation/pooling.

### 3. Multi-key read pool + per-key breaker (`9d716b0f`)
Spread unsigned reads round-robin across a pool of keys, skipping any key whose breaker is open. **Auth + scrobble stay on the primary key** (Last.fm session keys are bound to the key that created them). Extra keys need no secret. Config: `lastfm.extraApiKeys=key2,key3` (empty by default → single-key unchanged).

### 4. Worker proxy spec (`3e29abab`)
`docs/.../2026-05-31-lastfm-worker-proxy-design.md` — the durable fix that decouples Last.fm load from user count (proxy generic reads through a Cloudflare Worker with a shared, server-keyed cache). Specced, not built.

> Note: key-pooling to exceed the per-application limit is against Last.fm ToS 4.4 — it's opt-in (pool empty by default) pending the proxy.

### Tests
`LastFmRateLimitGateTest` (5, per-key) + `LastFmReadKeySelectorTest` (6) + `LastFmCacheKeyTest` (3), all green. Migration + reads verified on-device with a fresh key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
