### PR TITLE
feat: Last.fm Worker proxy + shared cache (durable rate-limit fix)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,11 @@ val lastFmApiSecret: String =
 // primary key above. Empty by default.
 val lastFmExtraApiKeys: String =
     localProperties.getProperty("lastfm.extraApiKeys") ?: System.getenv("LASTFM_EXTRA_API_KEYS").orEmpty()
+// Optional Stash Last.fm proxy Worker base URL. When set, generic read lookups
+// route through it (the Worker holds the server key + shared cache), decoupling
+// Last.fm load from user count. Empty = app talks to Last.fm directly.
+val lastFmProxyUrl: String =
+    localProperties.getProperty("lastfm.proxyUrl") ?: System.getenv("LASTFM_PROXY_URL").orEmpty()
 
 android {
     namespace = "com.stash.app"
@@ -88,6 +93,7 @@ android {
         buildConfigField("String", "LASTFM_API_KEY", "\"$lastFmApiKey\"")
         buildConfigField("String", "LASTFM_API_SECRET", "\"$lastFmApiSecret\"")
         buildConfigField("String", "LASTFM_EXTRA_API_KEYS", "\"$lastFmExtraApiKeys\"")
+        buildConfigField("String", "LASTFM_PROXY_URL", "\"$lastFmProxyUrl\"")
         // v0.9.13: TipJarRepository fetches the public supporters JSON from
         // this URL on Home foreground (cache-aware, ~15 min refresh). Edit
         // the JSON and push to update the supporter list without an APK

--- a/app/src/main/kotlin/com/stash/app/di/LastFmCredentialsModule.kt
+++ b/app/src/main/kotlin/com/stash/app/di/LastFmCredentialsModule.kt
@@ -32,5 +32,7 @@ object LastFmCredentialsModule {
             .split(",")
             .map { it.trim() }
             .filter { it.isNotBlank() },
+        // Optional Worker proxy base URL; blank = direct to Last.fm.
+        proxyUrl = BuildConfig.LASTFM_PROXY_URL.trim().ifBlank { null },
     )
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmApiClient.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmApiClient.kt
@@ -410,29 +410,50 @@ class LastFmApiClient @Inject constructor(
                 }
             }
 
-            // Pick a read key from the pool, round-robin, skipping any key
-            // whose breaker is open. null = every key throttled → fail fast
-            // without touching the network (continuing only prolongs the block).
             val now = System.currentTimeMillis()
-            val readKey = selectReadKey(
-                keys = credentials.readApiKeys,
-                startIndex = readKeyCounter.getAndIncrement(),
-                isOpen = { rateLimitGate.isOpen(it, now) },
-            ) ?: error("Last.fm rate-limited; skipping request (all keys throttled)")
+            val proxyUrl = credentials.proxyUrl
 
-            // Swap the primary key baked into `params` for the rotated read key.
-            val paramsWithFormat = params + ("api_key" to readKey) + ("format" to "json")
-            val url = API_URL.toHttpUrl().newBuilder().apply {
-                paramsWithFormat.forEach { (k, v) -> addQueryParameter(k, v) }
+            // Target + key selection. Two paths:
+            //  - Proxy: when a Worker proxy URL is set, route cacheable reads
+            //    through it. The Worker injects its OWN server-side key, so we
+            //    strip api_key and don't rotate. Breaker keyed by "proxy".
+            //  - Direct: round-robin a read key from the pool, skipping any
+            //    whose breaker is open. null = all throttled → fail fast.
+            val useProxy = cacheable && !proxyUrl.isNullOrBlank()
+            val targetBase: String
+            val breakerKey: String
+            val outgoing = params.toMutableMap()
+            if (useProxy) {
+                if (rateLimitGate.isOpen(PROXY_BREAKER_KEY, now)) {
+                    error("Last.fm proxy rate-limited; skipping request (circuit open)")
+                }
+                targetBase = proxyUrl!!
+                breakerKey = PROXY_BREAKER_KEY
+                outgoing.remove("api_key") // the Worker supplies its own key
+            } else {
+                val readKey = selectReadKey(
+                    keys = credentials.readApiKeys,
+                    startIndex = readKeyCounter.getAndIncrement(),
+                    isOpen = { rateLimitGate.isOpen(it, now) },
+                ) ?: error("Last.fm rate-limited; skipping request (all keys throttled)")
+                targetBase = API_URL
+                breakerKey = readKey
+                outgoing["api_key"] = readKey
+            }
+            outgoing["format"] = "json"
+
+            val url = targetBase.toHttpUrl().newBuilder().apply {
+                outgoing.forEach { (k, v) -> addQueryParameter(k, v) }
             }.build()
             val request = Request.Builder().url(url).get().build()
             val (code, body) = okHttpClient.newCall(request).execute().use {
                 it.code to it.body?.string()
             }
 
-            // HTTP 429 — hard rate limit. Trip this key's breaker, then fail.
+            // HTTP 429 — hard rate limit (direct key or proxy). Trip the
+            // breaker for whichever source we used, then fail.
             if (code == 429) {
-                rateLimitGate.recordRateLimited(readKey, System.currentTimeMillis())
+                rateLimitGate.recordRateLimited(breakerKey, System.currentTimeMillis())
                 error("Last.fm GET failed: HTTP 429 (rate limited)")
             }
             check(code in 200..299) { "Last.fm GET failed: HTTP $code" }
@@ -444,14 +465,14 @@ class LastFmApiClient @Inject constructor(
             // Surface those so callers don't treat garbage as success.
             root["error"]?.jsonPrimitive?.content?.let { err ->
                 val msg = root["message"]?.jsonPrimitive?.content ?: "unknown"
-                // error 29 == "Rate Limit Exceeded" → trip this key's breaker
+                // error 29 == "Rate Limit Exceeded" → trip this source's breaker
                 // so the next calls rotate past it instead of piling on.
-                if (err == "29") rateLimitGate.recordRateLimited(readKey, System.currentTimeMillis())
+                if (err == "29") rateLimitGate.recordRateLimited(breakerKey, System.currentTimeMillis())
                 error("Last.fm API error $err: $msg")
             }
 
-            // A clean response means this key isn't throttled — close its breaker.
-            rateLimitGate.recordSuccess(readKey)
+            // A clean response means this source isn't throttled — close its breaker.
+            rateLimitGate.recordSuccess(breakerKey)
 
             // Cache only successful (non-error) bodies, keyed independently of
             // api_key so the entry is shared across key rotation/pooling.
@@ -561,6 +582,9 @@ class LastFmApiClient @Inject constructor(
          * the repeated cross-user traffic that throttled the shared key.
          */
         private const val CACHE_TTL_MS = 7L * 24 * 60 * 60 * 1000
+
+        /** Synthetic breaker key for the Worker proxy source (vs. real api keys). */
+        private const val PROXY_BREAKER_KEY = "__proxy__"
     }
 }
 
@@ -598,6 +622,13 @@ data class LastFmCredentials(
      * them — rotating those would break scrobbling.
      */
     val extraReadApiKeys: List<String> = emptyList(),
+    /**
+     * Optional base URL of the Stash Last.fm proxy Worker (e.g.
+     * `https://stash-lastfm-proxy.<sub>.workers.dev/lastfm`). When set, generic
+     * cacheable reads route through it (the Worker supplies its own key); auth,
+     * scrobble and per-user reads always go direct. Blank/null = direct.
+     */
+    val proxyUrl: String? = null,
 ) {
     val isConfigured: Boolean get() = apiKey.isNotBlank() && apiSecret.isNotBlank()
 

--- a/infra/lastfm-proxy/README.md
+++ b/infra/lastfm-proxy/README.md
@@ -1,0 +1,87 @@
+# Stash Last.fm Proxy (Cloudflare Worker)
+
+Proxies the **generic, cross-user** Last.fm read lookups that power Stash Mixes
+(`tag.getTopTracks`, `artist.getSimilar`, etc.) through **one server-side API
+key** with an **edge cache**. Each unique query is fetched from Last.fm at most
+once per TTL and served to every user from cache — so the key never hits the
+per-application rate limit (error 29), no matter how many app installs there
+are. This is the durable fix for the shared-key throttling that breaks custom
+mixes. Design: [`../../docs/superpowers/specs/2026-05-31-lastfm-worker-proxy-design.md`](../../docs/superpowers/specs/2026-05-31-lastfm-worker-proxy-design.md).
+
+**Does NOT proxy** auth/scrobble (signed; stay on the app's primary key) or
+per-user reads (`user.*`, `track.getInfo` w/ username). It rejects any
+`api_key`/`api_sig`/`sk`/`user`/`username` param. Personalization is unaffected
+— the proxy only serves the generic candidate pool; the app scores/filters it
+per user.
+
+## Endpoint
+
+```
+GET https://stash-lastfm-proxy.<your-subdomain>.workers.dev/lastfm?method=<m>&<params>
+```
+
+Example:
+```
+/lastfm?method=tag.gettoptracks&tag=shoegaze&limit=50
+```
+Returns the raw Last.fm JSON. `X-Stash-Cache: HIT|MISS|BYPASS` header shows cache
+status. `429` (with `Retry-After`) if upstream is rate-limited.
+
+## Deploy
+
+Prereqs: Node 18+, a Cloudflare account (the same one running `stash-tipjar`).
+
+```bash
+cd infra/lastfm-proxy
+npm install
+
+# 1. Log in (opens browser once)
+npx wrangler login
+
+# 2. Set the server-side Last.fm key as a secret (NOT committed).
+#    Use a DEDICATED key for the proxy — register a fresh one at
+#    https://www.last.fm/api/account/create — so proxy traffic is isolated
+#    from any key the app still ships.
+npx wrangler secret put LASTFM_API_KEY
+#    (paste the key when prompted)
+
+# 3. Deploy
+npx wrangler deploy
+```
+
+`wrangler deploy` prints the live URL. Smoke-test it:
+```bash
+curl "https://stash-lastfm-proxy.<subdomain>.workers.dev/lastfm?method=tag.gettoptracks&tag=techno&limit=2"
+# run twice — second response should show  X-Stash-Cache: HIT
+```
+
+## Local dev
+
+```bash
+npx wrangler dev          # runs locally
+# in another shell, set a key for the local session if needed, then:
+curl "http://localhost:8787/lastfm?method=artist.getsimilar&artist=radiohead&limit=2"
+```
+
+## Wire the app to it
+
+In `local.properties` (and the release secret), point the app at the Worker:
+```
+lastfm.proxyUrl=https://stash-lastfm-proxy.<subdomain>.workers.dev/lastfm
+```
+The app routes only its **generic read** lookups through the proxy (omitting its
+own api_key); auth/scrobble and per-user reads stay direct. The on-device cache
+and per-key breaker still apply as a fast L1 / fallback. Leave `lastfm.proxyUrl`
+empty to disable (app talks to Last.fm directly).
+
+## Tests
+
+```bash
+npm test    # node --test — covers cache-key normalization, error parsing, allowlist
+```
+
+## Tuning
+
+- `CACHE_TTL_SECONDS` in `src/index.js` (default 14 days). These charts move
+  slowly; raise it to cut upstream calls further.
+- `ALLOWED_METHODS` — the read methods the proxy will serve. Keep it minimal.

--- a/infra/lastfm-proxy/package.json
+++ b/infra/lastfm-proxy/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "stash-lastfm-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cloudflare Worker that proxies generic Last.fm read lookups (tag/similar/etc.) with an edge cache, so Stash Mixes never hit the shared API key's rate limit regardless of user count.",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail",
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "wrangler": "^4.88.0"
+  }
+}

--- a/infra/lastfm-proxy/src/index.js
+++ b/infra/lastfm-proxy/src/index.js
@@ -1,0 +1,213 @@
+/**
+ * Stash Last.fm Proxy — Cloudflare Worker
+ *
+ * Proxies the GENERIC, cross-user Last.fm read lookups that power Stash Mixes
+ * (tag→tracks, artist→similar, etc.) through a single server-side API key with
+ * an edge cache. This decouples Last.fm request volume from the number of app
+ * installs: each unique query is fetched from Last.fm at most once per TTL and
+ * served to every user from cache, so the shared key never gets rate-limited
+ * (error 29) no matter how the user base grows.
+ *
+ * What this does NOT proxy (by design):
+ *   - Auth + scrobbling (signed, bound to a user's session) — stay direct from
+ *     the app on its primary key; the secret never reaches this Worker.
+ *   - Per-user reads (user.getTop*, track.getInfo WITH username) — personal,
+ *     low-volume; the Worker rejects any `user`/`username`/`sk`/`api_sig`.
+ *
+ * Personalization is unaffected: the Worker only serves the generic candidate
+ * POOL. Seed selection, scoring and filtering all happen on-device per user.
+ *
+ * Endpoint:
+ *   GET /lastfm?method=<m>&<lookup params...>
+ *     → injects the server api_key + format=json, proxies to Last.fm, caches
+ *       the body, returns JSON. 429 (with Retry-After) on Last.fm rate-limit.
+ *
+ * Secret: LASTFM_API_KEY  (set via `wrangler secret put LASTFM_API_KEY`).
+ * Deploy: see ../README.md (this lives at infra/lastfm-proxy).
+ */
+
+const LASTFM_BASE = "https://ws.audioscrobbler.com/2.0/";
+
+/** Cache TTL for generic lookups, in seconds. These charts move slowly. */
+const CACHE_TTL_SECONDS = 14 * 24 * 60 * 60; // 14 days
+
+/**
+ * Read-only, generic (non-personalized) methods this proxy is allowed to
+ * serve. Anything else is rejected — the Worker must not become an open
+ * Last.fm proxy, and must never touch signed/per-user endpoints.
+ */
+export const ALLOWED_METHODS = new Set([
+    "tag.gettoptracks",
+    "tag.gettopartists",
+    "artist.getsimilar",
+    "artist.gettoptracks",
+    "artist.gettoptags",
+    "track.getsimilar",
+    "track.gettoptags",
+    "track.getinfo",
+]);
+
+/** Params a client may NOT send — they'd make the request signed or per-user. */
+export const FORBIDDEN_PARAMS = new Set(["api_key", "api_sig", "sk", "user", "username"]);
+
+export default {
+    async fetch(request, env, ctx) {
+        if (request.method !== "GET") {
+            return json({ error: "method_not_allowed" }, 405);
+        }
+        const url = new URL(request.url);
+        if (url.pathname !== "/lastfm") {
+            return json({ error: "not_found" }, 404);
+        }
+        return handleLastFmRead(url, env, ctx);
+    },
+};
+
+async function handleLastFmRead(url, env, ctx) {
+    const apiKey = env.LASTFM_API_KEY;
+    if (!apiKey) {
+        return json({ error: "server_misconfigured", message: "LASTFM_API_KEY not set" }, 500);
+    }
+
+    const params = url.searchParams;
+    const method = (params.get("method") || "").toLowerCase();
+
+    if (!ALLOWED_METHODS.has(method)) {
+        return json({ error: "method_not_allowed", message: `method '${method}' not proxied` }, 400);
+    }
+    for (const forbidden of FORBIDDEN_PARAMS) {
+        if (params.has(forbidden)) {
+            return json({ error: "forbidden_param", message: `'${forbidden}' is not accepted` }, 400);
+        }
+    }
+
+    // Canonical cache key: sorted client params (method + lookup args), with the
+    // injected api_key/format excluded — so the cache is keyed by the logical
+    // query alone (and is naturally shared across every caller).
+    const cacheKey = buildCacheKey(params);
+    const cache = caches.default;
+
+    const cached = await cache.match(cacheKey);
+    if (cached) {
+        const hit = new Response(cached.body, cached);
+        hit.headers.set("X-Stash-Cache", "HIT");
+        return hit;
+    }
+
+    // Build the upstream Last.fm request: copy the client's params, then inject
+    // the server key + json format.
+    const upstream = new URL(LASTFM_BASE);
+    for (const [k, v] of params) upstream.searchParams.set(k, v);
+    upstream.searchParams.set("api_key", apiKey);
+    upstream.searchParams.set("format", "json");
+
+    let lfmResponse;
+    try {
+        lfmResponse = await fetch(upstream.toString(), {
+            headers: { "User-Agent": "Stash-LastFm-Proxy/1.0" },
+        });
+    } catch (e) {
+        return json({ error: "upstream_unreachable", message: String(e) }, 502);
+    }
+
+    // Hard HTTP rate limit.
+    if (lfmResponse.status === 429) {
+        return rateLimited();
+    }
+    if (!lfmResponse.ok) {
+        return json({ error: "upstream_error", status: lfmResponse.status }, 502);
+    }
+
+    const body = await lfmResponse.text();
+
+    // Last.fm returns HTTP 200 with { "error": N } on soft failures. error 29 is
+    // the rate limit — surface as 429 and DO NOT cache. Other errors (e.g. 6
+    // "not found") are passed through but also not cached (they're often
+    // transient or query-specific noise).
+    const errorCode = extractErrorCode(body);
+    if (errorCode === 29) {
+        return rateLimited();
+    }
+    if (errorCode !== null) {
+        return new Response(body, {
+            status: 200,
+            headers: { "content-type": "application/json", "X-Stash-Cache": "BYPASS" },
+        });
+    }
+
+    const response = new Response(body, {
+        status: 200,
+        headers: {
+            "content-type": "application/json",
+            "cache-control": `public, max-age=${CACHE_TTL_SECONDS}`,
+            "X-Stash-Cache": "MISS",
+        },
+    });
+    // Store a cacheable clone (the X-Stash-Cache header on the stored copy is
+    // overwritten to HIT when served from cache above).
+    ctx.waitUntil(cache.put(cacheKey, response.clone()));
+    return response;
+}
+
+/**
+ * Builds the edge-cache key as a normalized GET Request. Sorts the client
+ * params and drops anything we inject upstream, so logically-identical queries
+ * collapse to one cache entry regardless of param order.
+ */
+function buildCacheKey(params) {
+    // Host is arbitrary but must be stable — it only namespaces the cache.
+    return new Request(
+        `https://stash-lastfm-cache.internal/lastfm?${normalizeQuery(params)}`,
+        { method: "GET" },
+    );
+}
+
+/**
+ * Sorts the query params and drops `api_key`/`format`, so logically-identical
+ * lookups collapse to one cache entry regardless of order or which key served
+ * them. Pure + exported for unit tests.
+ */
+export function normalizeQuery(params) {
+    const entries = [];
+    for (const [k, v] of params) {
+        if (k === "api_key" || k === "format") continue;
+        entries.push([k, v]);
+    }
+    entries.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+    return entries
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .join("&");
+}
+
+/** Returns the numeric Last.fm error code in a 200 body, or null if none. */
+export function extractErrorCode(body) {
+    try {
+        const parsed = JSON.parse(body);
+        if (typeof parsed.error === "number") return parsed.error;
+        if (typeof parsed.error === "string") return parseInt(parsed.error, 10);
+    } catch {
+        // Non-JSON body — treat as no structured error.
+    }
+    return null;
+}
+
+function rateLimited() {
+    return new Response(
+        JSON.stringify({ error: 29, message: "Rate Limit Exceeded (upstream)" }),
+        {
+            status: 429,
+            headers: {
+                "content-type": "application/json",
+                "retry-after": "300",
+                "X-Stash-Cache": "BYPASS",
+            },
+        },
+    );
+}
+
+function json(obj, status) {
+    return new Response(JSON.stringify(obj), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+}

--- a/infra/lastfm-proxy/test/logic.test.js
+++ b/infra/lastfm-proxy/test/logic.test.js
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+    normalizeQuery,
+    extractErrorCode,
+    ALLOWED_METHODS,
+    FORBIDDEN_PARAMS,
+} from "../src/index.js";
+
+test("normalizeQuery is order-independent and drops api_key/format", () => {
+    const a = normalizeQuery(new URLSearchParams("method=tag.gettoptracks&tag=techno&api_key=K1&format=json"));
+    const b = normalizeQuery(new URLSearchParams("tag=techno&method=tag.gettoptracks&api_key=K2"));
+    assert.equal(a, b, "same logical query must collapse to one cache key regardless of key/order");
+    assert.equal(a, "method=tag.gettoptracks&tag=techno");
+});
+
+test("normalizeQuery distinguishes different lookups", () => {
+    assert.notEqual(
+        normalizeQuery(new URLSearchParams("method=tag.gettoptracks&tag=techno")),
+        normalizeQuery(new URLSearchParams("method=tag.gettoptracks&tag=house")),
+    );
+});
+
+test("extractErrorCode reads numeric and string error codes", () => {
+    assert.equal(extractErrorCode('{"error":29,"message":"Rate Limit Exceeded"}'), 29);
+    assert.equal(extractErrorCode('{"error":"6","message":"not found"}'), 6);
+    assert.equal(extractErrorCode('{"tracks":{"track":[]}}'), null);
+    assert.equal(extractErrorCode("not json"), null);
+});
+
+test("allowlist covers the generic read methods and excludes signed/per-user", () => {
+    for (const m of [
+        "tag.gettoptracks", "tag.gettopartists", "artist.getsimilar",
+        "artist.gettoptracks", "artist.gettoptags", "track.getsimilar",
+        "track.gettoptags", "track.getinfo",
+    ]) {
+        assert.ok(ALLOWED_METHODS.has(m), `${m} should be allowed`);
+    }
+    for (const m of ["auth.getsession", "track.scrobble", "user.gettoptracks"]) {
+        assert.ok(!ALLOWED_METHODS.has(m), `${m} must NOT be proxied`);
+    }
+});
+
+test("forbidden params block signed/per-user requests", () => {
+    for (const p of ["api_key", "api_sig", "sk", "user", "username"]) {
+        assert.ok(FORBIDDEN_PARAMS.has(p), `${p} must be rejected`);
+    }
+});

--- a/infra/lastfm-proxy/wrangler.toml
+++ b/infra/lastfm-proxy/wrangler.toml
@@ -1,0 +1,11 @@
+name = "stash-lastfm-proxy"
+main = "src/index.js"
+compatibility_date = "2026-05-01"
+
+# Secret: LASTFM_API_KEY
+# The server-side Last.fm API key this proxy uses for ALL generic read
+# lookups. Set via `wrangler secret put LASTFM_API_KEY` (do NOT commit it).
+# Use a DEDICATED key for the proxy — not a key also shipped in the app —
+# so the two traffic sources are isolated. See ../README.md.
+#
+# No KV binding needed: caching uses the edge Cache API (caches.default).


### PR DESCRIPTION
The durable fix for the shared-key Last.fm rate limit (error 29) that breaks custom Stash Mixes. Stacks on #146 — **review/merge #146 first** (this PR's app-side change builds on its `unsignedGet`).

### The Worker (`infra/lastfm-proxy/`)
Proxies the **generic, cross-user** Last.fm read lookups (`tag.getTopTracks`, `artist.getSimilar`, etc.) through **one server-side key** with an **edge cache**. Each unique query hits Last.fm at most once per TTL and is served to every user from cache — so Last.fm request volume is **decoupled from user count**, and the key can't get throttled regardless of growth.

- `GET /lastfm?method=…` — method-allowlisted generic reads only; rejects `api_key`/`api_sig`/`sk`/`user`/`username` (never signed, never per-user).
- Injects its own key (Worker secret `LASTFM_API_KEY`), caches via the edge Cache API (14-day TTL), returns 429 on upstream error 29.
- Mirrors `infra/tipjar-worker`. `node:test` logic tests (cache-key normalization, error parsing, allowlist) — 5 green. README has deploy + wiring steps.

### App toggle
`LastFmCredentials.proxyUrl` (← `lastfm.proxyUrl` / `BuildConfig.LASTFM_PROXY_URL`). When set, `unsignedGet` routes cacheable reads through the Worker (strips api_key; breaker keyed `__proxy__`); auth/scrobble/per-user reads stay direct. **Blank by default = no-op** until you deploy + set the URL.

### Personalization is unchanged
The proxy serves only the generic candidate *pool*; seed selection, scoring and filtering stay on-device per user. The on-device cache + per-key breaker (from #146) act as L1/fallback in front of the Worker.

### To deploy
`infra/lastfm-proxy/README.md` — `wrangler login`, `wrangler secret put LASTFM_API_KEY` (use a dedicated key), `wrangler deploy`, then set `lastfm.proxyUrl`. (Deployment needs your Cloudflare account — can't be done from CI here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
