### PR TITLE
feat(likes): mirror Stash hearts to Spotify / YouTube Music (opt-in, symmetric)

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -63,4 +63,5 @@ dependencies {
     testImplementation("org.mockito:mockito-core:5.11.0")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
     testImplementation("io.mockk:mockk:1.13.8")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -977,6 +977,21 @@ interface TrackDao {
     suspend fun markYtMusicSaved(trackId: Long, ts: Long)
 
     /**
+     * v0.9.52 like-mirroring: clears the Spotify dedup timestamp after a
+     * successful symmetric un-like (`DELETE /v1/me/tracks`), so a future
+     * re-heart re-fires the external save.
+     */
+    @Query("UPDATE tracks SET spotify_saved_at = NULL WHERE id = :trackId")
+    suspend fun clearSpotifySaved(trackId: Long)
+
+    /**
+     * v0.9.52 like-mirroring: clears the YT Music dedup timestamp after a
+     * successful InnerTube `like/removelike`.
+     */
+    @Query("UPDATE tracks SET ytmusic_saved_at = NULL WHERE id = :trackId")
+    suspend fun clearYtMusicSaved(trackId: Long)
+
+    /**
      * v0.9.13: Mark a track as added to the local Stash "Liked Songs"
      * playlist. Called by [StashLikedPlaylistRepository.add] after the
      * cross-ref is in place.

--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/LikePreferences.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/LikePreferences.kt
@@ -34,6 +34,10 @@ private val Context.likeDataStore: DataStore<Preferences> by preferencesDataStor
  *
  * Auto-save off by default. Even with Spotify connected, opt-in
  * required.
+ *
+ * v0.9.52 like-mirroring: `mirror_likes_*` opt-ins, default false —
+ * deliberately NOT reusing `heart_default_*`, whose true-defaults would
+ * auto-enable external writes for every existing user on update.
  */
 @Singleton
 class LikePreferences @Inject constructor(
@@ -44,6 +48,8 @@ class LikePreferences @Inject constructor(
     private val heartDefaultStashKey = booleanPreferencesKey("heart_default_stash")
     private val heartDefaultSpotifyKey = booleanPreferencesKey("heart_default_spotify")
     private val heartDefaultYtMusicKey = booleanPreferencesKey("heart_default_ytmusic")
+    private val mirrorLikesSpotifyKey = booleanPreferencesKey("mirror_likes_spotify")
+    private val mirrorLikesYtMusicKey = booleanPreferencesKey("mirror_likes_youtube")
 
     val autoSaveEnabled: Flow<Boolean> =
         context.likeDataStore.data.map { it[autoSaveEnabledKey] ?: false }
@@ -62,11 +68,19 @@ class LikePreferences @Inject constructor(
     val heartDefaultYtMusic: Flow<Boolean> =
         context.likeDataStore.data.map { it[heartDefaultYtMusicKey] ?: false }
 
+    val mirrorLikesSpotify: Flow<Boolean> =
+        context.likeDataStore.data.map { it[mirrorLikesSpotifyKey] ?: false }
+
+    val mirrorLikesYtMusic: Flow<Boolean> =
+        context.likeDataStore.data.map { it[mirrorLikesYtMusicKey] ?: false }
+
     suspend fun autoSaveEnabledNow(): Boolean = autoSaveEnabled.first()
     suspend fun autoSaveThresholdNow(): Int = autoSaveThreshold.first()
     suspend fun heartDefaultStashNow(): Boolean = heartDefaultStash.first()
     suspend fun heartDefaultSpotifyNow(): Boolean = heartDefaultSpotify.first()
     suspend fun heartDefaultYtMusicNow(): Boolean = heartDefaultYtMusic.first()
+    suspend fun mirrorLikesSpotifyNow(): Boolean = mirrorLikesSpotify.first()
+    suspend fun mirrorLikesYtMusicNow(): Boolean = mirrorLikesYtMusic.first()
 
     suspend fun setAutoSaveEnabled(value: Boolean) {
         context.likeDataStore.edit { it[autoSaveEnabledKey] = value }
@@ -86,5 +100,13 @@ class LikePreferences @Inject constructor(
 
     suspend fun setHeartDefaultYtMusic(value: Boolean) {
         context.likeDataStore.edit { it[heartDefaultYtMusicKey] = value }
+    }
+
+    suspend fun setMirrorLikesSpotify(value: Boolean) {
+        context.likeDataStore.edit { it[mirrorLikesSpotifyKey] = value }
+    }
+
+    suspend fun setMirrorLikesYtMusic(value: Boolean) {
+        context.likeDataStore.edit { it[mirrorLikesYtMusicKey] = value }
     }
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/social/LikeCoordinator.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/social/LikeCoordinator.kt
@@ -1,0 +1,159 @@
+package com.stash.core.data.social
+
+import android.util.Log
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.mapper.toDomain
+import com.stash.core.data.prefs.LikePreferences
+import com.stash.core.data.social.spotify.SpotifyRateLimitException
+import com.stash.core.data.social.stash.StashLikedPlaylistRepository
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+
+/**
+ * v0.9.52: single entry point for the heart button. Both heart entry
+ * points (NowPlayingViewModel.onLikeTap, StashPlaybackService
+ * COMMAND_TOGGLE_LIKE) call [setLiked] instead of touching
+ * StashLikedPlaylistRepository directly.
+ *
+ * Contract:
+ *  1. Local first, always. The Stash like/unlike runs synchronously in
+ *     the caller's coroutine and its failure propagates (callers keep
+ *     their existing snackbar + optimistic-rollback UX). Local state
+ *     never depends on external success — hearts work offline.
+ *  2. Mirroring is fire-and-forget. When a `mirror_likes_*` pref is on,
+ *     an op is enqueued onto a single-consumer queue; the drain loop is
+ *     the pacing mechanism (serialized, [minGapMs] between external
+ *     bursts, Spotify Retry-After honored). Deliberately not a token
+ *     bucket — one slow writer defangs multi-select bursts and
+ *     heart-spam by construction.
+ *  3. Prefs AND the track row are re-read at fire time, not enqueue
+ *     time. That's what makes rapid like→unlike→like converge: the
+ *     dispatcher's `*_saved_at` guards see the columns as the previous
+ *     op left them, and a mid-queue toggle-off drops remaining ops.
+ *  4. Failures are best-effort: log + leave dedup column untouched →
+ *     organic retry on the next heart of that track (same recovery as
+ *     AutoSaveScrobbler). At most ONE [mirrorFailures] emission per
+ *     process lifetime — no nagging.
+ *
+ * Forward-only by design (no backfill of pre-existing likes — bulk
+ * writes are the most bot-shaped action). A future opt-in trickle
+ * backfill can reuse this queue by enqueueing (trackId, liked=true)
+ * ops; the seam is already here.
+ *
+ * App-lifetime scope is instantiated inline like AutoSaveScrobbler /
+ * LosslessUrlPrefetcher — no Hilt ApplicationScope qualifier exists in
+ * this codebase. The internal constructor is the test seam (TestScope +
+ * virtual-time minGap).
+ */
+@Singleton
+class LikeCoordinator internal constructor(
+    private val stashLikedRepository: StashLikedPlaylistRepository,
+    private val likePreferences: LikePreferences,
+    private val dispatcher: LikeDestinationDispatcher,
+    private val trackDao: TrackDao,
+    scope: CoroutineScope,
+    private val minGapMs: Long,
+) {
+    @Inject constructor(
+        stashLikedRepository: StashLikedPlaylistRepository,
+        likePreferences: LikePreferences,
+        dispatcher: LikeDestinationDispatcher,
+        trackDao: TrackDao,
+    ) : this(
+        stashLikedRepository,
+        likePreferences,
+        dispatcher,
+        trackDao,
+        CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        MIN_GAP_MS_DEFAULT,
+    )
+
+    private data class MirrorOp(val trackId: Long, val liked: Boolean)
+
+    private val queue = Channel<MirrorOp>(capacity = Channel.UNLIMITED)
+    private val failureSignalled = AtomicBoolean(false)
+
+    private val _mirrorFailures = MutableSharedFlow<String>(extraBufferCapacity = 1)
+
+    /** One subtle "couldn't sync — will retry" per session; UI collects this. */
+    val mirrorFailures: SharedFlow<String> = _mirrorFailures
+
+    init {
+        scope.launch { drainLoop() }
+    }
+
+    /**
+     * Toggle the heart for [trackId]. [trackId] must be a real Room PK —
+     * callers already resolve synthetic/streaming ids (ensureTrackPersisted
+     * / resolveTrackIdForLike) before calling.
+     */
+    suspend fun setLiked(trackId: Long, liked: Boolean) {
+        if (liked) stashLikedRepository.add(trackId) else stashLikedRepository.remove(trackId)
+
+        // Fast-path gate so a mirroring-off install never churns the queue.
+        // The drain loop re-checks at fire time anyway (see class KDoc #3).
+        if (!likePreferences.mirrorLikesSpotifyNow() && !likePreferences.mirrorLikesYtMusicNow()) return
+        queue.send(MirrorOp(trackId, liked))
+    }
+
+    private suspend fun drainLoop() {
+        for (op in queue) {
+            runCatching { process(op) }
+                .onFailure { e ->
+                    if (e is CancellationException) throw e
+                    Log.w(TAG, "mirror op crashed for track ${op.trackId}", e)
+                }
+        }
+    }
+
+    private suspend fun process(op: MirrorOp) {
+        val mirrorSpotify = likePreferences.mirrorLikesSpotifyNow()
+        val mirrorYt = likePreferences.mirrorLikesYtMusicNow()
+        val track = trackDao.getById(op.trackId)?.toDomain() ?: return
+        val destinations = buildSet {
+            if (mirrorSpotify && track.spotifyUri != null) add(Destination.SPOTIFY)
+            if (mirrorYt && track.youtubeId != null) add(Destination.YT_MUSIC)
+        }
+        if (destinations.isEmpty()) return
+
+        val verb = if (op.liked) "like" else "unlike"
+        val results = if (op.liked) {
+            dispatcher.like(track, destinations)
+        } else {
+            dispatcher.unlike(track, destinations)
+        }
+
+        var anyFailed = false
+        results.forEach { (dest, result) ->
+            result.onFailure { e ->
+                anyFailed = true
+                Log.w(TAG, "mirror $verb → $dest failed for track ${track.id}: ${e.message}")
+            }
+        }
+        if (anyFailed && failureSignalled.compareAndSet(false, true)) {
+            _mirrorFailures.tryEmit("Couldn't sync your like — will retry")
+        }
+
+        // Pacing: min gap between bursts; a 429's Retry-After stretches it.
+        val retryAfterMs = results.values
+            .mapNotNull { (it.exceptionOrNull() as? SpotifyRateLimitException)?.retryAfterSeconds }
+            .maxOrNull()
+            ?.times(1_000L) ?: 0L
+        delay(maxOf(minGapMs, retryAfterMs))
+    }
+
+    companion object {
+        private const val TAG = "LikeCoordinator"
+        private const val MIN_GAP_MS_DEFAULT = 1_500L
+    }
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/social/LikeDestinationDispatcher.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/social/LikeDestinationDispatcher.kt
@@ -78,6 +78,55 @@ class LikeDestinationDispatcher @Inject constructor(
         }
     }
 
+    /**
+     * v0.9.52 symmetric un-like. Mirrors [like], with the inverted
+     * guard: a destination only fires when its `*_saved_at` timestamp
+     * is non-null (never un-Like what Stash never Liked). A successful
+     * remote remove clears the timestamp so a future re-heart re-fires
+     * the save. Failures leave the column untouched → organic retry.
+     */
+    suspend fun unlike(
+        track: Track,
+        destinations: Set<Destination>,
+    ): Map<Destination, Result<Unit>> = coroutineScope {
+        if (destinations.isEmpty()) return@coroutineScope emptyMap()
+        destinations.associateWith { dest ->
+            async { fireUnlikeDestination(track, dest) }
+        }.mapValues { it.value.await() }
+    }
+
+    private suspend fun fireUnlikeDestination(track: Track, dest: Destination): Result<Unit> {
+        if (!alreadySaved(track, dest)) {
+            Log.d(TAG, "skip unlike $dest for track ${track.id} — never saved by Stash")
+            return Result.success(Unit)
+        }
+
+        return try {
+            when (dest) {
+                Destination.STASH -> {
+                    stashLikedRepository.remove(track.id)
+                }
+                Destination.SPOTIFY -> {
+                    val uri = track.spotifyUri ?: throw NoSpotifyUriException()
+                    spotifyLibraryClient.removeTracks(listOf(uri))
+                    runCatching { trackDao.clearSpotifySaved(track.id) }
+                        .onFailure { Log.w(TAG, "clearSpotifySaved failed for ${track.id}", it) }
+                }
+                Destination.YT_MUSIC -> {
+                    val videoId = track.youtubeId ?: throw NoYouTubeIdException()
+                    ytMusicLibraryClient.removeLike(videoId)
+                    runCatching { trackDao.clearYtMusicSaved(track.id) }
+                        .onFailure { Log.w(TAG, "clearYtMusicSaved failed for ${track.id}", it) }
+                }
+            }
+            Result.success(Unit)
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (t: Throwable) {
+            Result.failure(t)
+        }
+    }
+
     private fun alreadySaved(track: Track, dest: Destination): Boolean = when (dest) {
         Destination.STASH -> track.stashLikedAt != null
         Destination.SPOTIFY -> track.spotifySavedAt != null

--- a/core/data/src/main/kotlin/com/stash/core/data/social/spotify/SpotifyLibraryApiClient.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/social/spotify/SpotifyLibraryApiClient.kt
@@ -17,13 +17,16 @@ class SpotifyApiException(val code: Int, val body: String?) :
     Exception("Spotify API error $code: $body")
 
 /**
- * v0.9.13: Wraps Spotify Web API's "Save Tracks for User" endpoint.
+ * v0.9.13: Wraps Spotify Web API's "Save/Remove Tracks for User"
+ * endpoints.
  *
- * Public API: `PUT /v1/me/tracks?ids=<id1>,<id2>,...`
+ * Public API:
+ *   - save:   `PUT /v1/me/tracks?ids=<id1>,<id2>,...`
+ *   - remove: `DELETE /v1/me/tracks?ids=<id1>,<id2>,...` (v0.9.52, symmetric un-like)
  * Scope: `user-library-modify` — covered by the existing sp_dc-derived
  *   web-player token (Spotify Web's Like button uses the same scope).
  *   No Premium requirement.
- * Idempotent: re-saving an already-saved track is a no-op (no error).
+ * Idempotent: re-saving / re-removing a track is a no-op (no error).
  * Batch limit: 50 IDs per request.
  *
  * Auth: routes through TokenManager.getSpotifyAccessToken (auto-refresh)
@@ -31,12 +34,31 @@ class SpotifyApiException(val code: Int, val body: String?) :
  * NO direct dependency on SpotifyAuthManager.
  */
 @Singleton
-class SpotifyLibraryApiClient @Inject constructor(
+class SpotifyLibraryApiClient internal constructor(
     private val tokenManager: TokenManager,
     private val httpClient: OkHttpClient,
+    private val baseUrl: String,
 ) {
-    suspend fun saveTracks(spotifyUris: List<String>) = withContext(Dispatchers.IO) {
-        require(spotifyUris.isNotEmpty()) { "saveTracks: empty list" }
+    @Inject constructor(
+        tokenManager: TokenManager,
+        httpClient: OkHttpClient,
+    ) : this(tokenManager, httpClient, "https://api.spotify.com")
+
+    suspend fun saveTracks(spotifyUris: List<String>) = mutateSavedTracks(spotifyUris, save = true)
+
+    /**
+     * v0.9.52: symmetric un-like. `DELETE /v1/me/tracks?ids=...` — same
+     * scope (`user-library-modify`), same idempotency, same 50-id cap
+     * as the save call.
+     */
+    suspend fun removeTracks(spotifyUris: List<String>) = mutateSavedTracks(spotifyUris, save = false)
+
+    private suspend fun mutateSavedTracks(
+        spotifyUris: List<String>,
+        save: Boolean,
+    ) = withContext(Dispatchers.IO) {
+        val verb = if (save) "saveTracks" else "removeTracks"
+        require(spotifyUris.isNotEmpty()) { "$verb: empty list" }
         require(spotifyUris.size <= 50) { "Spotify caps at 50 IDs per call (got ${spotifyUris.size})" }
 
         val token = tokenManager.getSpotifyAccessToken()
@@ -44,23 +66,23 @@ class SpotifyLibraryApiClient @Inject constructor(
 
         // Strip "spotify:track:" prefix; Spotify accepts bare IDs.
         val ids = spotifyUris.joinToString(",") { it.removePrefix("spotify:track:") }
-        val url = "https://api.spotify.com/v1/me/tracks?ids=$ids"
+        val url = "$baseUrl/v1/me/tracks?ids=$ids"
 
-        // PUT /v1/me/tracks expects an empty body (IDs are in the query).
+        // PUT/DELETE /v1/me/tracks expect an empty body (IDs are in the query).
         val emptyBody = ByteArray(0).toRequestBody(null)
         val request = Request.Builder()
             .url(url)
-            .put(emptyBody)
+            .apply { if (save) put(emptyBody) else delete(emptyBody) }
             .header("Authorization", "Bearer $token")
             .build()
 
         httpClient.newCall(request).execute().use { response ->
             when (response.code) {
                 200, 201, 204 -> {
-                    Log.d(TAG, "saved ${spotifyUris.size} track(s) to Spotify")
+                    Log.d(TAG, "$verb: ${spotifyUris.size} track(s) ok")
                 }
                 401 -> {
-                    Log.w(TAG, "401 — invalidating Spotify token")
+                    Log.w(TAG, "$verb: 401 — invalidating Spotify token")
                     tokenManager.forceRefreshSpotifyAccessToken()
                     throw SpotifyAuthException()
                 }

--- a/core/data/src/main/kotlin/com/stash/core/data/social/ytmusic/YtMusicLibraryApiClient.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/social/ytmusic/YtMusicLibraryApiClient.kt
@@ -7,11 +7,11 @@ import javax.inject.Singleton
 class YtMusicLibraryException(message: String) : Exception(message)
 
 /**
- * v0.9.13: Thin wrapper around [InnerTubeClient.likeVideo]. Translates
- * a "false" return into an exception so the dispatcher's
- * `runCatching` lifts it into `Result.failure`. Existing
- * InnerTubeClient handles SAPISID-hash auth, cookies, headers via its
- * existing internal request path.
+ * v0.9.13: Thin wrapper around [InnerTubeClient.likeVideo] /
+ * [InnerTubeClient.removeLike] (v0.9.52). Translates a "false" return
+ * into an exception so the dispatcher's `runCatching` lifts it into
+ * `Result.failure`. Existing InnerTubeClient handles SAPISID-hash auth,
+ * cookies, headers via its existing internal request path.
  */
 @Singleton
 class YtMusicLibraryApiClient @Inject constructor(
@@ -20,5 +20,10 @@ class YtMusicLibraryApiClient @Inject constructor(
     suspend fun likeVideo(videoId: String) {
         val ok = innerTubeClient.likeVideo(videoId)
         if (!ok) throw YtMusicLibraryException("InnerTube likeVideo($videoId) failed")
+    }
+
+    suspend fun removeLike(videoId: String) {
+        val ok = innerTubeClient.removeLike(videoId)
+        if (!ok) throw YtMusicLibraryException("InnerTube removeLike($videoId) failed")
     }
 }

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackDaoSavedAtClearTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackDaoSavedAtClearTest.kt
@@ -1,0 +1,84 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.TrackEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * v0.9.52 like-mirroring: symmetric un-like must clear the
+ * `*_saved_at` dedup columns so a future re-heart re-fires the
+ * external write. Each clear touches ONLY its own column.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class TrackDaoSavedAtClearTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: TrackDao
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.trackDao()
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun clearSpotifySaved_nullsOnlySpotifyColumn() = runTest {
+        dao.insert(track(id = 1L, spotifySavedAt = 111L, ytMusicSavedAt = 222L))
+
+        dao.clearSpotifySaved(1L)
+
+        val row = dao.getById(1L)!!
+        assertNull(row.spotifySavedAt)
+        assertEquals(222L, row.ytMusicSavedAt)
+    }
+
+    @Test fun clearYtMusicSaved_nullsOnlyYtColumn() = runTest {
+        dao.insert(track(id = 1L, spotifySavedAt = 111L, ytMusicSavedAt = 222L))
+
+        dao.clearYtMusicSaved(1L)
+
+        val row = dao.getById(1L)!!
+        assertEquals(111L, row.spotifySavedAt)
+        assertNull(row.ytMusicSavedAt)
+    }
+
+    @Test fun clears_areNoOpsOnOtherRows() = runTest {
+        dao.insert(track(id = 1L, spotifySavedAt = 111L, ytMusicSavedAt = 222L))
+        dao.insert(track(id = 2L, spotifySavedAt = 333L, ytMusicSavedAt = 444L))
+
+        dao.clearSpotifySaved(1L)
+        dao.clearYtMusicSaved(1L)
+
+        val other = dao.getById(2L)!!
+        assertEquals(333L, other.spotifySavedAt)
+        assertEquals(444L, other.ytMusicSavedAt)
+    }
+
+    private fun track(
+        id: Long,
+        spotifySavedAt: Long? = null,
+        ytMusicSavedAt: Long? = null,
+    ) = TrackEntity(
+        id = id,
+        title = "Title $id",
+        artist = "Artist $id",
+        canonicalTitle = "title $id",
+        canonicalArtist = "artist $id",
+        spotifySavedAt = spotifySavedAt,
+        ytMusicSavedAt = ytMusicSavedAt,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/prefs/LikePreferencesMirrorTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/prefs/LikePreferencesMirrorTest.kt
@@ -1,0 +1,73 @@
+package com.stash.core.data.prefs
+
+import android.content.Context
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+/**
+ * Like-mirroring opt-in prefs. Both MUST default to false: defaulting
+ * Spotify on (like the vestigial heart_default_spotify does) would
+ * silently start external writes for every existing user on update.
+ */
+@RunWith(RobolectricTestRunner::class)
+class LikePreferencesMirrorTest {
+
+    private lateinit var context: Context
+    private lateinit var prefs: LikePreferences
+    private lateinit var file: File
+
+    @Before fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        file = context.preferencesDataStoreFile("like_preferences")
+        if (file.exists()) file.delete()
+        prefs = LikePreferences(context)
+    }
+
+    @After fun tearDown() {
+        if (file.exists()) file.delete()
+    }
+
+    @Test fun mirrorLikesSpotify_defaultsToFalse() = runTest {
+        assertFalse(prefs.mirrorLikesSpotify.first())
+        assertFalse(prefs.mirrorLikesSpotifyNow())
+    }
+
+    @Test fun mirrorLikesYtMusic_defaultsToFalse() = runTest {
+        assertFalse(prefs.mirrorLikesYtMusic.first())
+        assertFalse(prefs.mirrorLikesYtMusicNow())
+    }
+
+    @Test fun mirrorLikesSpotify_roundTrips() = runTest {
+        prefs.setMirrorLikesSpotify(true)
+        assertTrue(prefs.mirrorLikesSpotify.first())
+        prefs.setMirrorLikesSpotify(false)
+        assertFalse(prefs.mirrorLikesSpotify.first())
+    }
+
+    @Test fun mirrorLikesYtMusic_roundTrips() = runTest {
+        prefs.setMirrorLikesYtMusic(true)
+        assertTrue(prefs.mirrorLikesYtMusicNow())
+        // Reset so the shared process-singleton DataStore doesn't leak a
+        // cached `true` into the order-independent default tests.
+        prefs.setMirrorLikesYtMusic(false)
+    }
+
+    @Test fun mirrorPrefs_doNotDisturbExistingHeartDefaults() = runTest {
+        prefs.setMirrorLikesSpotify(true)
+        // Vestigial prefs keep their legacy defaults (stash=true, spotify=true, yt=false).
+        assertTrue(prefs.heartDefaultSpotifyNow())
+        assertFalse(prefs.heartDefaultYtMusicNow())
+        // Reset so the cached value doesn't leak into the default tests.
+        prefs.setMirrorLikesSpotify(false)
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/social/LikeCoordinatorTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/social/LikeCoordinatorTest.kt
@@ -1,0 +1,179 @@
+package com.stash.core.data.social
+
+import app.cash.turbine.test
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.prefs.LikePreferences
+import com.stash.core.data.social.spotify.SpotifyRateLimitException
+import com.stash.core.data.social.stash.StashLikedPlaylistRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * v0.9.52 LikeCoordinator contract:
+ *  - local Stash like is synchronous, sacred, and independent of mirroring
+ *  - mirror prefs are read at FIRE time (gating + convergence)
+ *  - per-destination skip when the track lacks that platform id
+ *  - ops are serialized with a min gap; Spotify Retry-After stretches the gap
+ *  - external failures signal at most one snackbar per session
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LikeCoordinatorTest {
+
+    private val stashLiked = mockk<StashLikedPlaylistRepository>(relaxed = true)
+    private val prefs = mockk<LikePreferences>()
+    private val dispatcher = mockk<LikeDestinationDispatcher>()
+    private val trackDao = mockk<TrackDao>()
+
+    private fun entity(
+        id: Long = 7L,
+        spotifyUri: String? = "spotify:track:abc",
+        youtubeId: String? = "vid123",
+    ) = TrackEntity(
+        id = id,
+        title = "Title $id",
+        artist = "Artist $id",
+        canonicalTitle = "title $id",
+        canonicalArtist = "artist $id",
+        spotifyUri = spotifyUri,
+        youtubeId = youtubeId,
+    )
+
+    private fun mirrorPrefs(spotify: Boolean, yt: Boolean) {
+        coEvery { prefs.mirrorLikesSpotifyNow() } returns spotify
+        coEvery { prefs.mirrorLikesYtMusicNow() } returns yt
+    }
+
+    private fun kotlinx.coroutines.test.TestScope.coordinator(minGapMs: Long = 1_500L) =
+        LikeCoordinator(stashLiked, prefs, dispatcher, trackDao, backgroundScope, minGapMs)
+
+    @Test fun `local like always happens, mirroring off touches nothing external`() = runTest {
+        mirrorPrefs(spotify = false, yt = false)
+        val c = coordinator()
+
+        c.setLiked(7L, liked = true)
+        runCurrent()
+
+        coVerify { stashLiked.add(7L) }
+        coVerify(exactly = 0) { dispatcher.like(any(), any()) }
+    }
+
+    @Test fun `local failure propagates to caller and nothing is enqueued`() = runTest {
+        mirrorPrefs(spotify = true, yt = false)
+        coEvery { stashLiked.add(7L) } throws RuntimeException("db full")
+        val c = coordinator()
+
+        try {
+            c.setLiked(7L, liked = true)
+            fail("expected local failure to propagate")
+        } catch (_: RuntimeException) { }
+        runCurrent()
+
+        coVerify(exactly = 0) { dispatcher.like(any(), any()) }
+    }
+
+    @Test fun `mirrors like to enabled destinations the track has ids for`() = runTest {
+        mirrorPrefs(spotify = true, yt = true)
+        coEvery { trackDao.getById(7L) } returns entity(youtubeId = null) // no YT id → skip YT
+        coEvery { dispatcher.like(any(), any()) } returns
+            mapOf(Destination.SPOTIFY to Result.success(Unit))
+        val c = coordinator()
+
+        c.setLiked(7L, liked = true)
+        advanceTimeBy(10_000L); runCurrent()
+
+        coVerify(exactly = 1) { dispatcher.like(match { it.id == 7L }, setOf(Destination.SPOTIFY)) }
+        coVerify(exactly = 0) { dispatcher.unlike(any(), any()) }
+    }
+
+    @Test fun `un-heart routes to dispatcher unlike`() = runTest {
+        mirrorPrefs(spotify = true, yt = false)
+        coEvery { trackDao.getById(7L) } returns entity()
+        coEvery { dispatcher.unlike(any(), any()) } returns
+            mapOf(Destination.SPOTIFY to Result.success(Unit))
+        val c = coordinator()
+
+        c.setLiked(7L, liked = false)
+        advanceTimeBy(10_000L); runCurrent()
+
+        coVerify { stashLiked.remove(7L) }
+        coVerify { dispatcher.unlike(any(), setOf(Destination.SPOTIFY)) }
+    }
+
+    @Test fun `ops are serialized with the min gap between external calls`() = runTest {
+        mirrorPrefs(spotify = true, yt = false)
+        coEvery { trackDao.getById(any()) } answers { entity(id = firstArg()) }
+        coEvery { dispatcher.like(any(), any()) } returns
+            mapOf(Destination.SPOTIFY to Result.success(Unit))
+        val c = coordinator(minGapMs = 1_500L)
+
+        c.setLiked(1L, liked = true)
+        c.setLiked(2L, liked = true)
+        runCurrent() // first op fires immediately
+
+        coVerify(exactly = 1) { dispatcher.like(any(), any()) }
+
+        advanceTimeBy(1_400L); runCurrent() // still inside the gap
+        coVerify(exactly = 1) { dispatcher.like(any(), any()) }
+
+        advanceTimeBy(200L); runCurrent() // gap elapsed
+        coVerify(exactly = 2) { dispatcher.like(any(), any()) }
+    }
+
+    @Test fun `Spotify Retry-After stretches the gap`() = runTest {
+        mirrorPrefs(spotify = true, yt = false)
+        coEvery { trackDao.getById(any()) } answers { entity(id = firstArg()) }
+        coEvery { dispatcher.like(any(), any()) } returnsMany listOf(
+            mapOf(Destination.SPOTIFY to Result.failure(SpotifyRateLimitException(30))),
+            mapOf(Destination.SPOTIFY to Result.success(Unit)),
+        )
+        val c = coordinator(minGapMs = 1_500L)
+
+        c.setLiked(1L, liked = true)
+        c.setLiked(2L, liked = true)
+        runCurrent()
+
+        advanceTimeBy(29_000L); runCurrent() // inside Retry-After window
+        coVerify(exactly = 1) { dispatcher.like(any(), any()) }
+
+        advanceTimeBy(2_000L); runCurrent()
+        coVerify(exactly = 2) { dispatcher.like(any(), any()) }
+    }
+
+    @Test fun `external failure emits at most one snackbar signal per session`() = runTest {
+        mirrorPrefs(spotify = true, yt = false)
+        coEvery { trackDao.getById(any()) } answers { entity(id = firstArg()) }
+        coEvery { dispatcher.like(any(), any()) } returns
+            mapOf(Destination.SPOTIFY to Result.failure(RuntimeException("down")))
+        val c = coordinator()
+
+        c.mirrorFailures.test {
+            c.setLiked(1L, liked = true)
+            advanceTimeBy(10_000L); runCurrent()
+            assertEquals("Couldn't sync your like — will retry", awaitItem())
+
+            c.setLiked(2L, liked = true)
+            advanceTimeBy(10_000L); runCurrent()
+            expectNoEvents() // second failure stays quiet — no nagging
+        }
+    }
+
+    @Test fun `track gone from DB is a silent skip`() = runTest {
+        mirrorPrefs(spotify = true, yt = false)
+        coEvery { trackDao.getById(7L) } returns null
+        val c = coordinator()
+
+        c.setLiked(7L, liked = true)
+        advanceTimeBy(10_000L); runCurrent()
+
+        coVerify(exactly = 0) { dispatcher.like(any(), any()) }
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/social/LikeDestinationDispatcherUnlikeTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/social/LikeDestinationDispatcherUnlikeTest.kt
@@ -1,0 +1,89 @@
+package com.stash.core.data.social
+
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.social.spotify.SpotifyLibraryApiClient
+import com.stash.core.data.social.stash.StashLikedPlaylistRepository
+import com.stash.core.data.social.ytmusic.YtMusicLibraryApiClient
+import com.stash.core.model.Track
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * v0.9.52 symmetric un-like. The load-bearing rule: NEVER un-Like
+ * what Stash never Liked — a destination only fires when its
+ * `*_saved_at` timestamp is non-null, and a successful remote remove
+ * clears that timestamp so a future re-heart re-fires.
+ */
+class LikeDestinationDispatcherUnlikeTest {
+
+    private val spotify = mockk<SpotifyLibraryApiClient>(relaxed = true)
+    private val ytMusic = mockk<YtMusicLibraryApiClient>(relaxed = true)
+    private val stashLiked = mockk<StashLikedPlaylistRepository>(relaxed = true)
+    private val trackDao = mockk<TrackDao>(relaxed = true)
+    private val dispatcher = LikeDestinationDispatcher(spotify, ytMusic, stashLiked, trackDao)
+
+    private fun track(
+        spotifySavedAt: Long? = null,
+        ytMusicSavedAt: Long? = null,
+        spotifyUri: String? = "spotify:track:abc",
+        youtubeId: String? = "vid123",
+    ) = Track(
+        id = 7L,
+        title = "t",
+        artist = "a",
+        spotifyUri = spotifyUri,
+        youtubeId = youtubeId,
+        spotifySavedAt = spotifySavedAt,
+        ytMusicSavedAt = ytMusicSavedAt,
+    )
+
+    @Test fun `skips destination Stash never saved`() = runBlocking {
+        val result = dispatcher.unlike(track(spotifySavedAt = null), setOf(Destination.SPOTIFY))
+
+        assertTrue(result[Destination.SPOTIFY]!!.isSuccess)
+        coVerify(exactly = 0) { spotify.removeTracks(any()) }
+        coVerify(exactly = 0) { trackDao.clearSpotifySaved(any()) }
+    }
+
+    @Test fun `removes on Spotify and clears dedup column when saved`() = runBlocking {
+        val result = dispatcher.unlike(track(spotifySavedAt = 111L), setOf(Destination.SPOTIFY))
+
+        assertTrue(result[Destination.SPOTIFY]!!.isSuccess)
+        coVerify { spotify.removeTracks(listOf("spotify:track:abc")) }
+        coVerify { trackDao.clearSpotifySaved(7L) }
+    }
+
+    @Test fun `removes on YT Music and clears dedup column when saved`() = runBlocking {
+        val result = dispatcher.unlike(track(ytMusicSavedAt = 222L), setOf(Destination.YT_MUSIC))
+
+        assertTrue(result[Destination.YT_MUSIC]!!.isSuccess)
+        coVerify { ytMusic.removeLike("vid123") }
+        coVerify { trackDao.clearYtMusicSaved(7L) }
+    }
+
+    @Test fun `API failure leaves dedup column untouched for organic retry`() = runBlocking {
+        coEvery { spotify.removeTracks(any()) } throws RuntimeException("boom")
+
+        val result = dispatcher.unlike(track(spotifySavedAt = 111L), setOf(Destination.SPOTIFY))
+
+        assertTrue(result[Destination.SPOTIFY]!!.isFailure)
+        coVerify(exactly = 0) { trackDao.clearSpotifySaved(any()) }
+    }
+
+    @Test fun `unlike routes STASH to local repository remove`() = runBlocking {
+        val t = track().copy(stashLikedAt = 333L)
+
+        val result = dispatcher.unlike(t, setOf(Destination.STASH))
+
+        assertTrue(result[Destination.STASH]!!.isSuccess)
+        coVerify { stashLiked.remove(7L) }
+    }
+
+    @Test fun `empty destination set is a no-op`() = runBlocking {
+        assertTrue(dispatcher.unlike(track(), emptySet()).isEmpty())
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/social/spotify/SpotifyLibraryApiClientTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/social/spotify/SpotifyLibraryApiClientTest.kt
@@ -1,0 +1,92 @@
+package com.stash.core.data.social.spotify
+
+import com.stash.core.auth.TokenManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * v0.9.52: removeTracks is the DELETE mirror of saveTracks — same
+ * endpoint, same auth/429/401 handling, used by the symmetric
+ * un-like path. saveTracks behaviour is pinned too (it had no test).
+ */
+class SpotifyLibraryApiClientTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var tokenManager: TokenManager
+
+    @Before fun setUp() {
+        server = MockWebServer()
+        server.start()
+        tokenManager = mockk(relaxed = true)
+        coEvery { tokenManager.getSpotifyAccessToken() } returns "tok"
+    }
+
+    @After fun tearDown() { server.shutdown() }
+
+    private fun client() = SpotifyLibraryApiClient(
+        tokenManager = tokenManager,
+        httpClient = OkHttpClient(),
+        baseUrl = server.url("/").toString().removeSuffix("/"),
+    )
+
+    @Test fun `removeTracks issues DELETE with bare ids and bearer token`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client().removeTracks(listOf("spotify:track:abc123", "def456"))
+
+        val recorded = server.takeRequest()
+        assertEquals("DELETE", recorded.method)
+        assertEquals("/v1/me/tracks?ids=abc123,def456", recorded.path)
+        assertEquals("Bearer tok", recorded.getHeader("Authorization"))
+    }
+
+    @Test fun `saveTracks still issues PUT`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client().saveTracks(listOf("spotify:track:abc123"))
+
+        assertEquals("PUT", server.takeRequest().method)
+    }
+
+    @Test fun `removeTracks maps 429 to SpotifyRateLimitException with Retry-After`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(429).setHeader("Retry-After", "30"))
+
+        try {
+            client().removeTracks(listOf("abc123"))
+            fail("expected SpotifyRateLimitException")
+        } catch (e: SpotifyRateLimitException) {
+            assertEquals(30, e.retryAfterSeconds)
+        }
+    }
+
+    @Test fun `removeTracks maps 401 to SpotifyAuthException and invalidates token`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(401))
+
+        try {
+            client().removeTracks(listOf("abc123"))
+            fail("expected SpotifyAuthException")
+        } catch (e: SpotifyAuthException) {
+            coVerify { tokenManager.forceRefreshSpotifyAccessToken() }
+        }
+    }
+
+    @Test fun `removeTracks rejects more than 50 ids`() = runBlocking {
+        try {
+            client().removeTracks(List(51) { "id$it" })
+            fail("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message!!.contains("50"))
+        }
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/social/ytmusic/YtMusicLibraryApiClientTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/social/ytmusic/YtMusicLibraryApiClientTest.kt
@@ -1,0 +1,35 @@
+package com.stash.core.data.social.ytmusic
+
+import com.stash.data.ytmusic.InnerTubeClient
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.fail
+import org.junit.Test
+
+class YtMusicLibraryApiClientTest {
+
+    private val innerTube = mockk<InnerTubeClient>()
+    private val client = YtMusicLibraryApiClient(innerTube)
+
+    @Test fun `removeLike passes through on success`() = runBlocking {
+        coEvery { innerTube.removeLike("vid") } returns true
+        client.removeLike("vid") // must not throw
+    }
+
+    @Test fun `removeLike lifts false into YtMusicLibraryException`() = runBlocking {
+        coEvery { innerTube.removeLike("vid") } returns false
+        try {
+            client.removeLike("vid")
+            fail("expected YtMusicLibraryException")
+        } catch (_: YtMusicLibraryException) { }
+    }
+
+    @Test fun `likeVideo lifts false into YtMusicLibraryException`() = runBlocking {
+        coEvery { innerTube.likeVideo("vid") } returns false
+        try {
+            client.likeVideo("vid")
+            fail("expected YtMusicLibraryException")
+        } catch (_: YtMusicLibraryException) { }
+    }
+}

--- a/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
@@ -23,7 +23,7 @@ import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.stash.core.data.db.dao.PlaylistDao
 import com.stash.core.data.db.dao.TrackDao
-import com.stash.core.data.social.stash.StashLikedPlaylistRepository
+import com.stash.core.data.social.LikeCoordinator
 import com.stash.core.media.R
 import com.stash.core.media.equalizer.EqController
 import com.stash.core.media.equalizer.LoudnessController
@@ -74,7 +74,7 @@ class StashPlaybackService : MediaLibraryService() {
     @Inject lateinit var loudnessController: LoudnessController
     @Inject lateinit var trackDao: TrackDao
     @Inject lateinit var playlistDao: PlaylistDao
-    @Inject lateinit var stashLikedRepository: StashLikedPlaylistRepository
+    @Inject lateinit var likeCoordinator: LikeCoordinator
     @Inject lateinit var prefetchOrchestrator: PrefetchOrchestrator
     @Inject lateinit var streamingMediaSourceFactory: StreamingMediaSourceFactory
     @Inject lateinit var playbackResumer: PlaybackResumer
@@ -1173,8 +1173,10 @@ class StashPlaybackService : MediaLibraryService() {
                                     metadata = mediaMetadata,
                                 )
 
-                                if (newLikeState) stashLikedRepository.add(realId)
-                                else              stashLikedRepository.remove(realId)
+                                // v0.9.52: route through LikeCoordinator — local
+                                // Stash like stays synchronous; optional Spotify/YT
+                                // mirroring (off by default) layers on top.
+                                likeCoordinator.setLiked(realId, liked = newLikeState)
                             }.onFailure { e ->
                                 android.util.Log.w(
                                     "StashPlayback",

--- a/core/media/src/test/kotlin/com/stash/core/media/service/StashPlaybackServiceLoudnessTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/service/StashPlaybackServiceLoudnessTest.kt
@@ -4,7 +4,7 @@ package com.stash.core.media.service
 import androidx.media3.common.MediaItem
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.db.entity.TrackEntity
-import com.stash.core.data.social.stash.StashLikedPlaylistRepository
+import com.stash.core.data.social.LikeCoordinator
 import com.stash.core.media.equalizer.EqController
 import com.stash.core.media.equalizer.LoudnessController
 import com.stash.core.media.streaming.PrefetchOrchestrator
@@ -31,7 +31,7 @@ class StashPlaybackServiceLoudnessTest {
     private val trackDao = mockk<TrackDao>(relaxed = true)
     private val loudnessController = mockk<LoudnessController>(relaxed = true)
     private val eqController = mockk<EqController>(relaxed = true)
-    private val stashLikedRepository = mockk<StashLikedPlaylistRepository>(relaxed = true)
+    private val likeCoordinator = mockk<LikeCoordinator>(relaxed = true)
     private val prefetchOrchestrator = mockk<PrefetchOrchestrator>(relaxed = true)
 
     private fun newService(): StashPlaybackService {
@@ -42,7 +42,7 @@ class StashPlaybackServiceLoudnessTest {
         service.trackDao = trackDao
         service.loudnessController = loudnessController
         service.eqController = eqController
-        service.stashLikedRepository = stashLikedRepository
+        service.likeCoordinator = likeCoordinator
         service.prefetchOrchestrator = prefetchOrchestrator
         return service
     }

--- a/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/InnerTubeClient.kt
+++ b/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/InnerTubeClient.kt
@@ -346,23 +346,39 @@ class InnerTubeClient @Inject constructor(
      * (signed-out, network down, endpoint blocked) — caller treats
      * non-success as "skip this destination, surface snackbar."
      */
-    suspend fun likeVideo(videoId: String): Boolean = runCatching {
+    suspend fun likeVideo(videoId: String): Boolean =
+        sendLikeAction("$BASE_URL/like/like", videoId)
+
+    /**
+     * v0.9.52: symmetric un-like — sets likeStatus back to INDIFFERENT
+     * and removes the track from Liked Music. Same payload/auth shape
+     * as [likeVideo]; same boolean soft-failure contract.
+     */
+    suspend fun removeLike(videoId: String): Boolean =
+        sendLikeAction("$BASE_URL/like/removelike", videoId)
+
+    private suspend fun sendLikeAction(url: String, videoId: String): Boolean = runCatching {
         val variant = InnerTubeVariant.WEB_REMIX
         val payload = buildJsonObject {
             put("context", buildContext(variant))
             put("target", buildJsonObject { put("videoId", videoId) })
         }
         val outcome = executeRequestWithStatus(
-            url = "$BASE_URL/like/like",
+            url = url,
             body = payload,
             cookie = null,
             variant = variant,
         )
         outcome.body != null && outcome.statusCode in 200..299
     }.getOrElse { e ->
-        Log.w(TAG, "likeVideo failed for $videoId: ${e.message}")
+        Log.w(TAG, "like action failed for $videoId at $url: ${e.message}")
         false
     }
+
+    /** Test-only seam mirroring [executeRequestWithStatusForTest] — lets a test
+     * point the like action at a MockWebServer URL. */
+    internal suspend fun sendLikeActionForTest(url: String, videoId: String): Boolean =
+        sendLikeAction(url, videoId)
 
     /**
      * Audio-focused player lookup. Tries each variant in [AUDIO_VARIANT_ORDER]

--- a/data/ytmusic/src/test/kotlin/com/stash/data/ytmusic/InnerTubeClientLikeActionTest.kt
+++ b/data/ytmusic/src/test/kotlin/com/stash/data/ytmusic/InnerTubeClientLikeActionTest.kt
@@ -1,0 +1,64 @@
+package com.stash.data.ytmusic
+
+import com.stash.core.auth.TokenManager
+import com.stash.core.auth.youtube.YouTubeCookieHelper
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * v0.9.52: like/removelike share one payload builder. Pins the JSON
+ * shape ({context, target:{videoId}}) and the 2xx+body success rule
+ * for both directions.
+ */
+class InnerTubeClientLikeActionTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After fun tearDown() { server.shutdown() }
+
+    private fun client(): InnerTubeClient {
+        val token = mock<TokenManager>()
+        val cookies = mock<YouTubeCookieHelper>()
+        runBlocking { whenever(token.getYouTubeCookie()).thenReturn(null) }
+        return InnerTubeClient(OkHttpClient(), token, cookies)
+    }
+
+    @Test fun `like action returns true on 2xx with body and posts target videoId`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"ok":true}"""))
+
+        val ok = client().sendLikeActionForTest(server.url("/like/removelike").toString(), "vid123")
+
+        assertTrue(ok)
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        val body = recorded.body.readUtf8()
+        assertTrue("payload carries target.videoId", body.contains(""""videoId":"vid123""""))
+        assertTrue("payload carries an InnerTube context", body.contains(""""context""""))
+    }
+
+    @Test fun `like action returns false on 4xx`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(403).setBody("denied"))
+        assertFalse(client().sendLikeActionForTest(server.url("/like/removelike").toString(), "vid123"))
+    }
+
+    @Test fun `like action returns false on connection failure`() = runBlocking {
+        val url = server.url("/like/removelike").toString()
+        server.shutdown()
+        assertFalse(client().sendLikeActionForTest(url, "vid123"))
+    }
+}

--- a/docs/superpowers/specs/2026-06-12-like-mirroring-and-review-handoff.md
+++ b/docs/superpowers/specs/2026-06-12-like-mirroring-and-review-handoff.md
@@ -1,0 +1,155 @@
+# Handoff: Like-Mirroring feature + Code-Review backlog (2026-06-12)
+
+Checkpoint written mid-brainstorm so a fresh model session can pick up cleanly.
+Two independent tracks below: **(A)** the in-progress like-mirroring feature design,
+and **(B)** the code-review work — what already shipped to `master` (must be in the
+next release) and what remains as a backlog.
+
+---
+
+## A. Like-Mirroring feature (brainstorm IN PROGRESS — not yet a final spec)
+
+**Goal:** when you ❤️ a track in Stash, also Like it on Spotify and/or YouTube
+Music; un-hearting removes it there too. User is TOS-aware and wants this gated so
+"only a certain type of user (e.g. on a backup account)" opts in.
+
+### Key discovery — most infrastructure already exists, but is half-wired
+Verified by reading the code (file paths are load-bearing for the next session):
+
+- **Spotify like WRITE works:** `core/data/.../social/spotify/SpotifyLibraryApiClient.kt`
+  → `PUT /v1/me/tracks` with the sp_dc web token (scope `user-library-modify`, no
+  Premium, idempotent, 50/batch). Same call the official web Like button makes.
+- **YouTube like WRITE works:** `core/data/.../social/ytmusic/YtMusicLibraryApiClient.kt`
+  → `InnerTubeClient.likeVideo()` → `POST /like/like` (WEB_REMIX context, SAPISID-cookie
+  auth). `data/ytmusic/.../InnerTubeClient.kt:349`.
+- **Fan-out dispatcher exists:** `core/data/.../social/LikeDestinationDispatcher.kt` —
+  `like(track, Set<Destination>)`, parallel, per-destination dedup via `*_saved_at`.
+  `Destination` enum = STASH, SPOTIFY, YT_MUSIC.
+- **Dedup columns exist:** `tracks.spotifySavedAt`, `tracks.ytMusicSavedAt`,
+  `tracks.stashLikedAt`. DAO: `markSpotifySaved`, `markYtMusicSaved`.
+- **Prefs exist:** `core/data/.../prefs/LikePreferences.kt` —
+  `heart_default_stash` (default true), `heart_default_spotify` (default **true**),
+  `heart_default_ytmusic` (default false). ⚠️ These are VESTIGIAL — defined with
+  settings setters but **nothing reads them at the actual heart action.**
+- **Auto-save Beta switch:** `core/data/.../sync/workers/AutoSaveScrobbler.kt` — the
+  ONLY current writer to Spotify likes. Trigger is **play-frequency** (played on ≥N
+  distinct days within 30, default 3), NOT hearts. Hardcoded `setOf(Destination.SPOTIFY)`.
+  Started in `StashApplication` (`autoSaveScrobbler.start()`). Settings UI:
+  `feature/settings/.../components/SpotifyAutoSaveSection.kt` ("Auto-save liked tracks" + Beta pill).
+
+### The gap
+The real heart button is **Stash-local only** and never touches the dispatcher:
+- `feature/nowplaying/.../NowPlayingViewModel.kt:684 onLikeTap()` → `stashLikedRepository.add/remove` (lines 706/708)
+- `core/media/.../service/StashPlaybackService.kt:1148` COMMAND_TOGGLE_LIKE → `stashLikedRepository.add/remove` (lines 1176/1177)
+
+Those are the **only two heart entry points** — both must route through the new coordinator.
+
+### Decisions LOCKED this session
+1. **Trigger = mirror-on-heart.** (Not the play-frequency threshold.)
+2. **Symmetric un-like.** Un-hearting in Stash removes the remote Like too.
+3. **Forward-only.** No backfill of existing Stash likes (bulk write = most bot-shaped/flag-worthy action). Leave a clean seam for an opt-in trickle-backfill later.
+4. **Architecture = new `LikeCoordinator`** (in `core/data/social`) that both heart entry points call:
+   ```
+   setLiked(track, liked):
+     1. local first, always: stashLikedRepository.add/remove (instant, offline-proof)
+     2. read mirror prefs (default OFF); for each ENABLED external destination:
+          liked=true  -> dispatcher.like(track, {dest})
+          liked=false -> dispatcher.unlike(track, {dest})   # unlike() is NEW
+     3. per-destination skip if track lacks that id (no spotifyUri / no youtubeId)
+   ```
+   - Rewire the two heart entry points to call `LikeCoordinator` instead of `stashLikedRepository` directly. Local-like behavior unchanged; mirroring layered on top.
+   - **New write paths to add** (clean mirrors of existing adds): `LikeDestinationDispatcher.unlike()`, `SpotifyLibraryApiClient.removeTracks()` (`DELETE /v1/me/tracks`), `InnerTubeClient.removeLike()` (`POST /like/removelike`) + `YtMusicLibraryApiClient.removeLike()`. On successful unlike, clear the existing `*_saved_at` column. **NO schema change.**
+   - Existing Spotify-only auto-save Beta switch stays untouched; `*_saved_at` dedup means the two writers never double-fire.
+   - Rejected approaches: (B) burying mirroring inside `StashLikedPlaylistRepository` (overloads local repo with network/auth/TOS, makes local like depend on external state); (C) WorkManager job per like (heavyweight for one idempotent write, scheduling jitter fights pacing).
+5. **Settings + gating + defaults:**
+   - **Two NEW prefs** `mirror_likes_spotify` / `mirror_likes_youtube`, both **default false**. ⚠️ Do NOT reuse `heart_default_spotify` — it defaults *true*, so reusing it would silently start Spotify writes for every existing user on update. Leave the old `heart_default_*` prefs alone (cleanup later, out of scope).
+   - **New "Sync your likes" settings section** (Beta pill style), two toggles, each visible/enabled only when that account is connected (Spotify connected / YT cookies present) — same gating the auto-save card uses.
+   - **One-time warning dialog** the first time each toggle is enabled: what it does (incl. symmetric un-like), the risk (private unofficial write path, can break / rarely flag an account), the mitigation (use a secondary/backup account), explicit **"I understand"** to enable. No ack = no writes.
+   - Card subtitle states **forward-only** ("applies to new likes only").
+   - Net: new installs AND existing users start with mirroring OFF; nothing writes externally until deliberate opt-in past a warning.
+6. **Safety rails / failure / edge cases:**
+   - **Pacing:** single serialized writer (one coroutine draining a queue), min gap ≈1–2s between external calls, respect `Retry-After` on 429 (`SpotifyRateLimitException` carries `retryAfterSeconds`). Defangs bursts (multi-select bulk-like, heart-spam, symmetric-unlike doubling). Simple: serialized + min-gap + backoff, not a token-bucket.
+   - **Best-effort, local is sacred:** local Stash like is source of truth, never depends on external success; toggling ❤️ always works instantly/offline. External failure → log (diagnostics) + leave dedup column untouched so it **retries organically on next heart of that track** (same recovery the auto-save scrobbler uses). MVP UX: at most a single subtle "couldn't sync — will retry" snackbar; no nagging.
+   - **Edge cases (skip, never error):** no `spotifyUri` → skip Spotify; no `youtubeId` → skip YT (dispatcher already throws typed exceptions caught into `Result.failure`). Un-like only fires if `*_saved_at` non-null (never un-Like what we never Liked). Account disconnected/token expired → fail → organic retry; local unaffected. Rapid like→unlike→like → serialized queue processes in order, converges (no op-coalescing in MVP). Offline → local works, external retries on next action (no persistent offline queue in MVP).
+
+### Remaining brainstorm steps (NOT yet done)
+- **Section 4 — Testing** (not yet presented/approved). Sketch: unit-test `LikeCoordinator` (local-always, prefs-gating, per-destination skip, symmetric unlike, unlike-only-if-mirrored); dispatcher `unlike()` paths; the paced writer (ordering/min-gap/Retry-After); new API client methods with a mock web server. Both heart entry points route through the coordinator.
+- Write final design doc → spec-review loop → user review → `writing-plans` skill → implement.
+- **Fable should feel free to rewrite this plan** — these are the decisions captured, not a finished spec.
+
+---
+
+## B. Code-review work
+
+### B1. SHIPPED TO `master`, NOT YET RELEASED — must be in the next release
+Last release tag = **v0.9.51** (`b1dca09a`). Everything after it is unreleased and
+should go out in the next release (call it v0.9.52):
+
+- `66bfafa1` — **fix(streaming): antra cache-poisoning.** Speculative background-fill
+  (`allowAntra=false`) cached a lossy YouTube fallback during a Qobuz outage, which the
+  antra-allowed foreground/prefetch paths then served — so users got YouTube AAC when
+  antra FLAC was available. Now a youtube-origin result from an `allowAntra=false`
+  resolve is provisional and not cached. (Device-verified no-regression; outage path
+  unit-tested.)
+- `07fd4333` — **fix(review): three priority items from the full-app review:**
+  1. **StreamUrlCache** — LRU-bounded (512) + monotonic TTL (`System.nanoTime`-anchored,
+     immune to wall-clock changes). Internal only; public get/put/invalidate unchanged.
+  2. **EqController / LoudnessController** — moved the `runBlocking { migrate + DataStore
+     read }` out of the `@Singleton` constructors into `scope.launch` (no main-thread I/O
+     risk; corrupt DataStore no longer crashes DI-graph construction). Tests share one
+     StandardTestDispatcher so `awaitInit()` advances under async init.
+  3. **Migration tests** for the two newest, previously-untested migrations (30→31
+     `lastfm_response_cache`, 31→32 `spotify_resolution`).
+  - Verified locally (completed runs): StreamUrlCacheTest 10/10, Eq/Loudness 5/5 each,
+    both migration tests 1/1. Full `core:media` regression left to CI (`tests.yml`).
+    NOTE: `tests.yml` runs `:core:media` only — it does NOT run the new `core:data`
+    migration tests; those passed locally.
+
+### B2. Code-review BACKLOG — found but NOT fixed (future releases)
+From the harsh full-app review. Priority order roughly as listed.
+
+- **God objects → split.** `PlayerRepositoryImpl` (1853, 7 responsibilities + 9 @Volatile
+  fields — the cache-poison bug lived in its seams), `TrackDao` (1879, DAO doing a
+  repo's job), `SettingsScreen` (2107) / `HomeScreen` (1973) / `LibraryScreen` (1795)
+  god-composables (huge recomposition scope, untestable), `StashPlaybackService` (1309).
+- **Concurrency smells.** `runBlocking` still inside OkHttp interceptors
+  (`AntraCookieInterceptor.kt:61`, `SquidWtfCaptchaInterceptor.kt:62`) — blocks a network
+  thread on DataStore. `lastSavedQueueIds`/`lastSavedShuffle` in `PlayerRepositoryImpl:296-297`
+  are plain `var` while 9 siblings are `@Volatile` — resolve the inconsistency (the class's
+  true threading model is unclear).
+- **Silent failures.** ~424 `runCatching`/`catch(Exception)` sites, ~101 swallow to null
+  with NO log — the genre that produces "synced but didn't download / playlist empty"
+  reports nobody can diagnose. Audit; every catch-returning-null in the sync/download
+  pipeline needs at least a `Log.w` with track/playlist id; re-throw `CancellationException`
+  first where broad catches can swallow it.
+- **Migration test gaps remain** at 19→20, 22→23, 24→25 (newest two now covered in B1).
+- **UI test hole.** 19 ViewModels / 12 tests → 7 untested (incl. Home/Settings VMs where
+  mix-gen + sync-toggle logic lives); 2000-line composables untestable at that size.
+- **Streaming has NO degradation detection; downloads do.** `DownloadManager` rejects 30s
+  preview-stubs and fails over (`DownloadManager.kt:448-465`); the streaming path has no
+  equivalent, so a kennyy 30s-stub streams truncated with no failover. Port the duration
+  backstop to streaming.
+- **Other edge cases to harden:** antra quota-boundary mid-queue has no clear user signal;
+  prefetch-vs-background-fill race makes next-up quality non-deterministic; storage-full /
+  SAF-permission-revoked mid-download cleanup + user-facing error; token/cookie expiry
+  mid-sync can leave half-populated playlists that `snapshotId` then treats as up-to-date;
+  yt-dlp nightly auto-update is a single point of failure on an external binary YouTube
+  fights (no pinned-fallback-on-canary-failure); `durationMs==0` from bad metadata defeats
+  the download duration-backstop exactly when metadata is poor.
+- **Credit (don't "fix"):** `DiagnosticsRedactor` token redaction, the download
+  duration-backstop + health-gate failover, schema export on, the
+  `forceAntraOnly`/`forceYouTubeFallback` outage-drill toggles, user-supplied OAuth creds
+  in DataStore. Overall test ratio (213 test / 491 source) is respectable; gaps are
+  concentrated in UI + (now-closed) newest migrations.
+
+---
+
+## Pointers / conventions for the next session
+- Release procedure (matches v0.9.50/51): bump `versionCode`/`versionName` in
+  `app/build.gradle.kts` inside a single `release: vX` commit whose **body** is the
+  natural-language notes (release body = tagged-commit message); lightweight tag; push
+  master + tag → `release.yml` publishes the APK.
+- ⚠️ Local `core:media` has a ~6-min COLD compile before any test runs; do NOT background
+  it and park the session waiting, and do NOT `gradlew --stop` between runs (forces another
+  cold compile). Verify with targeted `--tests "*Class"` runs; let CI do the full sweep.
+- Subagent model on this project: always `opus`.

--- a/docs/superpowers/specs/2026-06-12-like-mirroring-and-review-handoff.md
+++ b/docs/superpowers/specs/2026-06-12-like-mirroring-and-review-handoff.md
@@ -9,6 +9,8 @@ next release) and what remains as a backlog.
 
 ## A. Like-Mirroring feature (brainstorm IN PROGRESS — not yet a final spec)
 
+> Superseded by docs/superpowers/plans/2026-06-12-like-mirroring.md (implementation plan; decisions unchanged). Implemented on branch feat/like-mirroring (Tasks 1–10 done, all targeted tests green + app assembles; on-device checklist still owed).
+
 **Goal:** when you ❤️ a track in Stash, also Like it on Spotify and/or YouTube
 Music; un-hearting removes it there too. User is TOS-aware and wants this gated so
 "only a certain type of user (e.g. on a backup account)" opts in.

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
@@ -62,7 +62,7 @@ import javax.inject.Inject
 class NowPlayingViewModel @Inject constructor(
     private val playerRepository: PlayerRepository,
     private val musicRepository: MusicRepository,
-    private val stashLikedRepository: com.stash.core.data.social.stash.StashLikedPlaylistRepository,
+    private val likeCoordinator: com.stash.core.data.social.LikeCoordinator,
     private val losslessUpgrader: LosslessUpgrader,
     // v0.9.36 Task 12 — lyrics sheet observes the lyrics row and may
     // enqueue a priority on-open fetch. WorkManager is sourced via
@@ -192,6 +192,17 @@ class NowPlayingViewModel @Inject constructor(
         observeUserPlaylists()
         observeStreamingHaltedEvents()
         observePlayerUserMessages()
+        collectMirrorFailures()
+    }
+
+    /**
+     * v0.9.52: best-effort mirror sync failures surface as one subtle
+     * snackbar per session (LikeCoordinator gates the frequency).
+     */
+    private fun collectMirrorFailures() {
+        viewModelScope.launch {
+            likeCoordinator.mirrorFailures.collect { _userMessages.tryEmit(it) }
+        }
     }
 
     // ------------------------------------------------------------------
@@ -702,11 +713,10 @@ class NowPlayingViewModel @Inject constructor(
                 // "Couldn't add to Liked Songs" (issue #105).
                 val finalTrackId = musicRepository.ensureTrackPersisted(track)
 
-                if (wasLiked) {
-                    stashLikedRepository.remove(finalTrackId)
-                } else {
-                    stashLikedRepository.add(finalTrackId)
-                }
+                // v0.9.52: route through LikeCoordinator. The local Stash
+                // like still happens synchronously (same behavior as before);
+                // optional Spotify/YT mirroring (off by default) layers on top.
+                likeCoordinator.setLiked(finalTrackId, liked = !wasLiked)
                 // Once the DB write is confirmed, we can clear the optimistic
                 // override; Room's own emission will carry the truth.
                 optimisticLikeState.update { it - trackKey }

--- a/feature/nowplaying/src/test/kotlin/com/stash/feature/nowplaying/NowPlayingViewModelTest.kt
+++ b/feature/nowplaying/src/test/kotlin/com/stash/feature/nowplaying/NowPlayingViewModelTest.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import app.cash.turbine.test
 import com.stash.core.data.lossless.LosslessUpgrader
 import com.stash.core.data.repository.MusicRepository
-import com.stash.core.data.social.stash.StashLikedPlaylistRepository
+import com.stash.core.data.social.LikeCoordinator
 import com.stash.core.media.PlayerRepository
 import com.stash.core.model.PlayerState
 import com.stash.core.model.Track
@@ -16,6 +16,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -185,7 +186,9 @@ class NowPlayingViewModelFindInFlacTest {
         every { observeTrackById(any()) } returns flowOf(null)
         every { getUserCreatedPlaylists() } returns flowOf(emptyList())
     }
-    private val stashLikedRepository: StashLikedPlaylistRepository = mockk(relaxed = true)
+    private val likeCoordinator: LikeCoordinator = mockk(relaxed = true) {
+        every { mirrorFailures } returns MutableSharedFlow()
+    }
     private val upgrader: LosslessUpgrader = mockk()
     // v0.9.36 Task 12 — Now Playing now depends on the lyrics repository
     // (for the lyrics sheet) and an application Context (used as a
@@ -198,7 +201,7 @@ class NowPlayingViewModelFindInFlacTest {
     private fun newViewModel(): NowPlayingViewModel = NowPlayingViewModel(
         playerRepository = playerRepository,
         musicRepository = musicRepository,
-        stashLikedRepository = stashLikedRepository,
+        likeCoordinator = likeCoordinator,
         losslessUpgrader = upgrader,
         lyricsRepository = lyricsRepository,
         appContext = appContext,
@@ -286,5 +289,73 @@ class NowPlayingViewModelFindInFlacTest {
         }
 
         coVerify(exactly = 0) { upgrader.upgradeToLossless(any()) }
+    }
+}
+
+/**
+ * v0.9.52: the heart routes through LikeCoordinator (local + optional
+ * external mirroring) instead of the local-only repository.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NowPlayingViewModelLikeRoutingTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @Before fun setUp() { Dispatchers.setMain(dispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    private val playerStateFlow = MutableStateFlow(PlayerState())
+    private val positionFlow = MutableStateFlow(0L)
+
+    private val playerRepository: PlayerRepository = mockk(relaxed = true) {
+        every { playerState } returns playerStateFlow
+        every { currentPosition } returns positionFlow
+    }
+    private val musicRepository: MusicRepository = mockk(relaxed = true) {
+        every { observeTrackById(any()) } returns flowOf(null)
+        every { getUserCreatedPlaylists() } returns flowOf(emptyList())
+    }
+    private val likeCoordinator: LikeCoordinator = mockk(relaxed = true) {
+        every { mirrorFailures } returns MutableSharedFlow()
+    }
+    private val upgrader: LosslessUpgrader = mockk(relaxed = true)
+    private val lyricsRepository: LyricsRepository = mockk(relaxed = true)
+    private val appContext: Context = mockk(relaxed = true)
+
+    private fun newViewModel(): NowPlayingViewModel = NowPlayingViewModel(
+        playerRepository = playerRepository,
+        musicRepository = musicRepository,
+        likeCoordinator = likeCoordinator,
+        losslessUpgrader = upgrader,
+        lyricsRepository = lyricsRepository,
+        appContext = appContext,
+    )
+
+    private val unlikedTrack = Track(id = 42L, title = "song", artist = "artist", stashLikedAt = null)
+    private val likedTrack = unlikedTrack.copy(stashLikedAt = 123L)
+
+    @Test fun `onLikeTap routes through LikeCoordinator with resolved id and new state`() =
+        runTest(dispatcher) {
+            coEvery { musicRepository.ensureTrackPersisted(any()) } returns 42L
+            playerStateFlow.value = playerStateFlow.value.copy(currentTrack = unlikedTrack)
+            val vm = newViewModel()
+            advanceUntilIdle()
+
+            vm.onLikeTap()
+            advanceUntilIdle()
+
+            coVerify { likeCoordinator.setLiked(42L, true) }
+        }
+
+    @Test fun `onLikeTap on a liked track requests un-like`() = runTest(dispatcher) {
+        coEvery { musicRepository.ensureTrackPersisted(any()) } returns 42L
+        playerStateFlow.value = playerStateFlow.value.copy(currentTrack = likedTrack)
+        val vm = newViewModel()
+        advanceUntilIdle()
+
+        vm.onLikeTap()
+        advanceUntilIdle()
+
+        coVerify { likeCoordinator.setLiked(42L, false) }
     }
 }

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsScreen.kt
@@ -80,8 +80,11 @@ import com.stash.data.download.lossless.LosslessQualityTier
 import com.stash.core.ui.components.GlassCard
 import com.stash.core.ui.theme.StashTheme
 import androidx.compose.material3.AlertDialog
+import com.stash.core.data.social.Destination
 import com.stash.feature.settings.components.AccountConnectionCard
 import com.stash.feature.settings.components.AudioQualityPicker
+import com.stash.feature.settings.components.LikeMirrorSection
+import com.stash.feature.settings.components.LikeMirrorWarningDialog
 import com.stash.feature.settings.components.SpotifyCookieDialog
 import com.stash.feature.settings.components.YouTubeCookieDialog
 import com.stash.feature.settings.components.YouTubeHistorySyncSection
@@ -246,6 +249,9 @@ fun SettingsScreen(
         onHeartDefaultStashChanged = viewModel::onHeartDefaultStashChanged,
         onHeartDefaultSpotifyChanged = viewModel::onHeartDefaultSpotifyChanged,
         onHeartDefaultYtMusicChanged = viewModel::onHeartDefaultYtMusicChanged,
+        onMirrorToggleRequested = viewModel::onMirrorToggleRequested,
+        onMirrorWarningConfirmed = viewModel::onMirrorWarningConfirmed,
+        onMirrorWarningDismissed = viewModel::onMirrorWarningDismissed,
         onExportDatabase = viewModel::onExportDatabase,
         onImportDatabase = viewModel::onImportDatabase,
         onConfirmImportDatabase = {
@@ -317,6 +323,9 @@ private fun SettingsContent(
     onHeartDefaultStashChanged: (Boolean) -> Unit,
     onHeartDefaultSpotifyChanged: (Boolean) -> Unit,
     onHeartDefaultYtMusicChanged: (Boolean) -> Unit,
+    onMirrorToggleRequested: (Destination, Boolean) -> Unit,
+    onMirrorWarningConfirmed: () -> Unit,
+    onMirrorWarningDismissed: () -> Unit,
     onExportDatabase: (Uri) -> Unit,
     onImportDatabase: (Uri) -> Unit,
     onConfirmImportDatabase: () -> Unit,
@@ -599,6 +608,21 @@ private fun SettingsContent(
                 )
             },
         )
+
+        // v0.9.52: like-mirroring opt-ins. Standalone GlassCard (not an
+        // AccountConnectionCard) — it spans both services. Each row greys
+        // itself out + shows a "Connect … first" hint when disconnected.
+        GlassCard {
+            LikeMirrorSection(
+                spotifyEnabled = uiState.mirrorLikesSpotify,
+                ytMusicEnabled = uiState.mirrorLikesYtMusic,
+                spotifyConnected = uiState.spotifyAuthState is com.stash.core.auth.model.AuthState.Connected,
+                ytConnected = uiState.youTubeAuthState is com.stash.core.auth.model.AuthState.Connected,
+                onSpotifyToggle = { onMirrorToggleRequested(Destination.SPOTIFY, it) },
+                onYtMusicToggle = { onMirrorToggleRequested(Destination.YT_MUSIC, it) },
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            )
+        }
 
         // Last.fm lives in the Accounts group (v0.4.1 relocation) so
         // users who are scanning for "sign-in / connect" surfaces see
@@ -1335,6 +1359,16 @@ private fun SettingsContent(
                         Text("Cancel")
                     }
                 },
+            )
+        }
+
+        // v0.9.52: like-mirroring opt-in ack. Confirming writes the pref;
+        // dismissing leaves mirroring off (no writes without this ack).
+        uiState.pendingMirrorWarning?.let { dest ->
+            LikeMirrorWarningDialog(
+                serviceName = if (dest == Destination.SPOTIFY) "Spotify" else "YouTube Music",
+                onConfirm = onMirrorWarningConfirmed,
+                onDismiss = onMirrorWarningDismissed,
             )
         }
 

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
@@ -133,6 +133,11 @@ data class SettingsUiState(
     val heartDefaultYtMusic: Boolean = false,
     /** v0.9.13: count of tracks auto-saved in the last 7 days, for the diagnostics line. */
     val autoSavedCountLast7Days: Int = 0,
+    /** v0.9.52 like-mirroring: per-service opt-in (default off), gated behind the warning dialog. */
+    val mirrorLikesSpotify: Boolean = false,
+    val mirrorLikesYtMusic: Boolean = false,
+    /** Non-null while the "I understand" warning dialog is showing for that destination. */
+    val pendingMirrorWarning: com.stash.core.data.social.Destination? = null,
     /**
      * v0.9.17: when lossless is on, controls whether yt-dlp is allowed
      * to take over a track that no lossless source could resolve. When

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -12,6 +12,7 @@ import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.diagnostics.CrashFileStore
 import com.stash.core.data.prefs.DownloadNetworkPreference
 import com.stash.core.data.prefs.LikePreferences
+import com.stash.core.data.social.Destination
 import com.stash.core.data.prefs.QualityPreference
 import com.stash.core.data.prefs.StoragePreference
 import com.stash.core.data.prefs.ThemePreference
@@ -257,6 +258,8 @@ class SettingsViewModel @Inject constructor(
         losslessPrefs.youtubeFallbackEnabled,
         stashMixPreference.enabled,
         losslessPrefs.antraUsername,
+        likePreferences.mirrorLikesSpotify,
+        likePreferences.mirrorLikesYtMusic,
     ) { values ->
         @Suppress("UNCHECKED_CAST")
         val spotifyAuth = values[0] as AuthState
@@ -287,6 +290,8 @@ class SettingsViewModel @Inject constructor(
         val youtubeFallbackEnabled = values[25] as Boolean
         val stashMixesEnabled = values[26] as Boolean
         val antraUsername = (values[27] as String?)
+        val mirrorLikesSpotify = values[28] as Boolean
+        val mirrorLikesYtMusic = values[29] as Boolean
 
         val lastFmState: LastFmAuthState = local.lastFmAuthOverride
             ?: when {
@@ -335,6 +340,9 @@ class SettingsViewModel @Inject constructor(
             heartDefaultSpotify = heartDefaultSpotify,
             heartDefaultYtMusic = heartDefaultYtMusic,
             autoSavedCountLast7Days = autoSavedCount7d,
+            mirrorLikesSpotify = mirrorLikesSpotify,
+            mirrorLikesYtMusic = mirrorLikesYtMusic,
+            pendingMirrorWarning = local.pendingMirrorWarning,
             youtubeFallbackEnabled = youtubeFallbackEnabled,
             hasCrashReport = local.hasCrashReport,
             databaseBackupState = local.databaseBackupState,
@@ -1013,6 +1021,37 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch { likePreferences.setHeartDefaultYtMusic(value) }
     }
 
+    /**
+     * v0.9.52 like-mirroring. Enabling a mirror requires the explicit
+     * "I understand" ack — the pref is only written on confirm (see
+     * [onMirrorWarningConfirmed]); disabling is immediate, no dialog.
+     */
+    fun onMirrorToggleRequested(destination: Destination, enable: Boolean) {
+        if (!enable) {
+            viewModelScope.launch { setMirrorPref(destination, false) }
+            return
+        }
+        _localState.update { it.copy(pendingMirrorWarning = destination) }
+    }
+
+    fun onMirrorWarningConfirmed() {
+        val destination = _localState.value.pendingMirrorWarning ?: return
+        _localState.update { it.copy(pendingMirrorWarning = null) }
+        viewModelScope.launch { setMirrorPref(destination, true) }
+    }
+
+    fun onMirrorWarningDismissed() {
+        _localState.update { it.copy(pendingMirrorWarning = null) }
+    }
+
+    private suspend fun setMirrorPref(destination: Destination, value: Boolean) {
+        when (destination) {
+            Destination.SPOTIFY -> likePreferences.setMirrorLikesSpotify(value)
+            Destination.YT_MUSIC -> likePreferences.setMirrorLikesYtMusic(value)
+            Destination.STASH -> Unit // local likes are always on; not a mirror target
+        }
+    }
+
     // -- Internal state -------------------------------------------------------
 
     /**
@@ -1057,6 +1096,12 @@ class SettingsViewModel @Inject constructor(
          * "Share latest crash report" button + render its subtitle.
          */
         val hasCrashReport: Boolean = false,
+        /**
+         * v0.9.52: non-null while the like-mirroring "I understand" warning
+         * dialog is showing for that destination. The pref is only written
+         * on confirm, so dismissing leaves mirroring off.
+         */
+        val pendingMirrorWarning: Destination? = null,
     )
 
     // -- Diagnostics ----------------------------------------------------------

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/BetaPill.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/BetaPill.kt
@@ -1,0 +1,33 @@
+package com.stash.feature.settings.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+
+/**
+ * Small "Beta" pill shared by Settings sections that surface brand-new,
+ * still-being-evaluated behaviour (auto-save, like-mirroring). Extracted
+ * from SpotifyAutoSaveSection in v0.9.52 so LikeMirrorSection can reuse it.
+ */
+@Composable
+internal fun BetaPill() {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .background(MaterialTheme.colorScheme.tertiaryContainer)
+            .padding(horizontal = 6.dp, vertical = 1.dp),
+    ) {
+        Text(
+            text = "Beta",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onTertiaryContainer,
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LikeMirrorSection.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LikeMirrorSection.kt
@@ -1,0 +1,128 @@
+package com.stash.feature.settings.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+/**
+ * v0.9.52 "Sync your likes" (Beta): per-service opt-in for mirroring
+ * the Stash heart to Spotify / YouTube Music — symmetric (un-heart
+ * removes the remote Like), forward-only (new likes only; no backfill
+ * of the existing library). Both toggles default OFF and only enable
+ * past the [LikeMirrorWarningDialog] ack, which the caller owns.
+ *
+ * Each row gates on its own account connection, same as
+ * [SpotifyAutoSaveSection] — visible but greyed with a "Connect …
+ * first" hint when disconnected.
+ *
+ * Pure presentation; caller owns all state.
+ */
+@Composable
+fun LikeMirrorSection(
+    spotifyEnabled: Boolean,
+    ytMusicEnabled: Boolean,
+    spotifyConnected: Boolean,
+    ytConnected: Boolean,
+    onSpotifyToggle: (Boolean) -> Unit,
+    onYtMusicToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "Sync your likes",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.padding(horizontal = 4.dp))
+            BetaPill()
+        }
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(
+            text = "Mirror hearts to your accounts. Applies to new likes only.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        MirrorToggleRow(
+            label = "Spotify",
+            connected = spotifyConnected,
+            enabled = spotifyEnabled,
+            connectHint = "Connect Spotify first",
+            onToggle = onSpotifyToggle,
+        )
+        MirrorToggleRow(
+            label = "YouTube Music",
+            connected = ytConnected,
+            enabled = ytMusicEnabled,
+            connectHint = "Connect YouTube Music first",
+            onToggle = onYtMusicToggle,
+        )
+    }
+}
+
+@Composable
+private fun MirrorToggleRow(
+    label: String,
+    connected: Boolean,
+    enabled: Boolean,
+    connectHint: String,
+    onToggle: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(
+                if (connected) {
+                    Modifier.clickable(
+                        role = Role.Switch,
+                        onClickLabel = if (enabled) "Disable" else "Enable",
+                    ) { onToggle(!enabled) }
+                } else {
+                    Modifier
+                }
+            )
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (connected) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+            )
+            if (!connected) {
+                Text(
+                    text = connectHint,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Switch(
+            checked = enabled,
+            onCheckedChange = onToggle,
+            enabled = connected,
+            modifier = Modifier.semantics { role = Role.Switch },
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LikeMirrorWarningDialog.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LikeMirrorWarningDialog.kt
@@ -1,0 +1,45 @@
+package com.stash.feature.settings.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+
+/**
+ * v0.9.52: explicit opt-in ack before enabling like-mirroring for a
+ * service. The pref is only written when the user taps "I understand"
+ * — dismissing leaves mirroring off, so no writes ever happen without
+ * this ack. Copy covers: what it does (incl. symmetric un-like), the
+ * risk (private, unofficial write path), the mitigation (secondary /
+ * backup account).
+ */
+@Composable
+fun LikeMirrorWarningDialog(
+    serviceName: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Mirror likes to $serviceName?") },
+        text = {
+            Text(
+                "Hearting a track in Stash will also Like it on $serviceName, " +
+                    "and removing a heart will remove the Like there too. " +
+                    "Only likes you add from now on are mirrored.\n\n" +
+                    "This uses the same private endpoint the $serviceName web player " +
+                    "uses — not an official API. It can stop working at any time and, " +
+                    "rarely, unofficial access can get an account flagged. Consider " +
+                    "enabling this only on a secondary or backup account.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text("I understand") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SpotifyAutoSaveSection.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SpotifyAutoSaveSection.kt
@@ -1,15 +1,12 @@
 package com.stash.feature.settings.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
@@ -17,7 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
@@ -116,21 +112,5 @@ fun SpotifyAutoSaveSection(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-    }
-}
-
-@Composable
-private fun BetaPill() {
-    Box(
-        modifier = Modifier
-            .clip(RoundedCornerShape(50))
-            .background(MaterialTheme.colorScheme.tertiaryContainer)
-            .padding(horizontal = 6.dp, vertical = 1.dp),
-    ) {
-        Text(
-            text = "Beta",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onTertiaryContainer,
-        )
     }
 }


### PR DESCRIPTION
## Summary
Optionally mirror the Stash heart to Spotify and/or YouTube Music, gated behind per-service opt-in toggles + an "I understand" risk dialog. Both default **off** — no behavior change for existing users until they explicitly enable it.

- **Local first, always.** The Stash like/unlike stays synchronous and offline-proof; mirroring is fire-and-forget on top.
- **`LikeCoordinator`** is the single entry point for both heart buttons (Now Playing VM + playback-notification command). It drains a single-consumer paced queue (min-gap ~1.5s, honors Spotify `Retry-After`), re-reading prefs + the track row **at fire time** so rapid like→unlike→like converges.
- **Symmetric un-like** (`DELETE /v1/me/tracks`, InnerTube `like/removelike`) — but only if Stash set it (`*_saved_at` non-null guard: never un-Like what we never Liked). Success clears the dedup column → organic retry on the next heart.
- **Forward-only** (no backfill), best-effort externals (failure → log + at most one subtle "couldn't sync" snackbar per session), skip-never-error on missing ids / disconnected / offline.
- No schema change — un-like clears the existing `spotify_saved_at` / `ytmusic_saved_at` columns.

Implements `docs/superpowers/plans/2026-06-12-like-mirroring.md` (Tasks 1–10). Spec Section A marked superseded.

## Verification done
- ✅ All targeted unit suites green (prefs, DAO clears, `SpotifyLibraryApiClient.removeTracks`, `InnerTubeClient.removeLike`, `YtMusicLibraryApiClient`, `LikeDestinationDispatcher.unlike`, **`LikeCoordinator`** incl. virtual-time pacing / Retry-After / once-per-session snackbar, NowPlaying routing)
- ✅ `:app:assembleDebug` links the full Hilt graph with `LikeCoordinator` in both heart entry points
- ℹ️ 6 pre-existing `YTMusicApiClientTest` reds (mockito matcher misuse) fail on `master` too — unrelated to this PR

## Test Plan (on-device — owed before release)
- [ ] Settings: "Sync your likes" appears with Beta pill; toggles greyed + "Connect … first" when an account is disconnected
- [ ] Enabling a toggle shows the warning dialog; **Cancel leaves it off**; "I understand" turns it on
- [ ] Spotify mirroring ON: ❤️ a track with a `spotifyUri` → appears in Spotify Liked Songs; un-heart → removed
- [ ] ❤️ a YouTube-only track (no `spotifyUri`) with only Spotify on → local like works, no Spotify call
- [ ] YT mirroring ON (cookies present): ❤️ → in YT Music Liked Music; un-heart → removed
- [ ] Heart from the **notification** mirrors too
- [ ] Airplane mode: heart toggles instantly; ≤1 "Couldn't sync" snackbar; re-heart after reconnect syncs (organic retry)
- [ ] Mirroring OFF (fresh): heart behaves exactly as before — no external traffic
- [ ] Existing Spotify auto-save Beta toggle still works (dedup prevents double-fire)

## Release note
Not a release by itself. v0.9.52 must also carry the already-merged-but-unreleased review fixes (`66bfafa1`, `07fd4333`) per spec Section B1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)