### PR TITLE
Fix Bluetooth/Android Auto resume (full queue + position), add Resume shortcut & test CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,83 @@
+name: Unit tests
+
+# Runs JVM unit tests on push and PR. The repo previously had no test CI —
+# only release.yml, which builds the APK on `v*` tags. This validates the
+# media module (playback resume, queue, streaming) on every change and also
+# builds a debug APK artifact for manual on-device testing.
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  unit-tests:
+    name: core:media unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle cache
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Fix gradlew permission
+        run: chmod +x gradlew
+
+      - name: Run core:media unit tests
+        run: ./gradlew :core:media:testDebugUnitTest --no-daemon
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: core-media-test-results
+          path: |
+            core/media/build/test-results/testDebugUnitTest/
+            core/media/build/reports/tests/testDebugUnitTest/
+
+  build-debug-apk:
+    name: Build debug APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle cache
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Fix gradlew permission
+        run: chmod +x gradlew
+
+      - name: Assemble debug APK
+        run: ./gradlew :app:assembleDebug --no-daemon
+
+      - name: Locate debug APK
+        id: find_apk
+        run: |
+          APK=$(find app/build/outputs/apk/debug -name "*.apk" | head -n1)
+          if [ -z "$APK" ]; then
+            echo "::error::No debug APK produced by assembleDebug"
+            exit 1
+          fi
+          echo "apk_path=$APK" >> "$GITHUB_OUTPUT"
+          echo "Built: $APK ($(du -h "$APK" | cut -f1))"
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: stash-debug-apk
+          path: ${{ steps.find_apk.outputs.apk_path }}

--- a/app/src/debug/res/xml/shortcuts.xml
+++ b/app/src/debug/res/xml/shortcuts.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <!--
+        Debug-variant override of app/src/main/res/xml/shortcuts.xml. Identical
+        except targetPackage carries the ".debug" applicationIdSuffix so the
+        explicit shortcut intent resolves in debug builds (com.stash.app.debug).
+        targetClass is the Kotlin class name and is unchanged across variants.
+    -->
+    <shortcut
+        android:shortcutId="resume_playback"
+        android:enabled="true"
+        android:icon="@drawable/ic_resume_playback"
+        android:shortcutShortLabel="@string/resume_playback_short"
+        android:shortcutLongLabel="@string/resume_playback_long">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.stash.app.debug"
+            android:targetClass="com.stash.app.ResumePlaybackActivity" />
+    </shortcut>
+</shortcuts>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,24 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Stash">
+        <!--
+            No-UI trampoline launched by the "Resume playback" app shortcut
+            (and Samsung Bixby Routines). Resumes the last queue and finishes
+            immediately, so it uses Theme.NoDisplay and is kept out of the
+            recents/back stack. exported=true so Routines can launch it.
+        -->
+        <!--
+            Launched explicitly (by class) from the "Resume playback" static
+            shortcut, so it needs no intent-filter — only exported=true so the
+            launcher / Bixby Routines can start it from another process.
+        -->
+        <activity
+            android:name=".ResumePlaybackActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.NoDisplay" />
         <activity android:name=".MainActivity" android:exported="true" android:theme="@style/Theme.Stash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -41,6 +59,11 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="audio/*" />
             </intent-filter>
+            <!-- Static app shortcuts (e.g. "Resume playback"). Must live on
+                 the launcher activity. -->
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
         <receiver
             android:name="com.stash.core.data.sync.BootReceiver"

--- a/app/src/main/kotlin/com/stash/app/ResumePlaybackActivity.kt
+++ b/app/src/main/kotlin/com/stash/app/ResumePlaybackActivity.kt
@@ -1,0 +1,33 @@
+package com.stash.app
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import com.stash.core.media.PlayerRepository
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+/**
+ * No-UI trampoline that resumes the last-played queue and exits immediately.
+ *
+ * Surfaced as an app shortcut ("Resume playback") so a Samsung Bixby Routine
+ * (or the launcher long-press menu) can target it. Unlike the generic "play
+ * music" media-button action, launching an explicit activity cold-starts the
+ * app and works behind the lock screen — which is exactly why the equivalent
+ * VLC shortcut works from a dead process while a plain media key does not.
+ *
+ * The actual resume runs fire-and-forget on the repository's own scope
+ * ([PlayerRepository.resumeLastQueue]), so this activity can finish right
+ * away without a visible window (see Theme.NoDisplay in the manifest).
+ */
+@AndroidEntryPoint
+class ResumePlaybackActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var playerRepository: PlayerRepository
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        playerRepository.resumeLastQueue()
+        finish()
+    }
+}

--- a/app/src/main/res/drawable/ic_resume_playback.xml
+++ b/app/src/main/res/drawable/ic_resume_playback.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <!--
+        Self-contained launcher-shortcut icon: a solid Stash-purple
+        (#8B5CF6) background with a white play triangle. The full-bleed
+        background keeps it visible on any launcher popup (light or dark)
+        and survives circular masking — the previous icon was a white
+        glyph that vanished on white backgrounds.
+    -->
+    <path
+        android:fillColor="#8B5CF6"
+        android:pathData="M0,0h108v108h-108z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M42,34L42,74L76,54Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,2 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources><string name="app_name">Stash</string></resources>
+<resources>
+    <string name="app_name">Stash</string>
+    <string name="resume_playback_short">Resume</string>
+    <string name="resume_playback_long">Resume playback</string>
+</resources>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <!--
+        Static "Resume playback" launcher shortcut, surfaced on launcher
+        long-press and selectable as a Samsung Bixby Routine action. Matches
+        VLC's working setup: an EXPLICIT target component (launchers/Routines
+        drop static shortcuts whose intent doesn't resolve to a real activity,
+        which is why an implicit-action intent did not appear).
+
+        targetPackage is the applicationId, which carries a ".debug" suffix in
+        debug builds — so a debug-variant override of this file lives at
+        app/src/debug/res/xml/shortcuts.xml. targetClass is the Kotlin class
+        name and is identical across variants.
+    -->
+    <shortcut
+        android:shortcutId="resume_playback"
+        android:enabled="true"
+        android:icon="@drawable/ic_resume_playback"
+        android:shortcutShortLabel="@string/resume_playback_short"
+        android:shortcutLongLabel="@string/resume_playback_long">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.stash.app"
+            android:targetClass="com.stash.app.ResumePlaybackActivity" />
+    </shortcut>
+</shortcuts>

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -375,6 +375,14 @@ interface TrackDao {
     @Query("SELECT * FROM tracks WHERE id = :trackId LIMIT 1")
     suspend fun getById(trackId: Long): TrackEntity?
 
+    /**
+     * Batch lookup by primary key. SQLite's `IN` does not preserve the
+     * order of [trackIds]; callers that need the original order (e.g.
+     * restoring a persisted playback queue) must re-sort the result.
+     */
+    @Query("SELECT * FROM tracks WHERE id IN (:trackIds)")
+    suspend fun getByIds(trackIds: List<Long>): List<TrackEntity>
+
     // ── Download tracking ────────────────────────────────────────────────
 
     /**

--- a/core/media/src/main/kotlin/com/stash/core/media/PlaybackResumer.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlaybackResumer.kt
@@ -1,0 +1,67 @@
+package com.stash.core.media
+
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.TrackEntity
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Builds the playback queue to hand back to Media3's
+ * [androidx.media3.session.MediaLibraryService.MediaLibrarySession.Callback.onPlaybackResumption]
+ * contract when a controller (Bluetooth / Android Auto) asks to resume
+ * playback after the process was killed.
+ *
+ * The decision logic lives here, free of Android `MediaItem` types, so it
+ * can be unit-tested on the JVM — the host service is responsible only for
+ * turning a [ResumePlan] into `MediaItem`s. This mirrors the
+ * [com.stash.core.media.streaming.PrefetchOrchestrator] extraction pattern.
+ *
+ * Returning `null` means "no restorable queue was persisted" and the caller
+ * should fall back to its single-track behaviour (last-played / most
+ * recently added).
+ */
+@Singleton
+class PlaybackResumer @Inject constructor(
+    private val playbackStateStore: PlaybackStateStore,
+    private val trackDao: TrackDao,
+) {
+
+    /**
+     * The fully-resolved queue to resume into.
+     *
+     * @property tracks      Ordered queue tracks, ready to be mapped to `MediaItem`s.
+     * @property startIndex  Index within [tracks] of the track to start on.
+     * @property positionMs  Position within the start track to resume from (>= 0).
+     * @property isShuffled  Whether shuffle mode was active when last saved.
+     */
+    data class ResumePlan(
+        val tracks: List<TrackEntity>,
+        val startIndex: Int,
+        val positionMs: Long,
+        val isShuffled: Boolean,
+    )
+
+    suspend fun buildResumePlan(): ResumePlan? {
+        val saved = playbackStateStore.getLastPlaybackState() ?: return null
+        if (saved.queueTrackIds.isEmpty()) return null
+
+        // `IN` doesn't preserve order, so re-sort into the saved queue order.
+        // Tracks that no longer exist in the DB are silently dropped.
+        val byId = trackDao.getByIds(saved.queueTrackIds).associateBy { it.id }
+        val ordered = saved.queueTrackIds.mapNotNull { byId[it] }
+        if (ordered.isEmpty()) return null
+
+        // Prefer locating the saved current track by id (robust to dropped
+        // rows shifting positions); fall back to the saved index clamped
+        // into range if that track is gone.
+        val startIndex = ordered.indexOfFirst { it.id == saved.trackId }
+            .let { if (it >= 0) it else saved.queueIndex.coerceIn(0, ordered.size - 1) }
+
+        return ResumePlan(
+            tracks = ordered,
+            startIndex = startIndex,
+            positionMs = saved.positionMs.coerceAtLeast(0),
+            isShuffled = saved.isShuffled,
+        )
+    }
+}

--- a/core/media/src/main/kotlin/com/stash/core/media/PlaybackStateStore.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlaybackStateStore.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
@@ -23,6 +25,15 @@ data class SavedPlaybackState(
     val trackId: Long,
     val positionMs: Long,
     val queueIndex: Int,
+    /**
+     * The full playback queue as an ordered list of track ids, in the
+     * player's window order (the order `getMediaItemAt` returns, which is
+     * the original insertion order regardless of shuffle). Empty when no
+     * queue has been persisted yet — callers fall back to a single-track
+     * resume in that case.
+     */
+    val queueTrackIds: List<Long>,
+    val isShuffled: Boolean,
 )
 
 @Singleton
@@ -33,6 +44,8 @@ class PlaybackStateStore @Inject constructor(
         val TRACK_ID = longPreferencesKey("last_track_id")
         val POSITION_MS = longPreferencesKey("last_position_ms")
         val QUEUE_INDEX = intPreferencesKey("last_queue_index")
+        val QUEUE_IDS = stringPreferencesKey("last_queue_ids")
+        val IS_SHUFFLED = booleanPreferencesKey("last_is_shuffled")
     }
 
     suspend fun savePosition(trackId: Long, positionMs: Long, queueIndex: Int) {
@@ -43,13 +56,32 @@ class PlaybackStateStore @Inject constructor(
         }
     }
 
+    /**
+     * Persists the full queue separately from the (frequently updated)
+     * position. Caller should only invoke this when the queue contents or
+     * shuffle state actually change, not on every position tick, so the
+     * comma-joined id list isn't rewritten 4×/second.
+     */
+    suspend fun saveQueue(trackIds: List<Long>, isShuffled: Boolean) {
+        context.playbackDataStore.edit { prefs ->
+            prefs[Keys.QUEUE_IDS] = trackIds.joinToString(",")
+            prefs[Keys.IS_SHUFFLED] = isShuffled
+        }
+    }
+
     suspend fun getLastPlaybackState(): SavedPlaybackState? {
         val prefs = context.playbackDataStore.data.first()
         val trackId = prefs[Keys.TRACK_ID] ?: return null
+        val queueTrackIds = prefs[Keys.QUEUE_IDS]
+            ?.split(",")
+            ?.mapNotNull { it.toLongOrNull() }
+            ?: emptyList()
         return SavedPlaybackState(
             trackId = trackId,
             positionMs = prefs[Keys.POSITION_MS] ?: 0L,
             queueIndex = prefs[Keys.QUEUE_INDEX] ?: 0,
+            queueTrackIds = queueTrackIds,
+            isShuffled = prefs[Keys.IS_SHUFFLED] ?: false,
         )
     }
 

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepository.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepository.kt
@@ -119,6 +119,20 @@ interface PlayerRepository {
     suspend fun setQueue(tracks: List<Track>, startIndex: Int = 0)
 
     /**
+     * Restore the last-played queue — full queue, saved current track,
+     * saved position, and shuffle state — and start playing. Reuses the
+     * normal [setQueue] resolution path, so it works in both offline and
+     * online modes (downloaded files and streamed tracks) with background
+     * queue fill, exactly like a normal playlist tap.
+     *
+     * Fire-and-forget: the work runs on the repository's own scope so the
+     * caller (a no-UI trampoline activity launched from an app shortcut /
+     * Bluetooth routine) can finish immediately. Falls back to the most
+     * recently played / added track when no queue has been persisted yet.
+     */
+    fun resumeLastQueue()
+
+    /**
      * v0.9.14: Replace the queue with a freshly-shuffled snapshot of the
      * user's entire downloaded library, begin playback, and arm the
      * auto-grow watcher so the queue refills from the unused remainder

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -15,6 +15,7 @@ import androidx.media3.session.SessionToken
 import com.stash.core.common.constants.StashConstants
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.mapper.toDomain
 import com.stash.core.data.prefs.StreamingPreference
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.service.StashPlaybackService
@@ -85,6 +86,7 @@ class PlayerRepositoryImpl @Inject constructor(
     private val streamUrlCache: StreamUrlCache,
     private val connectivity: ConnectivityMonitor,
     private val trackDao: TrackDao,
+    private val playbackResumer: PlaybackResumer,
 ) : PlayerRepository {
 
     /**
@@ -250,6 +252,15 @@ class PlayerRepositoryImpl @Inject constructor(
     @Volatile
     private var setQueueEpoch: Long = 0L
 
+    /**
+     * Last queue id-list + shuffle state persisted to [PlaybackStateStore].
+     * Used to avoid rewriting the comma-joined queue string on every 250 ms
+     * position tick — the queue only needs re-saving when its contents or
+     * shuffle state actually change.
+     */
+    private var lastSavedQueueIds: List<Long>? = null
+    private var lastSavedShuffle: Boolean? = null
+
     private val _userMessages = kotlinx.coroutines.flow.MutableSharedFlow<String>(
         extraBufferCapacity = 4,
         onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST,
@@ -302,7 +313,17 @@ class PlayerRepositoryImpl @Inject constructor(
         ensureController()?.seekTo(positionMs)
     }
 
-    override suspend fun setQueue(tracks: List<Track>, startIndex: Int) {
+    override suspend fun setQueue(tracks: List<Track>, startIndex: Int) =
+        setQueueInternal(tracks, startIndex, startPositionMs = 0L)
+
+    /**
+     * Backing implementation for [setQueue] that also accepts a start
+     * position. Kept private (not on the interface) so the public
+     * [setQueue] signature — and every test that stubs/verifies it with
+     * argument matchers — stays unchanged. [resumeLastQueue] uses this to
+     * continue from the saved position.
+     */
+    private suspend fun setQueueInternal(tracks: List<Track>, startIndex: Int, startPositionMs: Long) {
         // Any prior background fill belongs to a previous queue; kill it
         // so its addMediaItem calls can't pollute the new one.
         queueBuildJob?.cancel()
@@ -377,7 +398,7 @@ class PlayerRepositoryImpl @Inject constructor(
                 "${tracks.size - 1} more to resolve in background",
         )
 
-        controller.setMediaItems(listOf(startItem), /* startIndex = */ 0, /* startPositionMs = */ 0L)
+        controller.setMediaItems(listOf(startItem), /* startIndex = */ 0, startPositionMs)
         controller.prepare()
         controller.play()
 
@@ -417,6 +438,32 @@ class PlayerRepositoryImpl @Inject constructor(
                 throw e
             } catch (e: Exception) {
                 Log.w(TAG, "setQueue: background fill failed", e)
+            }
+        }
+    }
+
+    override fun resumeLastQueue() {
+        // Fire-and-forget on the repository scope so a no-UI trampoline
+        // activity can finish immediately while resolution + playback
+        // continue. Reuses setQueue, so offline and online queues both work
+        // with the same proven resolution + background-fill path.
+        scope.launch {
+            val plan = playbackResumer.buildResumePlan()
+            if (plan != null) {
+                val tracks = plan.tracks.map { it.toDomain() }
+                ensureController()?.shuffleModeEnabled = plan.isShuffled
+                setQueueInternal(tracks, plan.startIndex, plan.positionMs)
+                return@launch
+            }
+            // No persisted queue yet — fall back to the most recently played
+            // (or most recently added) single track, matching the service's
+            // onPlaybackResumption fallback.
+            val fallback = trackDao.getLastPlayedTrack()
+                ?: trackDao.getRecentlyAdded(1).first().firstOrNull()
+            if (fallback != null) {
+                setQueueInternal(listOf(fallback.toDomain()), startIndex = 0, startPositionMs = 0L)
+            } else {
+                Log.i(TAG, "resumeLastQueue: nothing to resume")
             }
         }
     }
@@ -1349,6 +1396,21 @@ class PlayerRepositoryImpl @Inject constructor(
                     positionMs = newState.positionMs,
                     queueIndex = newState.currentIndex,
                 )
+            }
+        }
+
+        // Persist the full queue so Bluetooth/Android Auto resumption can
+        // restore it (next/prev working) rather than a single track. Only
+        // re-save when the queue contents or shuffle state change — not on
+        // every position tick.
+        val queueIds = queue.map { it.id }
+        if (queueIds != lastSavedQueueIds || newState.isShuffleEnabled != lastSavedShuffle) {
+            lastSavedQueueIds = queueIds
+            lastSavedShuffle = newState.isShuffleEnabled
+            if (queueIds.isNotEmpty()) {
+                scope.launch {
+                    playbackStateStore.saveQueue(queueIds, newState.isShuffleEnabled)
+                }
             }
         }
     }

--- a/core/media/src/main/kotlin/com/stash/core/media/ResumePlayGate.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/ResumePlayGate.kt
@@ -1,0 +1,59 @@
+package com.stash.core.media
+
+/**
+ * Decides whether a Bluetooth / Android Auto playback-resumption should
+ * actually start playing once the restored queue lands on the player.
+ *
+ * Media3 is supposed to auto-play after
+ * [androidx.media3.session.MediaLibraryService.MediaLibrarySession.Callback.onPlaybackResumption]
+ * on a real play request, but from a warm process that auto-play doesn't
+ * reliably take and the queue lands paused. The host service arms this gate
+ * when resumption returns items and consults it on the next timeline change
+ * to force playback.
+ *
+ * The decision logic lives here (free of Android `Player`/`Timeline` types)
+ * so it can be unit-tested on the JVM, mirroring the [PlaybackResumer]
+ * extraction. The service maps the returned [Action] onto real player calls.
+ *
+ * Not thread-safe: arm + consume both happen on the player's application
+ * thread.
+ */
+class ResumePlayGate {
+
+    enum class Action {
+        /** Do nothing. */
+        NONE,
+
+        /** Player already has media prepared — just start playback. */
+        PLAY,
+
+        /** Player is idle — prepare first, then start playback. */
+        PREPARE_THEN_PLAY,
+    }
+
+    private var armed = false
+
+    /**
+     * Arms (or disarms) the gate from `onPlaybackResumption`.
+     *
+     * @param isForPlayback Media3's flag: `true` for a genuine play request
+     *   (should end in playback), `false` for boot-time notification
+     *   population (must never start playing on its own). Passing `false`
+     *   leaves the gate closed.
+     */
+    fun arm(isForPlayback: Boolean) {
+        armed = isForPlayback
+    }
+
+    /**
+     * Consulted on every timeline change. Returns the play action to apply
+     * and consumes the latch (one-shot) only once the restored queue has
+     * actually landed ([windowCount] > 0); an empty intermediate timeline
+     * leaves the gate armed so the real queue still triggers playback.
+     */
+    fun onTimelineChanged(windowCount: Int, isIdle: Boolean): Action {
+        if (!armed || windowCount == 0) return Action.NONE
+        armed = false
+        return if (isIdle) Action.PREPARE_THEN_PLAY else Action.PLAY
+    }
+}

--- a/core/media/src/main/kotlin/com/stash/core/media/ResumeStreamResolver.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/ResumeStreamResolver.kt
@@ -1,0 +1,58 @@
+package com.stash.core.media
+
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.prefs.StreamingPreference
+import com.stash.core.media.streaming.ConnectivityMonitor
+import com.stash.core.media.streaming.StreamSourceRegistry
+import com.stash.core.media.streaming.StreamUrlCache
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Resolves a playable stream URL for the *current* track on the native
+ * Bluetooth / Android Auto resumption path
+ * ([com.stash.core.media.service.StashPlaybackService.onPlaybackResumption]).
+ *
+ * The service's ExoPlayer uses the default media-source factory, so a streamed
+ * track must carry a real `http(s)` URL before it reaches the player. In normal
+ * playback that resolution happens in
+ * [PlayerRepositoryImpl] before items reach the controller; on the native
+ * resume path the repository isn't in the loop, so without this the current
+ * streamed track would have no URI and error/skip — i.e. online-mode resume
+ * would play nothing.
+ *
+ * The gating here intentionally mirrors the streaming arm of
+ * [PlayerRepositoryImpl.buildMediaItemForTrack] (streaming-pref / connectivity
+ * / cellular) and reuses the same [StreamSourceRegistry] + [StreamUrlCache]
+ * primitives. It returns only the URL (no Media3 `MediaItem`), so the decision
+ * is unit-testable on the JVM and the service owns item construction. A future
+ * refactor could unify this with `buildMediaItemForTrack`.
+ */
+@Singleton
+class ResumeStreamResolver @Inject constructor(
+    private val streamingPreference: StreamingPreference,
+    private val connectivity: ConnectivityMonitor,
+    private val streamUrlCache: StreamUrlCache,
+    private val streamResolver: StreamSourceRegistry,
+) {
+    /**
+     * @return an `http(s)` stream URL to play [track] from, or null when the
+     *   caller should use the local file (downloaded track) or when the track
+     *   can't be streamed right now (streaming off / offline / cellular
+     *   refused / no stream available).
+     */
+    suspend fun resolveStreamUrl(track: TrackEntity): String? {
+        // Downloaded tracks play from disk — caller uses the local file path.
+        if (track.isDownloaded && !track.filePath.isNullOrBlank()) return null
+        if (!streamingPreference.current()) return null
+        if (!connectivity.isConnected()) return null
+        if (connectivity.isCellular() && !streamingPreference.streamOnCellular.first()) return null
+
+        val cached = streamUrlCache.get(track.id)
+        val stream = cached ?: streamResolver.resolve(track, allowYouTube = true)?.also {
+            streamUrlCache.put(track.id, it)
+        }
+        return stream?.url
+    }
+}

--- a/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
@@ -6,6 +6,7 @@ import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.common.Timeline
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
@@ -28,6 +29,9 @@ import com.stash.core.media.equalizer.EqController
 import com.stash.core.media.equalizer.LoudnessController
 import com.stash.core.media.equalizer.StashRenderersFactory
 import com.stash.core.media.equalizer.computeGain
+import com.stash.core.media.PlaybackResumer
+import com.stash.core.media.ResumePlayGate
+import com.stash.core.media.ResumeStreamResolver
 import com.stash.core.media.streaming.PrefetchOrchestrator
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -45,6 +49,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.guava.future
 import javax.inject.Inject
+import androidx.core.app.ServiceCompat
 import androidx.core.net.toUri
 import com.stash.core.data.db.entity.TrackEntity
 
@@ -69,6 +74,8 @@ class StashPlaybackService : MediaLibraryService() {
     @Inject lateinit var playlistDao: PlaylistDao
     @Inject lateinit var stashLikedRepository: StashLikedPlaylistRepository
     @Inject lateinit var prefetchOrchestrator: PrefetchOrchestrator
+    @Inject lateinit var playbackResumer: PlaybackResumer
+    @Inject lateinit var resumeStreamResolver: ResumeStreamResolver
 
     companion object {
         /** Custom command action for toggling shuffle mode. */
@@ -165,6 +172,18 @@ class StashPlaybackService : MediaLibraryService() {
      */
     private var prefetchPollJob: Job? = null
 
+    /**
+     * Forces playback to start when a real *play* request restores a queue
+     * onto the empty player. Media3 is supposed to auto-play after
+     * resumption on a play request, but from a warm process that auto-play
+     * sometimes doesn't take and the queue loads paused. Armed in
+     * [onPlaybackResumption] and consumed in [onTimelineChanged] once the
+     * restored timeline lands. Stays closed for boot-time notification
+     * population so the device never starts playing on its own after a
+     * reboot. See [ResumePlayGate].
+     */
+    private val resumePlayGate = ResumePlayGate()
+
     @OptIn(UnstableApi::class)
     override fun onCreate() {
         super.onCreate()
@@ -257,6 +276,27 @@ class StashPlaybackService : MediaLibraryService() {
                 }
             }
 
+            override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+                // When a play-triggered resumption lands its restored queue
+                // on the (previously empty) player, force playback to start.
+                // The gate keeps this scoped to resumption only — normal
+                // in-app setQueue never arms it, and boot-time notification
+                // population (isForPlayback = false) leaves it closed so the
+                // device doesn't auto-play after a reboot. Idempotent with
+                // Media3's own post-resumption play().
+                when (resumePlayGate.onTimelineChanged(
+                    timeline.windowCount,
+                    player.playbackState == Player.STATE_IDLE,
+                )) {
+                    ResumePlayGate.Action.PREPARE_THEN_PLAY -> {
+                        player.prepare()
+                        player.play()
+                    }
+                    ResumePlayGate.Action.PLAY -> player.play()
+                    ResumePlayGate.Action.NONE -> Unit
+                }
+            }
+
             override fun onRepeatModeChanged(repeatMode: Int) {
                 updateCustomLayout()
             }
@@ -266,6 +306,49 @@ class StashPlaybackService : MediaLibraryService() {
             }
         })
         updateCustomLayout()
+    }
+
+    /**
+     * Posts a lightweight "Resuming…" foreground notification so a
+     * media-button-triggered resumption (started via startForegroundService
+     * on a dead process) satisfies the OS ~5s "must call startForeground"
+     * deadline even when the current track needs a slow stream-URL resolve.
+     *
+     * Reuses Media3's default notification id so the real media notification
+     * replaces this placeholder seamlessly once playback starts — no
+     * lingering "Resuming…" entry.
+     */
+    @OptIn(UnstableApi::class)
+    private fun showResumingForegroundNotification() {
+        val channelId = "stash_playback_resume"
+        val nm = getSystemService(android.app.NotificationManager::class.java)
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O &&
+            nm.getNotificationChannel(channelId) == null
+        ) {
+            nm.createNotificationChannel(
+                android.app.NotificationChannel(
+                    channelId,
+                    getString(R.string.resuming_channel_name),
+                    android.app.NotificationManager.IMPORTANCE_LOW,
+                ),
+            )
+        }
+        val notification = androidx.core.app.NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setContentTitle(getString(R.string.resuming_notification_title))
+            .setOngoing(true)
+            .setPriority(androidx.core.app.NotificationCompat.PRIORITY_LOW)
+            .build()
+        val id = androidx.media3.session.DefaultMediaNotificationProvider.DEFAULT_NOTIFICATION_ID
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            startForeground(
+                id,
+                notification,
+                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
+            )
+        } else {
+            startForeground(id, notification)
+        }
     }
 
     /**
@@ -1014,6 +1097,42 @@ class StashPlaybackService : MediaLibraryService() {
             return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
         }
 
+        /**
+         * Builds a resumable [MediaItem] from a DB row, mirroring the URI
+         * resolution in [resolveMediaItem]: downloaded tracks get a
+         * `file://` URI. When [streamUrl] is non-null (the current track was
+         * resolved via [ResumeStreamResolver] for online-mode resume), it is
+         * used as the playback URI. Otherwise a streaming-only row is left
+         * without a URI, which the player surfaces as an onPlayerError →
+         * skip-next recovery (see [resolveMediaItem]).
+         */
+        private fun buildResumeItem(track: TrackEntity, streamUrl: String? = null): MediaItem {
+            val builder = MediaItem.Builder()
+                .setMediaId(track.id.toString())
+                .setMediaMetadata(track.toMediaMetadata())
+            val localPath = track.filePath
+            when {
+                track.isDownloaded && !localPath.isNullOrBlank() -> {
+                    val uri = if (localPath.startsWith("/")) {
+                        "file://$localPath".toUri()
+                    } else {
+                        localPath.toUri()
+                    }
+                    builder.setUri(uri)
+                }
+                streamUrl != null -> builder.setUri(streamUrl.toUri())
+                !localPath.isNullOrBlank() -> {
+                    val uri = if (localPath.startsWith("/")) {
+                        "file://$localPath".toUri()
+                    } else {
+                        localPath.toUri()
+                    }
+                    builder.setUri(uri)
+                }
+            }
+            return builder.build()
+        }
+
         @OptIn(UnstableApi::class)
         override fun onPlaybackResumption(
             session: MediaSession,
@@ -1021,31 +1140,72 @@ class StashPlaybackService : MediaLibraryService() {
             isForPlayback: Boolean,
         ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> {
             return serviceScope.future {
-                val track = trackDao.getLastPlayedTrack()
-                val item = if (track != null) {
-                    MediaItem.Builder()
-                        .setMediaId(track.id.toString())
-                        .setUri(track.filePath ?: "")
-                        .setMediaMetadata(track.toMediaMetadata())
-                        .build()
-                } else {
-                    // Fallback to most recently added if no last-played record exists
-                    trackDao.getRecentlyAdded(1).first().firstOrNull()?.let { recentlyAdded ->
-                        MediaItem.Builder()
-                            .setMediaId(recentlyAdded.id.toString())
-                            .setUri(recentlyAdded.filePath ?: "")
-                            .setMediaMetadata(recentlyAdded.toMediaMetadata())
-                            .build()
+                // This callback can run for a genuine play request started via
+                // startForegroundService (media button on a dead process). The
+                // current track may need a (possibly slow) stream-URL resolve
+                // for online mode, which can blow the OS 5s "must call
+                // startForeground" window. Post a lightweight "Resuming…"
+                // foreground notification first to satisfy it; Media3 replaces
+                // it with the real media notification once playback starts.
+                // Only for a real play request — never for boot-time
+                // notification population (isForPlayback = false).
+                if (isForPlayback) showResumingForegroundNotification()
+
+                // Preferred path: restore the full persisted queue at the
+                // saved track + position so next/prev work and playback
+                // continues where it stopped.
+                val plan = playbackResumer.buildResumePlan()
+                if (plan != null) {
+                    // Resolve ONLY the current track's stream URL in the
+                    // foreground so it plays in online mode; other streamed
+                    // tracks resolve later via the prefetch/skip path.
+                    // Downloaded tracks return null here and use their file.
+                    val currentStreamUrl = resumeStreamResolver
+                        .resolveStreamUrl(plan.tracks[plan.startIndex])
+                    val items = plan.tracks.mapIndexed { index, track ->
+                        buildResumeItem(
+                            track,
+                            streamUrl = if (index == plan.startIndex) currentStreamUrl else null,
+                        )
                     }
+                    kotlinx.coroutines.withContext(Dispatchers.Main) {
+                        session.player.shuffleModeEnabled = plan.isShuffled
+                    }
+                    // Force play once the queue lands iff this is a real play
+                    // request (not boot-time notification population).
+                    resumePlayGate.arm(isForPlayback)
+                    return@future MediaSession.MediaItemsWithStartPosition(
+                        ImmutableList.copyOf(items),
+                        plan.startIndex,
+                        plan.positionMs,
+                    )
+                }
+
+                // Fallback (no persisted queue yet): single last-played
+                // track, or the most recently added track if none.
+                val track = trackDao.getLastPlayedTrack()
+                    ?: trackDao.getRecentlyAdded(1).first().firstOrNull()
+                val item = track?.let {
+                    buildResumeItem(it, streamUrl = resumeStreamResolver.resolveStreamUrl(it))
                 }
 
                 if (item != null) {
+                    resumePlayGate.arm(isForPlayback)
                     MediaSession.MediaItemsWithStartPosition(
                         ImmutableList.of(item),
                         /* startIndex= */ 0,
                         /* startPositionMs= */ C.TIME_UNSET,
                     )
                 } else {
+                    // Nothing to resume (empty library). Drop the "Resuming…"
+                    // placeholder we may have posted so it doesn't linger as a
+                    // stuck foreground notification, then signal no-resume.
+                    if (isForPlayback) {
+                        ServiceCompat.stopForeground(
+                            this@StashPlaybackService,
+                            ServiceCompat.STOP_FOREGROUND_REMOVE,
+                        )
+                    }
                     throw UnsupportedOperationException()
                 }
             }

--- a/core/media/src/main/res/values/strings.xml
+++ b/core/media/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="notification_action_shuffle_on">Shuffle On</string>
     <string name="notification_action_shuffle_off">Shuffle Off</string>
     <string name="shuffle_play">Shuffle Play</string>
+    <string name="resuming_channel_name">Playback</string>
+    <string name="resuming_notification_title">Resuming…</string>
 </resources>

--- a/core/media/src/test/kotlin/com/stash/core/media/PlaybackResumerTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/PlaybackResumerTest.kt
@@ -1,0 +1,106 @@
+package com.stash.core.media
+
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.TrackEntity
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Unit tests for [PlaybackResumer] — the testable extract of the
+ * Bluetooth / Android Auto "resume the full queue" decision wired into
+ * [com.stash.core.media.service.StashPlaybackService.onPlaybackResumption].
+ *
+ * Reproduces the original bug: resumption returned a single-item queue at
+ * position 0, so next/prev did nothing and playback restarted the wrong
+ * track from the beginning.
+ */
+class PlaybackResumerTest {
+
+    private val playbackStateStore: PlaybackStateStore = mockk()
+    private val trackDao: TrackDao = mockk()
+
+    private val resumer = PlaybackResumer(playbackStateStore, trackDao)
+
+    private fun track(id: Long) = TrackEntity(id = id, title = "t$id", artist = "a$id")
+
+    @Test
+    fun fullQueueRestored_atSavedTrackAndPosition() = runTest {
+        coEvery { playbackStateStore.getLastPlaybackState() } returns SavedPlaybackState(
+            trackId = 20,
+            positionMs = 42_000,
+            queueIndex = 1,
+            queueTrackIds = listOf(10, 20, 30),
+            isShuffled = false,
+        )
+        // `IN` returns rows in arbitrary order — resumer must re-sort.
+        coEvery { trackDao.getByIds(listOf(10, 20, 30)) } returns
+            listOf(track(30), track(10), track(20))
+
+        val plan = resumer.buildResumePlan()!!
+
+        // The whole queue is restored — this is what makes next/prev work.
+        assertThat(plan.tracks.map { it.id }).containsExactly(10L, 20L, 30L).inOrder()
+        // Resumes on the saved current track, at the saved position.
+        assertThat(plan.startIndex).isEqualTo(1)
+        assertThat(plan.positionMs).isEqualTo(42_000)
+        assertThat(plan.isShuffled).isFalse()
+    }
+
+    @Test
+    fun noSavedState_returnsNullForSingleTrackFallback() = runTest {
+        coEvery { playbackStateStore.getLastPlaybackState() } returns null
+
+        assertThat(resumer.buildResumePlan()).isNull()
+    }
+
+    @Test
+    fun emptyPersistedQueue_returnsNullForSingleTrackFallback() = runTest {
+        coEvery { playbackStateStore.getLastPlaybackState() } returns SavedPlaybackState(
+            trackId = 7,
+            positionMs = 0,
+            queueIndex = 0,
+            queueTrackIds = emptyList(),
+            isShuffled = false,
+        )
+
+        assertThat(resumer.buildResumePlan()).isNull()
+    }
+
+    @Test
+    fun savedTrackMissing_startsFromClampedSavedIndex() = runTest {
+        // Saved current track (20) was deleted from the DB; the other two
+        // remain. Start index falls back to the saved queueIndex, clamped
+        // into the rebuilt list's range.
+        coEvery { playbackStateStore.getLastPlaybackState() } returns SavedPlaybackState(
+            trackId = 20,
+            positionMs = 5_000,
+            queueIndex = 5,
+            queueTrackIds = listOf(10, 20, 30),
+            isShuffled = true,
+        )
+        coEvery { trackDao.getByIds(listOf(10, 20, 30)) } returns listOf(track(10), track(30))
+
+        val plan = resumer.buildResumePlan()!!
+
+        assertThat(plan.tracks.map { it.id }).containsExactly(10L, 30L).inOrder()
+        assertThat(plan.startIndex).isEqualTo(1) // coerced from 5 into [0, 1]
+        assertThat(plan.isShuffled).isTrue()
+    }
+
+    @Test
+    fun allQueueRowsGone_returnsNullForSingleTrackFallback() = runTest {
+        coEvery { playbackStateStore.getLastPlaybackState() } returns SavedPlaybackState(
+            trackId = 20,
+            positionMs = 0,
+            queueIndex = 0,
+            queueTrackIds = listOf(10, 20),
+            isShuffled = false,
+        )
+        coEvery { trackDao.getByIds(listOf(10, 20)) } returns emptyList()
+
+        assertThat(resumer.buildResumePlan()).isNull()
+    }
+}

--- a/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryStreamingTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryStreamingTest.kt
@@ -67,6 +67,7 @@ class PlayerRepositoryStreamingTest {
             streamUrlCache = streamUrlCache,
             connectivity = connectivity,
             trackDao = trackDao,
+            playbackResumer = PlaybackResumer(playbackStateStore, trackDao),
         )
         // Tests that don't care about disk existence get a "file is there"
         // default; the not-downloaded tests can override per-test.
@@ -94,6 +95,7 @@ class PlayerRepositoryStreamingTest {
             streamUrlCache = streamUrlCache,
             connectivity = connectivity,
             trackDao = trackDao,
+            playbackResumer = PlaybackResumer(playbackStateStore, trackDao),
         )
 
         val empty = File.createTempFile("stash-empty", ".flac").apply { deleteOnExit() }

--- a/core/media/src/test/kotlin/com/stash/core/media/ResumePlayGateTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/ResumePlayGateTest.kt
@@ -1,0 +1,85 @@
+package com.stash.core.media
+
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.media.ResumePlayGate.Action
+import org.junit.Test
+
+/**
+ * Unit tests for [ResumePlayGate] — the testable extract of the
+ * "force playback to start after a Bluetooth / Android Auto resumption"
+ * latch wired into [com.stash.core.media.service.StashPlaybackService].
+ *
+ * Covers the warm-process bug (queue restored but stayed paused) and the
+ * reboot-safety rule (boot-time notification population must never play).
+ */
+class ResumePlayGateTest {
+
+    @Test
+    fun armedPlayRequest_idlePlayer_preparesThenPlays_once() {
+        val gate = ResumePlayGate()
+        gate.arm(isForPlayback = true)
+
+        // Restored queue lands on an idle player → prepare + play.
+        assertThat(gate.onTimelineChanged(windowCount = 3, isIdle = true))
+            .isEqualTo(Action.PREPARE_THEN_PLAY)
+
+        // One-shot: a later timeline change (e.g. queue edit) does nothing.
+        assertThat(gate.onTimelineChanged(windowCount = 3, isIdle = true))
+            .isEqualTo(Action.NONE)
+    }
+
+    @Test
+    fun armedPlayRequest_nonIdlePlayer_justPlays() {
+        val gate = ResumePlayGate()
+        gate.arm(isForPlayback = true)
+
+        assertThat(gate.onTimelineChanged(windowCount = 1, isIdle = false))
+            .isEqualTo(Action.PLAY)
+    }
+
+    @Test
+    fun notForPlayback_neverPlays_evenWhenQueueLands() {
+        // Boot-time notification population: items land on the player but
+        // the device must NOT start playing on its own.
+        val gate = ResumePlayGate()
+        gate.arm(isForPlayback = false)
+
+        assertThat(gate.onTimelineChanged(windowCount = 5, isIdle = true))
+            .isEqualTo(Action.NONE)
+    }
+
+    @Test
+    fun emptyIntermediateTimeline_keepsGateArmed() {
+        val gate = ResumePlayGate()
+        gate.arm(isForPlayback = true)
+
+        // An empty timeline change before the queue lands must not consume
+        // the latch — otherwise the real queue would arrive disarmed.
+        assertThat(gate.onTimelineChanged(windowCount = 0, isIdle = true))
+            .isEqualTo(Action.NONE)
+        assertThat(gate.onTimelineChanged(windowCount = 4, isIdle = true))
+            .isEqualTo(Action.PREPARE_THEN_PLAY)
+    }
+
+    @Test
+    fun neverArmed_doesNothing() {
+        // Normal in-app setQueue: the gate is never armed, so a timeline
+        // change must not hijack playback.
+        val gate = ResumePlayGate()
+
+        assertThat(gate.onTimelineChanged(windowCount = 2, isIdle = true))
+            .isEqualTo(Action.NONE)
+    }
+
+    @Test
+    fun rearmingAfterDisarm_works() {
+        val gate = ResumePlayGate()
+
+        // A false (boot) arm followed by a real play arm must play.
+        gate.arm(isForPlayback = false)
+        gate.arm(isForPlayback = true)
+
+        assertThat(gate.onTimelineChanged(windowCount = 1, isIdle = false))
+            .isEqualTo(Action.PLAY)
+    }
+}

--- a/core/media/src/test/kotlin/com/stash/core/media/ResumeStreamResolverTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/ResumeStreamResolverTest.kt
@@ -1,0 +1,108 @@
+package com.stash.core.media
+
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.prefs.StreamingPreference
+import com.stash.core.media.streaming.ConnectivityMonitor
+import com.stash.core.media.streaming.StreamSourceRegistry
+import com.stash.core.media.streaming.StreamUrl
+import com.stash.core.media.streaming.StreamUrlCache
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Unit tests for [ResumeStreamResolver] — the current-track stream-URL
+ * resolution used on the native Bluetooth/Auto resumption path so online-mode
+ * resume actually plays. Pure JVM (no Robolectric): the resolver returns a
+ * URL string, not a Media3 MediaItem.
+ */
+class ResumeStreamResolverTest {
+
+    private val streamingPreference: StreamingPreference = mockk()
+    private val connectivity: ConnectivityMonitor = mockk()
+    private val streamUrlCache: StreamUrlCache = mockk(relaxUnitFun = true)
+    private val streamResolver: StreamSourceRegistry = mockk()
+
+    private val resolver = ResumeStreamResolver(
+        streamingPreference, connectivity, streamUrlCache, streamResolver,
+    )
+
+    private fun streamable(id: Long) = TrackEntity(
+        id = id, title = "t$id", artist = "a$id", isDownloaded = false, isStreamable = true,
+    )
+
+    @Test
+    fun downloadedTrack_returnsNull_soCallerUsesLocalFile() = runTest {
+        val track = TrackEntity(
+            id = 1L, title = "t", artist = "a",
+            filePath = "/music/t.flac", isDownloaded = true,
+        )
+        assertThat(resolver.resolveStreamUrl(track)).isNull()
+    }
+
+    @Test
+    fun streamingOff_returnsNull() = runTest {
+        coEvery { streamingPreference.current() } returns false
+        assertThat(resolver.resolveStreamUrl(streamable(2L))).isNull()
+    }
+
+    @Test
+    fun noConnectivity_returnsNull() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        every { connectivity.isConnected() } returns false
+        assertThat(resolver.resolveStreamUrl(streamable(3L))).isNull()
+    }
+
+    @Test
+    fun cellularWithoutCellularPref_returnsNull() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        every { connectivity.isConnected() } returns true
+        every { connectivity.isCellular() } returns true
+        every { streamingPreference.streamOnCellular } returns flowOf(false)
+        assertThat(resolver.resolveStreamUrl(streamable(4L))).isNull()
+    }
+
+    @Test
+    fun cacheHit_returnsCachedUrl_withoutResolving() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        every { connectivity.isConnected() } returns true
+        every { connectivity.isCellular() } returns false
+        every { streamUrlCache.get(5L) } returns StreamUrl("https://cdn/cached", 999L)
+
+        assertThat(resolver.resolveStreamUrl(streamable(5L))).isEqualTo("https://cdn/cached")
+        // Resolver is never consulted on a cache hit.
+        coVerify(exactly = 0) { streamResolver.resolve(any(), any()) }
+    }
+
+    @Test
+    fun cacheMiss_resolvesAndCachesUrl() = runTest {
+        val track = streamable(6L)
+        coEvery { streamingPreference.current() } returns true
+        every { connectivity.isConnected() } returns true
+        every { connectivity.isCellular() } returns false
+        every { streamUrlCache.get(6L) } returns null
+        coEvery { streamResolver.resolve(track, allowYouTube = true) } returns
+            StreamUrl("https://cdn/fresh", 1234L)
+
+        assertThat(resolver.resolveStreamUrl(track)).isEqualTo("https://cdn/fresh")
+        verify { streamUrlCache.put(6L, match { it.url == "https://cdn/fresh" }) }
+    }
+
+    @Test
+    fun resolverReturnsNull_returnsNull() = runTest {
+        val track = streamable(7L)
+        coEvery { streamingPreference.current() } returns true
+        every { connectivity.isConnected() } returns true
+        every { connectivity.isCellular() } returns false
+        every { streamUrlCache.get(7L) } returns null
+        coEvery { streamResolver.resolve(track, allowYouTube = true) } returns null
+
+        assertThat(resolver.resolveStreamUrl(track)).isNull()
+    }
+}

--- a/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
@@ -56,6 +56,7 @@ class ListeningRecorderSkipTest {
         override suspend fun skipPrevious() = Unit
         override suspend fun seekTo(positionMs: Long) = Unit
         override suspend fun setQueue(tracks: List<Track>, startIndex: Int) = Unit
+        override fun resumeLastQueue() = Unit
         override suspend fun shuffleLibrary() = Unit
         override suspend fun addNext(track: Track) = Unit
         override suspend fun addToQueue(track: Track) = Unit


### PR DESCRIPTION
## TL;DR

Fixes Bluetooth / Android Auto **playback resumption**, which previously replayed the *wrong* track as a one-song queue.

- **Fixes #155** — on a cold start, resume now continues the **last-played queue at the saved track and position** instead of playing the most-recently-downloaded song.
- **next / previous work after resuming** — the whole queue is restored, not a single item.
- **Playback actually starts** — both from a warm process (it used to load but stay paused) and from a cold start.
- **Works in online (streaming) mode too**, not just downloaded files.
- Adds a **"Resume playback" app shortcut** (launcher long-press + Samsung Bixby Routines) that reliably resumes from a **cold start and the lock screen** — the generic "play music" media-button action can't.
- Adds **GitHub Actions** (unit tests + a debug-APK artifact) so contributors without a local Android build/test environment can still get CI feedback and an installable build.

Single squashed commit, rebased on current `master`. `core:media` unit tests and the debug APK build green in CI; the resume + shortcut behaviour was verified on-device (Samsung / Android Auto / car Bluetooth).

---

## The bug (#155)

`StashPlaybackService.onPlaybackResumption()` returned a **single** `MediaItem` with `startPositionMs = C.TIME_UNSET`:

- It fetched only the last-played track (falling back to the most-recently-*added* track), so a cold boot played the newest download — exactly what #155 describes.
- The returned queue had **one** item, so next/previous had nowhere to go.
- The saved position was discarded, so it always restarted from 0:00.

`PlaybackStateStore` already persisted `trackId` / `positionMs` / `queueIndex`, but nothing read them back, and the **queue list itself was never persisted** — so even the saved index was meaningless.

## What this PR changes

### 1. Restore the full queue, track and position
- `PlaybackStateStore` now also persists the ordered **queue track ids** + shuffle state (`saveQueue`), written from `PlayerRepositoryImpl.updateState()` only when the queue/shuffle actually changes (not on every position tick).
- `PlaybackResumer` (new, unit-tested) rebuilds the ordered queue, locates the saved current track by id (robust to deleted rows), and returns the start index + position + shuffle.
- `onPlaybackResumption` hands Media3 the **whole queue** at the saved index/position; the old single-track behaviour remains only as a fallback when nothing has been persisted yet.

### 2. Make playback actually start
From a warm process the queue would load but stay **paused** until a second trigger. Media3 is supposed to auto-play after `onPlaybackResumption` on a real play request, but that didn't reliably take. `ResumePlayGate` (new, unit-tested) arms on a genuine play request (`isForPlayback`) and forces `play()` once the restored queue lands — while staying inert for boot-time notification population, so the device never auto-plays after a reboot.

### 3. Online (streaming) mode
The service's player uses the default media-source factory, so a streamed track needs a resolved `http` URL before it reaches the player (normally done in `PlayerRepositoryImpl.setQueue`, which isn't in the loop on the native resume path). `ResumeStreamResolver` (new, unit-tested) resolves the current track's stream URL on resume, reusing the existing `StreamSourceRegistry` / `StreamUrlCache` and the same streaming gates (pref / connectivity / cellular). Because that resolve can be slow and this path is started via `startForegroundService`, a brief **"Resuming…"** foreground notification is posted to satisfy the OS 5-second `startForeground` deadline, reusing Media3's notification id so the real media notification replaces it seamlessly.

### 4. "Resume playback" app shortcut (the cold-start / lock-screen path)
A routine that fires the generic **"play music"** media-button at a *dead* app can't reliably wake it — Android won't deliver media buttons to a not-running (or force-stopped) process. VLC works around this with a dedicated **app shortcut**: launching an explicit activity cold-starts the app and works behind the lock screen, unlike a media key.

This PR adds the same: a static `shortcuts.xml` → `ResumePlaybackActivity` (a no-UI trampoline that calls `PlayerRepository.resumeLastQueue()` and finishes). `resumeLastQueue()` reuses the normal `setQueue` path, so it resolves + plays in **both** offline and online modes with the existing background queue-fill. The shortcut appears on launcher long-press and is selectable as a **Bixby Routine** action — point the car routine at it instead of "play music".

> Note on force-stop: if the app is **force-stopped** from Settings, Android puts it in the stopped state and won't deliver media buttons or start it for resumption until it's manually launched again — that's an OS guarantee no app can override. Normal process death (memory reclaim, swipe-away) is unaffected.

### 5. GitHub Actions for contributors without a local build/test env
The repo previously had only `release.yml` (tag-triggered APK build). This adds `tests.yml` (on push / PR):
- **`core:media` unit tests** — fast feedback on the playback logic.
- **A debug APK artifact** — so a contributor (or tester) without Android Studio / a build environment can download an installable build straight from the run.

> The debug APK carries the ~145 MB yt-dlp/Python bundle, so the artifact is large; feel free to trim that job or shorten retention if it's too heavy for the project's Actions usage.

## Testing
- New unit tests: `PlaybackResumerTest`, `ResumePlayGateTest`, `ResumeStreamResolverTest`; existing `PlayerRepositoryStreamingTest` updated for the new constructor. All `core:media` tests pass in CI.
- Manually verified on a Samsung device with Android Auto / car Bluetooth: correct track + position on resume, working next/previous, playback starting from both warm and cold states, and the shortcut firing from a cold/locked phone.
- The trampoline-activity → `resumeLastQueue` → `setQueue` wiring needs a live `MediaController`, so it's covered by the on-device test rather than a unit test.

## Scope notes
- Only the **current** track is foreground-resolved on the native car/AVRCP resume path; subsequent streamed tracks resolve via the existing prefetch/skip path. The shortcut path background-fills the whole queue, so it's the stronger option for online next/previous from cold.
- Does **not** address #154 (tapping a song in the Android Auto browser not queueing the playlist) — that's a separate browse-tap code path.
