### PR TITLE
feat(i18n): add Simplified Chinese (zh-CN) localization

### DIFF
--- a/app/src/debug/res/values-zh-rCN/strings.xml
+++ b/app/src/debug/res/values-zh-rCN/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Stash Debug</string>
+</resources>

--- a/app/src/main/kotlin/com/stash/app/navigation/StashScaffold.kt
+++ b/app/src/main/kotlin/com/stash/app/navigation/StashScaffold.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -200,11 +201,11 @@ private fun StashBottomBar(
                 icon = {
                     Icon(
                         imageVector = if (isSelected) dest.selectedIcon else dest.unselectedIcon,
-                        contentDescription = dest.label,
+                        contentDescription = stringResource(dest.labelResId),
                     )
                 },
                 label = {
-                    Text(text = dest.label, style = MaterialTheme.typography.labelSmall)
+                    Text(text = stringResource(dest.labelResId), style = MaterialTheme.typography.labelSmall)
                 },
                 colors = NavigationBarItemDefaults.colors(
                     selectedIconColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/kotlin/com/stash/app/navigation/TopLevelDestination.kt
+++ b/app/src/main/kotlin/com/stash/app/navigation/TopLevelDestination.kt
@@ -13,12 +13,12 @@ import androidx.compose.material.icons.outlined.Sync
 import androidx.compose.ui.graphics.vector.ImageVector
 import kotlinx.serialization.Serializable
 
-enum class TopLevelDestination(val selectedIcon: ImageVector, val unselectedIcon: ImageVector, val label: String, val route: Any) {
-    HOME(Icons.Filled.Home, Icons.Outlined.Home, "Home", HomeRoute),
-    LIBRARY(Icons.Filled.LibraryMusic, Icons.Outlined.LibraryMusic, "Library", LibraryRoute),
-    SEARCH(Icons.Filled.Search, Icons.Outlined.Search, "Search", SearchRoute),
-    SYNC(Icons.Filled.Sync, Icons.Outlined.Sync, "Sync", SyncRoute),
-    SETTINGS(Icons.Filled.Settings, Icons.Outlined.Settings, "Settings", SettingsRoute),
+enum class TopLevelDestination(val selectedIcon: ImageVector, val unselectedIcon: ImageVector, val labelResId: Int, val route: Any) {
+    HOME(Icons.Filled.Home, Icons.Outlined.Home, com.stash.core.ui.R.string.nav_home, HomeRoute),
+    LIBRARY(Icons.Filled.LibraryMusic, Icons.Outlined.LibraryMusic, com.stash.core.ui.R.string.nav_library, LibraryRoute),
+    SEARCH(Icons.Filled.Search, Icons.Outlined.Search, com.stash.core.ui.R.string.nav_search, SearchRoute),
+    SYNC(Icons.Filled.Sync, Icons.Outlined.Sync, com.stash.core.ui.R.string.nav_sync, SyncRoute),
+    SETTINGS(Icons.Filled.Settings, Icons.Outlined.Settings, com.stash.core.ui.R.string.nav_settings, SettingsRoute),
 }
 
 @Serializable data object HomeRoute

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Stash</string>
+    <string name="resume_playback_short">恢复</string>
+    <string name="resume_playback_long">恢复播放</string>
+</resources>

--- a/core/common/src/main/kotlin/com/stash/core/common/extensions/LongExt.kt
+++ b/core/common/src/main/kotlin/com/stash/core/common/extensions/LongExt.kt
@@ -9,9 +9,9 @@ fun Long.formatDuration(): String {
     val minutes = (totalSeconds % 3600) / 60
     val seconds = totalSeconds % 60
     return if (hours > 0) {
-        String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
+        String.format(Locale.getDefault(), "%d:%02d:%02d", hours, minutes, seconds)
     } else {
-        String.format(Locale.US, "%d:%02d", minutes, seconds)
+        String.format(Locale.getDefault(), "%d:%02d", minutes, seconds)
     }
 }
 
@@ -24,7 +24,7 @@ fun Long.formatFileSize(): String {
         value /= 1024.0
         unitIndex++
     } while (value >= 1024 && unitIndex < units.lastIndex)
-    return String.format(Locale.US, "%.1f %s", value, units[unitIndex])
+    return String.format(Locale.getDefault(), "%.1f %s", value, units[unitIndex])
 }
 
 fun Long.toRelativeTimeString(): String {

--- a/core/media/src/main/res/values-zh-rCN/strings.xml
+++ b/core/media/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="notification_action_like">添加到喜欢的歌曲</string>
+    <string name="notification_action_unlike">从喜欢的歌曲中移除</string>
+    <string name="notification_action_repeat_off">关闭重复</string>
+    <string name="notification_action_repeat_all">全部重复</string>
+    <string name="notification_action_repeat_one">单曲重复</string>
+    <string name="notification_action_shuffle_on">开启随机播放</string>
+    <string name="notification_action_shuffle_off">关闭随机播放</string>
+    <string name="shuffle_play">随机播放</string>
+    <string name="resuming_channel_name">播放</string>
+    <string name="resuming_notification_title">正在恢复…</string>
+</resources>

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/DetailTrackRow.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/DetailTrackRow.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.stash.core.model.MusicSource
 import com.stash.core.model.Track
+import androidx.compose.ui.res.stringResource
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashTheme
 import com.stash.core.ui.util.formatDuration
 
@@ -200,7 +202,7 @@ fun DetailTrackRow(
             IconButton(onClick = onMoreClick, modifier = Modifier.size(32.dp)) {
                 Icon(
                     imageVector = Icons.Default.MoreVert,
-                    contentDescription = "More options",
+                    contentDescription = stringResource(R.string.cd_more_options),
                     tint = extendedColors.textTertiary,
                     modifier = Modifier.size(18.dp),
                 )

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/DiscoveryErrorCard.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/DiscoveryErrorCard.kt
@@ -17,7 +17,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 
 /**
  * Reusable full-width error card for Discovery screens.
@@ -31,8 +33,9 @@ fun DiscoveryErrorCard(
     message: String,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
-    title: String = "Something went wrong",
+    title: String? = null,
 ) {
+    val resolvedTitle = title ?: stringResource(R.string.error_something_wrong)
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -48,7 +51,7 @@ fun DiscoveryErrorCard(
         )
         Spacer(Modifier.height(16.dp))
         Text(
-            text = title,
+            text = resolvedTitle,
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onBackground,
         )
@@ -63,7 +66,7 @@ fun DiscoveryErrorCard(
             onClick = onRetry,
             shape = RoundedCornerShape(12.dp),
         ) {
-            Text("Retry")
+            Text(stringResource(R.string.action_retry))
         }
     }
 }

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/FlacBadge.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/FlacBadge.kt
@@ -10,6 +10,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import com.stash.core.ui.R
 
 /**
  * "FLAC" pill that surfaces wherever a track row is rendered. Renders a
@@ -70,10 +72,11 @@ fun FlacBadge(
  * Playing quality line can reuse the same "Hi-Res qualifier or not"
  * rule without duplicating the threshold logic.
  */
+@Composable
 internal fun flacBadgeText(bitsPerSample: Int?, sampleRateHz: Int?): String = when {
-    bitsPerSample == null || sampleRateHz == null -> "FLAC"
-    bitsPerSample <= 16 && sampleRateHz <= 44_100 -> "FLAC"
-    else -> "FLAC ${bitsPerSample}/${sampleRateHz / 1000}"
+    bitsPerSample == null || sampleRateHz == null -> stringResource(R.string.badge_flac)
+    bitsPerSample <= 16 && sampleRateHz <= 44_100 -> stringResource(R.string.badge_flac)
+    else -> stringResource(R.string.badge_flac_format, bitsPerSample, sampleRateHz / 1000)
 }
 
 private val LOSSLESS_CODECS = setOf("flac", "alac", "wav", "ape", "tta", "wv", "aiff")

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/LikeButton.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/LikeButton.kt
@@ -15,7 +15,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 
 /**
  * v0.9.13: Heart icon — standard like-button toggle. Tap on an unliked
@@ -59,7 +61,7 @@ fun LikeButton(
     ) {
         Icon(
             imageVector = if (isLiked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
-            contentDescription = if (isLiked) "Unlike" else "Like",
+            contentDescription = if (isLiked) stringResource(R.string.cd_unlike) else stringResource(R.string.cd_like),
             tint = if (isLiked) {
                 MaterialTheme.colorScheme.error
             } else {

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/LikeDestinationSheet.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/LikeDestinationSheet.kt
@@ -22,7 +22,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 
 /**
  * v0.9.13: Per-track override sheet. Pre-checked according to the
@@ -56,13 +58,13 @@ fun LikeDestinationSheet(
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Text(
-                text = "Save to…",
+                text = stringResource(R.string.action_save_to),
                 style = MaterialTheme.typography.titleMedium,
             )
             Spacer(modifier = Modifier.height(8.dp))
 
             DestinationRow(
-                label = "Stash Liked Songs",
+                label = stringResource(R.string.like_dest_stash),
                 subtitle = if (state.stashAlreadySaved) "✓ Already saved" else null,
                 checked = stashChecked,
                 onCheckedChange = { stashChecked = it },
@@ -70,7 +72,7 @@ fun LikeDestinationSheet(
 
             if (state.spotifyVisible) {
                 DestinationRow(
-                    label = "Spotify Liked Songs",
+                    label = stringResource(R.string.like_dest_spotify),
                     subtitle = if (state.spotifyAlreadySaved) "✓ Already saved" else null,
                     checked = spotifyChecked,
                     onCheckedChange = { spotifyChecked = it },
@@ -79,7 +81,7 @@ fun LikeDestinationSheet(
 
             if (state.ytVisible) {
                 DestinationRow(
-                    label = "YouTube Music Liked Music",
+                    label = stringResource(R.string.like_dest_youtube),
                     subtitle = if (state.ytAlreadySaved) "✓ Already saved" else null,
                     checked = ytChecked,
                     onCheckedChange = { ytChecked = it },
@@ -98,7 +100,7 @@ fun LikeDestinationSheet(
                 },
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Text("Save")
+                Text(stringResource(R.string.action_save_btn))
             }
         }
     }

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/MiniPlayerBar.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/MiniPlayerBar.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.stash.core.model.PlayerState
+import androidx.compose.ui.res.stringResource
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashTheme
 
 @Composable
@@ -60,8 +62,8 @@ fun MiniPlayerBar(playerState: PlayerState, onPlayPauseClick: () -> Unit, onSkip
                     }
                     Text(track.artist, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
-                IconButton(onClick = onPlayPauseClick) { Icon(if (playerState.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow, contentDescription = if (playerState.isPlaying) "Pause" else "Play", tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.size(28.dp)) }
-                IconButton(onClick = onSkipNextClick) { Icon(Icons.Default.SkipNext, contentDescription = "Skip", tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.size(24.dp)) }
+                IconButton(onClick = onPlayPauseClick) { Icon(if (playerState.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow, contentDescription = if (playerState.isPlaying) stringResource(R.string.cd_pause) else stringResource(R.string.cd_play), tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.size(28.dp)) }
+                IconButton(onClick = onSkipNextClick) { Icon(Icons.Default.SkipNext, contentDescription = stringResource(R.string.cd_skip), tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.size(24.dp)) }
             }
         }
     }

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/OnlineOfflinePicker.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/OnlineOfflinePicker.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashTheme
 
 /**
@@ -55,14 +57,14 @@ fun OnlineOfflinePicker(
     ) {
         ModeTile(
             icon = Icons.Default.CloudQueue,
-            label = "Online",
+            label = stringResource(R.string.mode_online),
             selected = streamingEnabled,
             onClick = { onSelect(true) },
             modifier = Modifier.weight(1f),
         )
         ModeTile(
             icon = Icons.Default.OfflinePin,
-            label = "Offline",
+            label = stringResource(R.string.mode_offline),
             selected = !streamingEnabled,
             onClick = { onSelect(false) },
             modifier = Modifier.weight(1f),

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/SaveToPlaylistSheet.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/SaveToPlaylistSheet.kt
@@ -31,7 +31,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 
 /**
  * Lightweight model for the playlist picker. Keeps the UI component
@@ -66,7 +68,7 @@ fun SaveToPlaylistSheet(
         // Title + divider stay above the scroll region so the user always
         // knows what sheet they're on.
         Text(
-            text = "Save to Playlist",
+            text = stringResource(R.string.title_save_to_playlist),
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
@@ -99,7 +101,7 @@ fun SaveToPlaylistSheet(
                     )
                     Spacer(modifier = Modifier.width(16.dp))
                     Text(
-                        text = "Create New Playlist",
+                        text = stringResource(R.string.action_create_new_playlist),
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.primary,
                     )
@@ -165,12 +167,12 @@ fun CreatePlaylistDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Create Playlist") },
+        title = { Text(stringResource(R.string.title_create_playlist_dialog)) },
         text = {
             OutlinedTextField(
                 value = name,
                 onValueChange = { name = it },
-                label = { Text("Playlist name") },
+                label = { Text(stringResource(R.string.hint_playlist_name)) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -180,12 +182,12 @@ fun CreatePlaylistDialog(
                 onClick = { onConfirm(name.trim()) },
                 enabled = name.isNotBlank(),
             ) {
-                Text("Create")
+                Text(stringResource(R.string.action_create_btn))
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("Cancel")
+                Text(stringResource(R.string.action_cancel))
             }
         },
     )

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/SearchFilterBar.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/SearchFilterBar.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashTheme
 
 /**
@@ -57,7 +59,7 @@ fun SearchFilterBar(
             .focusRequester(focusRequester),
         placeholder = {
             Text(
-                text = "Filter tracks...",
+                text = stringResource(R.string.hint_filter_tracks),
                 style = MaterialTheme.typography.bodyMedium,
             )
         },
@@ -73,7 +75,7 @@ fun SearchFilterBar(
                 IconButton(onClick = onClear) {
                     Icon(
                         imageVector = Icons.Default.Close,
-                        contentDescription = "Clear search",
+                        contentDescription = stringResource(R.string.cd_clear_search),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/SourceIndicator.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/SourceIndicator.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.stash.core.model.MusicSource
+import androidx.compose.ui.res.stringResource
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashTheme
 
 /**
@@ -43,7 +45,7 @@ fun SourceIndicator(
             Box(Modifier.size(size).clip(CircleShape).background(extendedColors.spotifyGreen))
             if (showLabel) {
                 Text(
-                    text = "Spotify",
+                    text = stringResource(R.string.filter_spotify),
                     style = MaterialTheme.typography.labelSmall,
                     color = extendedColors.textTertiary,
                 )
@@ -53,7 +55,7 @@ fun SourceIndicator(
             Box(Modifier.size(size).clip(CircleShape).background(extendedColors.youtubeRed))
             if (showLabel) {
                 Text(
-                    text = "YouTube",
+                    text = stringResource(R.string.filter_youtube),
                     style = MaterialTheme.typography.labelSmall,
                     color = extendedColors.textTertiary,
                 )
@@ -63,7 +65,7 @@ fun SourceIndicator(
             Box(Modifier.size(size).clip(CircleShape).background(MaterialTheme.colorScheme.primary))
             if (showLabel) {
                 Text(
-                    text = "Local",
+                    text = stringResource(R.string.filter_local),
                     style = MaterialTheme.typography.labelSmall,
                     color = extendedColors.textTertiary,
                 )

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/TrackListItem.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/TrackListItem.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.stash.core.model.MusicSource
 import com.stash.core.model.Track
+import androidx.compose.ui.res.stringResource
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashTheme
 
 /**
@@ -173,7 +175,7 @@ fun TrackListItem(
             )
             isPlaying -> Icon(
                 imageVector = Icons.Default.GraphicEq,
-                contentDescription = "Now playing",
+                contentDescription = stringResource(R.string.cd_now_playing),
                 tint = primaryColor,
                 modifier = Modifier.size(18.dp),
             )
@@ -194,7 +196,7 @@ fun TrackListItem(
             IconButton(onClick = onMoreClick, modifier = Modifier.size(32.dp)) {
                 Icon(
                     imageVector = Icons.Default.MoreVert,
-                    contentDescription = "More options",
+                    contentDescription = stringResource(R.string.cd_more_options),
                     tint = extendedColors.textTertiary,
                     modifier = Modifier.size(18.dp),
                 )

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/TrackOptionsSheet.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/TrackOptionsSheet.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.stash.core.model.Track
+import androidx.compose.ui.res.stringResource
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashTheme
 
 /**
@@ -132,21 +134,21 @@ fun TrackOptionsSheet(
         // -- Play Next option --
         SheetOptionRow(
             icon = Icons.Default.PlaylistPlay,
-            label = "Play Next",
+            label = stringResource(R.string.selection_play_next),
             onClick = { onPlayNext(track) },
         )
 
         // -- Add to Queue option --
         SheetOptionRow(
             icon = Icons.Default.PlaylistAdd,
-            label = "Add to Queue",
+            label = stringResource(R.string.action_add_to_queue),
             onClick = { onAddToQueue(track) },
         )
 
         // -- Save to Playlist option --
         SheetOptionRow(
             icon = Icons.Default.FavoriteBorder,
-            label = "Save to Playlist",
+            label = stringResource(R.string.title_save_to_playlist),
             onClick = { onSaveToPlaylist(track) },
         )
 
@@ -158,13 +160,13 @@ fun TrackOptionsSheet(
         if (track.isDownloaded && onRemoveDownload != null) {
             SheetOptionRow(
                 icon = Icons.Default.DownloadDone,
-                label = "Remove download",
+                label = stringResource(R.string.selection_remove_download),
                 onClick = { onRemoveDownload(track) },
             )
         } else if (!track.isDownloaded && onDownload != null) {
             SheetOptionRow(
                 icon = Icons.Default.Download,
-                label = "Download",
+                label = stringResource(R.string.selection_download),
                 onClick = { onDownload(track) },
             )
         }
@@ -174,7 +176,7 @@ fun TrackOptionsSheet(
         // -- Delete option --
         SheetOptionRow(
             icon = Icons.Default.Delete,
-            label = "Delete",
+            label = stringResource(R.string.selection_delete),
             tint = MaterialTheme.colorScheme.error,
             onClick = { onDelete(track) },
         )

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/streaming/StreamingModeChip.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/streaming/StreamingModeChip.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.stash.core.common.constants.StashConstants
@@ -73,7 +74,7 @@ fun StreamingModeChip(
             modifier = Modifier.size(14.dp),
         )
         Text(
-            text = if (streamingEnabled) "Online" else "Offline",
+            text = if (streamingEnabled) stringResource(com.stash.core.ui.R.string.mode_online) else stringResource(com.stash.core.ui.R.string.mode_offline),
             style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
             color = MaterialTheme.colorScheme.onSurface,
         )

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/streaming/StreamingModeSheet.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/streaming/StreamingModeSheet.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -58,14 +59,14 @@ fun StreamingModeSheet(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                text = "Playback Mode",
+                text = stringResource(com.stash.core.ui.R.string.title_playback_mode),
                 style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = TextAlign.Center,
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = "Switch between streaming and downloaded-only",
+                text = stringResource(com.stash.core.ui.R.string.desc_streaming_mode),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,

--- a/core/ui/src/main/kotlin/com/stash/core/ui/selection/SelectionBars.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/selection/SelectionBars.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashTheme
 
 /** One batch action surfaced in the [SelectionBottomBar]. */
@@ -84,7 +86,7 @@ fun SelectionTopBar(
             IconButton(onClick = onClose) {
                 Icon(
                     imageVector = Icons.Default.Close,
-                    contentDescription = "Exit selection",
+                    contentDescription = stringResource(R.string.selection_exit),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }
@@ -106,7 +108,7 @@ fun SelectionTopBar(
                 )
                 Spacer(modifier = Modifier.width(6.dp))
                 Text(
-                    text = "Select all",
+                    text = stringResource(R.string.selection_select_all),
                     style = MaterialTheme.typography.labelLarge,
                 )
             }
@@ -161,7 +163,7 @@ fun SelectionBottomBar(
                 Box {
                     LabeledAction(
                         icon = Icons.Default.MoreVert,
-                        label = "More",
+                        label = stringResource(R.string.selection_more),
                         onClick = { overflowExpanded = true },
                     )
                     DropdownMenu(

--- a/core/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/core/ui/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,695 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- ===== App ===== -->
+    <string name="app_name">Stash</string>
+
+    <!-- ===== Common Actions ===== -->
+    <string name="action_cancel">取消</string>
+    <string name="action_delete">删除</string>
+    <string name="action_remove">移除</string>
+    <string name="action_ok">确定</string>
+    <string name="action_save">保存</string>
+    <string name="action_connect">连接</string>
+    <string name="action_enable">启用</string>
+    <string name="action_download">下载</string>
+    <string name="action_download_all">全部下载</string>
+    <string name="action_play_all">播放全部</string>
+    <string name="action_play">播放</string>
+    <string name="action_radio">电台</string>
+    <string name="action_shuffle">随机播放</string>
+    <string name="action_queue">队列</string>
+    <string name="action_add_to_queue">添加到队列</string>
+    <string name="action_play_next">下一首播放</string>
+    <string name="action_remove_downloads">移除下载</string>
+    <string name="action_remove_playlist">移除播放列表</string>
+    <string name="action_delete_playlist_and_songs">删除播放列表及歌曲</string>
+    <string name="action_delete_and_block">删除并屏蔽</string>
+    <string name="action_unblock">取消屏蔽</string>
+    <string name="action_create_playlist">创建播放列表</string>
+    <string name="action_create_mix">创建\n混音</string>
+    <string name="action_refresh_mix">刷新此混音</string>
+    <string name="action_edit_mix">编辑混音</string>
+    <string name="action_donate">捐赠</string>
+    <string name="action_star">星标</string>
+    <string name="action_import">导入</string>
+    <string name="action_import_backup">导入备份</string>
+    <string name="action_change_folder">更改文件夹</string>
+    <string name="action_pick_folder">选择 SD 卡/文件夹</string>
+    <string name="action_use_internal">使用内部存储</string>
+    <string name="action_delete_from_library">从库中删除</string>
+    <string name="action_delete_and_block_forever">删除并永久屏蔽</string>
+    <string name="action_find_in_flac">查找 FLAC 版本</string>
+    <string name="action_find_better_match">查找更佳匹配</string>
+    <string name="action_view_lyrics">查看歌词 ♪</string>
+    <string name="action_shuffle_library">随机播放曲库</string>
+    <string name="action_play_all_by_artist">播放此艺人全部</string>
+    <string name="action_delete_all_by_artist">删除此艺人全部</string>
+    <string name="action_play_album">播放专辑</string>
+    <string name="action_stop_sync">停止同步</string>
+    <string name="action_reauthenticate">重新认证</string>
+    <string name="action_reauthenticate_spotify">重新认证 Spotify</string>
+    <string name="action_reauthenticate_youtube">重新认证 YouTube</string>
+    <string name="action_switch_to_refresh">切换到刷新模式</string>
+    <string name="action_connect_lastfm">连接 Last.fm</string>
+    <string name="action_finish_connecting">完成连接</string>
+    <string name="action_setup_lossless">立即设置 →</string>
+    <string name="action_retry_yt_sync">重试 YouTube 同步</string>
+    <string name="action_reset_lossless_attempts">重置无损尝试</string>
+    <string name="action_refresh_quality_info">刷新质量信息</string>
+    <string name="action_remove_image">移除图片</string>
+    <string name="action_play_both">双源播放</string>
+    <string name="action_got_it">知道了</string>
+    <string name="action_i_understand">我明白了</string>
+
+    <!-- ===== Navigation / CD ===== -->
+    <string name="cd_back">返回</string>
+    <string name="cd_close">关闭</string>
+    <string name="cd_search">搜索</string>
+    <string name="cd_clear_search">清除搜索</string>
+    <string name="cd_dismiss">关闭</string>
+    <string name="cd_more_actions">更多操作</string>
+    <string name="cd_download">下载</string>
+    <string name="cd_downloaded">已下载</string>
+    <string name="cd_preview">预览</string>
+    <string name="cd_stop_preview">停止预览</string>
+    <string name="cd_preview_match">预览匹配</string>
+    <string name="cd_preview_replacement">预览替换</string>
+    <string name="cd_approve_match">确认匹配</string>
+    <string name="cd_swap_match">切换到此匹配</string>
+    <string name="cd_unflag_match">取消标记（保留当前匹配）</string>
+    <string name="cd_save_preset">保存预设</string>
+    <string name="cd_save_to_playlist">保存到播放列表</string>
+    <string name="cd_queue">队列</string>
+    <string name="cd_flag_wrong_match">标记为错误匹配</string>
+    <string name="cd_open_artist">打开艺人</string>
+    <string name="cd_open_lyrics">打开歌词</string>
+    <string name="cd_open_browser">打开浏览器</string>
+    <string name="cd_copy_code">复制代码</string>
+    <string name="cd_filter_tracks">筛选曲目</string>
+    <string name="cd_set_cover_image">设置封面图片</string>
+    <string name="cd_shuffle">随机播放</string>
+    <string name="cd_previous">上一首</string>
+    <string name="cd_next">下一首</string>
+    <string name="cd_repeat">重复</string>
+    <string name="cd_streaming">在线播放</string>
+    <string name="cd_album_art">专辑封面</string>
+    <string name="cd_drag_to_reorder">拖拽排序</string>
+    <string name="cd_clear_filter">清除筛选</string>
+    <string name="cd_waiting_lossless">等待无损音源</string>
+    <string name="cd_dismiss_lossless_banner">关闭无损横幅</string>
+    <string name="cd_join_discord">加入 Stash Discord</string>
+    <string name="cd_report_issue">在 GitHub 上报告问题</string>
+    <string name="cd_supporters_kofi">Ko-fi 支持者</string>
+    <string name="cd_app_logo">Stash</string>
+    <string name="cd_play_all_mixes">播放全部 %1$s 混音</string>
+    <string name="cd_play_both_mixes">播放两个平台的混音</string>
+
+    <!-- ===== Titles ===== -->
+    <string name="title_settings">设置</string>
+    <string name="title_playback">播放</string>
+    <string name="title_playback_mode">播放模式</string>
+    <string name="title_audio_quality">音频与质量</string>
+    <string name="title_accounts_sync">账户与同步</string>
+    <string name="title_library_storage">曲库与存储</string>
+    <string name="title_appearance">外观</string>
+    <string name="title_about_help">关于与帮助</string>
+    <string name="title_library">曲库</string>
+    <string name="title_sync">同步</string>
+    <string name="title_sync_time">同步时间</string>
+    <string name="title_equalizer">均衡器</string>
+    <string name="title_library_health">曲库健康</string>
+    <string name="title_blocked_songs">已屏蔽歌曲</string>
+    <string name="title_failed_downloads">下载失败</string>
+    <string name="title_lyrics">歌词</string>
+    <string name="title_up_next">即将播放</string>
+    <string name="title_support_stash">支持 Stash</string>
+    <string name="title_diagnostics">诊断信息</string>
+    <string name="title_connect_arcod">连接 ARCOD</string>
+    <string name="title_verify_captcha">验证 squid.wtf 验证码</string>
+    <string name="title_search_prompt">搜索 YouTube Music</string>
+
+    <!-- ===== Dialog Titles ===== -->
+    <string name="dialog_title_delete_playlist">删除 %1$s？</string>
+    <string name="dialog_title_delete_songs">删除 %1$d 首歌曲？</string>
+    <string name="dialog_title_delete_track">删除 %1$s？</string>
+    <string name="dialog_title_delete_artist">删除 %1$s 的全部歌曲？</string>
+    <string name="dialog_title_remove_liked">从喜欢中移除 %1$d 首歌曲？</string>
+    <string name="dialog_title_batch_delete">从曲库中删除 %1$d 首歌曲？</string>
+    <string name="dialog_title_batch_remove">移除 %1$d 首歌曲</string>
+    <string name="dialog_title_overwrite_library">覆盖曲库与设置？</string>
+    <string name="dialog_title_wrong_match">这首歌有什么问题？</string>
+    <string name="dialog_title_stop_retrying">停止重试此歌曲？</string>
+    <string name="dialog_title_switch_refresh">切换到刷新模式？</string>
+    <string name="dialog_title_download_all">全部下载？</string>
+    <string name="dialog_title_connect_spotify">连接 Spotify</string>
+    <string name="dialog_title_connect_youtube">连接 YouTube Music</string>
+    <string name="dialog_title_yt_credentials">YouTube Music 凭据</string>
+    <string name="dialog_title_yt_history">将播放记录发送到 YouTube Music？</string>
+    <string name="dialog_title_mirror_likes">将喜欢同步到 %1$s？</string>
+    <string name="dialog_title_save_preset">保存预设</string>
+    <string name="dialog_title_streaming_disclosure">在线播放</string>
+
+    <!-- ===== Dialog Bodies ===== -->
+    <string name="dialog_body_delete_playlist">这将删除此播放列表中已下载到设备的歌曲。</string>
+    <string name="dialog_body_delete_playlist_cascade">%1$s 首歌曲将被删除。%2$s 首受保护的歌曲将保留。</string>
+    <string name="dialog_body_delete_songs">%1$d 首歌曲将从曲库中移除。此操作不可撤销。</string>
+    <string name="dialog_body_delete_track_library">此曲目将从曲库中删除。此操作不可撤销。</string>
+    <string name="dialog_body_delete_track_playlist">将此歌曲从播放列表中移除。已下载的文件保留在磁盘上。</string>
+    <string name="dialog_body_delete_artist">这将删除此艺人的全部 %1$d 首已下载歌曲。</string>
+    <string name="dialog_body_delete_playlist_permanent">%1$s 及其所有曲目将从曲库中移除。</string>
+    <string name="dialog_body_remove_liked">从喜欢中移除歌曲。</string>
+    <string name="dialog_body_batch_delete_library">这些曲目将从曲库中删除。此操作不可撤销。</string>
+    <string name="dialog_body_batch_delete_playlist">将这些歌曲从播放列表中移除。已下载的文件保留在磁盘上。</string>
+    <string name="dialog_body_overwrite_library">这将用备份数据完全替换您现有的曲库和设置。</string>
+    <string name="dialog_body_wrong_match">选择要对 \'%1$s\' 执行的操作。</string>
+    <string name="dialog_body_stop_retrying">\'%1$s\' 将不会被下载，并从下载失败列表中移除。</string>
+    <string name="dialog_body_switch_refresh">刷新模式每次同步拉取新曲目。现有离线曲目保持不变。立即切换？</string>
+    <string name="dialog_body_all_downloaded">所有曲目已下载。</string>
+    <string name="dialog_body_download_count">下载 %1$d 首曲目到曲库？</string>
+    <string name="dialog_body_spotify_cookie">在浏览器中登录 Spotify，获取 sp_dc cookie，然后粘贴到下方。</string>
+    <string name="dialog_body_yt_cookie">粘贴您的 YouTube Music cookie 以连接。</string>
+    <string name="dialog_body_yt_credentials">输入您的 Google Cloud OAuth 凭据以连接 YouTube Music。</string>
+    <string name="dialog_body_yt_history">您在 Stash 中听完的每首曲目都将发送到您的 YouTube Music 历史记录。</string>
+    <string name="dialog_body_mirror_likes">在 Stash 中点亮红心的曲目也会在 %1$s 中点亮。此操作对过去的红心不可撤销。</string>
+    <string name="dialog_body_streaming_disclosure">Stash 通过社区 Qobuz 代理进行串流。串流质量取决于代理。下载不受影响。</string>
+
+    <!-- ===== Labels ===== -->
+    <string name="label_spotify">Spotify</string>
+    <string name="label_youtube_music">YouTube Music</string>
+    <string name="label_youtube">YouTube</string>
+    <string name="label_liked_songs">喜欢的歌曲</string>
+    <string name="label_no_matching_songs">无匹配歌曲</string>
+    <string name="label_no_tracks_found">未找到曲目</string>
+    <string name="label_no_tracks_available">无可用曲目</string>
+    <string name="label_no_liked_songs">还没有喜欢的歌曲</string>
+    <string name="label_no_blocked_songs">无已屏蔽歌曲</string>
+    <string name="label_no_failed_downloads">无下载失败。</string>
+    <string name="label_no_unmatched_songs">无未匹配歌曲。</string>
+    <string name="label_no_match_found">未找到匹配</string>
+    <string name="label_no_replacement">未找到替换</string>
+    <string name="label_no_upcoming_tracks">无即将播放的曲目</string>
+    <string name="label_no_lyrics_found">未找到歌词</string>
+    <string name="label_lyrics_load_error">无法加载歌词</string>
+    <string name="label_no_results">未找到结果</string>
+    <string name="label_no_playlists_match">没有匹配 \"%1$s\" 的播放列表</string>
+    <string name="label_no_downloaded_tracks">还没有下载的曲目。请先运行同步。</string>
+    <string name="label_no_details">无其他详细信息</string>
+    <string name="label_all_caught_up">全部完成！</string>
+    <string name="label_flagged_wrong">您标记为错误的曲目</string>
+    <string name="label_empty_tracks_synced">同步曲库后即可在此看到曲目</string>
+    <string name="label_empty_tracks_no_service">在设置中连接服务以查看曲目</string>
+    <string name="label_also_block_songs">同时屏蔽这些歌曲，不再同步</string>
+    <string name="label_also_block_song">同时屏蔽此歌曲，不再同步</string>
+    <string name="label_powered_by">由 </string>
+    <string name="label_mix_name_optional">混音名称（可选）</string>
+    <string name="label_familiar">熟悉的</string>
+    <string name="label_brand_new">全新的</string>
+    <string name="label_beta">Beta</string>
+    <string name="label_routing">路由</string>
+    <string name="label_dark">深色</string>
+    <string name="label_light">浅色</string>
+    <string name="label_follow_system">跟随系统</string>
+    <string name="label_download_quality">下载质量</string>
+    <string name="label_lossless_downloads">无损下载</string>
+    <string name="label_direct_qobuz">直连 Qobuz</string>
+    <string name="label_account">账户</string>
+    <string name="label_auto">自动</string>
+    <string name="label_paste_token">粘贴令牌</string>
+    <string name="label_on_wifi">Wi-Fi 下</string>
+    <string name="label_on_cellular">蜂窝数据下</string>
+    <string name="label_save_data">省流模式</string>
+    <string name="label_youtube_fallback">YouTube 回退</string>
+    <string name="label_use_youtube_fallback">无损失败时使用 YouTube</string>
+    <string name="label_advanced">高级</string>
+    <string name="label_captcha_verified_at">captcha_verified_at 值</string>
+    <string name="label_playback">播放</string>
+    <string name="label_audio_quality">音频与质量</string>
+    <string name="label_accounts_sync">账户与同步</string>
+    <string name="label_library_storage">曲库与存储</string>
+    <string name="label_appearance">外观</string>
+    <string name="label_about_help">关于与帮助</string>
+    <string name="label_library_health">曲库健康</string>
+    <string name="label_total_tracks">总曲目数</string>
+    <string name="label_storage_used">已用存储</string>
+    <string name="label_download_location">下载位置</string>
+    <string name="label_existing_library">现有曲库</string>
+    <string name="label_backup">备份</string>
+    <string name="label_total_downloaded">总下载量</string>
+    <string name="label_version">版本</string>
+    <string name="label_license">许可证</string>
+    <string name="label_share_crash_report">分享最新崩溃报告</string>
+    <string name="label_share_diagnostics">分享诊断信息</string>
+    <string name="label_scrobble_plays">记录播放历史</string>
+    <string name="label_sync_likes">同步喜欢</string>
+    <string name="label_send_plays_yt">发送播放记录到 YouTube Music</string>
+    <string name="label_connect_yt_first">请先连接 YouTube Music</string>
+    <string name="label_how_it_works">工作原理</string>
+    <string name="label_risk">风险</string>
+    <string name="label_auto_save_liked">自动保存喜欢的曲目</string>
+    <string name="label_auto_save_threshold">阈值：30 天内 %1$d 天</string>
+    <string name="label_auto_save_last_7_days">最近 7 天：%1$d 首曲目已自动保存</string>
+    <string name="label_how_to_get_cookie">如何获取 sp_dc cookie：</string>
+    <string name="label_how_to_get_cookies">如何获取 cookie：</string>
+    <string name="label_sp_dc_cookie">sp_dc cookie</string>
+    <string name="label_spotify_username_optional">Spotify 用户名（可选）</string>
+    <string name="label_signin_blocked">登录被阻止或无法使用？</string>
+    <string name="label_client_id">Client ID</string>
+    <string name="label_client_secret">Client Secret</string>
+    <string name="label_cookie">Cookie</string>
+    <string name="label_stream_cellular">使用蜂窝数据串流</string>
+    <string name="label_stream_youtube">通过 YouTube 串流</string>
+    <string name="label_stream_amz">通过 amz 串流（测试）</string>
+    <string name="label_force_qobuz">强制仅直连 Qobuz（测试）</string>
+    <string name="label_crossfade">交叉淡入淡出</string>
+    <string name="label_duration">时长</string>
+    <string name="label_repeat_on">重复于</string>
+    <string name="label_not_scheduled">未设置计划 — 请至少选择一天</string>
+    <string name="label_last_sync">上次同步</string>
+    <string name="label_last_sync_time">上次同步 %1$s</string>
+    <string name="label_tracks">曲目</string>
+    <string name="label_storage">存储</string>
+    <string name="label_error_prefix">错误：%1$s</string>
+    <string name="label_diagnostics">诊断信息：</string>
+    <string name="label_blocked_songs">已屏蔽歌曲</string>
+    <string name="label_failed_downloads">下载失败</string>
+    <string name="label_mix_sync_mode">混合同步模式</string>
+    <string name="label_studio_recordings_only">仅录音室版本</string>
+    <string name="label_stash_mixes_beta">Stash 混音（beta）</string>
+    <string name="label_run_recommendations">运行推荐条件</string>
+    <string name="label_streaming_unavailable">此版本不支持在线播放。</string>
+
+    <!-- ===== Descriptions ===== -->
+    <string name="desc_blocked_songs_hint">被屏蔽的歌曲不会重新下载。稍后可在设置中取消屏蔽。</string>
+    <string name="desc_sync_to_start">同步曲库即可开始</string>
+    <string name="desc_try_different_search">尝试其他搜索词</string>
+    <string name="desc_search_prompt">查找任意歌曲或艺人并下载到曲库</string>
+    <string name="desc_support_stash">如果 Stash 为您省下了一笔订阅费，请考虑支持它的开发。</string>
+    <string name="desc_follow_system">跟随系统以匹配您设备的日间/夜间设置。</string>
+    <string name="desc_lossless_active">FLAC 路由已激活。文件大小约为 MP3 的 10 倍。</string>
+    <string name="desc_lossless_inactive">通过 Qobuz 获取录音室品质 FLAC。文件大小约为 MP3 的 10 倍。</string>
+    <string name="desc_direct_qobuz">高分辨率 FLAC，直接来自 Qobuz。</string>
+    <string name="desc_auto_token">推荐 — 使用可用账户并在失败时回退</string>
+    <string name="desc_save_data">启用后在所有网络上请求最低串流质量。</string>
+    <string name="desc_stream_cellular">允许通过移动数据（5G/LTE）串流。禁用以仅在 Wi-Fi 下串流。</string>
+    <string name="desc_stream_youtube">跳过无损音源（Qobuz），直接从 YouTube 串流。</string>
+    <string name="desc_stream_amz">将串流和下载路由到 amz.squid.wtf 而非 Qobuz 代理。</string>
+    <string name="desc_force_qobuz">仅通过直连 Qobuz 路由串流和下载。无回退。</string>
+    <string name="desc_crossfade">自动切换时将结尾曲目淡入下一首。在下方调整时长。</string>
+    <string name="desc_loudness_normalization">以一致音量播放所有曲目。</string>
+    <string name="desc_loudness_backfill">充电时自动继续。</string>
+    <string name="desc_blocked_songs_empty">通过"删除并屏蔽"屏蔽的歌曲会显示在此。每次同步时会跳过它们。</string>
+    <string name="desc_blocked_songs_header">每次同步时会跳过这些歌曲。取消屏蔽可重新允许同步。</string>
+    <string name="desc_lastfm_no_api_key">此版本的 Stash 不包含 Last.fm API 密钥。Last.fm 记录功能不可用。</string>
+    <string name="desc_lastfm_awaiting_auth">浏览器应已打开 Last.fm 页面。批准 Stash 以完成连接。</string>
+    <string name="desc_like_mirror">将红心同步到您的账户。在 Stash 中点亮的红心也会同步到相应服务。</string>
+    <string name="desc_yt_history_how">Stash 使用非官方 YouTube 端点发送您的收听历史。</string>
+    <string name="desc_yt_history_risk">YouTube 进行速率限制或标记此活动虽有罕见但并非零风险。</string>
+    <string name="desc_spotify_cookie_steps">在电脑上最方便：\n1. 打开 open.spotify.com 并登录\n2. 按 F12 → Application → Cookies\n3. 复制 sp_dc 的值</string>
+    <string name="desc_yt_cookie_steps">1. 打开隐私/无痕窗口\n2. 前往 music.youtube.com 并登录\n3. 按 F12 → Application → Cookies\n4. 以 JSON 格式复制所有 cookie</string>
+    <string name="desc_spotify_username_hint">在 spotify.com/account 的"用户名"下查找</string>
+    <string name="desc_device_code_prompt">前往下方网址并输入此代码：</string>
+    <string name="desc_paste_captcha_cookie">或直接粘贴 captcha_verified_at cookie 值：</string>
+    <string name="desc_backup">导出设置和数据库，或从之前的备份导入。</string>
+    <string name="desc_external_storage">曲目存储在此文件夹中。更改位置不会移动现有文件。</string>
+    <string name="desc_new_downloads_location">新下载将保存到所选位置。现有文件保持不变。</string>
+    <string name="desc_move_failed">失败的曲目保留在内部存储中。请稍后重试。</string>
+    <string name="desc_re_extract_quality">重新提取 FLAC 曲目的位深和采样率。需要几分钟。</string>
+    <string name="desc_library_health">已下载曲库的格式和比特率分布。</string>
+    <string name="desc_share_diagnostics">打包最近的日志、同步历史和连接状态以供排查。</string>
+    <string name="desc_diagnostics_review">检查将要分享的内容。不包含密码或令牌。</string>
+    <string name="desc_lossless_routing">来自直连 Qobuz 的无损串流 — 通往 FLAC 的最快路径。</string>
+    <string name="desc_streaming_mode">在在线播放和仅下载播放之间切换。</string>
+    <string name="desc_retagging_progress">正在为现有文件添加专辑封面和元数据</string>
+    <string name="desc_retagging_saf_skipped">%1$d 首外部存储上的曲目标记失败。请将其移至内部存储后重试。</string>
+    <string name="desc_tap_chip_to_change">点击任意标签即可更改</string>
+    <string name="desc_connect_service">在设置中连接 Spotify 或 YouTube Music 以开始同步曲库。</string>
+    <string name="desc_tap_sync_now">点击"立即同步"下载您的播放列表和曲目。</string>
+    <string name="desc_tap_resync">点击上方重新同步以查找已标记曲目的替换版本。</string>
+    <string name="desc_tap_resync_replacements">点击重新同步以查找替换</string>
+    <string name="desc_empty_spotify">连接后您的 Spotify 播放列表和每日混音将显示在此。</string>
+    <string name="desc_empty_youtube">您的 YouTube Music 家庭混音、喜欢的歌曲和播放列表将显示在此。</string>
+    <string name="desc_studio_recordings_only">从同步结果中排除翻唱、现场录音和 UGC 上传。</string>
+    <string name="desc_mix_edit_hint">尝试用不同的流派或情绪编辑此混音。</string>
+    <string name="desc_building_mix">正在从您的流派和情绪中寻找新曲目…</string>
+    <string name="desc_lossless_prompt">通过 Qobuz 获取录音室品质 FLAC 下载。点击设置。</string>
+
+    <!-- ===== Status Messages ===== -->
+    <string name="status_building">构建中…</string>
+    <string name="status_building_mix">正在构建混音…</string>
+    <string name="status_mix_no_tracks">未找到曲目</string>
+    <string name="status_library_retagged">曲库已重新标记</string>
+    <string name="status_retagging_library">正在重新标记曲库</string>
+    <string name="status_login_successful">登录成功，正在连接…</string>
+    <string name="status_waiting_auth">等待授权…</string>
+    <string name="status_scanning">扫描中… %1$d / %2$d</string>
+    <string name="status_scan_complete">扫描完成：已处理 %1$d / %2$d 首曲目</string>
+    <string name="status_exporting_db">正在导出数据库</string>
+    <string name="status_importing_db">正在导入数据库</string>
+    <string name="status_importing_progress">正在导入 %1$s / %2$s…</string>
+    <string name="status_success">成功</string>
+    <string name="status_error">错误</string>
+    <string name="status_processing">处理中…</string>
+    <string name="status_moving_library">正在移动 %1$d / %2$d…</string>
+    <string name="status_active">活跃</string>
+    <string name="status_fallback">回退</string>
+    <string name="status_arcod_connected">已连接 — 正在保存并关闭。</string>
+    <string name="status_captcha_saved">已获取 — 正在保存并关闭。</string>
+    <string name="status_lastfm_not_configured">未配置</string>
+    <string name="status_lastfm_waiting">等待批准</string>
+    <string name="status_lastfm_connected">已连接为 %1$s</string>
+    <string name="status_lastfm_pending">正在记录播放历史。%1$d 条排队中。等待网络连接。</string>
+    <string name="status_lastfm_up_to_date">正在记录播放历史。全部已是最新。</string>
+
+    <!-- ===== Errors ===== -->
+    <string name="error_load_album">无法加载专辑</string>
+    <string name="error_load_artist">无法加载艺人</string>
+    <string name="error_search_failed">搜索失败</string>
+    <string name="error_move_library">无法移动曲库</string>
+    <string name="error_import_failed">导入失败</string>
+    <string name="error_lastfm_connect">无法连接</string>
+    <string name="error_no_working_token">无可用令牌 — 请粘贴新令牌</string>
+    <string name="error_signin_expired_group">登录已过期</string>
+    <string name="error_signin_expired_short">登录过期</string>
+    <string name="error_storage_unreachable_group">存储不可达</string>
+    <string name="error_storage_unreachable_short">存储错误</string>
+    <string name="error_network_errors_group">网络错误</string>
+    <string name="error_network_errors_short">网络错误</string>
+    <string name="error_source_unavailable_group">音源不可用</string>
+    <string name="error_source_unavailable_short">音源不可用</string>
+    <string name="error_encoding_errors_group">编码错误</string>
+    <string name="error_encoding_errors_short">编码错误</string>
+    <string name="error_other_errors_group">其他错误</string>
+    <string name="error_unknown_short">未知错误</string>
+
+    <!-- ===== Sections ===== -->
+    <string name="section_your_mixes">我的混音</string>
+    <string name="section_your_collection">我的收藏</string>
+    <string name="section_recently_added">最近添加</string>
+    <string name="section_playlists">播放列表</string>
+    <string name="section_spotify_mixes">Spotify 混音</string>
+    <string name="section_your_playlists">我的播放列表</string>
+    <string name="section_home_mixes">首页混音</string>
+    <string name="section_other_playlists">其他播放列表</string>
+    <string name="section_stash_mixes">Stash 混音（Beta）</string>
+    <string name="section_recent_searches">最近搜索</string>
+    <string name="section_more_by_artist">此艺人更多作品</string>
+    <string name="section_popular">热门</string>
+    <string name="section_albums">专辑</string>
+    <string name="section_singles_eps">单曲与 EP</string>
+    <string name="section_fans_also_like">乐迷也喜欢</string>
+    <string name="section_library_breakdown">曲库分布</string>
+    <string name="section_backfill_metadata">回填元数据</string>
+    <string name="section_quality_info">质量信息</string>
+
+    <!-- ===== Hints / Placeholders ===== -->
+    <string name="hint_search">搜索歌曲、艺人…</string>
+    <string name="hint_search_settings">搜索设置</string>
+    <string name="hint_paste_sp_dc_cookie">在此粘贴 sp_dc cookie</string>
+    <string name="hint_spotify_username">您的 Spotify 用户名</string>
+    <string name="hint_paste_cookie">在此粘贴 cookie</string>
+    <string name="hint_user_auth_token">user_auth_token</string>
+    <string name="hint_captcha_value">例如 1777687404951</string>
+
+    <!-- ===== Notifications (existing from core/media) ===== -->
+    <string name="notification_action_like">添加到喜欢的歌曲</string>
+    <string name="notification_action_unlike">从喜欢的歌曲中移除</string>
+    <string name="notification_action_repeat_off">关闭重复</string>
+    <string name="notification_action_repeat_all">全部重复</string>
+    <string name="notification_action_repeat_one">单曲重复</string>
+    <string name="notification_action_shuffle_on">开启随机播放</string>
+    <string name="notification_action_shuffle_off">关闭随机播放</string>
+    <string name="shuffle_play">随机播放</string>
+    <string name="resuming_channel_name">播放</string>
+    <string name="resuming_notification_title">正在恢复…</string>
+    <string name="resume_playback_short">恢复</string>
+    <string name="resume_playback_long">恢复播放</string>
+
+    <!-- ===== Prompts ===== -->
+    <string name="prompt_try_lossless">试试无损音频</string>
+
+    <!-- ===== Bottom Navigation ===== -->
+    <string name="nav_home">首页</string>
+    <string name="nav_library">曲库</string>
+    <string name="nav_search">搜索</string>
+    <string name="nav_sync">同步</string>
+    <string name="nav_settings">设置</string>
+
+    <!-- ===== Playback Modes ===== -->
+    <string name="mode_online">在线</string>
+    <string name="mode_offline">离线</string>
+
+    <!-- ===== Sort / Filter Labels ===== -->
+    <string name="sort_recently_added">最近添加</string>
+    <string name="sort_alphabetical">A–Z</string>
+    <string name="sort_most_played">最多播放</string>
+    <string name="filter_all">全部</string>
+    <string name="filter_youtube">YouTube</string>
+    <string name="filter_spotify">Spotify</string>
+    <string name="filter_flac">FLAC</string>
+    <string name="filter_local">本地</string>
+
+    <!-- ===== Library Tabs ===== -->
+    <string name="tab_playlists">播放列表</string>
+    <string name="tab_tracks">曲目</string>
+    <string name="tab_artists">艺人</string>
+    <string name="tab_albums">专辑</string>
+
+    <!-- ===== Connection / Sync States ===== -->
+    <string name="status_never_synced">从未同步</string>
+    <string name="status_no_services_connected">未连接服务</string>
+    <string name="status_ready_to_sync">准备同步</string>
+    <string name="status_syncing">同步中…</string>
+    <string name="status_synced">已同步</string>
+    <string name="status_sync_failed">同步失败</string>
+    <string name="status_sync_interrupted">已中断</string>
+    <string name="status_sync_interrupted_count">已中断 — 已保存 %1$d 首</string>
+    <string name="status_partial_sync">部分同步 — 已保存 %1$d 首，%2$d 首失败</string>
+    <string name="status_connected">已连接</string>
+    <string name="status_disconnected">已断开</string>
+    <string name="status_not_connected">未连接</string>
+    <string name="status_nothing_to_sync">无内容可同步</string>
+    <string name="status_checking_updates">正在检查更新…</string>
+    <string name="status_no_crash_report">没有可分享的崩溃报告。</string>
+    <string name="status_no_app_available">没有可用的应用来分享报告。</string>
+
+    <!-- ===== Section Headers ===== -->
+    <string name="section_sources">来源</string>
+    <string name="section_schedule">计划</string>
+    <string name="section_library">曲库</string>
+    <string name="section_recent_syncs">最近同步</string>
+    <string name="section_diagnostics">诊断</string>
+    <string name="section_about">关于</string>
+    <string name="section_connections">连接</string>
+    <string name="section_theme">主题</string>
+    <string name="section_audio_quality">音频质量</string>
+    <string name="section_lossless">无损</string>
+    <string name="section_streaming">在线播放</string>
+    <string name="section_effects">音效</string>
+    <string name="section_mode">模式</string>
+    <string name="section_downloads">下载</string>
+    <string name="section_storage">存储</string>
+    <string name="section_5band_eq">5 段均衡器</string>
+    <string name="section_bass_boost">低音增强</string>
+    <string name="section_loudness_normalization">响度归一化</string>
+    <string name="section_preamp">前置放大</string>
+    <string name="section_songs">歌曲</string>
+    <string name="section_artists">艺人</string>
+
+    <!-- ===== Mix Builder ===== -->
+    <string name="label_moods">情绪</string>
+    <string name="label_genres">流派</string>
+    <string name="label_era_optional">年代 · 可选</string>
+    <string name="label_discovery_level">发现程度</string>
+    <string name="label_untitled_mix">未命名混音</string>
+    <string name="label_no_ingredients">尚无内容</string>
+    <string name="label_any_era">任意年代</string>
+    <string name="title_edit_mix">编辑混音</string>
+    <string name="title_create_mix">创建混音</string>
+    <string name="action_create_mix_btn">创建混音</string>
+
+    <!-- ===== Save / Like ===== -->
+    <string name="action_save_to">保存到…</string>
+    <string name="action_save_btn">保存</string>
+    <string name="action_create_btn">创建</string>
+    <string name="action_retry">重试</string>
+    <string name="action_confirm">确认</string>
+    <string name="action_share">分享</string>
+    <string name="action_copy">复制</string>
+    <string name="action_set">设置</string>
+    <string name="action_disconnect">断开连接</string>
+    <string name="action_refresh">刷新</string>
+    <string name="action_scan_files">扫描文件</string>
+    <string name="action_retry_scan">重新扫描</string>
+    <string name="action_retry_all">全部重试</string>
+    <string name="action_check_updates">检查更新</string>
+    <string name="action_export_backup">导出备份</string>
+    <string name="action_overwrite">覆盖</string>
+    <string name="action_change_image">更换图片</string>
+    <string name="action_add_image">添加图片</string>
+    <string name="action_clear_all">清除全部</string>
+    <string name="action_paste_cookie_instead">改为粘贴 Cookie</string>
+    <string name="action_sync_scrobbles_now">立即同步播放记录</string>
+    <string name="action_download_tracks">下载曲目到设备</string>
+    <string name="action_surface_streaming">准备曲库以在线播放</string>
+
+    <!-- ===== Selection Actions ===== -->
+    <string name="selection_queue">队列</string>
+    <string name="selection_playlist">播放列表</string>
+    <string name="selection_download">下载</string>
+    <string name="selection_delete">删除</string>
+    <string name="selection_share">分享</string>
+    <string name="selection_more">更多</string>
+    <string name="selection_select_all">全选</string>
+    <string name="selection_add_to_playlist">添加到播放列表</string>
+    <string name="selection_remove_download">移除下载</string>
+    <string name="selection_play_next">下一首播放</string>
+    <string name="selection_exit">退出选择</string>
+
+    <!-- ===== Player Controls ===== -->
+    <string name="cd_play">播放</string>
+    <string name="cd_pause">暂停</string>
+    <string name="cd_skip">跳过</string>
+    <string name="cd_now_playing">正在播放</string>
+    <string name="cd_more_options">更多选项</string>
+    <string name="cd_like">喜欢</string>
+    <string name="cd_unlike">取消喜欢</string>
+    <string name="cd_retry">重试</string>
+    <string name="cd_collapse">收起</string>
+    <string name="cd_expand">展开</string>
+    <string name="cd_block">屏蔽</string>
+    <string name="cd_stash_logo">Stash 标志</string>
+
+    <!-- ===== Like Destinations ===== -->
+    <string name="like_dest_stash">Stash 喜欢的歌曲</string>
+    <string name="like_dest_spotify">Spotify 喜欢的歌曲</string>
+    <string name="like_dest_youtube">YouTube Music 喜欢的音乐</string>
+
+    <!-- ===== Playlist ===== -->
+    <string name="title_save_to_playlist">保存到播放列表</string>
+    <string name="action_create_new_playlist">新建播放列表</string>
+    <string name="title_create_playlist_dialog">创建播放列表</string>
+    <string name="hint_playlist_name">播放列表名称</string>
+    <string name="hint_preset_name">预设名称</string>
+    <string name="hint_filter_playlists">筛选播放列表…</string>
+    <string name="hint_filter_tracks">筛选曲目…</string>
+
+    <!-- ===== Flac Badge ===== -->
+    <string name="badge_flac">FLAC</string>
+    <string name="badge_flac_format">FLAC %1$d/%2$d</string>
+
+    <!-- ===== Search ===== -->
+    <string name="label_artist_type">艺人</string>
+    <string name="label_song_type">歌曲</string>
+    <string name="label_album_type">专辑</string>
+
+    <!-- ===== Quality Tiers ===== -->
+    <string name="quality_max">最高</string>
+    <string name="quality_best">最佳</string>
+    <string name="quality_high">高</string>
+    <string name="quality_normal">标准</string>
+    <string name="quality_low">低</string>
+    <string name="quality_cd">CD (16-bit/44.1 kHz)</string>
+    <string name="quality_hires">Hi-Res (24-bit/96 kHz)</string>
+    <string name="quality_max_bit">Max (24-bit/192 kHz)</string>
+
+    <!-- ===== EQ Presets ===== -->
+    <string name="eq_flat">平坦</string>
+    <string name="eq_bass_boost">低音增强</string>
+    <string name="eq_treble_boost">高音增强</string>
+    <string name="eq_vocal">人声</string>
+    <string name="eq_rock">摇滚</string>
+    <string name="eq_pop">流行</string>
+    <string name="eq_jazz">爵士</string>
+    <string name="eq_classical">古典</string>
+
+    <!-- ===== Download Network ===== -->
+    <string name="network_wifi_charging">Wi-Fi + 充电</string>
+    <string name="network_wifi_anytime">仅 Wi-Fi</string>
+    <string name="network_any">任意网络</string>
+    <string name="network_wifi_charging_desc">最保守。仅在 Wi-Fi 且充电时下载。</string>
+    <string name="network_wifi_anytime_desc">通过 Wi-Fi 下载，无需充电。</string>
+    <string name="network_any_desc">也通过移动数据下载。会消耗流量。</string>
+
+    <!-- ===== Sync Phases ===== -->
+    <string name="sync_phase_authenticating">认证中…</string>
+    <string name="sync_phase_fetching">获取播放列表…</string>
+    <string name="sync_phase_diffing">比较变更…</string>
+    <string name="sync_phase_downloading">下载中 %1$s/%2$s…</string>
+    <string name="sync_phase_finalizing">完成中…</string>
+    <string name="sync_phase_complete">完成</string>
+    <string name="sync_phase_error">错误</string>
+
+    <!-- ===== Sync Misc ===== -->
+    <string name="label_auto_sync">自动同步</string>
+    <string name="label_daily">每天</string>
+    <string name="label_weekdays">工作日</string>
+    <string name="label_weekends">周末</string>
+    <string name="label_wifi_only">仅 Wi-Fi</string>
+    <string name="label_any_network">任意网络</string>
+    <string name="label_am">上午</string>
+    <string name="label_pm">下午</string>
+    <string name="label_refresh">刷新</string>
+    <string name="label_accumulate">累积</string>
+    <string name="desc_mix_refresh">每次同步更新为新曲目</string>
+    <string name="desc_mix_accumulate">新曲目叠加在旧曲目之上</string>
+    <string name="label_failed_downloads_header">%1$d 首曲目下载失败。</string>
+    <string name="label_blocked_count">%1$d 首歌曲将永远不会重新下载</string>
+    <string name="label_searching_resync">搜索中 %1$s…</string>
+    <string name="action_approve_all">全部批准 (%1$d)</string>
+    <string name="action_dismiss_all">全部关闭</string>
+    <string name="label_resync">重新同步</string>
+
+    <!-- ===== Failed Matches Tabs ===== -->
+    <string name="tab_songs_to_review">待审核歌曲</string>
+    <string name="tab_flagged_songs">已标记歌曲</string>
+    <string name="tab_unmatched_songs">未匹配歌曲</string>
+
+    <!-- ===== Auth Expired ===== -->
+    <string name="auth_signins_expired">登录已过期</string>
+    <string name="auth_signins_expired_desc">Spotify 和 YouTube 都需要重新登录才能恢复同步。</string>
+    <string name="auth_spotify_expired">Spotify 会话已过期</string>
+    <string name="auth_spotify_expired_desc">重新认证以在同步中包含您的 Spotify 曲库。</string>
+    <string name="auth_youtube_expired">YouTube 会话已过期</string>
+    <string name="auth_youtube_expired_desc">重新认证以在同步中包含您的 YouTube 曲库。</string>
+
+    <!-- ===== Sign In ===== -->
+    <string name="title_sign_in_spotify">登录 Spotify</string>
+    <string name="title_sign_in_youtube">登录 YouTube Music</string>
+
+    <!-- ===== Discover Error ===== -->
+    <string name="error_something_wrong">出了点问题</string>
+    <string name="error_diagnostics_failed">无法生成诊断信息</string>
+
+    <!-- ===== Loudness ===== -->
+    <string name="loudness_toast_on">响度归一化已开启。曲目音量将更加一致。</string>
+
+    <!-- ===== Library Empty States ===== -->
+    <string name="label_empty_playlists_synced">同步播放列表后即可在此查看</string>
+    <string name="label_empty_playlists_no_service">在设置中连接服务以查看播放列表</string>
+    <string name="label_empty_artists_synced">同步曲库后即可在此查看艺人</string>
+    <string name="label_empty_artists_no_service">在设置中连接服务以查看艺人</string>
+    <string name="label_empty_albums_synced">同步曲库后即可在此查看专辑</string>
+    <string name="label_empty_albums_no_service">在设置中连接服务以查看专辑</string>
+    <string name="label_hide_single_track">隐藏单曲专辑</string>
+    <string name="label_single_track_count">%1$d 张仅含 1 首曲目的专辑</string>
+
+    <!-- ===== Misc ===== -->
+    <string name="label_not_playing">未播放</string>
+    <string name="label_instrumental">♪ 纯音乐</string>
+    <string name="label_via_yt">来自 YT</string>
+    <string name="label_external_folder">外部文件夹</string>
+    <string name="label_internal_storage">内部存储 (应用私有)</string>
+    <string name="label_no_recent_crashes">最近无崩溃。</string>
+    <string name="label_crash_report_subject">Stash 崩溃报告</string>
+    <string name="label_share_crash_report_title">分享崩溃报告</string>
+    <string name="label_diagnostics_subject">Stash 诊断信息</string>
+    <string name="label_share_diagnostics_title">分享诊断信息</string>
+    <string name="label_clipboard_yt_code">YouTube 验证码</string>
+    <string name="partner_support_kofi">在 Ko-fi 上支持</string>
+    <string name="partner_discord">Discord</string>
+    <string name="label_cellular_on">移动数据已开启</string>
+    <string name="label_cellular_off">移动数据已关闭</string>
+    <string name="label_unit_tracks">首曲目</string>
+    <string name="label_unit_track">首曲目</string>
+    <string name="label_version_format">v%1$s</string>
+</resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -1,0 +1,695 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- ===== App ===== -->
+    <string name="app_name">Stash</string>
+
+    <!-- ===== Common Actions ===== -->
+    <string name="action_cancel">Cancel</string>
+    <string name="action_delete">Delete</string>
+    <string name="action_remove">Remove</string>
+    <string name="action_ok">OK</string>
+    <string name="action_save">Save</string>
+    <string name="action_connect">Connect</string>
+    <string name="action_enable">Enable</string>
+    <string name="action_download">Download</string>
+    <string name="action_download_all">Download All</string>
+    <string name="action_play_all">Play All</string>
+    <string name="action_play">Play</string>
+    <string name="action_radio">Radio</string>
+    <string name="action_shuffle">Shuffle</string>
+    <string name="action_queue">Queue</string>
+    <string name="action_add_to_queue">Add to Queue</string>
+    <string name="action_play_next">Play Next</string>
+    <string name="action_remove_downloads">Remove Downloads</string>
+    <string name="action_remove_playlist">Remove Playlist</string>
+    <string name="action_delete_playlist_and_songs">Delete Playlist &amp; Songs</string>
+    <string name="action_delete_and_block">Delete &amp; Block</string>
+    <string name="action_unblock">Unblock</string>
+    <string name="action_create_playlist">Create Playlist</string>
+    <string name="action_create_mix">Create\nmix</string>
+    <string name="action_refresh_mix">Refresh this mix</string>
+    <string name="action_edit_mix">Edit mix</string>
+    <string name="action_donate">Donate</string>
+    <string name="action_star">Star</string>
+    <string name="action_import">Import</string>
+    <string name="action_import_backup">Import Backup</string>
+    <string name="action_change_folder">Change folder</string>
+    <string name="action_pick_folder">Pick SD / folder</string>
+    <string name="action_use_internal">Use internal</string>
+    <string name="action_delete_from_library">Delete from library</string>
+    <string name="action_delete_and_block_forever">Delete and block forever</string>
+    <string name="action_find_in_flac">Find in FLAC</string>
+    <string name="action_find_better_match">Find a better match</string>
+    <string name="action_view_lyrics">View lyrics ♪</string>
+    <string name="action_shuffle_library">Shuffle Library</string>
+    <string name="action_play_all_by_artist">Play All by Artist</string>
+    <string name="action_delete_all_by_artist">Delete All by Artist</string>
+    <string name="action_play_album">Play Album</string>
+    <string name="action_stop_sync">Stop sync</string>
+    <string name="action_reauthenticate">Re-authenticate</string>
+    <string name="action_reauthenticate_spotify">Re-authenticate Spotify</string>
+    <string name="action_reauthenticate_youtube">Re-authenticate YouTube</string>
+    <string name="action_switch_to_refresh">Switch to Refresh</string>
+    <string name="action_connect_lastfm">Connect Last.fm</string>
+    <string name="action_finish_connecting">Finish connecting</string>
+    <string name="action_setup_lossless">Set up →</string>
+    <string name="action_retry_yt_sync">Retry YouTube sync</string>
+    <string name="action_reset_lossless_attempts">Reset lossless attempts</string>
+    <string name="action_refresh_quality_info">Refresh quality info</string>
+    <string name="action_remove_image">Remove Image</string>
+    <string name="action_play_both">Play Both</string>
+    <string name="action_got_it">Got it</string>
+    <string name="action_i_understand">I understand</string>
+
+    <!-- ===== Navigation / CD ===== -->
+    <string name="cd_back">Back</string>
+    <string name="cd_close">Close</string>
+    <string name="cd_search">Search</string>
+    <string name="cd_clear_search">Clear search</string>
+    <string name="cd_dismiss">Dismiss</string>
+    <string name="cd_more_actions">More actions</string>
+    <string name="cd_download">Download</string>
+    <string name="cd_downloaded">Downloaded</string>
+    <string name="cd_preview">Preview</string>
+    <string name="cd_stop_preview">Stop preview</string>
+    <string name="cd_preview_match">Preview match</string>
+    <string name="cd_preview_replacement">Preview replacement</string>
+    <string name="cd_approve_match">Approve match</string>
+    <string name="cd_swap_match">Swap to this match</string>
+    <string name="cd_unflag_match">Unflag (keep current match)</string>
+    <string name="cd_save_preset">Save preset</string>
+    <string name="cd_save_to_playlist">Save to Playlist</string>
+    <string name="cd_queue">Queue</string>
+    <string name="cd_flag_wrong_match">Flag as wrong match</string>
+    <string name="cd_open_artist">Open artist</string>
+    <string name="cd_open_lyrics">Open lyrics</string>
+    <string name="cd_open_browser">Open browser</string>
+    <string name="cd_copy_code">Copy code</string>
+    <string name="cd_filter_tracks">Filter tracks</string>
+    <string name="cd_set_cover_image">Set cover image</string>
+    <string name="cd_shuffle">Shuffle</string>
+    <string name="cd_previous">Previous</string>
+    <string name="cd_next">Next</string>
+    <string name="cd_repeat">Repeat</string>
+    <string name="cd_streaming">Streaming</string>
+    <string name="cd_album_art">Album art</string>
+    <string name="cd_drag_to_reorder">Drag to reorder</string>
+    <string name="cd_clear_filter">Clear filter</string>
+    <string name="cd_waiting_lossless">Waiting for lossless source</string>
+    <string name="cd_dismiss_lossless_banner">Dismiss lossless banner</string>
+    <string name="cd_join_discord">Join the Stash Discord</string>
+    <string name="cd_report_issue">Report an issue on GitHub</string>
+    <string name="cd_supporters_kofi">Supporters on Ko-fi</string>
+    <string name="cd_app_logo">Stash</string>
+    <string name="cd_play_all_mixes">Play all %1$s mixes</string>
+    <string name="cd_play_both_mixes">Play mixes from both services</string>
+
+    <!-- ===== Titles ===== -->
+    <string name="title_settings">Settings</string>
+    <string name="title_playback">Playback</string>
+    <string name="title_playback_mode">Playback Mode</string>
+    <string name="title_audio_quality">Audio &amp; Quality</string>
+    <string name="title_accounts_sync">Accounts &amp; Sync</string>
+    <string name="title_library_storage">Library &amp; Storage</string>
+    <string name="title_appearance">Appearance</string>
+    <string name="title_about_help">About &amp; Help</string>
+    <string name="title_library">Library</string>
+    <string name="title_sync">Sync</string>
+    <string name="title_sync_time">Sync time</string>
+    <string name="title_equalizer">Equalizer</string>
+    <string name="title_library_health">Library Health</string>
+    <string name="title_blocked_songs">Blocked Songs</string>
+    <string name="title_failed_downloads">Failed Downloads</string>
+    <string name="title_lyrics">Lyrics</string>
+    <string name="title_up_next">Up Next</string>
+    <string name="title_support_stash">Support Stash</string>
+    <string name="title_diagnostics">Diagnostics</string>
+    <string name="title_connect_arcod">Connect ARCOD</string>
+    <string name="title_verify_captcha">Verify squid.wtf captcha</string>
+    <string name="title_search_prompt">Search YouTube Music</string>
+
+    <!-- ===== Dialog Titles ===== -->
+    <string name="dialog_title_delete_playlist">Delete %1$s?</string>
+    <string name="dialog_title_delete_songs">Delete %1$d song(s)?</string>
+    <string name="dialog_title_delete_track">Delete %1$s?</string>
+    <string name="dialog_title_delete_artist">Delete all by %1$s?</string>
+    <string name="dialog_title_remove_liked">Remove %1$d song(s) from Liked Songs?</string>
+    <string name="dialog_title_batch_delete">Delete %1$d song(s) from library?</string>
+    <string name="dialog_title_batch_remove">Remove %1$d song(s)</string>
+    <string name="dialog_title_overwrite_library">Overwrite Library &amp; Settings?</string>
+    <string name="dialog_title_wrong_match">What\'s wrong with this song?</string>
+    <string name="dialog_title_stop_retrying">Stop retrying this song?</string>
+    <string name="dialog_title_switch_refresh">Switch to Refresh?</string>
+    <string name="dialog_title_download_all">Download all?</string>
+    <string name="dialog_title_connect_spotify">Connect Spotify</string>
+    <string name="dialog_title_connect_youtube">Connect YouTube Music</string>
+    <string name="dialog_title_yt_credentials">YouTube Music Credentials</string>
+    <string name="dialog_title_yt_history">Send your Stash plays to YouTube Music?</string>
+    <string name="dialog_title_mirror_likes">Mirror likes to %1$s?</string>
+    <string name="dialog_title_save_preset">Save Preset</string>
+    <string name="dialog_title_streaming_disclosure">Online streaming</string>
+
+    <!-- ===== Dialog Bodies ===== -->
+    <string name="dialog_body_delete_playlist">This will delete downloaded songs in this playlist from your device.</string>
+    <string name="dialog_body_delete_playlist_cascade">%1$s song(s) will be deleted. %2$s protected song(s) will stay.</string>
+    <string name="dialog_body_delete_songs">%1$d song(s) will be removed from your library. This cannot be undone.</string>
+    <string name="dialog_body_delete_track_library">This track will be deleted from your library. This cannot be undone.</string>
+    <string name="dialog_body_delete_track_playlist">Removes the song from this playlist. Downloaded files stay on disk.</string>
+    <string name="dialog_body_delete_artist">This will delete all %1$d downloaded songs by this artist.</string>
+    <string name="dialog_body_delete_playlist_permanent">%1$s and all its tracks will be removed from your library.</string>
+    <string name="dialog_body_remove_liked">Removes the song(s) from Liked Songs.</string>
+    <string name="dialog_body_batch_delete_library">These tracks will be deleted from your library. This cannot be undone.</string>
+    <string name="dialog_body_batch_delete_playlist">Removes the songs from this playlist. Downloaded files stay on disk.</string>
+    <string name="dialog_body_overwrite_library">This will completely replace your existing library and settings with the backup data.</string>
+    <string name="dialog_body_wrong_match">Pick what should happen to \'%1$s\'.</string>
+    <string name="dialog_body_stop_retrying">\'%1$s\' won\'t be downloaded and will be removed from failed downloads.</string>
+    <string name="dialog_body_switch_refresh">Refresh pulls fresh tracks each sync. Your existing offline tracks stay untouched. Switch now?</string>
+    <string name="dialog_body_all_downloaded">All tracks already downloaded.</string>
+    <string name="dialog_body_download_count">Download %1$d track(s) to your library?</string>
+    <string name="dialog_body_spotify_cookie">Log into Spotify in a real browser, grab your sp_dc cookie, and paste it below.</string>
+    <string name="dialog_body_yt_cookie">Paste your YouTube Music cookies to connect.</string>
+    <string name="dialog_body_yt_credentials">Enter your Google Cloud OAuth credentials to connect YouTube Music.</string>
+    <string name="dialog_body_yt_history">Every track you finish listening to in Stash will be sent to your YouTube Music history.</string>
+    <string name="dialog_body_mirror_likes">Hearting a track in Stash will also Like it in %1$s. This cannot be undone for past hearts.</string>
+    <string name="dialog_body_streaming_disclosure">Stash streams via a community Qobuz proxy. Streaming quality depends on the proxy. Downloads are not affected.</string>
+
+    <!-- ===== Labels ===== -->
+    <string name="label_spotify">Spotify</string>
+    <string name="label_youtube_music">YouTube Music</string>
+    <string name="label_youtube">YouTube</string>
+    <string name="label_liked_songs">Liked Songs</string>
+    <string name="label_no_matching_songs">No matching songs</string>
+    <string name="label_no_tracks_found">No tracks found</string>
+    <string name="label_no_tracks_available">No tracks available</string>
+    <string name="label_no_liked_songs">No liked songs yet</string>
+    <string name="label_no_blocked_songs">No blocked songs</string>
+    <string name="label_no_failed_downloads">No failed downloads.</string>
+    <string name="label_no_unmatched_songs">No unmatched songs.</string>
+    <string name="label_no_match_found">No match found</string>
+    <string name="label_no_replacement">No replacement found</string>
+    <string name="label_no_upcoming_tracks">No upcoming tracks</string>
+    <string name="label_no_lyrics_found">No lyrics found</string>
+    <string name="label_lyrics_load_error">Couldn\'t load lyrics</string>
+    <string name="label_no_results">No results found</string>
+    <string name="label_no_playlists_match">No playlists matching \"%1$s\"</string>
+    <string name="label_no_downloaded_tracks">No downloaded tracks yet. Run a sync first.</string>
+    <string name="label_no_details">No additional details available</string>
+    <string name="label_all_caught_up">All caught up!</string>
+    <string name="label_flagged_wrong">You flagged these as wrong</string>
+    <string name="label_empty_tracks_synced">Sync your library to see tracks here</string>
+    <string name="label_empty_tracks_no_service">Connect a service in Settings to see your tracks</string>
+    <string name="label_also_block_songs">Also block these songs from future syncs</string>
+    <string name="label_also_block_song">Also block this song from future syncs</string>
+    <string name="label_powered_by">Powered by </string>
+    <string name="label_mix_name_optional">Mix name (optional)</string>
+    <string name="label_familiar">Familiar</string>
+    <string name="label_brand_new">Brand new</string>
+    <string name="label_beta">Beta</string>
+    <string name="label_routing">ROUTING</string>
+    <string name="label_dark">Dark</string>
+    <string name="label_light">Light</string>
+    <string name="label_follow_system">Follow system</string>
+    <string name="label_download_quality">Download quality</string>
+    <string name="label_lossless_downloads">Lossless downloads</string>
+    <string name="label_direct_qobuz">Direct Qobuz</string>
+    <string name="label_account">Account</string>
+    <string name="label_auto">Auto</string>
+    <string name="label_paste_token">Paste token</string>
+    <string name="label_on_wifi">On Wi-Fi</string>
+    <string name="label_on_cellular">On cellular</string>
+    <string name="label_save_data">Save Data</string>
+    <string name="label_youtube_fallback">YouTube fallback</string>
+    <string name="label_use_youtube_fallback">Use YouTube when lossless fails</string>
+    <string name="label_advanced">Advanced</string>
+    <string name="label_captcha_verified_at">captcha_verified_at value</string>
+    <string name="label_playback">Playback</string>
+    <string name="label_audio_quality">Audio &amp; Quality</string>
+    <string name="label_accounts_sync">Accounts &amp; Sync</string>
+    <string name="label_library_storage">Library &amp; Storage</string>
+    <string name="label_appearance">Appearance</string>
+    <string name="label_about_help">About &amp; Help</string>
+    <string name="label_library_health">Library Health</string>
+    <string name="label_total_tracks">Total tracks</string>
+    <string name="label_storage_used">Storage used</string>
+    <string name="label_download_location">Download location</string>
+    <string name="label_existing_library">Existing library</string>
+    <string name="label_backup">Backup</string>
+    <string name="label_total_downloaded">Total downloaded</string>
+    <string name="label_version">Version</string>
+    <string name="label_license">License</string>
+    <string name="label_share_crash_report">Share latest crash report</string>
+    <string name="label_share_diagnostics">Share diagnostics</string>
+    <string name="label_scrobble_plays">Scrobble your plays</string>
+    <string name="label_sync_likes">Sync your likes</string>
+    <string name="label_send_plays_yt">Send plays to YouTube Music</string>
+    <string name="label_connect_yt_first">Connect YouTube Music first</string>
+    <string name="label_how_it_works">How it works</string>
+    <string name="label_risk">Risk</string>
+    <string name="label_auto_save_liked">Auto-save liked tracks</string>
+    <string name="label_auto_save_threshold">Threshold: %1$d day(s) in 30</string>
+    <string name="label_auto_save_last_7_days">Last 7 days: %1$d tracks auto-saved</string>
+    <string name="label_how_to_get_cookie">How to get your sp_dc cookie:</string>
+    <string name="label_how_to_get_cookies">How to get your cookies:</string>
+    <string name="label_sp_dc_cookie">sp_dc cookie</string>
+    <string name="label_spotify_username_optional">Spotify username (optional)</string>
+    <string name="label_signin_blocked">Sign-in blocked or not working?</string>
+    <string name="label_client_id">Client ID</string>
+    <string name="label_client_secret">Client Secret</string>
+    <string name="label_cookie">Cookie</string>
+    <string name="label_stream_cellular">Stream on cellular</string>
+    <string name="label_stream_youtube">Stream via YouTube</string>
+    <string name="label_stream_amz">Stream via amz (test)</string>
+    <string name="label_force_qobuz">Force Direct Qobuz only (test)</string>
+    <string name="label_crossfade">Crossfade</string>
+    <string name="label_duration">Duration</string>
+    <string name="label_repeat_on">REPEAT ON</string>
+    <string name="label_not_scheduled">Not scheduled — pick at least one day</string>
+    <string name="label_last_sync">LAST SYNC</string>
+    <string name="label_last_sync_time">Last sync %1$s</string>
+    <string name="label_tracks">Tracks</string>
+    <string name="label_storage">Storage</string>
+    <string name="label_error_prefix">Error: %1$s</string>
+    <string name="label_diagnostics">Diagnostics:</string>
+    <string name="label_blocked_songs">Blocked Songs</string>
+    <string name="label_failed_downloads">Failed Downloads</string>
+    <string name="label_mix_sync_mode">Mix sync mode</string>
+    <string name="label_studio_recordings_only">Studio recordings only</string>
+    <string name="label_stash_mixes_beta">Stash Mixes (beta)</string>
+    <string name="label_run_recommendations">Run recommendations when</string>
+    <string name="label_streaming_unavailable">Streaming is unavailable in this build.</string>
+
+    <!-- ===== Descriptions ===== -->
+    <string name="desc_blocked_songs_hint">Blocked songs never re-download. Unblock them in Settings later.</string>
+    <string name="desc_sync_to_start">Sync your library to get started</string>
+    <string name="desc_try_different_search">Try a different search term</string>
+    <string name="desc_search_prompt">Find any song or artist and download it to your library</string>
+    <string name="desc_support_stash">If Stash replaced a subscription for you, consider supporting its development.</string>
+    <string name="desc_follow_system">Follow system matches your device\'s day/night setting.</string>
+    <string name="desc_lossless_active">FLAC routing active. Files ~10× larger than MP3.</string>
+    <string name="desc_lossless_inactive">Studio-quality FLAC via Qobuz. Files ~10× larger than MP3.</string>
+    <string name="desc_direct_qobuz">Hi-Res FLAC, straight from Qobuz.</string>
+    <string name="desc_auto_token">Recommended — uses a working account and fails over</string>
+    <string name="desc_save_data">Request the lowest streaming quality on every network when enabled.</string>
+    <string name="desc_stream_cellular">Allow streaming over mobile data (5G / LTE). Disable to stream on Wi-Fi only.</string>
+    <string name="desc_stream_youtube">Skip the lossless sources (Qobuz) and stream directly from YouTube.</string>
+    <string name="desc_stream_amz">Route streaming AND downloads through amz.squid.wtf instead of Qobuz proxies.</string>
+    <string name="desc_force_qobuz">Route streaming AND downloads through Direct Qobuz only. No fallback.</string>
+    <string name="desc_crossfade">Fade the ending track into the next on auto-advance. Adjust duration below.</string>
+    <string name="desc_loudness_normalization">Plays every track at a consistent volume.</string>
+    <string name="desc_loudness_backfill">Continues automatically while charging.</string>
+    <string name="desc_blocked_songs_empty">Songs you block with \"Delete &amp; Block\" show up here. They skip during every sync.</string>
+    <string name="desc_blocked_songs_header">These songs are skipped during every sync. Unblock any to allow them again.</string>
+    <string name="desc_lastfm_no_api_key">This build of Stash doesn\'t include a Last.fm API key. Last.fm scrobbling isn\'t available.</string>
+    <string name="desc_lastfm_awaiting_auth">Your browser should be open on Last.fm. Approve Stash to finish connecting.</string>
+    <string name="desc_like_mirror">Mirror hearts to your accounts. Heart a track in Stash, it hearts in your service too.</string>
+    <string name="desc_yt_history_how">Stash uses an unofficial YouTube endpoint to send your listening history.</string>
+    <string name="desc_yt_history_risk">Rare but not zero chance of YouTube rate-limiting or flagging the activity.</string>
+    <string name="desc_spotify_cookie_steps">Easiest on a computer:\n1. Open open.spotify.com and log in\n2. Press F12 → Application → Cookies\n3. Copy the value of sp_dc</string>
+    <string name="desc_yt_cookie_steps">1. Open a Private/Incognito window\n2. Go to music.youtube.com and log in\n3. Press F12 → Application → Cookies\n4. Copy all cookies as JSON</string>
+    <string name="desc_spotify_username_hint">Find at spotify.com/account under \'Username\'</string>
+    <string name="desc_device_code_prompt">Go to the URL below and enter this code:</string>
+    <string name="desc_paste_captcha_cookie">Or paste the captcha_verified_at cookie value directly:</string>
+    <string name="desc_backup">Export settings and database or import from a previous backup.</string>
+    <string name="desc_external_storage">Tracks are stored in this folder. Changing location does not move existing files.</string>
+    <string name="desc_new_downloads_location">New downloads go to the selected location. Existing files stay where they are.</string>
+    <string name="desc_move_failed">Failed tracks stay in internal storage. Try again later.</string>
+    <string name="desc_re_extract_quality">Re-extract bit-depth + sample-rate for FLAC tracks. Takes a few minutes.</string>
+    <string name="desc_library_health">Format and bitrate breakdown of your downloaded library.</string>
+    <string name="desc_share_diagnostics">Bundle recent logs, sync history, and connection status for troubleshooting.</string>
+    <string name="desc_diagnostics_review">Review what will be shared. No passwords or tokens are included.</string>
+    <string name="desc_lossless_routing">Lossless streams from Direct Qobuz — the fastest path to FLAC.</string>
+    <string name="desc_streaming_mode">Switch between streaming and downloaded-only playback.</string>
+    <string name="desc_retagging_progress">Adding album art and metadata to existing files</string>
+    <string name="desc_retagging_saf_skipped">%1$d tracks on external storage couldn\'t be tagged. Move them to internal storage and try again.</string>
+    <string name="desc_tap_chip_to_change">Tap any chip to change</string>
+    <string name="desc_connect_service">Connect Spotify or YouTube Music in Settings to begin syncing your library.</string>
+    <string name="desc_tap_sync_now">Tap Sync Now to download your playlists and tracks.</string>
+    <string name="desc_tap_resync">Tap resync above to find replacements for flagged tracks.</string>
+    <string name="desc_tap_resync_replacements">Tap Resync to find replacements</string>
+    <string name="desc_empty_spotify">Your Spotify playlists and daily mixes will appear here once connected.</string>
+    <string name="desc_empty_youtube">Your Home Mixes, Liked Songs, and playlists from YouTube Music will appear here.</string>
+    <string name="desc_studio_recordings_only">Excludes covers, live recordings, and UGC uploads from sync results.</string>
+    <string name="desc_mix_edit_hint">Try editing this mix with different genres or moods.</string>
+    <string name="desc_building_mix">Finding fresh tracks from your genres and moods…</string>
+    <string name="desc_lossless_prompt">Studio-quality FLAC downloads via Qobuz. Tap to set up.</string>
+
+    <!-- ===== Status Messages ===== -->
+    <string name="status_building">Building…</string>
+    <string name="status_building_mix">Building your mix…</string>
+    <string name="status_mix_no_tracks">Couldn\'t find tracks</string>
+    <string name="status_library_retagged">Library re-tagged</string>
+    <string name="status_retagging_library">Re-tagging library</string>
+    <string name="status_login_successful">Login successful, connecting…</string>
+    <string name="status_waiting_auth">Waiting for authorization…</string>
+    <string name="status_scanning">Scanning… %1$d / %2$d</string>
+    <string name="status_scan_complete">Scan complete: %1$d of %2$d tracks processed</string>
+    <string name="status_exporting_db">Exporting Database</string>
+    <string name="status_importing_db">Importing Database</string>
+    <string name="status_importing_progress">Importing %1$s of %2$s…</string>
+    <string name="status_success">Success</string>
+    <string name="status_error">Error</string>
+    <string name="status_processing">Processing…</string>
+    <string name="status_moving_library">Moving %1$d of %2$d…</string>
+    <string name="status_active">active</string>
+    <string name="status_fallback">fallback</string>
+    <string name="status_arcod_connected">Connected — saving and closing.</string>
+    <string name="status_captcha_saved">Got it — saving and closing.</string>
+    <string name="status_lastfm_not_configured">Not configured</string>
+    <string name="status_lastfm_waiting">Waiting for approval</string>
+    <string name="status_lastfm_connected">Connected as %1$s</string>
+    <string name="status_lastfm_pending">Scrobbling your plays. %1$d queued. Waiting for network.</string>
+    <string name="status_lastfm_up_to_date">Scrobbling your plays. Everything up to date.</string>
+
+    <!-- ===== Errors ===== -->
+    <string name="error_load_album">Couldn\'t load album</string>
+    <string name="error_load_artist">Couldn\'t load artist</string>
+    <string name="error_search_failed">Search failed</string>
+    <string name="error_move_library">Couldn\'t move library</string>
+    <string name="error_import_failed">Import failed</string>
+    <string name="error_lastfm_connect">Couldn\'t connect</string>
+    <string name="error_no_working_token">No working token — paste a fresh one</string>
+    <string name="error_signin_expired_group">Sign-in expired</string>
+    <string name="error_signin_expired_short">Sign-in expired</string>
+    <string name="error_storage_unreachable_group">Storage unreachable</string>
+    <string name="error_storage_unreachable_short">Storage error</string>
+    <string name="error_network_errors_group">Network errors</string>
+    <string name="error_network_errors_short">Network error</string>
+    <string name="error_source_unavailable_group">Source unavailable</string>
+    <string name="error_source_unavailable_short">Source unavailable</string>
+    <string name="error_encoding_errors_group">Encoding errors</string>
+    <string name="error_encoding_errors_short">Encoding error</string>
+    <string name="error_other_errors_group">Other errors</string>
+    <string name="error_unknown_short">Unknown error</string>
+
+    <!-- ===== Sections ===== -->
+    <string name="section_your_mixes">Your Mixes</string>
+    <string name="section_your_collection">YOUR COLLECTION</string>
+    <string name="section_recently_added">Recently Added</string>
+    <string name="section_playlists">Playlists</string>
+    <string name="section_spotify_mixes">Spotify Mixes</string>
+    <string name="section_your_playlists">Your Playlists</string>
+    <string name="section_home_mixes">Home Mixes</string>
+    <string name="section_other_playlists">Other Playlists</string>
+    <string name="section_stash_mixes">Stash Mixes  (Beta)</string>
+    <string name="section_recent_searches">Recent searches</string>
+    <string name="section_more_by_artist">More by this artist</string>
+    <string name="section_popular">Popular</string>
+    <string name="section_albums">Albums</string>
+    <string name="section_singles_eps">Singles &amp; EPs</string>
+    <string name="section_fans_also_like">Fans also like</string>
+    <string name="section_library_breakdown">Library breakdown</string>
+    <string name="section_backfill_metadata">Backfill metadata</string>
+    <string name="section_quality_info">Quality info</string>
+
+    <!-- ===== Hints / Placeholders ===== -->
+    <string name="hint_search">Search songs, artists…</string>
+    <string name="hint_search_settings">Search settings</string>
+    <string name="hint_paste_sp_dc_cookie">Paste your sp_dc cookie here</string>
+    <string name="hint_spotify_username">Your Spotify username</string>
+    <string name="hint_paste_cookie">Paste your cookie here</string>
+    <string name="hint_user_auth_token">user_auth_token</string>
+    <string name="hint_captcha_value">e.g. 1777687404951</string>
+
+    <!-- ===== Notifications (existing from core/media) ===== -->
+    <string name="notification_action_like">Add to Liked Songs</string>
+    <string name="notification_action_unlike">Remove from Liked Songs</string>
+    <string name="notification_action_repeat_off">Repeat Off</string>
+    <string name="notification_action_repeat_all">Repeat All</string>
+    <string name="notification_action_repeat_one">Repeat One</string>
+    <string name="notification_action_shuffle_on">Shuffle On</string>
+    <string name="notification_action_shuffle_off">Shuffle Off</string>
+    <string name="shuffle_play">Shuffle Play</string>
+    <string name="resuming_channel_name">Playback</string>
+    <string name="resuming_notification_title">Resuming…</string>
+    <string name="resume_playback_short">Resume</string>
+    <string name="resume_playback_long">Resume playback</string>
+
+    <!-- ===== Prompts ===== -->
+    <string name="prompt_try_lossless">Try lossless audio</string>
+
+    <!-- ===== Bottom Navigation ===== -->
+    <string name="nav_home">Home</string>
+    <string name="nav_library">Library</string>
+    <string name="nav_search">Search</string>
+    <string name="nav_sync">Sync</string>
+    <string name="nav_settings">Settings</string>
+
+    <!-- ===== Playback Modes ===== -->
+    <string name="mode_online">Online</string>
+    <string name="mode_offline">Offline</string>
+
+    <!-- ===== Sort / Filter Labels ===== -->
+    <string name="sort_recently_added">Recently Added</string>
+    <string name="sort_alphabetical">A–Z</string>
+    <string name="sort_most_played">Most Played</string>
+    <string name="filter_all">All</string>
+    <string name="filter_youtube">YouTube</string>
+    <string name="filter_spotify">Spotify</string>
+    <string name="filter_flac">FLAC</string>
+    <string name="filter_local">Local</string>
+
+    <!-- ===== Library Tabs ===== -->
+    <string name="tab_playlists">Playlists</string>
+    <string name="tab_tracks">Tracks</string>
+    <string name="tab_artists">Artists</string>
+    <string name="tab_albums">Albums</string>
+
+    <!-- ===== Connection / Sync States ===== -->
+    <string name="status_never_synced">Never synced</string>
+    <string name="status_no_services_connected">No services connected</string>
+    <string name="status_ready_to_sync">Ready to sync</string>
+    <string name="status_syncing">Syncing…</string>
+    <string name="status_synced">Synced</string>
+    <string name="status_sync_failed">Sync failed</string>
+    <string name="status_sync_interrupted">Interrupted</string>
+    <string name="status_sync_interrupted_count">Interrupted — %1$d saved</string>
+    <string name="status_partial_sync">Partially synced — %1$d saved, %2$d failed</string>
+    <string name="status_connected">Connected</string>
+    <string name="status_disconnected">Disconnected</string>
+    <string name="status_not_connected">Not connected</string>
+    <string name="status_nothing_to_sync">Nothing to sync</string>
+    <string name="status_checking_updates">Checking for updates…</string>
+    <string name="status_no_crash_report">No crash report to share.</string>
+    <string name="status_no_app_available">No app available to share the report.</string>
+
+    <!-- ===== Section Headers ===== -->
+    <string name="section_sources">Sources</string>
+    <string name="section_schedule">Schedule</string>
+    <string name="section_library">Library</string>
+    <string name="section_recent_syncs">Recent syncs</string>
+    <string name="section_diagnostics">Diagnostics</string>
+    <string name="section_about">About</string>
+    <string name="section_connections">Connections</string>
+    <string name="section_theme">Theme</string>
+    <string name="section_audio_quality">Audio Quality</string>
+    <string name="section_lossless">Lossless</string>
+    <string name="section_streaming">Streaming</string>
+    <string name="section_effects">Effects</string>
+    <string name="section_mode">Mode</string>
+    <string name="section_downloads">Downloads</string>
+    <string name="section_storage">Storage</string>
+    <string name="section_5band_eq">5-Band EQ</string>
+    <string name="section_bass_boost">Bass Boost</string>
+    <string name="section_loudness_normalization">Loudness Normalization</string>
+    <string name="section_preamp">Pre-amp</string>
+    <string name="section_songs">Songs</string>
+    <string name="section_artists">Artists</string>
+
+    <!-- ===== Mix Builder ===== -->
+    <string name="label_moods">Moods</string>
+    <string name="label_genres">Genres</string>
+    <string name="label_era_optional">Era · optional</string>
+    <string name="label_discovery_level">Discovery level</string>
+    <string name="label_untitled_mix">Untitled mix</string>
+    <string name="label_no_ingredients">No ingredients yet</string>
+    <string name="label_any_era">Any era</string>
+    <string name="title_edit_mix">Edit Mix</string>
+    <string name="title_create_mix">Create a Mix</string>
+    <string name="action_create_mix_btn">Create mix</string>
+
+    <!-- ===== Save / Like ===== -->
+    <string name="action_save_to">Save to…</string>
+    <string name="action_save_btn">Save</string>
+    <string name="action_create_btn">Create</string>
+    <string name="action_retry">Retry</string>
+    <string name="action_confirm">Confirm</string>
+    <string name="action_share">Share</string>
+    <string name="action_copy">Copy</string>
+    <string name="action_set">Set</string>
+    <string name="action_disconnect">Disconnect</string>
+    <string name="action_refresh">Refresh</string>
+    <string name="action_scan_files">Scan files</string>
+    <string name="action_retry_scan">Retry scan</string>
+    <string name="action_retry_all">Retry all</string>
+    <string name="action_check_updates">Check for updates</string>
+    <string name="action_export_backup">Export Backup</string>
+    <string name="action_overwrite">Overwrite</string>
+    <string name="action_change_image">Change Image</string>
+    <string name="action_add_image">Add Image</string>
+    <string name="action_clear_all">Clear all</string>
+    <string name="action_paste_cookie_instead">Paste cookie instead</string>
+    <string name="action_sync_scrobbles_now">Sync scrobbles now</string>
+    <string name="action_download_tracks">Download Tracks to Device</string>
+    <string name="action_surface_streaming">Surface Library for Streaming</string>
+
+    <!-- ===== Selection Actions ===== -->
+    <string name="selection_queue">Queue</string>
+    <string name="selection_playlist">Playlist</string>
+    <string name="selection_download">Download</string>
+    <string name="selection_delete">Delete</string>
+    <string name="selection_share">Share</string>
+    <string name="selection_more">More</string>
+    <string name="selection_select_all">Select all</string>
+    <string name="selection_add_to_playlist">Add to playlist</string>
+    <string name="selection_remove_download">Remove download</string>
+    <string name="selection_play_next">Play next</string>
+    <string name="selection_exit">Exit selection</string>
+
+    <!-- ===== Player Controls ===== -->
+    <string name="cd_play">Play</string>
+    <string name="cd_pause">Pause</string>
+    <string name="cd_skip">Skip</string>
+    <string name="cd_now_playing">Now playing</string>
+    <string name="cd_more_options">More options</string>
+    <string name="cd_like">Like</string>
+    <string name="cd_unlike">Unlike</string>
+    <string name="cd_retry">Retry</string>
+    <string name="cd_collapse">Collapse</string>
+    <string name="cd_expand">Expand</string>
+    <string name="cd_block">Block</string>
+    <string name="cd_stash_logo">Stash logo</string>
+
+    <!-- ===== Like Destinations ===== -->
+    <string name="like_dest_stash">Stash Liked Songs</string>
+    <string name="like_dest_spotify">Spotify Liked Songs</string>
+    <string name="like_dest_youtube">YouTube Music Liked Music</string>
+
+    <!-- ===== Playlist ===== -->
+    <string name="title_save_to_playlist">Save to Playlist</string>
+    <string name="action_create_new_playlist">Create New Playlist</string>
+    <string name="title_create_playlist_dialog">Create Playlist</string>
+    <string name="hint_playlist_name">Playlist name</string>
+    <string name="hint_preset_name">Preset name</string>
+    <string name="hint_filter_playlists">Filter playlists…</string>
+    <string name="hint_filter_tracks">Filter tracks…</string>
+
+    <!-- ===== Flac Badge ===== -->
+    <string name="badge_flac">FLAC</string>
+    <string name="badge_flac_format">FLAC %1$d/%2$d</string>
+
+    <!-- ===== Search ===== -->
+    <string name="label_artist_type">Artist</string>
+    <string name="label_song_type">Song</string>
+    <string name="label_album_type">Album</string>
+
+    <!-- ===== Quality Tiers ===== -->
+    <string name="quality_max">Max</string>
+    <string name="quality_best">Best</string>
+    <string name="quality_high">High</string>
+    <string name="quality_normal">Normal</string>
+    <string name="quality_low">Low</string>
+    <string name="quality_cd">CD (16-bit/44.1 kHz)</string>
+    <string name="quality_hires">Hi-Res (24-bit/96 kHz)</string>
+    <string name="quality_max_bit">Max (24-bit/192 kHz)</string>
+
+    <!-- ===== EQ Presets ===== -->
+    <string name="eq_flat">Flat</string>
+    <string name="eq_bass_boost">Bass Boost</string>
+    <string name="eq_treble_boost">Treble Boost</string>
+    <string name="eq_vocal">Vocal</string>
+    <string name="eq_rock">Rock</string>
+    <string name="eq_pop">Pop</string>
+    <string name="eq_jazz">Jazz</string>
+    <string name="eq_classical">Classical</string>
+
+    <!-- ===== Download Network ===== -->
+    <string name="network_wifi_charging">Wi-Fi + charging</string>
+    <string name="network_wifi_anytime">Wi-Fi any time</string>
+    <string name="network_any">Any network</string>
+    <string name="network_wifi_charging_desc">Most conservative. Downloads only when on Wi-Fi and plugged in.</string>
+    <string name="network_wifi_anytime_desc">Downloads over Wi-Fi even without a charger.</string>
+    <string name="network_any_desc">Downloads over cellular too. Uses mobile data.</string>
+
+    <!-- ===== Sync Phases ===== -->
+    <string name="sync_phase_authenticating">Authenticating…</string>
+    <string name="sync_phase_fetching">Fetching playlists…</string>
+    <string name="sync_phase_diffing">Comparing changes…</string>
+    <string name="sync_phase_downloading">Downloading %1$s/%2$s…</string>
+    <string name="sync_phase_finalizing">Finalizing…</string>
+    <string name="sync_phase_complete">Complete</string>
+    <string name="sync_phase_error">Error</string>
+
+    <!-- ===== Sync Misc ===== -->
+    <string name="label_auto_sync">Auto-sync</string>
+    <string name="label_daily">Daily</string>
+    <string name="label_weekdays">Weekdays</string>
+    <string name="label_weekends">Weekends</string>
+    <string name="label_wifi_only">Wi-Fi only</string>
+    <string name="label_any_network">any network</string>
+    <string name="label_am">AM</string>
+    <string name="label_pm">PM</string>
+    <string name="label_refresh">Refresh</string>
+    <string name="label_accumulate">Accumulate</string>
+    <string name="desc_mix_refresh">Mixes update with fresh tracks each sync</string>
+    <string name="desc_mix_accumulate">New tracks stack on top of old ones</string>
+    <string name="label_failed_downloads_header">%1$d track%2$s couldn\'t download.</string>
+    <string name="label_blocked_count">%1$d song%2$s will never re-download</string>
+    <string name="label_searching_resync">Searching %1$s…</string>
+    <string name="action_approve_all">Approve All (%1$d)</string>
+    <string name="action_dismiss_all">Dismiss All</string>
+    <string name="label_resync">Resync</string>
+
+    <!-- ===== Failed Matches Tabs ===== -->
+    <string name="tab_songs_to_review">Songs to Review</string>
+    <string name="tab_flagged_songs">Flagged Songs</string>
+    <string name="tab_unmatched_songs">Unmatched Songs</string>
+
+    <!-- ===== Auth Expired ===== -->
+    <string name="auth_signins_expired">Sign-ins expired</string>
+    <string name="auth_signins_expired_desc">Both Spotify and YouTube need fresh sign-ins to resume sync.</string>
+    <string name="auth_spotify_expired">Spotify session expired</string>
+    <string name="auth_spotify_expired_desc">Re-authenticate to include your Spotify library in sync.</string>
+    <string name="auth_youtube_expired">YouTube session expired</string>
+    <string name="auth_youtube_expired_desc">Re-authenticate to include your YouTube library in sync.</string>
+
+    <!-- ===== Sign In ===== -->
+    <string name="title_sign_in_spotify">Sign in to Spotify</string>
+    <string name="title_sign_in_youtube">Sign in to YouTube Music</string>
+
+    <!-- ===== Discover Error ===== -->
+    <string name="error_something_wrong">Something went wrong</string>
+    <string name="error_diagnostics_failed">Failed to build diagnostics</string>
+
+    <!-- ===== Loudness ===== -->
+    <string name="loudness_toast_on">Loudness normalization is on. Tracks will sound more consistent in volume.</string>
+
+    <!-- ===== Library Empty States ===== -->
+    <string name="label_empty_playlists_synced">Sync your playlists to see them here</string>
+    <string name="label_empty_playlists_no_service">Connect a service in Settings to see your playlists</string>
+    <string name="label_empty_artists_synced">Sync your library to see artists here</string>
+    <string name="label_empty_artists_no_service">Connect a service in Settings to see your artists</string>
+    <string name="label_empty_albums_synced">Sync your library to see albums here</string>
+    <string name="label_empty_albums_no_service">Connect a service in Settings to see your albums</string>
+    <string name="label_hide_single_track">Hide single-track albums</string>
+    <string name="label_single_track_count">%1$d albums with 1 track</string>
+
+    <!-- ===== Misc ===== -->
+    <string name="label_not_playing">Not Playing</string>
+    <string name="label_instrumental">♪ Instrumental</string>
+    <string name="label_via_yt">via YT</string>
+    <string name="label_external_folder">External folder</string>
+    <string name="label_internal_storage">Internal (app-private)</string>
+    <string name="label_no_recent_crashes">No recent crashes.</string>
+    <string name="label_crash_report_subject">Stash crash report</string>
+    <string name="label_share_crash_report_title">Share crash report</string>
+    <string name="label_diagnostics_subject">Stash diagnostics</string>
+    <string name="label_share_diagnostics_title">Share diagnostics</string>
+    <string name="label_clipboard_yt_code">YouTube Code</string>
+    <string name="partner_support_kofi">Support on Ko-fi</string>
+    <string name="partner_discord">Discord</string>
+    <string name="label_cellular_on">Cellular on</string>
+    <string name="label_cellular_off">Cellular off</string>
+    <string name="label_unit_tracks">tracks</string>
+    <string name="label_unit_track">track</string>
+    <string name="label_version_format">v%1$s</string>
+</resources>

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
@@ -93,6 +93,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
@@ -205,7 +206,7 @@ fun HomeScreen(
                         id = if (isDark) R.drawable.wordmark_stash_dark
                         else R.drawable.wordmark_stash_light,
                     ),
-                    contentDescription = "Stash",
+                    contentDescription = stringResource(com.stash.core.ui.R.string.cd_app_logo),
                     modifier = Modifier.height(48.dp),
                 )
                 Spacer(modifier = Modifier.weight(1f))
@@ -230,7 +231,7 @@ fun HomeScreen(
                         painter = androidx.compose.ui.res.painterResource(
                             id = R.drawable.ic_discord,
                         ),
-                        contentDescription = "Join the Stash Discord",
+                        contentDescription = stringResource(com.stash.core.ui.R.string.cd_join_discord),
                         tint = androidx.compose.ui.graphics.Color(0xFF5865F2),
                         modifier = Modifier.size(20.dp),
                     )
@@ -242,7 +243,7 @@ fun HomeScreen(
                 ) {
                     androidx.compose.material3.Icon(
                         imageVector = Icons.Filled.Build,
-                        contentDescription = "Report an issue on GitHub",
+                        contentDescription = stringResource(com.stash.core.ui.R.string.cd_report_issue),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(20.dp),
                     )
@@ -319,7 +320,7 @@ fun HomeScreen(
             if (uiState.spotifyMixes.isNotEmpty()) {
                 item {
                     SourceSubHeader(
-                        label = "Spotify",
+                        label = stringResource(com.stash.core.ui.R.string.label_spotify),
                         source = MusicSource.SPOTIFY,
                         onPlayAll = { viewModel.playAllMixes(MusicSource.SPOTIFY) },
                     )
@@ -344,7 +345,7 @@ fun HomeScreen(
             if (uiState.youtubeMixes.isNotEmpty()) {
                 item {
                     SourceSubHeader(
-                        label = "YouTube Music",
+                        label = stringResource(com.stash.core.ui.R.string.label_youtube_music),
                         source = MusicSource.YOUTUBE,
                         onPlayAll = { viewModel.playAllMixes(MusicSource.YOUTUBE) },
                     )
@@ -376,7 +377,7 @@ fun HomeScreen(
         // for a user with zero mixes. When mixes exist the layout is
         // identical to before — they render first, Create tile last.
         item {
-            SectionHeader(title = "Stash Mixes  (Beta)")
+            SectionHeader(title = stringResource(com.stash.core.ui.R.string.section_stash_mixes))
         }
         item {
             LazyRow(
@@ -412,7 +413,7 @@ fun HomeScreen(
         // ── Recently Added ───────────────────────────────────────────
         if (uiState.recentlyAdded.isNotEmpty()) {
             item {
-                SectionHeader(title = "Recently Added")
+                SectionHeader(title = stringResource(com.stash.core.ui.R.string.section_recently_added))
             }
             item {
                 LazyRow(
@@ -465,7 +466,7 @@ fun HomeScreen(
         // Always rendered so the Create Playlist card is available even when
         // the user has no custom playlists yet.
         item {
-            SectionHeader(title = "Playlists")
+            SectionHeader(title = stringResource(com.stash.core.ui.R.string.section_playlists))
         }
         item {
             PlaylistSortChipRow(
@@ -602,7 +603,7 @@ fun HomeScreen(
             if (playlist.type == PlaylistType.STASH_MIX) {
                 HomeBottomSheetActionRow(
                     icon = Icons.Default.Refresh,
-                    label = "Refresh this mix",
+                    label = stringResource(com.stash.core.ui.R.string.action_refresh_mix),
                     onClick = {
                         viewModel.refreshMix(playlist.id)
                         selectedPlaylist = null
@@ -616,7 +617,7 @@ fun HomeScreen(
             if (uiState.customMixPlaylistIds.contains(playlist.id)) {
                 HomeBottomSheetActionRow(
                     icon = Icons.Default.Edit,
-                    label = "Edit mix",
+                    label = stringResource(com.stash.core.ui.R.string.action_edit_mix),
                     onClick = {
                         // Resolve the recipe id async, then route to the
                         // builder. Dismiss the sheet immediately.
@@ -628,7 +629,7 @@ fun HomeScreen(
                 )
                 HomeBottomSheetActionRow(
                     icon = Icons.Default.Delete,
-                    label = "Delete mix",
+                    label = stringResource(com.stash.core.ui.R.string.action_delete),
                     tint = MaterialTheme.colorScheme.error,
                     onClick = {
                         viewModel.deleteCustomMix(playlist)
@@ -638,7 +639,7 @@ fun HomeScreen(
             }
             HomeBottomSheetActionRow(
                 icon = Icons.Default.PlayArrow,
-                label = "Play All",
+                label = stringResource(com.stash.core.ui.R.string.action_play_all),
                 onClick = {
                     viewModel.playPlaylist(playlist)
                     selectedPlaylist = null
@@ -646,7 +647,7 @@ fun HomeScreen(
             )
             HomeBottomSheetActionRow(
                 icon = Icons.Default.PlaylistAdd,
-                label = "Add to Queue",
+                label = stringResource(com.stash.core.ui.R.string.action_add_to_queue),
                 onClick = {
                     viewModel.addPlaylistToQueue(playlist)
                     selectedPlaylist = null
@@ -654,7 +655,7 @@ fun HomeScreen(
             )
             HomeBottomSheetActionRow(
                 icon = Icons.Default.Download,
-                label = "Download All",
+                label = stringResource(com.stash.core.ui.R.string.action_download_all),
                 onClick = {
                     viewModel.queueDownloadsForPlaylist(playlist)
                     selectedPlaylist = null
@@ -662,7 +663,7 @@ fun HomeScreen(
             )
             HomeBottomSheetActionRow(
                 icon = Icons.Default.DownloadDone,
-                label = "Remove Downloads",
+                label = stringResource(com.stash.core.ui.R.string.action_remove_downloads),
                 onClick = {
                     viewModel.removeDownloadsForPlaylist(playlist)
                     selectedPlaylist = null
@@ -670,7 +671,7 @@ fun HomeScreen(
             )
             HomeBottomSheetActionRow(
                 icon = Icons.Default.RemoveCircleOutline,
-                label = "Remove Playlist",
+                label = stringResource(com.stash.core.ui.R.string.action_remove_playlist),
                 onClick = {
                     viewModel.removePlaylist(playlist)
                     selectedPlaylist = null
@@ -678,7 +679,7 @@ fun HomeScreen(
             )
             HomeBottomSheetActionRow(
                 icon = Icons.Default.Delete,
-                label = "Delete Playlist & Songs",
+                label = stringResource(com.stash.core.ui.R.string.action_delete_playlist_and_songs),
                 tint = MaterialTheme.colorScheme.error,
                 onClick = {
                     playlistToDelete = playlist
@@ -704,15 +705,15 @@ fun HomeScreen(
 
         androidx.compose.material3.AlertDialog(
             onDismissRequest = { playlistToDelete = null },
-            title = { Text("Delete ${playlist.name}?") },
+            title = { Text(stringResource(com.stash.core.ui.R.string.dialog_title_delete_playlist, playlist.name)) },
             text = {
                 Column {
                     val p = preview
                     Text(
                         text = when {
-                            p == null -> "This will delete downloaded songs in this playlist from your device."
-                            p.protectedCount == 0 -> "This will delete ${p.willDelete} downloaded song${if (p.willDelete != 1) "s" else ""} from your device."
-                            else -> "${p.willDelete} song${if (p.willDelete != 1) "s" else ""} will be deleted. ${p.protectedCount} ${if (p.protectedCount != 1) "are also in" else "is also in"} Liked Songs or a custom playlist and will stay."
+                            p == null -> stringResource(com.stash.core.ui.R.string.dialog_body_delete_playlist)
+                            p.protectedCount == 0 -> stringResource(com.stash.core.ui.R.string.dialog_body_delete_playlist_cascade, p.willDelete, 0)
+                            else -> stringResource(com.stash.core.ui.R.string.dialog_body_delete_playlist_cascade, p.willDelete, p.protectedCount)
                         },
                     )
                     Spacer(modifier = Modifier.height(12.dp))
@@ -727,11 +728,11 @@ fun HomeScreen(
                         Spacer(modifier = Modifier.width(4.dp))
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
-                                text = "Also block these songs from future syncs",
+                                text = stringResource(com.stash.core.ui.R.string.label_also_block_songs),
                                 style = MaterialTheme.typography.bodyMedium,
                             )
                             Text(
-                                text = "Blocked songs never re-download. Unblock them in Settings later.",
+                                text = stringResource(com.stash.core.ui.R.string.desc_blocked_songs_hint),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -747,14 +748,14 @@ fun HomeScreen(
                     },
                 ) {
                     Text(
-                        text = if (alsoBlacklist) "Delete & Block" else "Delete",
+                        text = if (alsoBlacklist) stringResource(com.stash.core.ui.R.string.action_delete_and_block) else stringResource(com.stash.core.ui.R.string.action_delete),
                         color = MaterialTheme.colorScheme.error,
                     )
                 }
             },
             dismissButton = {
                 androidx.compose.material3.TextButton(onClick = { playlistToDelete = null }) {
-                    Text("Cancel")
+                    Text(stringResource(com.stash.core.ui.R.string.action_cancel))
                 }
             },
         )
@@ -849,13 +850,13 @@ private fun DailyMixCard(
                                 strokeWidth = 1.5.dp,
                             )
                             Text(
-                                text = "Building…",
+                                text = stringResource(com.stash.core.ui.R.string.status_building),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = Color.White.copy(alpha = 0.75f),
                             )
                         }
                         MixBuildState.EMPTY -> Text(
-                            text = "No tracks found",
+                            text = stringResource(com.stash.core.ui.R.string.label_no_tracks_found),
                             style = MaterialTheme.typography.bodySmall,
                             color = Color.White.copy(alpha = 0.75f),
                         )
@@ -970,7 +971,7 @@ private fun MixesSectionHeader(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = "Your Mixes",
+            text = stringResource(com.stash.core.ui.R.string.section_your_mixes),
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onBackground,
         )
@@ -993,12 +994,12 @@ private fun MixesSectionHeader(
                 ) {
                     Icon(
                         imageVector = Icons.Default.PlayArrow,
-                        contentDescription = "Play mixes from both services",
+                        contentDescription = stringResource(com.stash.core.ui.R.string.cd_play_both_mixes),
                         tint = accent,
                         modifier = Modifier.size(16.dp),
                     )
                     Text(
-                        text = "Play Both",
+                        text = stringResource(com.stash.core.ui.R.string.action_play_both),
                         style = MaterialTheme.typography.labelSmall,
                         color = accent,
                     )
@@ -1067,12 +1068,12 @@ private fun SourceSubHeader(
                 ) {
                     Icon(
                         imageVector = Icons.Default.PlayArrow,
-                        contentDescription = "Play all $label mixes",
+                        contentDescription = stringResource(com.stash.core.ui.R.string.cd_play_all_mixes, label),
                         tint = accent,
                         modifier = Modifier.size(16.dp),
                     )
                     Text(
-                        text = "Play All",
+                        text = stringResource(com.stash.core.ui.R.string.action_play_all),
                         style = MaterialTheme.typography.labelSmall,
                         color = accent,
                     )
@@ -1193,7 +1194,7 @@ private fun LikedSongsCard(
                 // Text content on the left
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = "YOUR COLLECTION",
+                        text = stringResource(com.stash.core.ui.R.string.section_your_collection),
                         style = MaterialTheme.typography.labelSmall.copy(
                             letterSpacing = 1.5.sp,
                         ),
@@ -1205,7 +1206,7 @@ private fun LikedSongsCard(
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
                     ) {
                         Text(
-                            text = "Liked Songs",
+                            text = stringResource(com.stash.core.ui.R.string.label_liked_songs),
                             style = MaterialTheme.typography.titleLarge,
                             color = MaterialTheme.colorScheme.onSurface,
                         )
@@ -1289,9 +1290,9 @@ private fun SourceLikedChip(
         MusicSource.LOCAL, MusicSource.BOTH -> MaterialTheme.colorScheme.primary
     }
     val sourceName = when (source) {
-        MusicSource.SPOTIFY -> "Spotify"
-        MusicSource.YOUTUBE -> "YouTube"
-        MusicSource.LOCAL -> "Local"
+        MusicSource.SPOTIFY -> stringResource(com.stash.core.ui.R.string.filter_spotify)
+        MusicSource.YOUTUBE -> stringResource(com.stash.core.ui.R.string.filter_youtube)
+        MusicSource.LOCAL -> stringResource(com.stash.core.ui.R.string.filter_local)
         MusicSource.BOTH -> ""
     }
 
@@ -1494,7 +1495,7 @@ private fun CreatePlaylistCard(
                 modifier = Modifier.size(24.dp),
             )
             Text(
-                text = "Create Playlist",
+                text = stringResource(com.stash.core.ui.R.string.action_create_playlist),
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 2,
@@ -1554,7 +1555,7 @@ private fun CreateMixCard(
                 modifier = Modifier.size(24.dp),
             )
             Text(
-                text = "Create\nmix",
+                text = stringResource(com.stash.core.ui.R.string.action_create_mix),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = androidx.compose.ui.text.style.TextAlign.Center,
@@ -1634,18 +1635,18 @@ private fun LosslessConnectBanner(
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Try lossless audio",
+                    text = stringResource(com.stash.core.ui.R.string.prompt_try_lossless),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Text(
-                    text = "Studio-quality FLAC downloads via Qobuz. Tap to set up.",
+                    text = stringResource(com.stash.core.ui.R.string.desc_lossless_prompt),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
             Text(
-                text = "Set up →",
+                text = stringResource(com.stash.core.ui.R.string.action_setup_lossless),
                 style = MaterialTheme.typography.labelSmall,
                 color = accent,
             )
@@ -1658,7 +1659,7 @@ private fun LosslessConnectBanner(
             ) {
                 Icon(
                     imageVector = Icons.Default.Close,
-                    contentDescription = "Dismiss lossless banner",
+                    contentDescription = stringResource(com.stash.core.ui.R.string.cd_dismiss_lossless_banner),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(18.dp),
                 )
@@ -1751,7 +1752,7 @@ private fun SupporterPill(
         ) {
             androidx.compose.material3.Icon(
                 imageVector = androidx.compose.material.icons.Icons.Default.FavoriteBorder,
-                contentDescription = "Supporters on Ko-fi",
+                contentDescription = stringResource(com.stash.core.ui.R.string.cd_supporters_kofi),
                 tint = Color(0xFFFFC947),
                 modifier = Modifier
                     .size(16.dp)
@@ -1835,9 +1836,10 @@ private fun PlaylistSortChipRow(
     }
 }
 
+@Composable
 private fun PlaylistSortOrder.displayName(): String = when (this) {
-    PlaylistSortOrder.RECENT -> "Recently Added"
-    PlaylistSortOrder.ALPHABETICAL -> "A-Z"
-    PlaylistSortOrder.MOST_PLAYED -> "Most Played"
+    PlaylistSortOrder.RECENT -> stringResource(com.stash.core.ui.R.string.sort_recently_added)
+    PlaylistSortOrder.ALPHABETICAL -> stringResource(com.stash.core.ui.R.string.sort_alphabetical)
+    PlaylistSortOrder.MOST_PLAYED -> stringResource(com.stash.core.ui.R.string.sort_most_played)
 }
 

--- a/feature/home/src/main/kotlin/com/stash/feature/home/PartnerStrip.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/PartnerStrip.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
@@ -91,7 +92,7 @@ fun PartnerStrip(modifier: Modifier = Modifier) {
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = "Powered by ",
+                    text = stringResource(com.stash.core.ui.R.string.label_powered_by),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -179,7 +180,7 @@ private fun PartnerChip(
             }
             Spacer(modifier = Modifier.width(6.dp))
             Text(
-                text = if (isKofi) "Support on Ko-fi" else "Discord",
+                text = if (isKofi) stringResource(com.stash.core.ui.R.string.partner_support_kofi) else stringResource(com.stash.core.ui.R.string.partner_discord),
                 style = MaterialTheme.typography.labelMedium,
                 color = accent,
             )

--- a/feature/home/src/main/kotlin/com/stash/feature/home/banner/MetadataBackfillBanner.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/banner/MetadataBackfillBanner.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 
@@ -77,7 +78,7 @@ fun MetadataBackfillBanner(
                         horizontalArrangement = Arrangement.SpaceBetween,
                     ) {
                         Text(
-                            text = "Re-tagging library",
+                            text = stringResource(com.stash.core.ui.R.string.status_retagging_library),
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.onSurface,
                         )
@@ -88,7 +89,7 @@ fun MetadataBackfillBanner(
                         )
                     }
                     Text(
-                        text = "Adding album art and metadata to existing files",
+                        text = stringResource(com.stash.core.ui.R.string.desc_retagging_progress),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -106,13 +107,13 @@ fun MetadataBackfillBanner(
                 }
                 is MetadataBackfillBannerState.Finished -> {
                     Text(
-                        text = "Library re-tagged",
+                        text = stringResource(com.stash.core.ui.R.string.status_library_retagged),
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
                     if (state.safSkipped > 0) {
                         Text(
-                            text = "${state.safSkipped} tracks on external storage will be tagged on next download",
+                            text = stringResource(com.stash.core.ui.R.string.desc_retagging_saf_skipped, state.safSkipped),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )

--- a/feature/home/src/main/kotlin/com/stash/feature/home/components/StashVinylLogo.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/components/StashVinylLogo.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.stash.feature.home.R
@@ -45,7 +46,7 @@ fun StashVinylLogo(modifier: Modifier = Modifier, size: Dp = 64.dp) {
 
     Image(
         painter = painterResource(R.drawable.vinyl_record),
-        contentDescription = "Stash logo",
+        contentDescription = stringResource(com.stash.core.ui.R.string.cd_stash_logo),
         modifier = modifier
             .size(size)
             .graphicsLayer {

--- a/feature/home/src/main/kotlin/com/stash/feature/home/streaming/StreamingModePrompt.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/streaming/StreamingModePrompt.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.stash.core.ui.theme.StashTheme
 
@@ -22,17 +23,13 @@ fun StreamingDisclosureDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Online streaming") },
+        title = { Text(stringResource(com.stash.core.ui.R.string.dialog_title_streaming_disclosure)) },
         text = {
-            Text(
-                "Stash streams via a community Qobuz proxy. Quality is FLAC " +
-                    "where available, and tracks not in the catalog can't be " +
-                    "streamed.",
-            )
+            Text(stringResource(com.stash.core.ui.R.string.dialog_body_streaming_disclosure))
         },
         confirmButton = {
             TextButton(onClick = onDismiss) {
-                Text("Got it")
+                Text(stringResource(com.stash.core.ui.R.string.action_got_it))
             }
         },
     )

--- a/feature/library/src/main/kotlin/com/stash/feature/library/AlbumDetailScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/AlbumDetailScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -66,6 +67,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.stash.core.media.BulkPlayAction
 import com.stash.core.model.Track
+import com.stash.core.ui.R
 import com.stash.core.ui.components.DetailTrackRow
 import com.stash.core.ui.components.SearchFilterBar
 import com.stash.core.ui.components.TrackOptionsSheet
@@ -171,7 +173,7 @@ fun AlbumDetailScreen(
                             contentAlignment = Alignment.Center,
                         ) {
                             Text(
-                                text = "No matching songs",
+                                text = stringResource(R.string.label_no_matching_songs),
                                 style = MaterialTheme.typography.bodyLarge,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -222,22 +224,22 @@ fun AlbumDetailScreen(
         // Album detail has exactly four actions (no Delete) — all fit inline,
         // so none collapse into the ⋮ overflow.
         val selectionActions = listOf(
-            SelectionAction("add_queue", "Add to queue", Icons.Default.PlaylistAdd) {
+            SelectionAction("add_queue", stringResource(R.string.action_add_to_queue), Icons.Default.PlaylistAdd) {
                 viewModel.addSelectedToQueue(selectedTracks); selection.clear()
             },
-            SelectionAction("add_playlist", "Add to playlist", Icons.Default.PlaylistAddCheck) {
+            SelectionAction("add_playlist", stringResource(R.string.selection_add_to_playlist), Icons.Default.PlaylistAddCheck) {
                 showBatchSave = true
             },
             if (allDownloaded) {
-                SelectionAction("remove_download", "Remove download", Icons.Default.DownloadDone) {
+                SelectionAction("remove_download", stringResource(R.string.selection_remove_download), Icons.Default.DownloadDone) {
                     viewModel.removeDownloadsForSelected(selectedIds); selection.clear()
                 }
             } else {
-                SelectionAction("download", "Download", Icons.Default.Download) {
+                SelectionAction("download", stringResource(R.string.selection_download), Icons.Default.Download) {
                     viewModel.downloadSelected(selectedIds); selection.clear()
                 }
             },
-            SelectionAction("play_next", "Play next", Icons.Default.PlaylistPlay) {
+            SelectionAction("play_next", stringResource(R.string.action_play_next), Icons.Default.PlaylistPlay) {
                 viewModel.playSelectedNext(selectedTracks); selection.clear()
             },
         )
@@ -416,7 +418,7 @@ private fun AlbumDetailHeader(
             ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Back",
+                    contentDescription = stringResource(R.string.cd_back),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }
@@ -497,7 +499,7 @@ private fun AlbumDetailHeader(
                         modifier = Modifier.size(20.dp),
                     )
                     Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = "Play All", style = MaterialTheme.typography.labelLarge)
+                    Text(text = stringResource(R.string.action_play_all), style = MaterialTheme.typography.labelLarge)
                 }
 
                 BulkPlayButtonBox(
@@ -516,7 +518,7 @@ private fun AlbumDetailHeader(
                             modifier = Modifier.size(20.dp),
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = "Shuffle", style = MaterialTheme.typography.labelLarge)
+                        Text(text = stringResource(R.string.action_shuffle), style = MaterialTheme.typography.labelLarge)
                     }
                 }
 
@@ -532,7 +534,7 @@ private fun AlbumDetailHeader(
                 ) {
                     Icon(
                         imageVector = Icons.Default.Search,
-                        contentDescription = "Filter tracks",
+                        contentDescription = stringResource(R.string.cd_filter_tracks),
                         tint = MaterialTheme.colorScheme.onSurface,
                     )
                 }

--- a/feature/library/src/main/kotlin/com/stash/feature/library/ArtistDetailScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/ArtistDetailScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -62,6 +63,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stash.core.media.BulkPlayAction
 import com.stash.core.model.Track
+import com.stash.core.ui.R
 import com.stash.core.ui.components.DetailTrackRow
 import com.stash.core.ui.components.SearchFilterBar
 import com.stash.core.ui.components.TrackOptionsSheet
@@ -165,7 +167,7 @@ fun ArtistDetailScreen(
                             contentAlignment = Alignment.Center,
                         ) {
                             Text(
-                                text = "No matching songs",
+                                text = stringResource(R.string.label_no_matching_songs),
                                 style = MaterialTheme.typography.bodyLarge,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -216,22 +218,22 @@ fun ArtistDetailScreen(
         // Artist detail has exactly four actions (no Delete) — all fit inline,
         // so none collapse into the ⋮ overflow.
         val selectionActions = listOf(
-            SelectionAction("add_queue", "Add to queue", Icons.Default.PlaylistAdd) {
+            SelectionAction("add_queue", stringResource(R.string.action_add_to_queue), Icons.Default.PlaylistAdd) {
                 viewModel.addSelectedToQueue(selectedTracks); selection.clear()
             },
-            SelectionAction("add_playlist", "Add to playlist", Icons.Default.PlaylistAddCheck) {
+            SelectionAction("add_playlist", stringResource(R.string.selection_add_to_playlist), Icons.Default.PlaylistAddCheck) {
                 showBatchSave = true
             },
             if (allDownloaded) {
-                SelectionAction("remove_download", "Remove download", Icons.Default.DownloadDone) {
+                SelectionAction("remove_download", stringResource(R.string.selection_remove_download), Icons.Default.DownloadDone) {
                     viewModel.removeDownloadsForSelected(selectedIds); selection.clear()
                 }
             } else {
-                SelectionAction("download", "Download", Icons.Default.Download) {
+                SelectionAction("download", stringResource(R.string.selection_download), Icons.Default.Download) {
                     viewModel.downloadSelected(selectedIds); selection.clear()
                 }
             },
-            SelectionAction("play_next", "Play next", Icons.Default.PlaylistPlay) {
+            SelectionAction("play_next", stringResource(R.string.action_play_next), Icons.Default.PlaylistPlay) {
                 viewModel.playSelectedNext(selectedTracks); selection.clear()
             },
         )
@@ -359,7 +361,7 @@ private fun ArtistDetailHeader(
             ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Back",
+                    contentDescription = stringResource(R.string.cd_back),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }
@@ -441,7 +443,7 @@ private fun ArtistDetailHeader(
                     modifier = Modifier.size(20.dp),
                 )
                 Spacer(modifier = Modifier.width(8.dp))
-                Text(text = "Play All", style = MaterialTheme.typography.labelLarge)
+                Text(text = stringResource(R.string.action_play_all), style = MaterialTheme.typography.labelLarge)
             }
 
             BulkPlayButtonBox(
@@ -460,7 +462,7 @@ private fun ArtistDetailHeader(
                         modifier = Modifier.size(20.dp),
                     )
                     Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = "Shuffle", style = MaterialTheme.typography.labelLarge)
+                    Text(text = stringResource(R.string.action_shuffle), style = MaterialTheme.typography.labelLarge)
                 }
             }
 
@@ -477,7 +479,7 @@ private fun ArtistDetailHeader(
             ) {
                 Icon(
                     imageVector = Icons.Default.Search,
-                    contentDescription = "Filter tracks",
+                    contentDescription = stringResource(R.string.cd_filter_tracks),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
@@ -79,6 +79,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -89,6 +90,7 @@ import com.stash.core.model.Playlist
 import com.stash.core.model.PlaylistType
 import coil3.compose.AsyncImage
 import com.stash.core.model.Track
+import com.stash.core.ui.R
 import com.stash.core.ui.components.GlassCard
 import com.stash.core.ui.components.SourceIndicator
 import com.stash.core.ui.components.TrackListItem
@@ -177,25 +179,25 @@ fun LibraryScreen(
         val allDownloaded = selectedTracks.isNotEmpty() && selectedTracks.all { it.isDownloaded }
 
         val selectionActions = listOf(
-            SelectionAction("add_queue", "Add to queue", Icons.Default.PlaylistAdd) {
+            SelectionAction("add_queue", stringResource(R.string.action_add_to_queue), Icons.Default.PlaylistAdd) {
                 viewModel.addSelectedToQueue(selectedTracks); selection.clear()
             },
-            SelectionAction("add_playlist", "Add to playlist", Icons.Default.PlaylistAddCheck) {
+            SelectionAction("add_playlist", stringResource(R.string.selection_add_to_playlist), Icons.Default.PlaylistAddCheck) {
                 showBatchSave = true
             },
             if (allDownloaded) {
-                SelectionAction("remove_download", "Remove download", Icons.Default.DownloadDone) {
+                SelectionAction("remove_download", stringResource(R.string.selection_remove_download), Icons.Default.DownloadDone) {
                     viewModel.removeDownloadsForSelected(selectedIds); selection.clear()
                 }
             } else {
-                SelectionAction("download", "Download", Icons.Default.Download) {
+                SelectionAction("download", stringResource(R.string.selection_download), Icons.Default.Download) {
                     viewModel.downloadSelected(selectedIds); selection.clear()
                 }
             },
-            SelectionAction("delete", "Delete", Icons.Default.Delete) {
+            SelectionAction("delete", stringResource(R.string.action_delete), Icons.Default.Delete) {
                 showBatchDelete = true
             },
-            SelectionAction("play_next", "Play next", Icons.Default.PlaylistPlay) {
+            SelectionAction("play_next", stringResource(R.string.action_play_next), Icons.Default.PlaylistPlay) {
                 viewModel.playSelectedNext(selectedTracks); selection.clear()
             },
         )
@@ -247,12 +249,11 @@ fun LibraryScreen(
         var alsoBlacklist by remember(showBatchDelete) { mutableStateOf(false) }
         AlertDialog(
             onDismissRequest = { showBatchDelete = false },
-            title = { Text("Delete $n song${if (n != 1) "s" else ""}?") },
+            title = { Text(stringResource(R.string.dialog_title_delete_songs, n)) },
             text = {
                 Column {
                     Text(
-                        "${n} song${if (n != 1) "s" else ""} will be removed from your " +
-                            "library and deleted from disk.",
+                        stringResource(R.string.dialog_body_delete_songs, n),
                     )
                     Spacer(modifier = Modifier.height(12.dp))
                     Row(
@@ -266,11 +267,11 @@ fun LibraryScreen(
                         Spacer(modifier = Modifier.width(4.dp))
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
-                                text = "Also block these songs from future syncs",
+                                text = stringResource(R.string.label_also_block_songs),
                                 style = MaterialTheme.typography.bodyMedium,
                             )
                             Text(
-                                text = "Blocked songs never re-download. Unblock them in Settings later.",
+                                text = stringResource(R.string.desc_blocked_songs_hint),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -287,13 +288,13 @@ fun LibraryScreen(
                     },
                 ) {
                     Text(
-                        text = if (alsoBlacklist) "Delete & Block" else "Delete",
+                        text = if (alsoBlacklist) stringResource(R.string.action_delete_and_block) else stringResource(R.string.action_delete),
                         color = MaterialTheme.colorScheme.error,
                     )
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showBatchDelete = false }) { Text("Cancel") }
+                TextButton(onClick = { showBatchDelete = false }) { Text(stringResource(R.string.action_cancel)) }
             },
         )
     }
@@ -354,7 +355,7 @@ private fun LibraryContent(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "Library",
+                text = stringResource(R.string.title_library),
                 style = MaterialTheme.typography.headlineLarge,
                 color = MaterialTheme.colorScheme.onBackground,
                 modifier = Modifier.weight(1f),
@@ -377,7 +378,7 @@ private fun LibraryContent(
                 )
                 Spacer(modifier = Modifier.width(6.dp))
                 Text(
-                    text = "Import",
+                    text = stringResource(R.string.action_import),
                     style = MaterialTheme.typography.labelLarge,
                 )
             }
@@ -530,7 +531,7 @@ private fun ShuffleLibraryCard(
                 modifier = Modifier.size(20.dp),
             )
             Text(
-                text = "Shuffle Library",
+                text = stringResource(R.string.action_shuffle_library),
                 style = MaterialTheme.typography.titleSmall,
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onBackground,
@@ -569,7 +570,7 @@ private fun GlassSearchBar(
             leadingIcon = {
                 Icon(
                     imageVector = Icons.Default.Search,
-                    contentDescription = "Search",
+                    contentDescription = stringResource(R.string.cd_search),
                     tint = extendedColors.textTertiary,
                 )
             },
@@ -631,11 +632,12 @@ private fun TabChipRow(
 }
 
 /** Human-readable label for each tab. */
+@Composable
 private fun LibraryTab.displayName(): String = when (this) {
-    LibraryTab.PLAYLISTS -> "Playlists"
-    LibraryTab.TRACKS -> "Tracks"
-    LibraryTab.ARTISTS -> "Artists"
-    LibraryTab.ALBUMS -> "Albums"
+    LibraryTab.PLAYLISTS -> stringResource(R.string.tab_playlists)
+    LibraryTab.TRACKS -> stringResource(R.string.tab_tracks)
+    LibraryTab.ARTISTS -> stringResource(R.string.tab_artists)
+    LibraryTab.ALBUMS -> stringResource(R.string.tab_albums)
 }
 
 // ── Sort chips ───────────────────────────────────────────────────────────────
@@ -680,10 +682,11 @@ private fun SortChipRow(
     }
 }
 
+@Composable
 private fun SortOrder.displayName(): String = when (this) {
-    SortOrder.RECENT -> "Recently Added"
-    SortOrder.ALPHABETICAL -> "A-Z"
-    SortOrder.MOST_PLAYED -> "Most Played"
+    SortOrder.RECENT -> stringResource(R.string.sort_recently_added)
+    SortOrder.ALPHABETICAL -> stringResource(R.string.sort_alphabetical)
+    SortOrder.MOST_PLAYED -> stringResource(R.string.sort_most_played)
 }
 
 // ── Source filter chips ─────────────────────────────────────────────────────
@@ -728,11 +731,12 @@ private fun SourceFilterChipRow(
     }
 }
 
+@Composable
 private fun SourceFilter.displayName(): String = when (this) {
-    SourceFilter.ALL -> "All"
-    SourceFilter.YOUTUBE -> "YouTube"
-    SourceFilter.SPOTIFY -> "Spotify"
-    SourceFilter.FLAC -> "FLAC"
+    SourceFilter.ALL -> stringResource(R.string.filter_all)
+    SourceFilter.YOUTUBE -> stringResource(R.string.filter_youtube)
+    SourceFilter.SPOTIFY -> stringResource(R.string.filter_spotify)
+    SourceFilter.FLAC -> stringResource(R.string.filter_flac)
 }
 
 // ── Local import progress strip ─────────────────────────────────────────────
@@ -764,12 +768,12 @@ private fun LocalImportStrip(
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
                     Text(
-                        text = "Importing ${state.current} of ${state.total}\u2026",
+                        text = stringResource(R.string.status_importing_progress, state.current.toString(), state.total.toString()),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
                     androidx.compose.material3.TextButton(onClick = onCancel) {
-                        Text("Cancel")
+                        Text(stringResource(R.string.action_cancel))
                     }
                 }
                 androidx.compose.material3.LinearProgressIndicator(
@@ -801,7 +805,7 @@ private fun LocalImportStrip(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 androidx.compose.material3.TextButton(onClick = onDismiss) {
-                    Text("Dismiss")
+                    Text(stringResource(R.string.cd_dismiss))
                 }
             }
         }
@@ -816,7 +820,7 @@ private fun LocalImportStrip(
             ) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = "Import failed",
+                        text = stringResource(R.string.error_import_failed),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.error,
                     )
@@ -827,7 +831,7 @@ private fun LocalImportStrip(
                     )
                 }
                 androidx.compose.material3.TextButton(onClick = onDismiss) {
-                    Text("Dismiss")
+                    Text(stringResource(R.string.cd_dismiss))
                 }
             }
         }
@@ -850,8 +854,8 @@ private fun PlaylistsGrid(
 ) {
     if (playlists.isEmpty()) {
         EmptyTabMessage(
-            if (anyServiceConnected) "Sync your playlists to see them here"
-            else "Connect a service in Settings to see your playlists",
+            if (anyServiceConnected) stringResource(R.string.label_empty_playlists_synced)
+            else stringResource(R.string.label_empty_playlists_no_service),
         )
         return
     }
@@ -1006,7 +1010,7 @@ private fun PlaylistsGrid(
 
             BottomSheetActionRow(
                 icon = Icons.Default.PlayArrow,
-                label = "Play All",
+                label = stringResource(R.string.action_play_all),
                 onClick = {
                     onPlayPlaylist(playlist)
                     selectedPlaylist = null
@@ -1014,7 +1018,7 @@ private fun PlaylistsGrid(
             )
             BottomSheetActionRow(
                 icon = Icons.Default.PlaylistAdd,
-                label = "Add to Queue",
+                label = stringResource(R.string.action_add_to_queue),
                 onClick = {
                     onAddPlaylistToQueue(playlist)
                     selectedPlaylist = null
@@ -1024,7 +1028,7 @@ private fun PlaylistsGrid(
             if (playlist.type == PlaylistType.CUSTOM) {
                 BottomSheetActionRow(
                     icon = Icons.Default.Image,
-                    label = if (playlist.artUrl != null) "Change Image" else "Add Image",
+                    label = if (playlist.artUrl != null) stringResource(R.string.action_change_image) else stringResource(R.string.action_add_image),
                     onClick = {
                         playlistForImagePick = playlist
                         selectedPlaylist = null
@@ -1038,7 +1042,7 @@ private fun PlaylistsGrid(
                 if (playlist.artUrl != null) {
                     BottomSheetActionRow(
                         icon = Icons.Default.ImageNotSupported,
-                        label = "Remove Image",
+                        label = stringResource(R.string.action_remove_image),
                         onClick = {
                             onRemovePlaylistImage(playlist.id)
                             selectedPlaylist = null
@@ -1049,7 +1053,7 @@ private fun PlaylistsGrid(
 
             BottomSheetActionRow(
                 icon = Icons.Default.RemoveCircleOutline,
-                label = "Remove Playlist",
+                label = stringResource(R.string.action_remove_playlist),
                 onClick = {
                     onRemovePlaylist(playlist)
                     selectedPlaylist = null
@@ -1057,7 +1061,7 @@ private fun PlaylistsGrid(
             )
             BottomSheetActionRow(
                 icon = Icons.Default.Delete,
-                label = "Delete Playlist & Songs",
+                label = stringResource(R.string.action_delete_playlist_and_songs),
                 tint = MaterialTheme.colorScheme.error,
                 onClick = {
                     playlistToDelete = playlist
@@ -1074,12 +1078,11 @@ private fun PlaylistsGrid(
         var alsoBlacklist by remember(playlist.id) { mutableStateOf(false) }
         AlertDialog(
             onDismissRequest = { playlistToDelete = null },
-            title = { Text("Delete \"${playlist.name}\"?") },
+            title = { Text(stringResource(R.string.dialog_title_delete_playlist, playlist.name)) },
             text = {
                 Column {
                     Text(
-                        "\"${playlist.name}\" and all its tracks will be removed from " +
-                            "your library and deleted from disk. This cannot be undone.",
+                        stringResource(R.string.dialog_body_delete_playlist_permanent, playlist.name),
                     )
                     Spacer(modifier = Modifier.height(12.dp))
                     Row(
@@ -1093,11 +1096,11 @@ private fun PlaylistsGrid(
                         Spacer(modifier = Modifier.width(4.dp))
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
-                                text = "Also block these songs from future syncs",
+                                text = stringResource(R.string.label_also_block_songs),
                                 style = MaterialTheme.typography.bodyMedium,
                             )
                             Text(
-                                text = "Blocked songs never re-download. Unblock them in Settings later.",
+                                text = stringResource(R.string.desc_blocked_songs_hint),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -1113,14 +1116,14 @@ private fun PlaylistsGrid(
                     },
                 ) {
                     Text(
-                        text = if (alsoBlacklist) "Delete & Block" else "Delete",
+                        text = if (alsoBlacklist) stringResource(R.string.action_delete_and_block) else stringResource(R.string.action_delete),
                         color = MaterialTheme.colorScheme.error,
                     )
                 }
             },
             dismissButton = {
                 TextButton(onClick = { playlistToDelete = null }) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             },
         )
@@ -1143,8 +1146,8 @@ private fun TracksTab(
 ) {
     if (tracks.isEmpty()) {
         EmptyTabMessage(
-            if (anyServiceConnected) "Sync your library to see tracks here"
-            else "Connect a service in Settings to see your tracks",
+            if (anyServiceConnected) stringResource(R.string.label_empty_tracks_synced)
+            else stringResource(R.string.label_empty_tracks_no_service),
         )
         return
     }
@@ -1225,7 +1228,7 @@ private fun TracksTab(
             // Action rows
             BottomSheetActionRow(
                 icon = Icons.Default.PlaylistPlay,
-                label = "Play Next",
+                label = stringResource(R.string.action_play_next),
                 onClick = {
                     onPlayNext(track)
                     selectedTrack = null
@@ -1233,7 +1236,7 @@ private fun TracksTab(
             )
             BottomSheetActionRow(
                 icon = Icons.Default.PlaylistAdd,
-                label = "Add to Queue",
+                label = stringResource(R.string.action_add_to_queue),
                 onClick = {
                     onAddToQueue(track)
                     selectedTrack = null
@@ -1241,7 +1244,7 @@ private fun TracksTab(
             )
             BottomSheetActionRow(
                 icon = Icons.Default.Delete,
-                label = "Delete",
+                label = stringResource(R.string.action_delete),
                 tint = MaterialTheme.colorScheme.error,
                 onClick = {
                     trackToDelete = track
@@ -1259,12 +1262,11 @@ private fun TracksTab(
         var alsoBlacklist by remember(track.id) { mutableStateOf(false) }
         AlertDialog(
             onDismissRequest = { trackToDelete = null },
-            title = { Text("Delete \"${track.title}\"?") },
+            title = { Text(stringResource(R.string.dialog_title_delete_track, track.title)) },
             text = {
                 Column {
                     Text(
-                        "\"${track.title}\" by ${track.artist} will be removed from " +
-                            "your library and deleted from disk.",
+                        stringResource(R.string.dialog_body_delete_track_library),
                     )
                     Spacer(modifier = Modifier.height(12.dp))
                     Row(
@@ -1278,11 +1280,11 @@ private fun TracksTab(
                         Spacer(modifier = Modifier.width(4.dp))
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
-                                text = "Also block this song from future syncs",
+                                text = stringResource(R.string.label_also_block_song),
                                 style = MaterialTheme.typography.bodyMedium,
                             )
                             Text(
-                                text = "Blocked songs never re-download. Unblock them in Settings later.",
+                                text = stringResource(R.string.desc_blocked_songs_hint),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -1298,14 +1300,14 @@ private fun TracksTab(
                     },
                 ) {
                     Text(
-                        text = if (alsoBlacklist) "Delete & Block" else "Delete",
+                        text = if (alsoBlacklist) stringResource(R.string.action_delete_and_block) else stringResource(R.string.action_delete),
                         color = MaterialTheme.colorScheme.error,
                     )
                 }
             },
             dismissButton = {
                 TextButton(onClick = { trackToDelete = null }) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             },
         )
@@ -1363,8 +1365,8 @@ private fun ArtistsGrid(
 ) {
     if (artists.isEmpty() && singleTrackArtists.isEmpty()) {
         EmptyTabMessage(
-            if (anyServiceConnected) "Sync your library to see artists here"
-            else "Connect a service in Settings to see your artists",
+            if (anyServiceConnected) stringResource(R.string.label_empty_artists_synced)
+            else stringResource(R.string.label_empty_artists_no_service),
         )
         return
     }
@@ -1459,7 +1461,7 @@ private fun ArtistsGrid(
                         horizontalArrangement = Arrangement.SpaceBetween,
                     ) {
                         Text(
-                            text = if (showSingleTrack) "Hide single-track artists"
+                            text = if (showSingleTrack) stringResource(R.string.label_hide_single_track)
                             else "${singleTrackArtists.size} artists with 1 track",
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1510,7 +1512,7 @@ private fun ArtistsGrid(
 
             BottomSheetActionRow(
                 icon = Icons.Default.PlayArrow,
-                label = "Play All by Artist",
+                label = stringResource(R.string.action_play_all_by_artist),
                 onClick = {
                     onPlayArtist(artist.name)
                     selectedArtist = null
@@ -1518,7 +1520,7 @@ private fun ArtistsGrid(
             )
             BottomSheetActionRow(
                 icon = Icons.Default.PlaylistAdd,
-                label = "Add to Queue",
+                label = stringResource(R.string.action_add_to_queue),
                 onClick = {
                     onAddArtistToQueue(artist.name)
                     selectedArtist = null
@@ -1526,7 +1528,7 @@ private fun ArtistsGrid(
             )
             BottomSheetActionRow(
                 icon = Icons.Default.Delete,
-                label = "Delete All by Artist",
+                label = stringResource(R.string.action_delete_all_by_artist),
                 tint = MaterialTheme.colorScheme.error,
                 onClick = {
                     artistToDelete = artist
@@ -1542,8 +1544,8 @@ private fun ArtistsGrid(
     artistToDelete?.let { artist ->
         androidx.compose.material3.AlertDialog(
             onDismissRequest = { artistToDelete = null },
-            title = { Text("Delete all by ${artist.name}?") },
-            text = { Text("This will delete all ${artist.trackCount} downloaded songs by this artist from your device.") },
+            title = { Text(stringResource(R.string.dialog_title_delete_artist, artist.name)) },
+            text = { Text(stringResource(R.string.dialog_body_delete_artist, artist.trackCount)) },
             confirmButton = {
                 androidx.compose.material3.TextButton(
                     onClick = {
@@ -1551,12 +1553,12 @@ private fun ArtistsGrid(
                         artistToDelete = null
                     },
                 ) {
-                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                    Text(stringResource(R.string.action_delete), color = MaterialTheme.colorScheme.error)
                 }
             },
             dismissButton = {
                 androidx.compose.material3.TextButton(onClick = { artistToDelete = null }) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             },
         )
@@ -1576,8 +1578,8 @@ private fun AlbumsGrid(
 ) {
     if (albums.isEmpty() && singleTrackAlbums.isEmpty()) {
         EmptyTabMessage(
-            if (anyServiceConnected) "Sync your library to see albums here"
-            else "Connect a service in Settings to see your albums",
+            if (anyServiceConnected) stringResource(R.string.label_empty_albums_synced)
+            else stringResource(R.string.label_empty_albums_no_service),
         )
         return
     }
@@ -1678,7 +1680,7 @@ private fun AlbumsGrid(
                         horizontalArrangement = Arrangement.SpaceBetween,
                     ) {
                         Text(
-                            text = if (showSingleTrack) "Hide single-track albums"
+                            text = if (showSingleTrack) stringResource(R.string.label_hide_single_track)
                             else "${singleTrackAlbums.size} albums with 1 track",
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1731,7 +1733,7 @@ private fun AlbumsGrid(
 
             BottomSheetActionRow(
                 icon = Icons.Default.PlayArrow,
-                label = "Play Album",
+                label = stringResource(R.string.action_play_album),
                 onClick = {
                     onPlayAlbum(album.name, album.artist)
                     selectedAlbum = null
@@ -1739,7 +1741,7 @@ private fun AlbumsGrid(
             )
             BottomSheetActionRow(
                 icon = Icons.Default.PlaylistAdd,
-                label = "Add to Queue",
+                label = stringResource(R.string.action_add_to_queue),
                 onClick = {
                     onAddAlbumToQueue(album.name, album.artist)
                     selectedAlbum = null

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LikedSongsDetailScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LikedSongsDetailScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -64,6 +65,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stash.core.media.BulkPlayAction
 import com.stash.core.model.Track
+import com.stash.core.ui.R
 import com.stash.core.ui.components.DetailTrackRow
 import com.stash.core.ui.components.SearchFilterBar
 import com.stash.core.ui.components.SourceIndicator
@@ -183,7 +185,7 @@ fun LikedSongsDetailScreen(
                                 contentAlignment = Alignment.Center,
                             ) {
                                 Text(
-                                    text = "No matching songs",
+                                    text = stringResource(R.string.label_no_matching_songs),
                                     style = MaterialTheme.typography.bodyLarge,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
@@ -235,25 +237,25 @@ fun LikedSongsDetailScreen(
         // Action order mirrors the reference: Delete stays within the first four
         // (visible) and Play next collapses into the ⋮ overflow.
         val selectionActions = listOf(
-            SelectionAction("add_queue", "Add to queue", Icons.Default.PlaylistAdd) {
+            SelectionAction("add_queue", stringResource(R.string.action_add_to_queue), Icons.Default.PlaylistAdd) {
                 viewModel.addSelectedToQueue(selectedTracks); selection.clear()
             },
-            SelectionAction("add_playlist", "Add to playlist", Icons.Default.PlaylistAddCheck) {
+            SelectionAction("add_playlist", stringResource(R.string.selection_add_to_playlist), Icons.Default.PlaylistAddCheck) {
                 showBatchSave = true
             },
             if (allDownloaded) {
-                SelectionAction("remove_download", "Remove download", Icons.Default.DownloadDone) {
+                SelectionAction("remove_download", stringResource(R.string.selection_remove_download), Icons.Default.DownloadDone) {
                     viewModel.removeDownloadsForSelected(selectedIds); selection.clear()
                 }
             } else {
-                SelectionAction("download", "Download", Icons.Default.Download) {
+                SelectionAction("download", stringResource(R.string.selection_download), Icons.Default.Download) {
                     viewModel.downloadSelected(selectedIds); selection.clear()
                 }
             },
-            SelectionAction("delete", "Delete", Icons.Default.Delete) {
+            SelectionAction("delete", stringResource(R.string.selection_delete), Icons.Default.Delete) {
                 showBatchDelete = true
             },
-            SelectionAction("play_next", "Play next", Icons.Default.PlaylistPlay) {
+            SelectionAction("play_next", stringResource(R.string.action_play_next), Icons.Default.PlaylistPlay) {
                 viewModel.playSelectedNext(selectedTracks); selection.clear()
             },
         )
@@ -352,11 +354,11 @@ fun LikedSongsDetailScreen(
         AlertDialog(
             onDismissRequest = { showBatchDelete = false },
             title = {
-                Text("Remove $n song${if (n != 1) "s" else ""} from Liked Songs?")
+                Text(stringResource(R.string.dialog_title_remove_liked, n))
             },
             text = {
                 Text(
-                    text = "Removes the song${if (n != 1) "s" else ""} from Liked Songs.",
+                    text = stringResource(R.string.dialog_body_remove_liked),
                     style = MaterialTheme.typography.bodyMedium,
                 )
             },
@@ -368,11 +370,11 @@ fun LikedSongsDetailScreen(
                         selection.clear()
                     },
                 ) {
-                    Text(text = "Remove", color = MaterialTheme.colorScheme.error)
+                    Text(text = stringResource(R.string.action_remove), color = MaterialTheme.colorScheme.error)
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showBatchDelete = false }) { Text("Cancel") }
+                TextButton(onClick = { showBatchDelete = false }) { Text(stringResource(R.string.action_cancel)) }
             },
         )
     }
@@ -414,7 +416,7 @@ private fun LikedSongsEmptyState(
         ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "Back",
+                contentDescription = stringResource(R.string.cd_back),
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }
@@ -434,7 +436,7 @@ private fun LikedSongsEmptyState(
             Spacer(modifier = Modifier.height(16.dp))
 
             Text(
-                text = "No liked songs yet",
+                text = stringResource(R.string.label_no_liked_songs),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onBackground,
@@ -443,7 +445,7 @@ private fun LikedSongsEmptyState(
             Spacer(modifier = Modifier.height(4.dp))
 
             Text(
-                text = "Sync your library to get started",
+                text = stringResource(R.string.desc_sync_to_start),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -508,7 +510,7 @@ private fun LikedSongsHeader(
             ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Back",
+                    contentDescription = stringResource(R.string.cd_back),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }
@@ -592,7 +594,7 @@ private fun LikedSongsHeader(
                             modifier = Modifier.size(20.dp),
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = "Play All", style = MaterialTheme.typography.labelLarge)
+                        Text(text = stringResource(R.string.action_play_all), style = MaterialTheme.typography.labelLarge)
                     }
                 }
 
@@ -612,7 +614,7 @@ private fun LikedSongsHeader(
                             modifier = Modifier.size(20.dp),
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = "Shuffle", style = MaterialTheme.typography.labelLarge)
+                        Text(text = stringResource(R.string.action_shuffle), style = MaterialTheme.typography.labelLarge)
                     }
                 }
 
@@ -628,7 +630,7 @@ private fun LikedSongsHeader(
                 ) {
                     Icon(
                         imageVector = Icons.Default.Search,
-                        contentDescription = "Filter tracks",
+                        contentDescription = stringResource(R.string.cd_filter_tracks),
                         tint = MaterialTheme.colorScheme.onSurface,
                     )
                 }

--- a/feature/library/src/main/kotlin/com/stash/feature/library/PlaylistDetailScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/PlaylistDetailScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -75,6 +76,7 @@ import com.stash.core.data.mix.MixBuildState
 import com.stash.core.media.BulkPlayAction
 import com.stash.core.model.PlaylistType
 import com.stash.core.model.Track
+import com.stash.core.ui.R
 import com.stash.core.ui.components.DetailTrackRow
 import com.stash.core.ui.components.SearchFilterBar
 import com.stash.core.ui.components.SourceIndicator
@@ -200,7 +202,7 @@ fun PlaylistDetailScreen(
                             contentAlignment = Alignment.Center,
                         ) {
                             Text(
-                                text = "No matching songs",
+                                text = stringResource(R.string.label_no_matching_songs),
                                 style = MaterialTheme.typography.bodyLarge,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -224,12 +226,12 @@ fun PlaylistDetailScreen(
                             ) {
                                 CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
                                 Text(
-                                    text = "Building your mix…",
+                                    text = stringResource(R.string.status_building_mix),
                                     style = MaterialTheme.typography.titleMedium,
                                     color = MaterialTheme.colorScheme.onSurface,
                                 )
                                 Text(
-                                    text = "Finding fresh tracks from your genres — this can take a moment.",
+                                    text = stringResource(R.string.desc_building_mix),
                                     style = MaterialTheme.typography.bodyMedium,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     textAlign = androidx.compose.ui.text.style.TextAlign.Center,
@@ -246,12 +248,12 @@ fun PlaylistDetailScreen(
                                 verticalArrangement = Arrangement.spacedBy(8.dp),
                             ) {
                                 Text(
-                                    text = "Couldn't find tracks",
+                                    text = stringResource(R.string.status_mix_no_tracks),
                                     style = MaterialTheme.typography.titleMedium,
                                     color = MaterialTheme.colorScheme.onSurface,
                                 )
                                 Text(
-                                    text = "Try editing this mix with different genres or moods.",
+                                    text = stringResource(R.string.desc_mix_edit_hint),
                                     style = MaterialTheme.typography.bodyMedium,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     textAlign = androidx.compose.ui.text.style.TextAlign.Center,
@@ -306,25 +308,25 @@ fun PlaylistDetailScreen(
         // Action order: Delete must stay within the first four (visible) and
         // Play next collapses into the ⋮ overflow as the least-used action.
         val selectionActions = listOf(
-            SelectionAction("add_queue", "Add to queue", Icons.Default.PlaylistAdd) {
+            SelectionAction("add_queue", stringResource(R.string.action_add_to_queue), Icons.Default.PlaylistAdd) {
                 viewModel.addSelectedToQueue(selectedTracks); selection.clear()
             },
-            SelectionAction("add_playlist", "Add to playlist", Icons.Default.PlaylistAddCheck) {
+            SelectionAction("add_playlist", stringResource(R.string.selection_add_to_playlist), Icons.Default.PlaylistAddCheck) {
                 showBatchSave = true
             },
             if (allDownloaded) {
-                SelectionAction("remove_download", "Remove download", Icons.Default.DownloadDone) {
+                SelectionAction("remove_download", stringResource(R.string.selection_remove_download), Icons.Default.DownloadDone) {
                     viewModel.removeDownloadsForSelected(selectedIds); selection.clear()
                 }
             } else {
-                SelectionAction("download", "Download", Icons.Default.Download) {
+                SelectionAction("download", stringResource(R.string.selection_download), Icons.Default.Download) {
                     viewModel.downloadSelected(selectedIds); selection.clear()
                 }
             },
-            SelectionAction("delete", "Delete", Icons.Default.Delete) {
+            SelectionAction("delete", stringResource(R.string.action_delete), Icons.Default.Delete) {
                 showBatchDelete = true
             },
-            SelectionAction("play_next", "Play next", Icons.Default.PlaylistPlay) {
+            SelectionAction("play_next", stringResource(R.string.action_play_next), Icons.Default.PlaylistPlay) {
                 viewModel.playSelectedNext(selectedTracks); selection.clear()
             },
         )
@@ -426,16 +428,17 @@ fun PlaylistDetailScreen(
             onDismissRequest = { trackToDelete = null },
             title = {
                 Text(
-                    if (isDownloadsMix) "Delete from library?" else "Delete ${track.title}?"
+                    if (isDownloadsMix) stringResource(R.string.dialog_title_delete_track, track.title)
+                    else stringResource(R.string.dialog_title_delete_track, track.title)
                 )
             },
             text = {
                 Column {
                     Text(
                         text = if (isDownloadsMix) {
-                            "This track will be deleted from your library and the audio file removed from disk."
+                            stringResource(R.string.dialog_body_delete_track_library)
                         } else {
-                            "Removes the song from this playlist. If it's also in Liked Songs or an in-app playlist, the file stays so those lists keep playing."
+                            stringResource(R.string.dialog_body_delete_track_playlist)
                         },
                         style = MaterialTheme.typography.bodyMedium,
                     )
@@ -452,11 +455,11 @@ fun PlaylistDetailScreen(
                             Spacer(modifier = Modifier.width(4.dp))
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(
-                                    text = "Also block this song from future syncs",
+                                    text = stringResource(R.string.label_also_block_song),
                                     style = MaterialTheme.typography.bodyMedium,
                                 )
                                 Text(
-                                    text = "Blocked songs never re-download. Unblock in Settings later.",
+                                    text = stringResource(R.string.desc_blocked_songs_hint),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
@@ -473,13 +476,15 @@ fun PlaylistDetailScreen(
                     },
                 ) {
                     Text(
-                        text = if (isDownloadsMix) "Delete" else if (alsoBlacklist) "Delete & Block" else "Delete",
+                        text = if (isDownloadsMix) stringResource(R.string.action_delete)
+                        else if (alsoBlacklist) stringResource(R.string.action_delete_and_block)
+                        else stringResource(R.string.action_delete),
                         color = MaterialTheme.colorScheme.error,
                     )
                 }
             },
             dismissButton = {
-                TextButton(onClick = { trackToDelete = null }) { Text("Cancel") }
+                TextButton(onClick = { trackToDelete = null }) { Text(stringResource(R.string.action_cancel)) }
             },
         )
     }
@@ -496,17 +501,17 @@ fun PlaylistDetailScreen(
             onDismissRequest = { showBatchDelete = false },
             title = {
                 Text(
-                    if (isDownloadsMix) "Delete $n song${if (n != 1) "s" else ""} from library?"
-                    else "Remove $n song${if (n != 1) "s" else ""} from this playlist?"
+                    if (isDownloadsMix) stringResource(R.string.dialog_title_batch_delete, n)
+                    else stringResource(R.string.dialog_title_batch_remove, n)
                 )
             },
             text = {
                 Column {
                     Text(
                         text = if (isDownloadsMix) {
-                            "These tracks will be deleted from your library and their audio files removed from disk."
+                            stringResource(R.string.dialog_body_batch_delete_library)
                         } else {
-                            "Removes the songs from this playlist. If any are also in Liked Songs or an in-app playlist, the file stays so those lists keep playing."
+                            stringResource(R.string.dialog_body_batch_delete_playlist)
                         },
                         style = MaterialTheme.typography.bodyMedium,
                     )
@@ -523,11 +528,11 @@ fun PlaylistDetailScreen(
                             Spacer(modifier = Modifier.width(4.dp))
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(
-                                    text = "Also block these songs from future syncs",
+                                    text = stringResource(R.string.label_also_block_songs),
                                     style = MaterialTheme.typography.bodyMedium,
                                 )
                                 Text(
-                                    text = "Blocked songs never re-download. Unblock in Settings later.",
+                                    text = stringResource(R.string.desc_blocked_songs_hint),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
@@ -545,13 +550,15 @@ fun PlaylistDetailScreen(
                     },
                 ) {
                     Text(
-                        text = if (isDownloadsMix) "Delete" else if (alsoBlacklist) "Delete & Block" else "Delete",
+                        text = if (isDownloadsMix) stringResource(R.string.action_delete)
+                        else if (alsoBlacklist) stringResource(R.string.action_delete_and_block)
+                        else stringResource(R.string.action_delete),
                         color = MaterialTheme.colorScheme.error,
                     )
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showBatchDelete = false }) { Text("Cancel") }
+                TextButton(onClick = { showBatchDelete = false }) { Text(stringResource(R.string.action_cancel)) }
             },
         )
     }
@@ -653,7 +660,7 @@ private fun PlaylistHeader(
             ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Back",
+                    contentDescription = stringResource(R.string.cd_back),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }
@@ -735,7 +742,7 @@ private fun PlaylistHeader(
                             modifier = Modifier.size(20.dp),
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = "Play All", style = MaterialTheme.typography.labelLarge)
+                        Text(text = stringResource(R.string.action_play_all), style = MaterialTheme.typography.labelLarge)
                     }
                 }
 
@@ -755,7 +762,7 @@ private fun PlaylistHeader(
                             modifier = Modifier.size(20.dp),
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = "Shuffle", style = MaterialTheme.typography.labelLarge)
+                        Text(text = stringResource(R.string.action_shuffle), style = MaterialTheme.typography.labelLarge)
                     }
                 }
 
@@ -771,7 +778,7 @@ private fun PlaylistHeader(
                 ) {
                     Icon(
                         imageVector = Icons.Default.Search,
-                        contentDescription = "Filter tracks",
+                        contentDescription = stringResource(R.string.cd_filter_tracks),
                         tint = MaterialTheme.colorScheme.onSurface,
                     )
                 }
@@ -788,7 +795,7 @@ private fun PlaylistHeader(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Image,
-                            contentDescription = "Set cover image",
+                            contentDescription = stringResource(R.string.cd_set_cover_image),
                             tint = MaterialTheme.colorScheme.onSurface,
                         )
                     }

--- a/feature/library/src/main/kotlin/com/stash/feature/library/mixbuilder/MixBuilderScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/mixbuilder/MixBuilderScreen.kt
@@ -40,12 +40,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.stash.core.ui.R
 import com.stash.core.ui.components.GlassCard
 import com.stash.core.ui.theme.StashTheme
 import kotlin.math.roundToInt
@@ -84,7 +86,7 @@ fun MixBuilderScreen(
             TopAppBar(
                 title = {
                     Text(
-                        text = if (state.isEditing) "Edit Mix" else "Create a Mix",
+                        text = if (state.isEditing) stringResource(R.string.title_edit_mix) else stringResource(R.string.title_create_mix),
                         style = MaterialTheme.typography.titleLarge,
                         color = MaterialTheme.colorScheme.onBackground,
                     )
@@ -93,7 +95,7 @@ fun MixBuilderScreen(
                     IconButton(onClick = onBack) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back",
+                            contentDescription = stringResource(R.string.cd_back),
                             tint = MaterialTheme.colorScheme.onBackground,
                         )
                     }
@@ -117,7 +119,7 @@ fun MixBuilderScreen(
                 onValueChange = viewModel::setName,
                 placeholder = {
                     Text(
-                        text = "Mix name (optional)",
+                        text = stringResource(R.string.label_mix_name_optional),
                         style = MaterialTheme.typography.titleMedium,
                         color = StashTheme.extendedColors.textTertiary,
                     )
@@ -138,7 +140,7 @@ fun MixBuilderScreen(
             )
 
             // ── 2) Moods ───────────────────────────────────────────────────
-            EyebrowLabel("Moods")
+            EyebrowLabel(stringResource(R.string.label_moods))
             FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 state.moods.forEach { key ->
                     MixChip(
@@ -151,7 +153,7 @@ fun MixBuilderScreen(
             }
 
             // ── 3) Genres ──────────────────────────────────────────────────
-            EyebrowLabel("Genres")
+            EyebrowLabel(stringResource(R.string.label_genres))
             state.families.forEachIndexed { index, family ->
                 if (index > 0) Spacer(Modifier.height(14.dp))
                 Text(
@@ -172,14 +174,14 @@ fun MixBuilderScreen(
             }
 
             // ── 4) Era ─────────────────────────────────────────────────────
-            EyebrowLabel("Era · optional")
+            EyebrowLabel(stringResource(R.string.label_era_optional))
             EraSelector(
                 startYear = state.form.eraStartYear,
                 onEraSelected = viewModel::setEra,
             )
 
             // ── 5) Discovery level ─────────────────────────────────────────
-            EyebrowLabel("Discovery level")
+            EyebrowLabel(stringResource(R.string.label_discovery_level))
             Slider(
                 value = state.form.discoveryRatio,
                 onValueChange = viewModel::setDiscoveryRatio,
@@ -192,13 +194,13 @@ fun MixBuilderScreen(
             )
             Row(modifier = Modifier.fillMaxWidth()) {
                 Text(
-                    text = "Familiar",
+                    text = stringResource(R.string.label_familiar),
                     style = MaterialTheme.typography.labelSmall,
                     color = StashTheme.extendedColors.textTertiary,
                 )
                 Spacer(Modifier.weight(1f))
                 Text(
-                    text = "Brand new",
+                    text = stringResource(R.string.label_brand_new),
                     style = MaterialTheme.typography.labelSmall,
                     color = StashTheme.extendedColors.textTertiary,
                 )
@@ -215,7 +217,7 @@ fun MixBuilderScreen(
             GlassCard {
                 Column(modifier = Modifier.fillMaxWidth()) {
                     Text(
-                        text = if (state.form.isValid) state.form.displayName else "Untitled mix",
+                        text = if (state.form.isValid) state.form.displayName else stringResource(R.string.label_untitled_mix),
                         style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.onSurface,
                         maxLines = 1,
@@ -243,7 +245,7 @@ fun MixBuilderScreen(
                 ),
             ) {
                 Text(
-                    text = if (state.isEditing) "Save" else "Create mix",
+                    text = if (state.isEditing) stringResource(R.string.action_save) else stringResource(R.string.action_create_mix_btn),
                     style = MaterialTheme.typography.titleSmall,
                 )
             }
@@ -344,14 +346,15 @@ private fun MixChip(
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 /** Meta line for the summary card: ingredients · era · discovery. */
+@Composable
 private fun buildSummary(state: MixBuilderUiState): String {
     val form = state.form
     val tags = (form.genreTags + form.moodKeys)
         .map { it.replaceFirstChar { c -> c.uppercase() } }
-    val ingredients = if (tags.isEmpty()) "No ingredients yet" else tags.joinToString(", ")
+    val ingredients = if (tags.isEmpty()) stringResource(R.string.label_no_ingredients) else tags.joinToString(", ")
 
     val era = when {
-        form.eraStartYear == null -> "Any era"
+        form.eraStartYear == null -> stringResource(R.string.label_any_era)
         form.eraEndYear != null -> "${form.eraStartYear}–${form.eraEndYear}"
         else -> "${form.eraStartYear}+"
     }

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/MiniPlayer.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/MiniPlayer.kt
@@ -37,7 +37,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.ui.res.stringResource
 import coil3.compose.AsyncImage
+import com.stash.core.ui.R
 import coil3.request.ImageRequest
 
 /**
@@ -101,7 +103,7 @@ fun MiniPlayer(
                             model = ImageRequest.Builder(LocalContext.current)
                                 .data(artModel)
                                 .build(),
-                            contentDescription = "Album art",
+                            contentDescription = stringResource(R.string.cd_album_art),
                             contentScale = ContentScale.Crop,
                             modifier = Modifier
                                 .size(48.dp)
@@ -146,7 +148,7 @@ fun MiniPlayer(
                         } else {
                             Icon(
                                 imageVector = if (uiState.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                                contentDescription = if (uiState.isPlaying) "Pause" else "Play",
+                                contentDescription = if (uiState.isPlaying) stringResource(R.string.cd_pause) else stringResource(R.string.cd_play),
                                 tint = MaterialTheme.colorScheme.onSurface,
                                 modifier = Modifier.size(28.dp),
                             )
@@ -157,7 +159,7 @@ fun MiniPlayer(
                     IconButton(onClick = viewModel::onSkipNext) {
                         Icon(
                             imageVector = Icons.Default.SkipNext,
-                            contentDescription = "Next",
+                            contentDescription = stringResource(R.string.cd_next),
                             tint = MaterialTheme.colorScheme.onSurface,
                             modifier = Modifier.size(24.dp),
                         )

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -75,6 +76,7 @@ import com.stash.feature.nowplaying.ui.GlowingProgressBar
 import com.stash.feature.nowplaying.ui.LiveLyricsBar
 import com.stash.feature.nowplaying.ui.LyricsBottomSheet
 import com.stash.feature.nowplaying.ui.QueueBottomSheet
+import com.stash.core.ui.R
 
 /**
  * Full-screen Now Playing screen with premium visual design.
@@ -189,7 +191,7 @@ fun NowPlayingScreen(
             onDismissRequest = { showWrongMatchDialog = false },
             title = {
                 androidx.compose.material3.Text(
-                    text = "What's wrong with this song?",
+                    text = stringResource(R.string.dialog_title_wrong_match),
                     style = androidx.compose.material3.MaterialTheme.typography.titleMedium,
                     fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
                 )
@@ -199,7 +201,7 @@ fun NowPlayingScreen(
                     verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp),
                 ) {
                     androidx.compose.material3.Text(
-                        text = "Pick what should happen to '${track.title}'.",
+                        text = stringResource(R.string.dialog_body_wrong_match, track.title),
                         style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
                         color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -214,7 +216,7 @@ fun NowPlayingScreen(
                             },
                             modifier = Modifier.fillMaxWidth(),
                         ) {
-                            androidx.compose.material3.Text("Find in FLAC")
+                            androidx.compose.material3.Text(stringResource(R.string.action_find_in_flac))
                         }
                     }
                     androidx.compose.material3.OutlinedButton(
@@ -224,7 +226,7 @@ fun NowPlayingScreen(
                         },
                         modifier = Modifier.fillMaxWidth(),
                     ) {
-                        androidx.compose.material3.Text("Find a better match")
+                        androidx.compose.material3.Text(stringResource(R.string.action_find_better_match))
                     }
                     androidx.compose.material3.OutlinedButton(
                         onClick = {
@@ -233,7 +235,7 @@ fun NowPlayingScreen(
                         },
                         modifier = Modifier.fillMaxWidth(),
                     ) {
-                        androidx.compose.material3.Text("Delete from library")
+                        androidx.compose.material3.Text(stringResource(R.string.action_delete_from_library))
                     }
                     androidx.compose.material3.Button(
                         onClick = {
@@ -245,7 +247,7 @@ fun NowPlayingScreen(
                             containerColor = androidx.compose.material3.MaterialTheme.colorScheme.error,
                         ),
                     ) {
-                        androidx.compose.material3.Text("Delete and block forever")
+                        androidx.compose.material3.Text(stringResource(R.string.action_delete_and_block_forever))
                     }
                 }
             },
@@ -253,7 +255,7 @@ fun NowPlayingScreen(
                 androidx.compose.material3.TextButton(
                     onClick = { showWrongMatchDialog = false },
                 ) {
-                    androidx.compose.material3.Text("Cancel")
+                    androidx.compose.material3.Text(stringResource(R.string.action_cancel))
                 }
             },
         )
@@ -338,7 +340,7 @@ fun NowPlayingScreen(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
-                            text = track?.title ?: "Not Playing",
+                            text = track?.title ?: stringResource(R.string.label_not_playing),
                             fontSize = 22.sp,
                             fontWeight = FontWeight.Bold,
                             color = Color.White,
@@ -366,7 +368,7 @@ fun NowPlayingScreen(
                             } else {
                                 Icon(
                                     imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                    contentDescription = "Open artist",
+                                    contentDescription = stringResource(R.string.cd_open_artist),
                                     tint = Color.White.copy(alpha = 0.6f),
                                     modifier = Modifier.size(18.dp),
                                 )
@@ -509,7 +511,7 @@ private fun TopBar(
         IconButton(onClick = onDismiss) {
             Icon(
                 imageVector = Icons.Default.KeyboardArrowDown,
-                contentDescription = "Dismiss",
+                contentDescription = stringResource(R.string.cd_dismiss),
                 tint = Color.White,
                 modifier = Modifier.size(28.dp),
             )
@@ -538,7 +540,7 @@ private fun TopBar(
             IconButton(onClick = onFlagWrongMatch) {
                 Icon(
                     imageVector = Icons.Default.Flag,
-                    contentDescription = "Flag as wrong match",
+                    contentDescription = stringResource(R.string.cd_flag_wrong_match),
                     tint = Color.White,
                     modifier = Modifier.size(24.dp),
                 )
@@ -566,7 +568,7 @@ private fun TopBar(
                 IconButton(onClick = onDownloadTap) {
                     Icon(
                         imageVector = if (isDownloaded) Icons.Default.DownloadDone else Icons.Default.Download,
-                        contentDescription = if (isDownloaded) "Remove download" else "Download",
+                        contentDescription = if (isDownloaded) stringResource(R.string.selection_remove_download) else stringResource(R.string.action_download),
                         tint = Color.White,
                         modifier = Modifier.size(24.dp),
                     )
@@ -579,7 +581,7 @@ private fun TopBar(
             IconButton(onClick = onSaveClick) {
                 Icon(
                     imageVector = Icons.Default.BookmarkBorder,
-                    contentDescription = "Save to Playlist",
+                    contentDescription = stringResource(R.string.cd_save_to_playlist),
                     tint = Color.White,
                     modifier = Modifier.size(24.dp),
                 )
@@ -589,7 +591,7 @@ private fun TopBar(
         IconButton(onClick = onQueueClick) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.QueueMusic,
-                contentDescription = "Queue ($queueSize tracks)",
+                contentDescription = "${stringResource(R.string.cd_queue)} ($queueSize tracks)",
                 tint = Color.White,
                 modifier = Modifier.size(24.dp),
             )
@@ -638,7 +640,7 @@ private fun AlbumArtSection(
 
         AsyncImage(
             model = artRequest,
-            contentDescription = "Album art",
+            contentDescription = stringResource(R.string.cd_album_art),
             contentScale = ContentScale.Crop,
             onState = { state ->
                 if (state is AsyncImagePainter.State.Success) {
@@ -683,7 +685,7 @@ private fun PlaybackControls(
         IconButton(onClick = onToggleShuffle) {
             Icon(
                 imageVector = Icons.Default.Shuffle,
-                contentDescription = "Shuffle",
+                contentDescription = stringResource(R.string.cd_shuffle),
                 tint = if (shuffleEnabled) accentColor else Color.White.copy(alpha = 0.6f),
                 modifier = Modifier.size(24.dp),
             )
@@ -693,7 +695,7 @@ private fun PlaybackControls(
         IconButton(onClick = onSkipPrevious) {
             Icon(
                 imageVector = Icons.Default.SkipPrevious,
-                contentDescription = "Previous",
+                contentDescription = stringResource(R.string.cd_previous),
                 tint = Color.White,
                 modifier = Modifier.size(36.dp),
             )
@@ -724,7 +726,7 @@ private fun PlaybackControls(
             } else {
                 Icon(
                     imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                    contentDescription = if (isPlaying) "Pause" else "Play",
+                    contentDescription = if (isPlaying) stringResource(R.string.cd_pause) else stringResource(R.string.cd_play),
                     tint = Color.White,
                     modifier = Modifier.size(32.dp),
                 )
@@ -735,7 +737,7 @@ private fun PlaybackControls(
         IconButton(onClick = onSkipNext) {
             Icon(
                 imageVector = Icons.Default.SkipNext,
-                contentDescription = "Next",
+                contentDescription = stringResource(R.string.cd_next),
                 tint = Color.White,
                 modifier = Modifier.size(36.dp),
             )
@@ -748,7 +750,7 @@ private fun PlaybackControls(
                     RepeatMode.ONE -> Icons.Default.RepeatOne
                     else -> Icons.Default.Repeat
                 },
-                contentDescription = "Repeat",
+                contentDescription = stringResource(R.string.cd_repeat),
                 tint = when (repeatMode) {
                     RepeatMode.OFF -> Color.White.copy(alpha = 0.6f)
                     else -> accentColor
@@ -770,6 +772,7 @@ private fun PlaybackControls(
  * Returns null only when the codec is blank — in that case the caller
  * should render no line at all.
  */
+@Composable
 private fun trackQualityText(track: com.stash.core.model.Track): String? {
     // v0.9.13 fix: tracks downloaded before format-tracking was wired (pre-v0.9.11)
     // default to file_format = "opus" regardless of the actual codec — so a FLAC
@@ -802,7 +805,7 @@ private fun trackQualityText(track: com.stash.core.model.Track): String? {
         // two. We don't badge "via Kennyy" / "via squid" because those
         // are the expected primary sources; only the lossy fallback
         // deserves a callout.
-        if (track.streamOrigin == "youtube") add("via YT")
+        if (track.streamOrigin == "youtube") add(stringResource(R.string.label_via_yt))
     }.joinToString(" · ")
 }
 
@@ -832,7 +835,7 @@ private fun QualityLine(
         ) {
             Icon(
                 imageVector = Icons.Default.Wifi,
-                contentDescription = "Streaming",
+                contentDescription = stringResource(R.string.cd_streaming),
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(12.dp),
             )

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/GlowingProgressBar.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/GlowingProgressBar.kt
@@ -202,8 +202,8 @@ private fun formatTime(ms: Long): String {
     val seconds = totalSeconds % 60
 
     return if (hours > 0) {
-        String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
+        String.format(Locale.getDefault(), "%d:%02d:%02d", hours, minutes, seconds)
     } else {
-        String.format(Locale.US, "%d:%02d", minutes, seconds)
+        String.format(Locale.getDefault(), "%d:%02d", minutes, seconds)
     }
 }

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/LiveLyricsBar.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/LiveLyricsBar.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.res.stringResource
+import com.stash.core.ui.R
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.stash.data.lyrics.parser.LrcLine
@@ -97,7 +99,7 @@ fun LiveLyricsBar(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(onClickLabel = "Open lyrics", onClick = onTap)
+                .clickable(onClickLabel = stringResource(R.string.cd_open_lyrics), onClick = onTap)
                 .background(
                     Brush.verticalGradient(
                         0f to BarBase.copy(alpha = 0.30f),
@@ -144,7 +146,7 @@ fun LiveLyricsBar(
                     }
                 }
                 LiveBarMode.Static -> Text(
-                    text = "View lyrics ♪",
+                    text = stringResource(R.string.action_view_lyrics),
                     style = MaterialTheme.typography.titleSmall,
                     color = Color.White.copy(alpha = 0.45f),
                     maxLines = 1,

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/LyricsBottomSheet.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/LyricsBottomSheet.kt
@@ -21,6 +21,8 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.stash.core.ui.R
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
@@ -79,15 +81,15 @@ fun LyricsBottomSheet(
                         onLineTap = onSeek,
                     )
                     is LyricsViewState.Plain -> LyricsPlainRenderer(state.text)
-                    LyricsViewState.Instrumental -> CenteredPlacard("\u266A Instrumental")
+                    LyricsViewState.Instrumental -> CenteredPlacard(stringResource(R.string.label_instrumental))
                     LyricsViewState.None -> CenteredPlacard(
-                        label = "No lyrics found",
-                        action = "Retry",
+                        label = stringResource(R.string.label_no_lyrics_found),
+                        action = stringResource(R.string.cd_retry),
                         onAction = onRetry,
                     )
                     is LyricsViewState.Error -> CenteredPlacard(
-                        label = "Couldn't load lyrics",
-                        action = if (state.retryable) "Retry" else null,
+                        label = stringResource(R.string.label_lyrics_load_error),
+                        action = if (state.retryable) stringResource(R.string.cd_retry) else null,
                         onAction = onRetry,
                     )
                 }
@@ -111,12 +113,12 @@ private fun LyricsHeader(onClose: () -> Unit) {
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         Text(
-            text = "Lyrics",
+            text = stringResource(R.string.title_lyrics),
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
         )
         IconButton(onClick = onClose) {
-            Icon(Icons.Default.Close, contentDescription = "Close")
+            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.cd_close))
         }
     }
 }

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/QueueBottomSheet.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/QueueBottomSheet.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
@@ -60,6 +61,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import coil3.compose.AsyncImage
 import com.stash.core.model.Track
+import com.stash.core.ui.R
 import java.util.Collections
 import kotlin.math.roundToInt
 
@@ -117,7 +119,7 @@ fun QueueBottomSheet(
 
             if (localQueue.isNotEmpty()) {
                 Text(
-                    text = "Up Next",
+                    text = stringResource(R.string.title_up_next),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(start = 20.dp, top = 16.dp, bottom = 8.dp),
@@ -311,7 +313,7 @@ fun QueueBottomSheet(
                             ) {
                                 Icon(
                                     imageVector = Icons.Default.DragHandle,
-                                    contentDescription = "Drag to reorder",
+                                    contentDescription = stringResource(R.string.cd_drag_to_reorder),
                                     tint = if (isDragging) MaterialTheme.colorScheme.primary
                                     else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                                     modifier = Modifier.size(24.dp),
@@ -332,7 +334,7 @@ fun QueueBottomSheet(
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
-                        text = "No upcoming tracks",
+                        text = stringResource(R.string.label_no_upcoming_tracks),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -355,7 +357,7 @@ private fun QueueHeader(trackCount: Int, currentIndex: Int, onClose: () -> Unit)
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(Modifier.weight(1f)) {
-            Text("Queue", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+            Text(stringResource(R.string.cd_queue), style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
             if (trackCount > 0) {
                 Text(
                     "${currentIndex + 1} of $trackCount tracks",
@@ -370,7 +372,7 @@ private fun QueueHeader(trackCount: Int, currentIndex: Int, onClose: () -> Unit)
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
         )
         IconButton(onClick = onClose) {
-            Icon(Icons.Default.Close, "Close", Modifier.size(24.dp))
+            Icon(Icons.Default.Close, stringResource(R.string.cd_close), Modifier.size(24.dp))
         }
     }
 }
@@ -413,7 +415,7 @@ private fun CurrentTrackRow(track: Track, accentColor: Color) {
             )
         }
         Spacer(Modifier.width(8.dp))
-        Icon(Icons.Default.GraphicEq, "Now playing", tint = accentColor, modifier = Modifier.size(20.dp))
+        Icon(Icons.Default.GraphicEq, stringResource(R.string.cd_now_playing), tint = accentColor, modifier = Modifier.size(20.dp))
     }
 }
 

--- a/feature/search/src/main/kotlin/com/stash/feature/search/AlbumDiscoveryScreen.kt
+++ b/feature/search/src/main/kotlin/com/stash/feature/search/AlbumDiscoveryScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -36,6 +37,7 @@ import com.stash.core.model.TrackItem
 import com.stash.core.media.preview.PreviewState
 import com.stash.core.ui.components.DiscoveryErrorCard
 import com.stash.core.ui.components.SectionHeader
+import com.stash.core.ui.R
 import com.stash.data.ytmusic.model.AlbumSummary
 import kotlinx.coroutines.flow.merge
 
@@ -137,7 +139,7 @@ fun AlbumDiscoveryScreen(
                 }
                 is AlbumDiscoveryStatus.Error -> item {
                     DiscoveryErrorCard(
-                        title = "Couldn't load album",
+                        title = stringResource(R.string.error_load_album),
                         message = status.message,
                         onRetry = vm::retry,
                     )
@@ -152,7 +154,7 @@ fun AlbumDiscoveryScreen(
                                 contentAlignment = Alignment.Center,
                             ) {
                                 Text(
-                                    text = "No tracks available",
+                                    text = stringResource(R.string.label_no_tracks_available),
                                     style = MaterialTheme.typography.bodyLarge,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
@@ -207,7 +209,7 @@ fun AlbumDiscoveryScreen(
                             )
                         }
                         if (state.moreByArtist.isNotEmpty()) {
-                            item { SectionHeader(title = "More by this artist") }
+                            item { SectionHeader(title = stringResource(R.string.section_more_by_artist)) }
                             item {
                                 AlbumsRow(
                                     albums = state.moreByArtist,
@@ -224,26 +226,26 @@ fun AlbumDiscoveryScreen(
             val count = state.downloadConfirmQueue.size
             AlertDialog(
                 onDismissRequest = vm::onDownloadAllDismissed,
-                title = { Text("Download all?") },
+                title = { Text(stringResource(R.string.dialog_title_download_all)) },
                 text = {
                     Text(
                         text = if (count == 0) {
-                            "All tracks already downloaded."
+                            stringResource(R.string.dialog_body_all_downloaded)
                         } else {
-                            "Download $count track${if (count == 1) "" else "s"} to your library?"
+                            stringResource(R.string.dialog_body_download_count, count)
                         },
                     )
                 },
                 confirmButton = {
                     if (count == 0) {
-                        TextButton(onClick = vm::onDownloadAllDismissed) { Text("OK") }
+                        TextButton(onClick = vm::onDownloadAllDismissed) { Text(stringResource(R.string.action_ok)) }
                     } else {
-                        Button(onClick = vm::onDownloadAllConfirmed) { Text("Download") }
+                        Button(onClick = vm::onDownloadAllConfirmed) { Text(stringResource(R.string.action_download)) }
                     }
                 },
                 dismissButton = {
                     if (count != 0) {
-                        TextButton(onClick = vm::onDownloadAllDismissed) { Text("Cancel") }
+                        TextButton(onClick = vm::onDownloadAllDismissed) { Text(stringResource(R.string.action_cancel)) }
                     }
                 },
             )

--- a/feature/search/src/main/kotlin/com/stash/feature/search/AlbumHero.kt
+++ b/feature/search/src/main/kotlin/com/stash/feature/search/AlbumHero.kt
@@ -37,11 +37,13 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.stash.core.ui.theme.StashTheme
 import com.stash.core.ui.util.formatTotalDuration
+import com.stash.core.ui.R
 
 /**
  * Album Discovery hero card.
@@ -167,7 +169,7 @@ fun AlbumHero(
             ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Back",
+                    contentDescription = stringResource(R.string.cd_back),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }
@@ -244,7 +246,7 @@ fun AlbumHero(
                     )
                     Spacer(Modifier.width(6.dp))
                     Text(
-                        text = "Play",
+                        text = stringResource(R.string.action_play),
                         style = MaterialTheme.typography.labelLarge,
                     )
                 }
@@ -260,7 +262,7 @@ fun AlbumHero(
                     )
                     Spacer(Modifier.width(6.dp))
                     Text(
-                        text = "Queue",
+                        text = stringResource(R.string.action_queue),
                         style = MaterialTheme.typography.labelLarge,
                     )
                 }
@@ -277,7 +279,7 @@ fun AlbumHero(
                         )
                         Spacer(Modifier.width(6.dp))
                         Text(
-                            text = "Shuffle",
+                            text = stringResource(R.string.action_shuffle),
                             style = MaterialTheme.typography.labelLarge,
                         )
                     }
@@ -295,7 +297,7 @@ fun AlbumHero(
                         )
                         Spacer(Modifier.width(6.dp))
                         Text(
-                            text = "Download all",
+                            text = stringResource(R.string.action_download_all),
                             style = MaterialTheme.typography.labelLarge,
                         )
                     }

--- a/feature/search/src/main/kotlin/com/stash/feature/search/ArtistHero.kt
+++ b/feature/search/src/main/kotlin/com/stash/feature/search/ArtistHero.kt
@@ -32,10 +32,12 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.stash.core.common.ArtUrlUpgrader
+import com.stash.core.ui.R
 
 /**
  * Artist Profile hero card.
@@ -132,7 +134,7 @@ fun ArtistHero(
                     )
                     Spacer(Modifier.width(6.dp))
                     Text(
-                        text = "Play",
+                        text = stringResource(R.string.action_play),
                         style = MaterialTheme.typography.labelLarge,
                     )
                 }
@@ -149,7 +151,7 @@ fun ArtistHero(
                     )
                     Spacer(Modifier.width(6.dp))
                     Text(
-                        text = "Radio",
+                        text = stringResource(R.string.action_radio),
                         style = MaterialTheme.typography.labelLarge,
                     )
                 }
@@ -167,7 +169,7 @@ fun ArtistHero(
         ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "Back",
+                contentDescription = stringResource(R.string.cd_back),
                 tint = MaterialTheme.colorScheme.onBackground,
             )
         }

--- a/feature/search/src/main/kotlin/com/stash/feature/search/ArtistProfileScreen.kt
+++ b/feature/search/src/main/kotlin/com/stash/feature/search/ArtistProfileScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -24,6 +25,7 @@ import com.stash.core.ui.components.AlbumsRowSkeleton
 import com.stash.core.ui.components.DiscoveryErrorCard
 import com.stash.core.ui.components.PopularListSkeleton
 import com.stash.core.ui.components.SectionHeader
+import com.stash.core.ui.R
 import com.stash.core.model.TrackItem
 import com.stash.data.ytmusic.model.AlbumSummary
 import kotlinx.coroutines.flow.merge
@@ -132,7 +134,7 @@ fun ArtistProfileScreen(
             when (val status = state.status) {
                 is ArtistProfileStatus.Error -> item {
                     DiscoveryErrorCard(
-                        title = "Couldn't load artist",
+                        title = stringResource(R.string.error_load_artist),
                         message = status.message,
                         onRetry = vm::retry,
                     )
@@ -235,7 +237,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.contentSections(
     focus: AlbumFocusTarget?,
 ) {
     if (state.popular.isNotEmpty()) {
-        item { SectionHeader(title = "Popular") }
+        item { SectionHeader(title = stringResource(R.string.section_popular)) }
         item {
             PopularTracksSection(
                 tracks = state.popular,
@@ -256,7 +258,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.contentSections(
         }
     }
     if (state.albums.isNotEmpty()) {
-        item { SectionHeader(title = "Albums") }
+        item { SectionHeader(title = stringResource(R.string.section_albums)) }
         item {
             AlbumsRow(
                 albums = state.albums,
@@ -266,7 +268,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.contentSections(
         }
     }
     if (state.singles.isNotEmpty()) {
-        item { SectionHeader(title = "Singles & EPs") }
+        item { SectionHeader(title = stringResource(R.string.section_singles_eps)) }
         item {
             SinglesRow(
                 singles = state.singles,
@@ -276,7 +278,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.contentSections(
         }
     }
     if (state.related.isNotEmpty()) {
-        item { SectionHeader(title = "Fans also like") }
+        item { SectionHeader(title = stringResource(R.string.section_fans_also_like)) }
         item {
             RelatedArtistsRow(
                 artists = state.related,

--- a/feature/search/src/main/kotlin/com/stash/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/kotlin/com/stash/feature/search/SearchScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -81,6 +82,7 @@ import com.stash.core.ui.components.ArtistAvatarCard
 import com.stash.core.ui.components.SectionHeader
 import com.stash.core.ui.components.ShimmerPlaceholder
 import com.stash.core.ui.theme.StashTheme
+import com.stash.core.ui.R
 import com.stash.data.ytmusic.model.AlbumSummary
 import com.stash.data.ytmusic.model.ArtistSummary
 import com.stash.data.ytmusic.model.SearchResultSection
@@ -222,14 +224,14 @@ private fun SearchBar(
             .focusRequester(focusRequester),
         placeholder = {
             Text(
-                text = "Search songs, artists...",
+                text = stringResource(R.string.hint_search),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
         leadingIcon = {
             Icon(
                 imageVector = Icons.Default.Search,
-                contentDescription = "Search",
+                contentDescription = stringResource(R.string.cd_search),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
@@ -242,7 +244,7 @@ private fun SearchBar(
                 IconButton(onClick = onClear) {
                     Icon(
                         imageVector = Icons.Default.Clear,
-                        contentDescription = "Clear search",
+                        contentDescription = stringResource(R.string.cd_clear_search),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
@@ -300,12 +302,12 @@ private fun RecentSearches(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = "Recent searches",
+                    text = stringResource(R.string.section_recent_searches),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.weight(1f),
                 )
-                TextButton(onClick = onClearAll) { Text("Clear all") }
+                TextButton(onClick = onClearAll) { Text(stringResource(R.string.action_clear_all)) }
             }
         }
         items(entries, key = { "${it.type}:${it.text.lowercase()}" }) { entry ->
@@ -327,7 +329,7 @@ private fun RecentSearches(
                         overflow = TextOverflow.Ellipsis,
                     )
                     val sub = when (entry.type) {
-                        RecentSearch.Type.ARTIST -> "Artist"
+                        RecentSearch.Type.ARTIST -> stringResource(R.string.label_artist_type)
                         RecentSearch.Type.TRACK -> entry.subtitle
                         RecentSearch.Type.QUERY -> null
                     }
@@ -344,7 +346,7 @@ private fun RecentSearches(
                 IconButton(onClick = { onRemove(entry) }) {
                     Icon(
                         imageVector = Icons.Default.Clear,
-                        contentDescription = "Remove",
+                        contentDescription = stringResource(R.string.action_remove),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
@@ -482,7 +484,7 @@ private fun SectionedResultsList(
                     }
                 }
                 is SearchResultSection.Songs -> {
-                    item(key = "songs_header") { SectionHeader("Songs") }
+                    item(key = "songs_header") { SectionHeader(stringResource(R.string.section_songs)) }
                     items(section.tracks, key = { "song_" + it.videoId }) { t ->
                         val item = t.toSearchResultItem()
                         // Warm the lossless URL cache for each song row as it
@@ -513,7 +515,7 @@ private fun SectionedResultsList(
                     }
                 }
                 is SearchResultSection.Artists -> {
-                    item(key = "artists_header") { SectionHeader("Artists") }
+                    item(key = "artists_header") { SectionHeader(stringResource(R.string.section_artists)) }
                     item(key = "artists_row") {
                         LazyRow(
                             horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -530,7 +532,7 @@ private fun SectionedResultsList(
                     }
                 }
                 is SearchResultSection.Albums -> {
-                    item(key = "albums_header") { SectionHeader("Albums") }
+                    item(key = "albums_header") { SectionHeader(stringResource(R.string.section_albums)) }
                     item(key = "albums_row") {
                         LazyRow(
                             horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -635,9 +637,9 @@ private fun TopResultCard(
         Column(modifier = Modifier.weight(1f)) {
             val (primary, secondary, kind) = when (item) {
                 is TopResultItem.ArtistTop ->
-                    Triple(item.artist.name, null, "Artist")
+                    Triple(item.artist.name, null, stringResource(R.string.label_artist_type))
                 is TopResultItem.TrackTop ->
-                    Triple(item.track.title, item.track.artist, "Song")
+                    Triple(item.track.title, item.track.artist, stringResource(R.string.label_song_type))
             }
             Text(
                 text = kind,
@@ -681,12 +683,12 @@ private fun TopResultCard(
                     )
                     isPreviewPlaying -> Icon(
                         imageVector = Icons.Default.Stop,
-                        contentDescription = "Stop preview",
+                        contentDescription = stringResource(R.string.cd_stop_preview),
                         tint = MaterialTheme.colorScheme.primary,
                     )
                     else -> Icon(
                         imageVector = Icons.Default.PlayArrow,
-                        contentDescription = "Preview",
+                        contentDescription = stringResource(R.string.cd_preview),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
@@ -701,7 +703,7 @@ private fun TopResultCard(
                     isDownloaded -> {
                         Icon(
                             imageVector = Icons.Default.CheckCircle,
-                            contentDescription = "Downloaded",
+                            contentDescription = stringResource(R.string.cd_downloaded),
                             modifier = Modifier.size(24.dp),
                             tint = extendedColors.success,
                         )
@@ -717,7 +719,7 @@ private fun TopResultCard(
                         IconButton(onClick = onDownload) {
                             Icon(
                                 imageVector = Icons.Default.Download,
-                                contentDescription = "Download",
+                                contentDescription = stringResource(R.string.cd_download),
                                 modifier = Modifier.size(24.dp),
                                 tint = MaterialTheme.colorScheme.onSurface,
                             )
@@ -773,7 +775,7 @@ private fun ErrorMessage(message: String) {
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(
-                text = "Search failed",
+                text = stringResource(R.string.error_search_failed),
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onBackground,
             )
@@ -804,13 +806,13 @@ private fun NoResultsMessage() {
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(
-                text = "No results found",
+                text = stringResource(R.string.label_no_results),
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onBackground,
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = "Try a different search term",
+                text = stringResource(R.string.desc_try_different_search),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -835,13 +837,13 @@ private fun EmptySearchPrompt() {
             )
             Spacer(modifier = Modifier.height(16.dp))
             Text(
-                text = "Search YouTube Music",
+                text = stringResource(R.string.title_search_prompt),
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.onBackground,
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = "Find any song or artist and download it to your library",
+                text = stringResource(R.string.desc_search_prompt),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/feature/search/src/main/kotlin/com/stash/feature/search/SongRow.kt
+++ b/feature/search/src/main/kotlin/com/stash/feature/search/SongRow.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.GraphicEq
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.PlaylistAddCheck
 import androidx.compose.material.icons.filled.PlaylistPlay
@@ -39,6 +40,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
@@ -46,6 +48,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.stash.core.ui.theme.StashTheme
+import com.stash.core.ui.R
 
 /**
  * A row is the now-playing row iff it has a non-blank videoId equal to the player's
@@ -225,6 +228,30 @@ fun SongRow(
 
         Spacer(modifier = Modifier.width(8.dp))
 
+        // Preview button
+        IconButton(
+            onClick = if (isPreviewPlaying) onStopPreview else onPreview,
+            modifier = Modifier.size(40.dp),
+        ) {
+            when {
+                isPreviewLoading || isResolving -> CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                isPreviewPlaying -> Icon(
+                    imageVector = Icons.Default.Stop,
+                    contentDescription = stringResource(R.string.cd_stop_preview),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                else -> Icon(
+                    imageVector = Icons.Default.PlayArrow,
+                    contentDescription = stringResource(R.string.cd_preview),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
         // Download action button (hidden where download-by-id isn't supported).
         if (downloadSupported) {
         Box(
@@ -235,7 +262,7 @@ fun SongRow(
                 isDownloaded -> {
                     Icon(
                         imageVector = Icons.Default.CheckCircle,
-                        contentDescription = "Downloaded",
+                        contentDescription = stringResource(R.string.cd_downloaded),
                         modifier = Modifier.size(24.dp),
                         tint = extendedColors.success,
                     )
@@ -254,7 +281,7 @@ fun SongRow(
                     // it reads as informational rather than alerting.
                     Icon(
                         imageVector = Icons.Outlined.Schedule,
-                        contentDescription = "Waiting for lossless source",
+                        contentDescription = stringResource(R.string.cd_waiting_lossless),
                         modifier = Modifier.size(24.dp),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -263,7 +290,7 @@ fun SongRow(
                     IconButton(onClick = onDownload) {
                         Icon(
                             imageVector = Icons.Default.Download,
-                            contentDescription = "Download",
+                            contentDescription = stringResource(R.string.cd_download),
                             modifier = Modifier.size(24.dp),
                             tint = MaterialTheme.colorScheme.onSurface,
                         )
@@ -279,23 +306,23 @@ fun SongRow(
             IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(40.dp)) {
                 Icon(
                     imageVector = Icons.Default.MoreVert,
-                    contentDescription = "More actions",
+                    contentDescription = stringResource(R.string.cd_more_actions),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
             DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
                 DropdownMenuItem(
-                    text = { Text("Play next") },
+                    text = { Text(stringResource(R.string.selection_play_next)) },
                     leadingIcon = { Icon(Icons.Default.PlaylistPlay, contentDescription = null) },
                     onClick = { menuOpen = false; onPlayNext() },
                 )
                 DropdownMenuItem(
-                    text = { Text("Add to queue") },
+                    text = { Text(stringResource(R.string.action_add_to_queue)) },
                     leadingIcon = { Icon(Icons.Default.PlaylistAdd, contentDescription = null) },
                     onClick = { menuOpen = false; onAddToQueue() },
                 )
                 DropdownMenuItem(
-                    text = { Text("Add to playlist") },
+                    text = { Text(stringResource(R.string.selection_add_to_playlist)) },
                     leadingIcon = { Icon(Icons.Default.PlaylistAddCheck, contentDescription = null) },
                     onClick = { menuOpen = false; onAddToPlaylist() },
                 )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/BlockedSongsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/BlockedSongsScreen.kt
@@ -33,11 +33,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashTheme
 
 /**
@@ -78,7 +80,7 @@ fun BlockedSongsScreen(
             ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Back",
+                    contentDescription = stringResource(R.string.cd_back),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }
@@ -97,14 +99,14 @@ fun BlockedSongsScreen(
                 )
                 Spacer(modifier = Modifier.height(16.dp))
                 Text(
-                    text = "No blocked songs",
+                    text = stringResource(R.string.label_no_blocked_songs),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold,
                     color = MaterialTheme.colorScheme.onBackground,
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = "Songs you block with \u201CDelete & Block\u201D show up here. Tap Unblock to re-allow them on the next sync.",
+                    text = stringResource(R.string.desc_blocked_songs_empty),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = androidx.compose.ui.text.style.TextAlign.Center,
@@ -161,7 +163,7 @@ private fun BlockedSongsHeader(count: Int, onBack: () -> Unit) {
             ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Back",
+                    contentDescription = stringResource(R.string.cd_back),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }
@@ -174,14 +176,14 @@ private fun BlockedSongsHeader(count: Int, onBack: () -> Unit) {
                 .padding(horizontal = 20.dp),
         ) {
             Text(
-                text = "Blocked Songs",
+                text = stringResource(R.string.title_blocked_songs),
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onBackground,
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = "These songs are skipped during every sync. Tap Unblock to re-allow one.",
+                text = stringResource(R.string.desc_blocked_songs_header),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -252,7 +254,7 @@ private fun BlockedTrackListItem(
 
         TextButton(onClick = onUnblock) {
             Text(
-                text = "Unblock",
+                text = stringResource(R.string.action_unblock),
                 color = MaterialTheme.colorScheme.primary,
             )
         }

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAboutScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAboutScreen.kt
@@ -15,10 +15,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stash.core.data.sync.workers.UpdateCheckWorker
+import com.stash.core.ui.R
 import com.stash.core.ui.components.GlassCard
 import com.stash.feature.settings.components.SettingsScaffold
 import com.stash.feature.settings.components.SettingsSectionLabel
@@ -43,7 +45,7 @@ fun SettingsAboutScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    SettingsScaffold(title = "About & Help", onBack = onBack, modifier = modifier) {
+    SettingsScaffold(title = stringResource(R.string.title_about_help), onBack = onBack, modifier = modifier) {
         // -- Diagnostics section ----------------------------------------------
         // Crash-to-file: writes uncaught exceptions to cacheDir/crashes/ so
         // the user can attach the latest one to an email / Discord / GitHub
@@ -54,12 +56,18 @@ fun SettingsAboutScreen(
         val context = LocalContext.current
         LaunchedEffect(Unit) { viewModel.refreshDiagnostics() }
 
-        SettingsSectionLabel("Diagnostics")
+        // Pre-resolve strings used in non-Composable callbacks (Intent builders, Toast calls).
+        val crashReportSubject = stringResource(R.string.label_crash_report_subject)
+        val shareCrashReportTitle = stringResource(R.string.label_share_crash_report_title)
+        val noAppAvailableMsg = stringResource(R.string.status_no_app_available)
+        val checkingUpdatesMsg = stringResource(R.string.status_checking_updates)
+
+        SettingsSectionLabel(stringResource(R.string.section_diagnostics))
 
         GlassCard {
             Column(modifier = Modifier.fillMaxWidth()) {
                 Text(
-                    text = "Share latest crash report",
+                    text = stringResource(R.string.label_share_crash_report),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
@@ -68,7 +76,7 @@ fun SettingsAboutScreen(
                     text = if (uiState.hasCrashReport) {
                         "Attach the most recent crash log to email or chat. Stays on device until you share."
                     } else {
-                        "No recent crashes."
+                        stringResource(R.string.label_no_recent_crashes)
                     },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -85,14 +93,14 @@ fun SettingsAboutScreen(
                         val send = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
                             type = "text/plain"
                             putExtra(android.content.Intent.EXTRA_STREAM, target.contentUri)
-                            putExtra(android.content.Intent.EXTRA_SUBJECT, "Stash crash report")
+                            putExtra(android.content.Intent.EXTRA_SUBJECT, crashReportSubject)
                             addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
                         }
-                        val chooser = android.content.Intent.createChooser(send, "Share crash report")
+                        val chooser = android.content.Intent.createChooser(send, shareCrashReportTitle)
                             .apply { addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK) }
                         runCatching { context.startActivity(chooser) }
                             .onFailure {
-                                Toast.makeText(context, "No app available to share the report.", Toast.LENGTH_SHORT).show()
+                                Toast.makeText(context, noAppAvailableMsg, Toast.LENGTH_SHORT).show()
                             }
                     },
                     modifier = Modifier.fillMaxWidth(),
@@ -100,18 +108,18 @@ fun SettingsAboutScreen(
                         contentColor = MaterialTheme.colorScheme.primary,
                     ),
                 ) {
-                    Text("Share latest crash report")
+                    Text(stringResource(R.string.label_share_crash_report))
                 }
 
                 Spacer(modifier = Modifier.height(12.dp))
                 Text(
-                    text = "Share diagnostics",
+                    text = stringResource(R.string.label_share_diagnostics),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
-                    text = "Bundle recent logs, sync history, and connection status (no passwords) so a dev can debug your issue.",
+                    text = stringResource(R.string.desc_share_diagnostics),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -121,13 +129,13 @@ fun SettingsAboutScreen(
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.primary),
                 ) {
-                    Text("Share diagnostics")
+                    Text(stringResource(R.string.label_share_diagnostics))
                 }
             }
         }
 
         // -- About section ----------------------------------------------------
-        SettingsSectionLabel("About")
+        SettingsSectionLabel(stringResource(R.string.section_about))
 
         val installedVersion = remember(context) {
             runCatching {
@@ -137,21 +145,21 @@ fun SettingsAboutScreen(
 
         GlassCard {
             Column(modifier = Modifier.fillMaxWidth()) {
-                SettingsValueRow(label = "Version", value = installedVersion)
+                SettingsValueRow(label = stringResource(R.string.label_version), value = installedVersion)
                 Spacer(modifier = Modifier.height(8.dp))
-                SettingsValueRow(label = "License", value = "GPL-3.0")
+                SettingsValueRow(label = stringResource(R.string.label_license), value = "GPL-3.0")
                 Spacer(modifier = Modifier.height(12.dp))
                 OutlinedButton(
                     onClick = {
                         UpdateCheckWorker.enqueueOneTimeCheck(context)
-                        Toast.makeText(context, "Checking for updates…", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, checkingUpdatesMsg, Toast.LENGTH_SHORT).show()
                     },
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.outlinedButtonColors(
                         contentColor = MaterialTheme.colorScheme.primary,
                     ),
                 ) {
-                    Text("Check for updates")
+                    Text(stringResource(R.string.action_check_updates))
                 }
             }
         }

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAccountsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAccountsScreen.kt
@@ -13,9 +13,11 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.stash.core.ui.R
 import com.stash.core.ui.components.GlassCard
 import com.stash.feature.settings.components.AccountConnectionCard
 import com.stash.feature.settings.components.SettingsScaffold
@@ -90,7 +92,7 @@ fun SettingsAccountsScreen(
             shape = MaterialTheme.shapes.large,
             title = {
                 Text(
-                    text = "YouTube Music",
+                    text = stringResource(R.string.label_youtube_music),
                     style = MaterialTheme.typography.titleLarge,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
@@ -110,19 +112,19 @@ fun SettingsAccountsScreen(
         )
     }
 
-    SettingsScaffold(title = "Accounts & Sync", onBack = onBack, modifier = modifier) {
+    SettingsScaffold(title = stringResource(R.string.title_accounts_sync), onBack = onBack, modifier = modifier) {
         // Like-mirroring opt-in ack. Rendered at the top of the scaffold so it
         // overlays the content. Confirming writes the pref; dismissing leaves
         // mirroring off (no writes without this ack).
         uiState.pendingMirrorWarning?.let { dest ->
             com.stash.feature.settings.components.LikeMirrorWarningDialog(
-                serviceName = if (dest == com.stash.core.data.social.Destination.SPOTIFY) "Spotify" else "YouTube Music",
+                serviceName = if (dest == com.stash.core.data.social.Destination.SPOTIFY) stringResource(R.string.label_spotify) else stringResource(R.string.label_youtube_music),
                 onConfirm = viewModel::onMirrorWarningConfirmed,
                 onDismiss = viewModel::onMirrorWarningDismissed,
             )
         }
 
-        SettingsSectionLabel("Connections")
+        SettingsSectionLabel(stringResource(R.string.section_connections))
 
         AccountConnectionCard(
             serviceName = "Spotify",

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAppearanceScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAppearanceScreen.kt
@@ -28,10 +28,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stash.core.model.ThemeMode
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashBackground
 import com.stash.core.ui.theme.StashBackgroundLight
 import com.stash.core.ui.theme.StashPurple
@@ -57,15 +59,15 @@ fun SettingsAppearanceScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    SettingsScaffold(title = "Appearance", onBack = onBack, modifier = modifier) {
-        SettingsSectionLabel("Theme")
+    SettingsScaffold(title = stringResource(R.string.title_appearance), onBack = onBack, modifier = modifier) {
+        SettingsSectionLabel(stringResource(R.string.section_theme))
 
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             ThemeThumbnail(
-                label = "Dark",
+                label = stringResource(R.string.label_dark),
                 selected = uiState.themeMode == ThemeMode.DARK,
                 darkPalette = true,
                 followSystem = false,
@@ -73,7 +75,7 @@ fun SettingsAppearanceScreen(
                 modifier = Modifier.weight(1f),
             )
             ThemeThumbnail(
-                label = "Light",
+                label = stringResource(R.string.label_light),
                 selected = uiState.themeMode == ThemeMode.LIGHT,
                 darkPalette = false,
                 followSystem = false,
@@ -81,7 +83,7 @@ fun SettingsAppearanceScreen(
                 modifier = Modifier.weight(1f),
             )
             ThemeThumbnail(
-                label = "Follow system",
+                label = stringResource(R.string.label_follow_system),
                 selected = uiState.themeMode == ThemeMode.SYSTEM,
                 darkPalette = false,
                 followSystem = true,
@@ -91,7 +93,7 @@ fun SettingsAppearanceScreen(
         }
 
         Text(
-            text = "Follow system matches your device's day/night setting.",
+            text = stringResource(R.string.desc_follow_system),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(start = 4.dp, end = 4.dp, top = 4.dp),

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAudioQualityScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAudioQualityScreen.kt
@@ -38,9 +38,11 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.stash.core.ui.R
 import com.stash.core.ui.components.GlassCard
 import com.stash.data.download.lossless.LosslessQualityTier
 import com.stash.feature.settings.components.AudioQualityPicker
@@ -80,11 +82,11 @@ fun SettingsAudioQualityScreen(
     val qbdlxTokenChoices by viewModel.qbdlxTokenChoices.collectAsStateWithLifecycle()
     val qbdlxPinnedToken by viewModel.qbdlxPinnedToken.collectAsStateWithLifecycle()
 
-    SettingsScaffold(title = "Audio & Quality", onBack = onBack, modifier = modifier) {
+    SettingsScaffold(title = stringResource(R.string.title_audio_quality), onBack = onBack, modifier = modifier) {
         // (a) Download tier — only when lossless OFF. The standalone yt-dlp
         // tier picker governs downloads when lossless routing is disabled.
         if (!uiState.losslessEnabled) {
-            SettingsSectionLabel("Audio Quality")
+            SettingsSectionLabel(stringResource(R.string.section_audio_quality))
             GlassCard {
                 Column(
                     modifier = Modifier
@@ -92,7 +94,7 @@ fun SettingsAudioQualityScreen(
                         .selectableGroup(),
                 ) {
                     Text(
-                        text = "Download quality",
+                        text = stringResource(R.string.label_download_quality),
                         style = MaterialTheme.typography.titleSmall,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
@@ -106,15 +108,15 @@ fun SettingsAudioQualityScreen(
         }
 
         // (b) Lossless card.
-        SettingsSectionLabel("Lossless")
+        SettingsSectionLabel(stringResource(R.string.section_lossless))
         GlassCard {
             Column(modifier = Modifier.fillMaxWidth()) {
                 SettingsToggleRow(
-                    title = "Lossless downloads",
+                    title = stringResource(R.string.label_lossless_downloads),
                     subtitle = if (uiState.losslessEnabled) {
-                        "FLAC routing active. Files ~10× larger than MP3."
+                        stringResource(R.string.desc_lossless_active)
                     } else {
-                        "Studio-quality FLAC via Qobuz. Files ~10× larger than MP3."
+                        stringResource(R.string.desc_lossless_inactive)
                     },
                     checked = uiState.losslessEnabled,
                     onCheckedChange = viewModel::onLosslessEnabledChanged,
@@ -142,8 +144,8 @@ fun SettingsAudioQualityScreen(
                         // refresh path when the bundled pool ages out, and the
                         // badge surfaces all-dead.
                         SettingsToggleRow(
-                            title = "Direct Qobuz",
-                            subtitle = "Hi-Res FLAC, straight from Qobuz.",
+                            title = stringResource(R.string.label_direct_qobuz),
+                            subtitle = stringResource(R.string.desc_direct_qobuz),
                             checked = qbdlxEnabled,
                             onCheckedChange = viewModel::onQbdlxEnabledChange,
                         )
@@ -156,7 +158,7 @@ fun SettingsAudioQualityScreen(
                                 if (qbdlxExpired) {
                                     Spacer(modifier = Modifier.height(4.dp))
                                     Text(
-                                        text = "No working token — paste a fresh one",
+                                        text = stringResource(R.string.error_no_working_token),
                                         style = MaterialTheme.typography.bodySmall,
                                         color = MaterialTheme.colorScheme.error,
                                     )
@@ -164,15 +166,15 @@ fun SettingsAudioQualityScreen(
                                 if (qbdlxTokenChoices.size > 1) {
                                     Spacer(modifier = Modifier.height(4.dp))
                                     Text(
-                                        text = "Account",
+                                        text = stringResource(R.string.label_account),
                                         style = MaterialTheme.typography.titleSmall,
                                         color = MaterialTheme.colorScheme.onSurface,
                                     )
                                     Column(modifier = Modifier.selectableGroup()) {
                                         SettingsPickerRow(
                                             selected = qbdlxPinnedToken == null,
-                                            title = "Auto",
-                                            subtitle = "Recommended — uses a working account and fails over",
+                                            title = stringResource(R.string.label_auto),
+                                            subtitle = stringResource(R.string.desc_auto_token),
                                             onClick = { viewModel.onQbdlxTokenPinned(null) },
                                         )
                                         qbdlxTokenChoices.forEach { choice ->
@@ -195,9 +197,9 @@ fun SettingsAudioQualityScreen(
                                         viewModel.onQbdlxTokenPaste(it)
                                     },
                                     modifier = Modifier.fillMaxWidth(),
-                                    label = { Text("Paste token") },
+                                    label = { Text(stringResource(R.string.label_paste_token)) },
                                     singleLine = true,
-                                    placeholder = { Text("user_auth_token") },
+                                    placeholder = { Text(stringResource(R.string.hint_user_auth_token)) },
                                 )
                             }
                         }
@@ -205,7 +207,7 @@ fun SettingsAudioQualityScreen(
                         // -- Download quality picker --------------------------
                         Spacer(modifier = Modifier.height(8.dp))
                         Text(
-                            text = "Download quality",
+                            text = stringResource(R.string.label_download_quality),
                             style = MaterialTheme.typography.titleSmall,
                             color = MaterialTheme.colorScheme.onSurface,
                         )
@@ -231,14 +233,14 @@ fun SettingsAudioQualityScreen(
                         // override: when on, both pickers are dimmed + inert and
                         // policy forces CD on every network.
                         Spacer(modifier = Modifier.height(14.dp))
-                        SettingsSectionLabel("Streaming")
+                        SettingsSectionLabel(stringResource(R.string.section_streaming))
                         GlassCard {
                             Column(modifier = Modifier.fillMaxWidth()) {
                                 val saveData = uiState.streamingSaveData
                                 val pickerAlpha = if (saveData) 0.4f else 1f
 
                                 Text(
-                                    text = "On Wi-Fi",
+                                    text = stringResource(R.string.label_on_wifi),
                                     style = MaterialTheme.typography.titleSmall,
                                     color = MaterialTheme.colorScheme.onSurface,
                                 )
@@ -265,7 +267,7 @@ fun SettingsAudioQualityScreen(
 
                                 Spacer(modifier = Modifier.height(12.dp))
                                 Text(
-                                    text = "On cellular",
+                                    text = stringResource(R.string.label_on_cellular),
                                     style = MaterialTheme.typography.titleSmall,
                                     color = MaterialTheme.colorScheme.onSurface,
                                 )
@@ -292,9 +294,8 @@ fun SettingsAudioQualityScreen(
 
                                 Spacer(modifier = Modifier.height(8.dp))
                                 SettingsToggleRow(
-                                    title = "Save Data",
-                                    subtitle = "Request the lowest streaming quality on every network " +
-                                        "to minimize data. Not every source honors this yet.",
+                                    title = stringResource(R.string.label_save_data),
+                                    subtitle = stringResource(R.string.desc_save_data),
                                     checked = uiState.streamingSaveData,
                                     onCheckedChange = viewModel::onStreamingSaveDataChanged,
                                     titleTrailing = { BetaPill() },
@@ -331,7 +332,7 @@ fun SettingsAudioQualityScreen(
                             )
                             Spacer(modifier = Modifier.width(4.dp))
                             Text(
-                                text = "YouTube fallback",
+                                text = stringResource(R.string.label_youtube_fallback),
                                 style = MaterialTheme.typography.labelMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 modifier = Modifier.weight(1f),
@@ -357,7 +358,7 @@ fun SettingsAudioQualityScreen(
                                     )
                                     Spacer(modifier = Modifier.width(8.dp))
                                     Text(
-                                        text = "Use YouTube when lossless fails",
+                                        text = stringResource(R.string.label_use_youtube_fallback),
                                         style = MaterialTheme.typography.bodyMedium,
                                         color = MaterialTheme.colorScheme.onSurface,
                                     )
@@ -400,7 +401,7 @@ fun SettingsAudioQualityScreen(
                             )
                             Spacer(modifier = Modifier.width(4.dp))
                             Text(
-                                text = "Advanced",
+                                text = stringResource(R.string.label_advanced),
                                 style = MaterialTheme.typography.labelMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -414,7 +415,7 @@ fun SettingsAudioQualityScreen(
                             Column(modifier = Modifier.fillMaxWidth()) {
                                 Spacer(modifier = Modifier.height(4.dp))
                                 Text(
-                                    text = "Or paste the captcha_verified_at cookie value directly:",
+                                    text = stringResource(R.string.desc_paste_captcha_cookie),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
@@ -423,9 +424,9 @@ fun SettingsAudioQualityScreen(
                                     value = uiState.squidWtfCaptchaCookie,
                                     onValueChange = viewModel::onSquidWtfCaptchaCookieChanged,
                                     modifier = Modifier.fillMaxWidth(),
-                                    label = { Text("captcha_verified_at value") },
+                                    label = { Text(stringResource(R.string.label_captcha_verified_at)) },
                                     singleLine = true,
-                                    placeholder = { Text("e.g. 1777687404951") },
+                                    placeholder = { Text(stringResource(R.string.hint_captcha_value)) },
                                 )
                                 Spacer(modifier = Modifier.height(8.dp))
                                 TextButton(
@@ -433,7 +434,7 @@ fun SettingsAudioQualityScreen(
                                     modifier = Modifier.fillMaxWidth(),
                                 ) {
                                     Text(
-                                        text = "Reset lossless attempts",
+                                        text = stringResource(R.string.action_reset_lossless_attempts),
                                         style = MaterialTheme.typography.labelMedium,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )
@@ -446,9 +447,9 @@ fun SettingsAudioQualityScreen(
         }
 
         // (c) Effects.
-        SettingsSectionLabel("Effects")
+        SettingsSectionLabel(stringResource(R.string.section_effects))
         SettingsNavRow(
-            title = "Equalizer",
+            title = stringResource(R.string.title_equalizer),
             onClick = onNavigateToEqualizer,
         )
     }

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsHubScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsHubScreen.kt
@@ -20,9 +20,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.stash.core.ui.R
 import com.stash.feature.settings.components.SettingsGroupCard
 import com.stash.feature.settings.components.SettingsNavRow
 import com.stash.feature.settings.components.SettingsSearchField
@@ -90,7 +92,7 @@ fun SettingsHubScreen(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Text(
-            text = "Settings",
+            text = stringResource(R.string.title_settings),
             style = MaterialTheme.typography.headlineSmall,
             color = MaterialTheme.colorScheme.onSurface,
         )
@@ -100,7 +102,7 @@ fun SettingsHubScreen(
             rows = listOf(
                 {
                     SettingsNavRow(
-                        title = "Playback",
+                        title = stringResource(R.string.label_playback),
                         subtitle = summaries.playback,
                         leadingIcon = Icons.Rounded.PlayArrow,
                         onClick = onOpenPlayback,
@@ -108,7 +110,7 @@ fun SettingsHubScreen(
                 },
                 {
                     SettingsNavRow(
-                        title = "Audio & Quality",
+                        title = stringResource(R.string.label_audio_quality),
                         subtitle = summaries.audioQuality,
                         leadingIcon = Icons.Rounded.GraphicEq,
                         onClick = onOpenAudioQuality,
@@ -116,7 +118,7 @@ fun SettingsHubScreen(
                 },
                 {
                     SettingsNavRow(
-                        title = "Accounts & Sync",
+                        title = stringResource(R.string.label_accounts_sync),
                         subtitle = summaries.accounts,
                         leadingIcon = Icons.Rounded.Person,
                         onClick = onOpenAccounts,
@@ -124,7 +126,7 @@ fun SettingsHubScreen(
                 },
                 {
                     SettingsNavRow(
-                        title = "Library & Storage",
+                        title = stringResource(R.string.label_library_storage),
                         subtitle = summaries.libraryStorage,
                         leadingIcon = Icons.Rounded.FolderOpen,
                         onClick = onOpenLibraryStorage,
@@ -132,7 +134,7 @@ fun SettingsHubScreen(
                 },
                 {
                     SettingsNavRow(
-                        title = "Appearance",
+                        title = stringResource(R.string.label_appearance),
                         subtitle = summaries.appearance,
                         leadingIcon = Icons.Rounded.Palette,
                         onClick = onOpenAppearance,
@@ -140,7 +142,7 @@ fun SettingsHubScreen(
                 },
                 {
                     SettingsNavRow(
-                        title = "About & Help",
+                        title = stringResource(R.string.label_about_help),
                         subtitle = summaries.about,
                         leadingIcon = Icons.Rounded.Info,
                         onClick = onOpenAbout,

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsLibraryStorageScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsLibraryStorageScreen.kt
@@ -31,11 +31,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stash.core.model.DownloadNetworkMode
+import com.stash.core.ui.R
 import com.stash.core.ui.components.GlassCard
 import com.stash.core.ui.theme.StashTheme
 import com.stash.feature.settings.components.SettingsGroupCard
@@ -76,7 +78,7 @@ fun SettingsLibraryStorageScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val extendedColors = StashTheme.extendedColors
 
-    SettingsScaffold(title = "Library & Storage", onBack = onBack, modifier = modifier) {
+    SettingsScaffold(title = stringResource(R.string.title_library_storage), onBack = onBack, modifier = modifier) {
         val context = LocalContext.current
         val contentResolver = context.contentResolver
         // Tracks what action the user intended when they tapped the folder
@@ -119,7 +121,7 @@ fun SettingsLibraryStorageScreen(
         ) { uri -> if (uri != null) viewModel.onImportDatabase(uri) }
 
         // -- Downloads --------------------------------------------------------
-        SettingsSectionLabel("Downloads")
+        SettingsSectionLabel(stringResource(R.string.section_downloads))
 
         GlassCard {
             Column(
@@ -128,7 +130,7 @@ fun SettingsLibraryStorageScreen(
                     .selectableGroup(),
             ) {
                 Text(
-                    text = "Run recommendations when",
+                    text = stringResource(R.string.label_run_recommendations),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
@@ -176,7 +178,7 @@ fun SettingsLibraryStorageScreen(
             rows = listOf(
                 {
                     SettingsToggleRow(
-                        title = "Stash Mixes (beta)",
+                        title = stringResource(R.string.label_stash_mixes_beta),
                         subtitle = if (uiState.stashMixesEnabled) {
                             "Daily Discover, Deep Cuts, and First Listen mixes auto-refresh in the background."
                         } else {
@@ -190,12 +192,12 @@ fun SettingsLibraryStorageScreen(
         )
 
         // -- Library Health ---------------------------------------------------
-        SettingsSectionLabel("Library")
+        SettingsSectionLabel(stringResource(R.string.section_library))
         SettingsGroupCard(
             rows = listOf(
                 {
                     SettingsNavRow(
-                        title = "Library Health",
+                        title = stringResource(R.string.label_library_health),
                         onClick = onNavigateToLibraryHealth,
                     )
                 },
@@ -203,7 +205,7 @@ fun SettingsLibraryStorageScreen(
         )
 
         // -- Storage ----------------------------------------------------------
-        SettingsSectionLabel("Storage")
+        SettingsSectionLabel(stringResource(R.string.section_storage))
 
         val externalTree = uiState.externalTreeUri
         // Derive a human-readable folder name from the tree URI without
@@ -211,13 +213,14 @@ fun SettingsLibraryStorageScreen(
         // `content://com.android.externalstorage.documents/tree/primary%3AMusic%2FStash`
         // — after decoding, the last path segment after the colon is the
         // visible folder.
-        val externalFolderName = remember(externalTree) {
+        val externalFolderLabel = stringResource(R.string.label_external_folder)
+        val externalFolderName = remember(externalTree, externalFolderLabel) {
             externalTree?.lastPathSegment
                 ?.substringAfterLast(':', "")
                 ?.substringAfterLast('/', "")
                 ?.let { java.net.URLDecoder.decode(it, "UTF-8") }
                 ?.takeIf { it.isNotBlank() }
-                ?: externalTree?.let { "External folder" }
+                ?: externalTree?.let { externalFolderLabel }
                 ?: ""
         }
         val internalPath = remember(context) {
@@ -238,10 +241,10 @@ fun SettingsLibraryStorageScreen(
                 title = {
                     Text(
                         text = when (databaseBackupState) {
-                            DatabaseBackupState.Exporting -> "Exporting Database"
-                            DatabaseBackupState.Importing -> "Importing Database"
-                            is DatabaseBackupState.Success -> "Success"
-                            is DatabaseBackupState.Error -> "Error"
+                            DatabaseBackupState.Exporting -> stringResource(R.string.status_exporting_db)
+                            DatabaseBackupState.Importing -> stringResource(R.string.status_importing_db)
+                            is DatabaseBackupState.Success -> stringResource(R.string.status_success)
+                            is DatabaseBackupState.Error -> stringResource(R.string.status_error)
                         },
                         style = MaterialTheme.typography.titleLarge,
                     )
@@ -254,7 +257,7 @@ fun SettingsLibraryStorageScreen(
                                     modifier = Modifier.fillMaxWidth(),
                                 )
                                 Text(
-                                    text = "Processing...",
+                                    text = stringResource(R.string.status_processing),
                                     style = MaterialTheme.typography.bodyMedium,
                                 )
                             }
@@ -278,7 +281,7 @@ fun SettingsLibraryStorageScreen(
                     if (databaseBackupState is DatabaseBackupState.Success ||
                         databaseBackupState is DatabaseBackupState.Error) {
                         TextButton(onClick = viewModel::onDismissDatabaseBackupStatus) {
-                            Text("OK")
+                            Text(stringResource(R.string.action_ok))
                         }
                     }
                 },
@@ -292,14 +295,14 @@ fun SettingsLibraryStorageScreen(
                 shape = MaterialTheme.shapes.large,
                 title = {
                     Text(
-                        text = "Overwrite Library & Settings?",
+                        text = stringResource(R.string.dialog_title_overwrite_library),
                         style = MaterialTheme.typography.titleLarge,
                         color = MaterialTheme.colorScheme.error,
                     )
                 },
                 text = {
                     Text(
-                        text = "This will completely replace your existing library metadata, playlists, settings, and account connections. This action cannot be undone.",
+                        text = stringResource(R.string.dialog_body_overwrite_library),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -314,12 +317,12 @@ fun SettingsLibraryStorageScreen(
                         },
                         colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
                     ) {
-                        Text("Overwrite")
+                        Text(stringResource(R.string.action_overwrite))
                     }
                 },
                 dismissButton = {
                     TextButton(onClick = viewModel::onCancelImportDatabase) {
-                        Text("Cancel")
+                        Text(stringResource(R.string.action_cancel))
                     }
                 },
             )
@@ -329,13 +332,13 @@ fun SettingsLibraryStorageScreen(
             Column(modifier = Modifier.fillMaxWidth()) {
                 // Database Backup -----------------------------------------
                 Text(
-                    text = "Backup",
+                    text = stringResource(R.string.label_backup),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = "Export settings and database or import from a previous backup.",
+                    text = stringResource(R.string.desc_backup),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -352,7 +355,7 @@ fun SettingsLibraryStorageScreen(
                             contentColor = MaterialTheme.colorScheme.primary,
                         ),
                     ) {
-                        Text("Export Backup")
+                        Text(stringResource(R.string.action_export_backup))
                     }
                     OutlinedButton(
                         onClick = { importLauncher.launch(arrayOf("application/zip", "application/octet-stream", "*/*")) },
@@ -361,7 +364,7 @@ fun SettingsLibraryStorageScreen(
                             contentColor = MaterialTheme.colorScheme.primary,
                         ),
                     ) {
-                        Text("Import Backup")
+                        Text(stringResource(R.string.action_import_backup))
                     }
                 }
             }
@@ -369,9 +372,9 @@ fun SettingsLibraryStorageScreen(
 
         GlassCard {
             Column(modifier = Modifier.fillMaxWidth()) {
-                SettingsValueRow(label = "Total tracks", value = "${uiState.totalTracks}")
+                SettingsValueRow(label = stringResource(R.string.label_total_tracks), value = "${uiState.totalTracks}")
                 Spacer(modifier = Modifier.height(8.dp))
-                SettingsValueRow(label = "Storage used", value = libStorageFormatBytes(uiState.totalStorageBytes))
+                SettingsValueRow(label = stringResource(R.string.label_storage_used), value = libStorageFormatBytes(uiState.totalStorageBytes))
                 Spacer(modifier = Modifier.height(12.dp))
                 HorizontalDivider(
                     color = extendedColors.glassBorder,
@@ -380,14 +383,14 @@ fun SettingsLibraryStorageScreen(
 
                 // Current location ----------------------------------------
                 Text(
-                    text = "Download location",
+                    text = stringResource(R.string.label_download_location),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = when {
-                        externalTree == null -> "Internal (app-private)"
+                        externalTree == null -> stringResource(R.string.label_internal_storage)
                         externalFolderName.isBlank() -> "External folder (SD card / USB)"
                         else -> externalFolderName
                     },
@@ -397,7 +400,7 @@ fun SettingsLibraryStorageScreen(
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = if (externalTree != null) {
-                        "Tracks are stored in this folder and survive uninstall. Visible to other apps and over USB."
+                        stringResource(R.string.desc_external_storage)
                     } else {
                         internalPath
                     },
@@ -422,7 +425,7 @@ fun SettingsLibraryStorageScreen(
                         ),
                     ) {
                         Text(
-                            text = if (externalTree != null) "Change folder" else "Pick SD / folder",
+                            text = if (externalTree != null) stringResource(R.string.action_change_folder) else stringResource(R.string.action_pick_folder),
                         )
                     }
                     if (externalTree != null) {
@@ -433,13 +436,13 @@ fun SettingsLibraryStorageScreen(
                                 contentColor = MaterialTheme.colorScheme.primary,
                             ),
                         ) {
-                            Text("Use internal")
+                            Text(stringResource(R.string.action_use_internal))
                         }
                     }
                 }
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    text = "New downloads go to the selected location.",
+                    text = stringResource(R.string.desc_new_downloads_location),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -524,7 +527,7 @@ private fun LibStorageMoveLibrarySection(
     when (state) {
         com.stash.data.download.files.MoveLibraryState.Idle -> {
             Text(
-                text = "Existing library",
+                text = stringResource(R.string.label_existing_library),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -608,7 +611,7 @@ private fun LibStorageMoveLibrarySection(
         }
         is com.stash.data.download.files.MoveLibraryState.Error -> {
             Text(
-                text = "Couldn't move library",
+                text = stringResource(R.string.error_move_library),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.error,
             )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsPlaybackScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsPlaybackScreen.kt
@@ -13,9 +13,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stash.core.common.constants.StashConstants
+import com.stash.core.ui.R
 import com.stash.feature.settings.components.SettingsGroupCard
 import com.stash.feature.settings.components.SettingsRowPadH
 import com.stash.feature.settings.components.SettingsRowPadV
@@ -47,30 +49,30 @@ fun SettingsPlaybackScreen(
     val crossfadeEnabled by viewModel.crossfadeEnabled.collectAsStateWithLifecycle()
     val crossfadeDurationMs by viewModel.crossfadeDurationMs.collectAsStateWithLifecycle()
 
-    SettingsScaffold(title = "Playback", onBack = onBack, modifier = modifier) {
+    SettingsScaffold(title = stringResource(R.string.title_playback), onBack = onBack, modifier = modifier) {
         if (StashConstants.STREAMING_ENGINE_ENABLED) {
-            SettingsSectionLabel("Mode")
+            SettingsSectionLabel(stringResource(R.string.section_mode))
             SettingsSegmented(
-                options = listOf("Online", "Offline"),
+                options = listOf(stringResource(R.string.mode_online), stringResource(R.string.mode_offline)),
                 selectedIndex = if (streamingEnabled) 0 else 1,
                 onSelect = { viewModel.onStreamingToggle(it == 0) },
             )
 
-            SettingsSectionLabel("Streaming")
+            SettingsSectionLabel(stringResource(R.string.section_streaming))
             SettingsGroupCard(
                 rows = listOf(
                     {
                         SettingsToggleRow(
-                            title = "Stream on cellular",
-                            subtitle = "Allow streaming over mobile data (5G / LTE). Off by default to avoid surprise data use.",
+                            title = stringResource(R.string.label_stream_cellular),
+                            subtitle = stringResource(R.string.desc_stream_cellular),
                             checked = streamOnCellular,
                             onCheckedChange = viewModel::onStreamOnCellularToggle,
                         )
                     },
                     {
                         SettingsToggleRow(
-                            title = "Stream via YouTube",
-                            subtitle = "Skip the lossless sources (Qobuz) and stream everything via YouTube. Turn this on if lossless playback is down or only playing short clips.",
+                            title = stringResource(R.string.label_stream_youtube),
+                            subtitle = stringResource(R.string.desc_stream_youtube),
                             checked = forceYouTubeFallback,
                             onCheckedChange = viewModel::setForceYouTubeFallback,
                         )
@@ -81,16 +83,16 @@ fun SettingsPlaybackScreen(
                     // onCheckedChange = viewModel::setForceArcodOnly) to re-enable.
                     {
                         SettingsToggleRow(
-                            title = "Stream via amz (test)",
-                            subtitle = "Route streaming AND downloads through amz (Amazon Music) only — no Qobuz, no YouTube. For testing the amz source. Turn off after testing.",
+                            title = stringResource(R.string.label_stream_amz),
+                            subtitle = stringResource(R.string.desc_stream_amz),
                             checked = forceAmzOnly,
                             onCheckedChange = viewModel::setForceAmzOnly,
                         )
                     },
                     {
                         SettingsToggleRow(
-                            title = "Force Direct Qobuz only (test)",
-                            subtitle = "Route streaming AND downloads through Direct Qobuz only — no other sources, no YouTube. For testing the Direct Qobuz source. Turn off after testing.",
+                            title = stringResource(R.string.label_force_qobuz),
+                            subtitle = stringResource(R.string.desc_force_qobuz),
                             checked = forceQbdlxOnly,
                             onCheckedChange = viewModel::setForceQbdlxOnly,
                         )
@@ -99,7 +101,7 @@ fun SettingsPlaybackScreen(
             )
         } else {
             Text(
-                text = "Streaming is unavailable in this build.",
+                text = stringResource(R.string.label_streaming_unavailable),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -107,13 +109,13 @@ fun SettingsPlaybackScreen(
 
         // Crossfade applies to both streamed and downloaded tracks, so it sits
         // outside the streaming-engine gate.
-        SettingsSectionLabel("Crossfade")
+        SettingsSectionLabel(stringResource(R.string.label_crossfade))
         SettingsGroupCard(
             rows = buildList {
                 add {
                     SettingsToggleRow(
-                        title = "Crossfade",
-                        subtitle = "Fade the ending track into the next on auto-advance. Manual skips still cut instantly.",
+                        title = stringResource(R.string.label_crossfade),
+                        subtitle = stringResource(R.string.desc_crossfade),
                         checked = crossfadeEnabled,
                         onCheckedChange = viewModel::onCrossfadeToggle,
                     )
@@ -152,7 +154,7 @@ private fun CrossfadeDurationRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "Duration",
+                text = stringResource(R.string.label_duration),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
             )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/AccountConnectionCard.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/AccountConnectionCard.kt
@@ -28,8 +28,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stash.core.auth.model.AuthState
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashTheme
 
 /**
@@ -141,7 +143,7 @@ fun AccountConnectionCard(
                                 contentColor = MaterialTheme.colorScheme.error,
                             ),
                         ) {
-                            Text("Disconnect")
+                            Text(stringResource(R.string.action_disconnect))
                         }
                     }
                     else -> {
@@ -152,7 +154,7 @@ fun AccountConnectionCard(
                                 contentColor = Color.White,
                             ),
                         ) {
-                            Text("Connect")
+                            Text(stringResource(R.string.action_connect))
                         }
                     }
                 }

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/ArcodConnectScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/ArcodConnectScreen.kt
@@ -30,8 +30,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.stash.core.ui.R
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -65,6 +67,7 @@ fun ArcodConnectScreen(
         mutableStateOf("Sign in with Google to connect ARCOD. We'll detect it automatically.")
     }
     var captured by remember { mutableStateOf(false) }
+    val connectedText = stringResource(R.string.status_arcod_connected)
 
     // ── Session polling ─────────────────────────────────────────────────
     // Supabase writes the session to localStorage after the OAuth round-
@@ -91,7 +94,7 @@ fun ArcodConnectScreen(
             }
             val session = parseSupabaseSession(inner) ?: continue
             captured = true
-            statusText = "Connected — saving and closing."
+            statusText = connectedText
             onConnected(session.accessToken, session.refreshToken, session.expiresAtMs)
             // Brief beat so the success text is visible before the pop.
             delay(400)
@@ -139,13 +142,13 @@ fun ArcodConnectScreen(
             IconButton(onClick = onClose) {
                 Icon(
                     imageVector = Icons.Filled.Close,
-                    contentDescription = "Close",
+                    contentDescription = stringResource(R.string.cd_close),
                     tint = MaterialTheme.colorScheme.onBackground,
                 )
             }
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Connect ARCOD",
+                    text = stringResource(R.string.title_connect_arcod),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onBackground,
                 )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/BetaPill.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/BetaPill.kt
@@ -9,7 +9,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 
 /**
  * Small "Beta" pill shared by Settings sections that surface brand-new,
@@ -25,7 +27,7 @@ internal fun BetaPill() {
             .padding(horizontal = 6.dp, vertical = 1.dp),
     ) {
         Text(
-            text = "Beta",
+            text = stringResource(R.string.label_beta),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onTertiaryContainer,
         )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LastFmSection.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LastFmSection.kt
@@ -14,7 +14,9 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 import com.stash.feature.settings.LastFmAuthState
 
 /**
@@ -41,14 +43,13 @@ fun LastFmSection(
         when (state) {
             LastFmAuthState.NotConfigured -> {
                 Text(
-                    text = "Not configured",
+                    text = stringResource(R.string.status_lastfm_not_configured),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = "This build of Stash doesn't include a Last.fm API key. " +
-                        "A developer rebuilding with a key in local.properties unlocks this feature.",
+                    text = stringResource(R.string.desc_lastfm_no_api_key),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -59,7 +60,7 @@ fun LastFmSection(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        text = "Scrobble your plays",
+                        text = stringResource(R.string.label_scrobble_plays),
                         modifier = Modifier.weight(1f),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurface,
@@ -70,19 +71,19 @@ fun LastFmSection(
                             contentColor = MaterialTheme.colorScheme.primary,
                         ),
                     ) {
-                        Text("Connect Last.fm")
+                        Text(stringResource(R.string.action_connect_lastfm))
                     }
                 }
             }
             is LastFmAuthState.AwaitingAuth -> {
                 Text(
-                    text = "Waiting for approval",
+                    text = stringResource(R.string.status_lastfm_waiting),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = "Your browser should be open on Last.fm. Tap \"Yes, allow access\" on their page, then come back and tap Finish below.",
+                    text = stringResource(R.string.desc_lastfm_awaiting_auth),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -91,28 +92,28 @@ fun LastFmSection(
                     onClick = onFinish,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Text("Finish connecting")
+                    Text(stringResource(R.string.action_finish_connecting))
                 }
                 Spacer(modifier = Modifier.height(8.dp))
                 TextButton(
                     onClick = onDismissError,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             }
             is LastFmAuthState.Connected -> {
                 Text(
-                    text = "Connected as ${state.username}",
+                    text = stringResource(R.string.status_lastfm_connected, state.username),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = if (state.pendingScrobbles > 0) {
-                        "Scrobbling your plays. ${state.pendingScrobbles} queued to submit."
+                        stringResource(R.string.status_lastfm_pending, state.pendingScrobbles)
                     } else {
-                        "Scrobbling your plays. Everything up to date."
+                        stringResource(R.string.status_lastfm_up_to_date)
                     },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -147,7 +148,7 @@ fun LastFmSection(
             }
             is LastFmAuthState.Error -> {
                 Text(
-                    text = "Couldn't connect",
+                    text = stringResource(R.string.error_lastfm_connect),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.error,
                 )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LikeMirrorSection.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LikeMirrorSection.kt
@@ -13,10 +13,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 
 /**
  * v0.9.52 "Sync your likes" (Beta): per-service opt-in for mirroring
@@ -44,7 +46,7 @@ fun LikeMirrorSection(
     Column(modifier = modifier.fillMaxWidth()) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
-                text = "Sync your likes",
+                text = stringResource(R.string.label_sync_likes),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
             )
@@ -53,21 +55,21 @@ fun LikeMirrorSection(
         }
         Spacer(modifier = Modifier.height(2.dp))
         Text(
-            text = "Mirror hearts to your accounts. Applies to new likes only.",
+            text = stringResource(R.string.desc_like_mirror),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(modifier = Modifier.height(8.dp))
 
         MirrorToggleRow(
-            label = "Spotify",
+            label = stringResource(R.string.label_spotify),
             connected = spotifyConnected,
             enabled = spotifyEnabled,
             connectHint = "Connect Spotify first",
             onToggle = onSpotifyToggle,
         )
         MirrorToggleRow(
-            label = "YouTube Music",
+            label = stringResource(R.string.label_youtube_music),
             connected = ytConnected,
             enabled = ytMusicEnabled,
             connectHint = "Connect YouTube Music first",

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LikeMirrorWarningDialog.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LikeMirrorWarningDialog.kt
@@ -5,6 +5,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.stash.core.ui.R
 
 /**
  * v0.9.52: explicit opt-in ack before enabling like-mirroring for a
@@ -22,24 +24,18 @@ fun LikeMirrorWarningDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Mirror likes to $serviceName?") },
+        title = { Text(stringResource(R.string.dialog_title_mirror_likes, serviceName)) },
         text = {
             Text(
-                "Hearting a track in Stash will also Like it on $serviceName, " +
-                    "and removing a heart will remove the Like there too. " +
-                    "Only likes you add from now on are mirrored.\n\n" +
-                    "This uses the same private endpoint the $serviceName web player " +
-                    "uses — not an official API. It can stop working at any time and, " +
-                    "rarely, unofficial access can get an account flagged. Consider " +
-                    "enabling this only on a secondary or backup account.",
+                stringResource(R.string.dialog_body_mirror_likes, serviceName),
                 style = MaterialTheme.typography.bodyMedium,
             )
         },
         confirmButton = {
-            TextButton(onClick = onConfirm) { Text("I understand") }
+            TextButton(onClick = onConfirm) { Text(stringResource(R.string.action_i_understand)) }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
         },
     )
 }

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LosslessRoutingStatus.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LosslessRoutingStatus.kt
@@ -20,10 +20,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.stash.core.ui.R
 
 /**
  * ROUTING status block for the lossless source chain.
@@ -45,7 +47,7 @@ internal fun LosslessRoutingStatus(
     val mono = FontFamily.Monospace
     Column(modifier = modifier.fillMaxWidth()) {
         Text(
-            text = "ROUTING",
+            text = stringResource(R.string.label_routing),
             fontFamily = mono,
             style = MaterialTheme.typography.labelSmall.copy(
                 letterSpacing = 1.2.sp,
@@ -59,17 +61,16 @@ internal fun LosslessRoutingStatus(
         RoutingRow(
             host = "Direct Qobuz",
             configured = true,
-            statusLabel = "active",
+            statusLabel = stringResource(R.string.status_active),
         )
         RoutingRow(
             host = "amz.squid.wtf",
             configured = true,
-            statusLabel = "fallback",
+            statusLabel = stringResource(R.string.status_fallback),
         )
         Spacer(modifier = Modifier.height(6.dp))
         Text(
-            text = "Lossless streams from Direct Qobuz; amz.squid.wtf (Amazon Music) " +
-                "fills in when a track isn't on Qobuz.",
+            text = stringResource(R.string.desc_lossless_routing),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SettingsScaffold.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SettingsScaffold.kt
@@ -18,7 +18,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 
 /**
  * Shared frame for Settings sub-screens: a back-chevron top bar with a title,
@@ -42,7 +44,7 @@ fun SettingsScaffold(
             IconButton(onClick = onBack) {
                 Icon(
                     imageVector = Icons.Rounded.ChevronLeft,
-                    contentDescription = "Back",
+                    contentDescription = stringResource(R.string.cd_back),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SettingsSearchField.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SettingsSearchField.kt
@@ -20,7 +20,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashTheme
 
 /**
@@ -53,7 +55,7 @@ fun SettingsSearchField(
         )
         Spacer(modifier = Modifier.width(10.dp))
         Text(
-            text = "Search settings",
+            text = stringResource(R.string.hint_search_settings),
             style = MaterialTheme.typography.bodyMedium,
             color = extendedColors.textTertiary,
         )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SpotifyAutoSaveSection.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SpotifyAutoSaveSection.kt
@@ -14,10 +14,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 
 /**
  * v0.9.13: Spotify-side counterpart to [YouTubeHistorySyncSection] — auto-save
@@ -62,7 +64,7 @@ fun SpotifyAutoSaveSection(
             Column(modifier = Modifier.weight(1f)) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        text = "Auto-save liked tracks",
+                        text = stringResource(R.string.label_auto_save_liked),
                         style = MaterialTheme.typography.bodyMedium,
                         color = if (spotifyConnected) {
                             MaterialTheme.colorScheme.onSurface
@@ -96,7 +98,7 @@ fun SpotifyAutoSaveSection(
         if (enabled && spotifyConnected) {
             Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = "Threshold: $threshold day${if (threshold == 1) "" else "s"} in 30",
+                text = stringResource(R.string.label_auto_save_threshold, threshold),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -107,7 +109,7 @@ fun SpotifyAutoSaveSection(
                 steps = 8,
             )
             Text(
-                text = "Last 7 days: $autoSavedCountLast7Days tracks auto-saved",
+                text = stringResource(R.string.label_auto_save_last_7_days, autoSavedCountLast7Days),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SpotifyCookieDialog.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SpotifyCookieDialog.kt
@@ -19,8 +19,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 
 /**
  * Dialog for entering a Spotify sp_dc cookie to authenticate.
@@ -49,16 +51,14 @@ fun SpotifyCookieDialog(
         onDismissRequest = { if (!isValidating) onDismiss() },
         title = {
             Text(
-                text = "Connect Spotify",
+                text = stringResource(R.string.dialog_title_connect_spotify),
                 style = MaterialTheme.typography.headlineSmall,
             )
         },
         text = {
             Column {
                 Text(
-                    text = "Log into Spotify in a real browser and paste your " +
-                        "sp_dc cookie. This works even when in-app sign-in is " +
-                        "blocked by Spotify's bot check.",
+                    text = stringResource(R.string.dialog_body_spotify_cookie),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -66,7 +66,7 @@ fun SpotifyCookieDialog(
                 Spacer(modifier = Modifier.height(12.dp))
 
                 Text(
-                    text = "How to get your sp_dc cookie:",
+                    text = stringResource(R.string.label_how_to_get_cookie),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
@@ -74,12 +74,7 @@ fun SpotifyCookieDialog(
                 Spacer(modifier = Modifier.height(4.dp))
 
                 Text(
-                    text = "Easiest on a computer:\n" +
-                        "1. Open open.spotify.com and log in\n" +
-                        "2. Press F12 → Application → Cookies\n" +
-                        "3. Copy the value of 'sp_dc'\n\n" +
-                        "On a phone: use a browser that can show cookies " +
-                        "(e.g. Firefox add-ons, or a cookie-viewer app).",
+                    text = stringResource(R.string.desc_spotify_cookie_steps),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -89,8 +84,8 @@ fun SpotifyCookieDialog(
                 OutlinedTextField(
                     value = cookieValue,
                     onValueChange = { cookieValue = it },
-                    label = { Text("sp_dc cookie") },
-                    placeholder = { Text("Paste your sp_dc cookie here") },
+                    label = { Text(stringResource(R.string.label_sp_dc_cookie)) },
+                    placeholder = { Text(stringResource(R.string.hint_paste_sp_dc_cookie)) },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                     enabled = !isValidating,
@@ -120,8 +115,8 @@ fun SpotifyCookieDialog(
                 OutlinedTextField(
                     value = username,
                     onValueChange = { username = it },
-                    label = { Text("Spotify username (optional)") },
-                    placeholder = { Text("Your Spotify username") },
+                    label = { Text(stringResource(R.string.label_spotify_username_optional)) },
+                    placeholder = { Text(stringResource(R.string.hint_spotify_username)) },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                     enabled = !isValidating,
@@ -130,7 +125,7 @@ fun SpotifyCookieDialog(
                 Spacer(modifier = Modifier.height(4.dp))
 
                 Text(
-                    text = "Find at spotify.com/account under 'Username'",
+                    text = stringResource(R.string.desc_spotify_username_hint),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(start = 4.dp),
@@ -152,14 +147,14 @@ fun SpotifyCookieDialog(
                         containerColor = MaterialTheme.colorScheme.primary,
                     ),
                 ) {
-                    Text("Connect")
+                    Text(stringResource(R.string.action_connect))
                 }
             }
         },
         dismissButton = {
             if (!isValidating) {
                 TextButton(onClick = onDismiss) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             }
         },

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SpotifyLoginWebView.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SpotifyLoginWebView.kt
@@ -31,8 +31,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.stash.core.ui.R
 
 /**
  * Full-screen Spotify login via WebView.
@@ -101,10 +103,10 @@ fun SpotifyLoginWebView(
 
     Column(modifier = modifier.fillMaxSize()) {
         TopAppBar(
-            title = { Text("Sign in to Spotify") },
+            title = { Text(stringResource(R.string.title_sign_in_spotify)) },
             navigationIcon = {
                 TextButton(onClick = onDismiss) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             },
             actions = {
@@ -129,7 +131,7 @@ fun SpotifyLoginWebView(
 
         if (cookieFound) {
             Text(
-                text = "Login successful, connecting...",
+                text = stringResource(R.string.status_login_successful),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
@@ -236,13 +238,13 @@ fun SpotifyLoginWebView(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = "Sign-in blocked or not working?",
+                    text = stringResource(R.string.label_signin_blocked),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.weight(1f),
                 )
                 TextButton(onClick = onManualFallback) {
-                    Text("Paste cookie instead")
+                    Text(stringResource(R.string.action_paste_cookie_instead))
                 }
             }
         }

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SquidWtfCaptchaScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SquidWtfCaptchaScreen.kt
@@ -30,8 +30,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.stash.core.ui.R
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 
@@ -69,6 +71,7 @@ fun SquidWtfCaptchaScreen(
         )
     }
     var captured by remember { mutableStateOf(false) }
+    val captchaSavedText = stringResource(R.string.status_captcha_saved)
 
     // ── Cookie polling ──────────────────────────────────────────────────
     // Cheap in-process read, no network. Stops as soon as the cookie
@@ -80,7 +83,7 @@ fun SquidWtfCaptchaScreen(
             val match = COOKIE_REGEX.find(cookies.orEmpty())
             if (match != null) {
                 captured = true
-                statusText = "Got it — saving and closing."
+                statusText = captchaSavedText
                 onCookieCaptured(match.groupValues[1])
                 // Slight delay so the user sees the success text flash
                 // by before the route pops.
@@ -135,13 +138,13 @@ fun SquidWtfCaptchaScreen(
             IconButton(onClick = onClose) {
                 Icon(
                     imageVector = Icons.Filled.Close,
-                    contentDescription = "Close",
+                    contentDescription = stringResource(R.string.cd_close),
                     tint = MaterialTheme.colorScheme.onBackground,
                 )
             }
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Verify squid.wtf captcha",
+                    text = stringResource(R.string.title_verify_captcha),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onBackground,
                 )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SupportBanner.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SupportBanner.kt
@@ -25,7 +25,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashCyan
 import com.stash.core.ui.theme.StashPurple
 import com.stash.core.ui.theme.StashPurpleLight
@@ -61,12 +63,12 @@ fun SupportBanner(
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         Text(
-            text = "Support Stash",
+            text = stringResource(R.string.title_support_stash),
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurface,
         )
         Text(
-            text = "If Stash replaced a subscription for you, consider supporting the project.",
+            text = stringResource(R.string.desc_support_stash),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -87,7 +89,7 @@ fun SupportBanner(
                     modifier = Modifier.size(16.dp),
                 )
                 Spacer(modifier = Modifier.width(6.dp))
-                Text(text = "Donate", style = MaterialTheme.typography.labelMedium)
+                Text(text = stringResource(R.string.action_donate), style = MaterialTheme.typography.labelMedium)
             }
             OutlinedButton(
                 onClick = onStar,
@@ -102,7 +104,7 @@ fun SupportBanner(
                     modifier = Modifier.size(16.dp),
                 )
                 Spacer(modifier = Modifier.width(6.dp))
-                Text(text = "Star", style = MaterialTheme.typography.labelMedium)
+                Text(text = stringResource(R.string.action_star), style = MaterialTheme.typography.labelMedium)
             }
         }
     }

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/YouTubeCookieDialog.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/YouTubeCookieDialog.kt
@@ -19,8 +19,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 
 /**
  * Dialog for entering YouTube Music cookies to authenticate.
@@ -47,14 +49,14 @@ fun YouTubeCookieDialog(
         onDismissRequest = { if (!isValidating) onDismiss() },
         title = {
             Text(
-                text = "Connect YouTube Music",
+                text = stringResource(R.string.dialog_title_connect_youtube),
                 style = MaterialTheme.typography.headlineSmall,
             )
         },
         text = {
             Column {
                 Text(
-                    text = "Paste your YouTube Music cookies to connect.",
+                    text = stringResource(R.string.dialog_body_yt_cookie),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -62,7 +64,7 @@ fun YouTubeCookieDialog(
                 Spacer(modifier = Modifier.height(12.dp))
 
                 Text(
-                    text = "How to get your cookies:",
+                    text = stringResource(R.string.label_how_to_get_cookies),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
@@ -70,13 +72,7 @@ fun YouTubeCookieDialog(
                 Spacer(modifier = Modifier.height(4.dp))
 
                 Text(
-                    text = "1. Open a Private/Incognito window\n" +
-                        "2. Go to music.youtube.com and log in\n" +
-                        "3. Press F12 to open DevTools\n" +
-                        "4. Go to Network tab, click any request\n" +
-                        "5. Find 'Cookie' in Request Headers\n" +
-                        "6. Copy the ENTIRE cookie value\n\n" +
-                        "Must contain: SAPISID, LOGIN_INFO, SID",
+                    text = stringResource(R.string.desc_yt_cookie_steps),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -86,8 +82,8 @@ fun YouTubeCookieDialog(
                 OutlinedTextField(
                     value = cookieValue,
                     onValueChange = { cookieValue = it },
-                    label = { Text("Cookie") },
-                    placeholder = { Text("Paste your cookie here") },
+                    label = { Text(stringResource(R.string.label_cookie)) },
+                    placeholder = { Text(stringResource(R.string.hint_paste_cookie)) },
                     modifier = Modifier.fillMaxWidth(),
                     minLines = 3,
                     maxLines = 5,
@@ -123,14 +119,14 @@ fun YouTubeCookieDialog(
                         containerColor = MaterialTheme.colorScheme.primary,
                     ),
                 ) {
-                    Text("Connect")
+                    Text(stringResource(R.string.action_connect))
                 }
             }
         },
         dismissButton = {
             if (!isValidating) {
                 TextButton(onClick = onDismiss) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             }
         },

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/YouTubeCredentialsDialog.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/YouTubeCredentialsDialog.kt
@@ -15,8 +15,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import com.stash.core.ui.R
 
 /**
  * Dialog that collects the user's Google Cloud OAuth Client ID and Client Secret
@@ -45,7 +47,7 @@ fun YouTubeCredentialsDialog(
         shape = MaterialTheme.shapes.large,
         title = {
             Text(
-                text = "YouTube Music Credentials",
+                text = stringResource(R.string.dialog_title_yt_credentials),
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.onSurface,
             )
@@ -53,10 +55,7 @@ fun YouTubeCredentialsDialog(
         text = {
             Column(modifier = Modifier.fillMaxWidth()) {
                 Text(
-                    text = "Enter your Google Cloud OAuth credentials. " +
-                        "Create them at console.cloud.google.com with the " +
-                        "\"TVs and Limited Input devices\" type and enable " +
-                        "the YouTube Data API v3.",
+                    text = stringResource(R.string.dialog_body_yt_credentials),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -66,7 +65,7 @@ fun YouTubeCredentialsDialog(
                 OutlinedTextField(
                     value = clientId,
                     onValueChange = { clientId = it },
-                    label = { Text("Client ID") },
+                    label = { Text(stringResource(R.string.label_client_id)) },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -76,7 +75,7 @@ fun YouTubeCredentialsDialog(
                 OutlinedTextField(
                     value = clientSecret,
                     onValueChange = { clientSecret = it },
-                    label = { Text("Client Secret") },
+                    label = { Text(stringResource(R.string.label_client_secret)) },
                     singleLine = true,
                     visualTransformation = PasswordVisualTransformation(),
                     modifier = Modifier.fillMaxWidth(),
@@ -97,12 +96,12 @@ fun YouTubeCredentialsDialog(
                 onClick = { onConfirm(clientId.trim(), clientSecret.trim()) },
                 enabled = clientId.isNotBlank() && clientSecret.isNotBlank(),
             ) {
-                Text("Save & Connect")
+                Text(stringResource(R.string.action_connect))
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("Cancel")
+                Text(stringResource(R.string.action_cancel))
             }
         },
     )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/YouTubeDeviceCodeDialog.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/YouTubeDeviceCodeDialog.kt
@@ -37,7 +37,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.stringResource
 import com.stash.core.auth.model.DeviceCodeState
+import com.stash.core.ui.R
 import com.stash.core.ui.theme.StashTheme
 
 /**
@@ -65,7 +67,7 @@ fun YouTubeDeviceCodeDialog(
         shape = MaterialTheme.shapes.large,
         title = {
             Text(
-                text = "Connect YouTube Music",
+                text = stringResource(R.string.dialog_title_connect_youtube),
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.onSurface,
             )
@@ -76,7 +78,7 @@ fun YouTubeDeviceCodeDialog(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text(
-                    text = "Go to the URL below and enter this code:",
+                    text = stringResource(R.string.desc_device_code_prompt),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
@@ -125,10 +127,10 @@ fun YouTubeDeviceCodeDialog(
                     ) {
                         Icon(
                             imageVector = Icons.Outlined.ContentCopy,
-                            contentDescription = "Copy code",
+                            contentDescription = stringResource(R.string.cd_copy_code),
                             modifier = Modifier.padding(end = 4.dp),
                         )
-                        Text("Copy Code")
+                        Text(stringResource(R.string.cd_copy_code))
                     }
 
                     Button(
@@ -140,10 +142,10 @@ fun YouTubeDeviceCodeDialog(
                     ) {
                         Icon(
                             imageVector = Icons.Outlined.OpenInBrowser,
-                            contentDescription = "Open browser",
+                            contentDescription = stringResource(R.string.cd_open_browser),
                             modifier = Modifier.padding(end = 4.dp),
                         )
-                        Text("Open Browser")
+                        Text(stringResource(R.string.cd_open_browser))
                     }
                 }
 
@@ -163,7 +165,7 @@ fun YouTubeDeviceCodeDialog(
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        text = "Waiting for authorization...",
+                        text = stringResource(R.string.status_waiting_auth),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -173,7 +175,7 @@ fun YouTubeDeviceCodeDialog(
         confirmButton = {},
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("Cancel")
+                Text(stringResource(R.string.action_cancel))
             }
         },
     )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/YouTubeHistorySyncSection.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/YouTubeHistorySyncSection.kt
@@ -20,11 +20,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.stash.core.data.youtube.YouTubeScrobblerHealth
+import com.stash.core.ui.R
 
 /**
  * Settings row that exposes the YouTube Music history sync toggle.
@@ -87,7 +89,7 @@ fun YouTubeHistorySyncSection(
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Send plays to YouTube Music",
+                    text = stringResource(R.string.label_send_plays_yt),
                     style = MaterialTheme.typography.bodyMedium,
                     color = if (ytConnected) {
                         MaterialTheme.colorScheme.onSurface
@@ -98,7 +100,7 @@ fun YouTubeHistorySyncSection(
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = if (!ytConnected) {
-                        "Connect YouTube Music first"
+                        stringResource(R.string.label_connect_yt_first)
                     } else {
                         statusLine(health, pendingCount)
                     },
@@ -131,7 +133,7 @@ fun YouTubeHistorySyncSection(
                 modifier = Modifier.padding(top = 2.dp),
             ) {
                 Text(
-                    text = "Retry YouTube sync",
+                    text = stringResource(R.string.action_retry_yt_sync),
                     style = MaterialTheme.typography.labelMedium,
                 )
             }
@@ -168,7 +170,7 @@ private fun FirstEnableConfirmDialog(
         shape = MaterialTheme.shapes.large,
         title = {
             Text(
-                text = "Send your Stash plays to YouTube Music?",
+                text = stringResource(R.string.dialog_title_yt_history),
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.onSurface,
             )
@@ -176,31 +178,31 @@ private fun FirstEnableConfirmDialog(
         text = {
             Column {
                 Text(
-                    text = "Every track you finish listening to in Stash will be added to your YouTube Music Watch History. Your Daily Mix and other YouTube Music recommendations will learn from your Stash listening.",
+                    text = stringResource(R.string.dialog_body_yt_history),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Spacer(modifier = Modifier.height(12.dp))
                 Text(
-                    text = "How it works",
+                    text = stringResource(R.string.label_how_it_works),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = "Stash uses an unofficial YouTube endpoint (the same one the YouTube Music app uses). Google tolerates this pattern for personal-use apps but could change the rules without notice. If that happens, Stash will automatically stop sending plays until a new update fixes the integration.",
+                    text = stringResource(R.string.desc_yt_history_how),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Spacer(modifier = Modifier.height(12.dp))
                 Text(
-                    text = "Risk",
+                    text = stringResource(R.string.label_risk),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = "Rare but not zero chance of YouTube rate-limiting your account. Stash monitors for errors and pauses itself if it sees problems.",
+                    text = stringResource(R.string.desc_yt_history_risk),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -208,12 +210,12 @@ private fun FirstEnableConfirmDialog(
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("Cancel")
+                Text(stringResource(R.string.action_cancel))
             }
         },
         confirmButton = {
             TextButton(onClick = onConfirm) {
-                Text("Enable")
+                Text(stringResource(R.string.action_enable))
             }
         },
     )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/YouTubeLoginWebView.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/YouTubeLoginWebView.kt
@@ -26,8 +26,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.stash.core.ui.R
 
 /**
  * Full-screen YouTube Music login via WebView.
@@ -90,10 +92,10 @@ fun YouTubeLoginWebView(
 
     Column(modifier = modifier.fillMaxSize()) {
         TopAppBar(
-            title = { Text("Sign in to YouTube Music") },
+            title = { Text(stringResource(R.string.title_sign_in_youtube)) },
             navigationIcon = {
                 TextButton(onClick = onDismiss) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             },
             actions = {
@@ -118,7 +120,7 @@ fun YouTubeLoginWebView(
 
         if (cookieFound) {
             Text(
-                text = "Login successful, connecting...",
+                text = stringResource(R.string.status_login_successful),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/diagnostics/DiagnosticsPreviewScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/diagnostics/DiagnosticsPreviewScreen.kt
@@ -30,11 +30,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.stash.core.ui.R
 import com.stash.core.ui.components.GlassCard
 
 /**
@@ -56,6 +58,10 @@ fun DiagnosticsPreviewScreen(
     val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
 
+    // Pre-resolve strings used in non-Composable callbacks (Intent builders).
+    val diagnosticsSubject = stringResource(R.string.label_diagnostics_subject)
+    val shareDiagnosticsTitle = stringResource(R.string.label_share_diagnostics_title)
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -69,13 +75,13 @@ fun DiagnosticsPreviewScreen(
             IconButton(onClick = onNavigateBack) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Back",
+                    contentDescription = stringResource(R.string.cd_back),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }
             Spacer(Modifier.size(4.dp))
             Text(
-                text = "Diagnostics",
+                text = stringResource(R.string.title_diagnostics),
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
@@ -103,20 +109,20 @@ fun DiagnosticsPreviewScreen(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Text(
-                        text = state.error ?: "Failed to build diagnostics",
+                        text = state.error ?: stringResource(R.string.error_diagnostics_failed),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.error,
                     )
                     Spacer(Modifier.height(12.dp))
                     Button(onClick = viewModel::rebuild) {
-                        Text("Retry")
+                        Text(stringResource(R.string.action_retry))
                     }
                 }
             }
 
             else -> {
                 Text(
-                    text = "Review what will be shared. No passwords or tokens are included.",
+                    text = stringResource(R.string.desc_diagnostics_review),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 4.dp),
@@ -158,11 +164,11 @@ fun DiagnosticsPreviewScreen(
                                 putExtra(android.content.Intent.EXTRA_STREAM, uri)
                                 putExtra(
                                     android.content.Intent.EXTRA_SUBJECT,
-                                    "Stash diagnostics",
+                                    diagnosticsSubject,
                                 )
                                 addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
                             }
-                            val chooser = android.content.Intent.createChooser(send, "Share diagnostics")
+                            val chooser = android.content.Intent.createChooser(send, shareDiagnosticsTitle)
                                 .apply { addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK) }
                             runCatching { context.startActivity(chooser) }
                                 .onFailure {
@@ -175,7 +181,7 @@ fun DiagnosticsPreviewScreen(
                         },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Text("Share")
+                        Text(stringResource(R.string.action_share))
                     }
 
                     OutlinedButton(
@@ -185,7 +191,7 @@ fun DiagnosticsPreviewScreen(
                         },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Text("Copy")
+                        Text(stringResource(R.string.action_copy))
                     }
                 }
 

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/equalizer/EqualizerScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/equalizer/EqualizerScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -62,6 +63,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stash.core.media.equalizer.NamedPreset
+import com.stash.core.ui.R
 import com.stash.core.ui.components.GlassCard
 import com.stash.core.ui.theme.StashTheme
 
@@ -102,12 +104,16 @@ fun EqualizerScreen(
     // false forever and the Snackbar never reappears.
     val snackbarHostState = remember { SnackbarHostState() }
     val showFirstRunNotice by viewModel.showFirstRunNotice.collectAsStateWithLifecycle()
+
+    // Pre-resolve strings used in non-Composable LaunchedEffect block.
+    val loudnessToastMsg = stringResource(R.string.loudness_toast_on)
+    val dismissLabel = stringResource(R.string.cd_dismiss)
+
     LaunchedEffect(showFirstRunNotice) {
         if (showFirstRunNotice) {
             val result = snackbarHostState.showSnackbar(
-                message = "Loudness normalization is on. Tracks will sound more " +
-                    "consistent as your library is measured in the background.",
-                actionLabel = "Dismiss",
+                message = loudnessToastMsg,
+                actionLabel = dismissLabel,
                 duration = SnackbarDuration.Indefinite,
             )
             if (
@@ -150,7 +156,7 @@ fun EqualizerScreen(
                     .fillMaxWidth()
                     .alpha(if (state.enabled) 1f else 0.5f),
             ) {
-                SectionLabel("5-Band EQ")
+                SectionLabel(stringResource(R.string.section_5band_eq))
                 Spacer(Modifier.height(10.dp))
 
                 EqCurvePreview(
@@ -186,7 +192,7 @@ fun EqualizerScreen(
                     .fillMaxWidth()
                     .alpha(if (state.enabled) 1f else 0.5f),
             ) {
-                SectionLabel("Bass Boost")
+                SectionLabel(stringResource(R.string.section_bass_boost))
                 Spacer(Modifier.height(8.dp))
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -221,7 +227,7 @@ fun EqualizerScreen(
         GlassCard {
             Column(modifier = Modifier.fillMaxWidth()) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    SectionLabel("Loudness Normalization")
+                    SectionLabel(stringResource(R.string.section_loudness_normalization))
                     Spacer(Modifier.weight(1f))
                     Switch(
                         checked = loudnessState.enabled,
@@ -243,7 +249,7 @@ fun EqualizerScreen(
                 }
                 Spacer(Modifier.height(6.dp))
                 Text(
-                    text = "Plays every track at a consistent volume.",
+                    text = stringResource(R.string.desc_loudness_normalization),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -268,7 +274,7 @@ fun EqualizerScreen(
                     .fillMaxWidth()
                     .alpha(if (state.enabled) 1f else 0.5f),
             ) {
-                SectionLabel("Pre-amp")
+                SectionLabel(stringResource(R.string.section_preamp))
                 Spacer(Modifier.height(8.dp))
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -319,12 +325,12 @@ private fun EqHeader(
         IconButton(onClick = onBack) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "Back",
+                contentDescription = stringResource(R.string.cd_back),
                 tint = MaterialTheme.colorScheme.onBackground,
             )
         }
         Text(
-            text = "Equalizer",
+            text = stringResource(R.string.title_equalizer),
             style = MaterialTheme.typography.headlineMedium,
             color = MaterialTheme.colorScheme.onBackground,
             modifier = Modifier.weight(1f),
@@ -548,14 +554,14 @@ private fun PresetChipRow(
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
                             imageVector = Icons.Filled.Add,
-                            contentDescription = "Save preset",
+                            contentDescription = stringResource(R.string.cd_save_preset),
                             modifier = Modifier
                                 .height(16.dp)
                                 .width(16.dp),
                         )
                         Spacer(Modifier.width(2.dp))
                         Text(
-                            text = "Save",
+                            text = stringResource(R.string.action_save),
                             style = MaterialTheme.typography.labelMedium,
                         )
                     }
@@ -607,7 +613,7 @@ private fun LoudnessBackfillBlock(
         )
         Spacer(Modifier.height(6.dp))
         Text(
-            text = "Continues automatically while charging.",
+            text = stringResource(R.string.desc_loudness_backfill),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -630,7 +636,7 @@ fun CreatePresetDialog(
         shape = MaterialTheme.shapes.large,
         title = {
             Text(
-                text = "Save Preset",
+                text = stringResource(R.string.dialog_title_save_preset),
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.onSurface,
             )
@@ -639,7 +645,7 @@ fun CreatePresetDialog(
             OutlinedTextField(
                 value = name,
                 onValueChange = { name = it },
-                label = { Text("Preset name") },
+                label = { Text(stringResource(R.string.hint_preset_name)) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -649,12 +655,12 @@ fun CreatePresetDialog(
                 onClick = { if (name.isNotBlank()) onConfirm(name.trim()) },
                 enabled = name.isNotBlank(),
             ) {
-                Text("Save")
+                Text(stringResource(R.string.action_save))
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("Cancel")
+                Text(stringResource(R.string.action_cancel))
             }
         },
     )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/libraryhealth/LibraryHealthScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/libraryhealth/LibraryHealthScreen.kt
@@ -29,11 +29,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stash.core.data.db.dao.LibraryHealthBucket
+import com.stash.core.ui.R
 import com.stash.core.ui.components.GlassCard
 import com.stash.core.ui.components.SectionHeader
 import com.stash.core.ui.theme.StashTheme
@@ -70,8 +72,7 @@ fun LibraryHealthScreen(
         Spacer(Modifier.height(8.dp))
 
         Text(
-            text = "Format and bitrate breakdown of every downloaded track. Use this to " +
-                "verify what your sync is actually pulling down.",
+            text = stringResource(R.string.desc_library_health),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(horizontal = 4.dp),
@@ -79,7 +80,7 @@ fun LibraryHealthScreen(
 
         Spacer(Modifier.height(16.dp))
 
-        SectionHeader(title = "Library breakdown")
+        SectionHeader(title = stringResource(R.string.section_library_breakdown))
 
         if (state.buckets.isEmpty()) {
             EmptyHint()
@@ -111,13 +112,13 @@ private fun Header(onBack: () -> Unit) {
         IconButton(onClick = onBack) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "Back",
+                contentDescription = stringResource(R.string.cd_back),
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }
         Spacer(Modifier.size(4.dp))
         Text(
-            text = "Library Health",
+            text = stringResource(R.string.title_library_health),
             style = MaterialTheme.typography.headlineSmall,
             fontWeight = FontWeight.SemiBold,
             color = MaterialTheme.colorScheme.onSurface,
@@ -129,7 +130,7 @@ private fun Header(onBack: () -> Unit) {
 private fun EmptyHint() {
     GlassCard {
         Text(
-            text = "No downloaded tracks yet. Run a sync first.",
+            text = stringResource(R.string.label_no_downloaded_tracks),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier
@@ -155,7 +156,7 @@ private fun HistogramCard(buckets: List<LibraryHealthBucket>) {
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = "Total downloaded",
+                    text = stringResource(R.string.label_total_downloaded),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -247,7 +248,7 @@ private fun BackfillSection(
 
     if (unknownCount == 0 && status is BackfillStatus.Idle) return
 
-    SectionHeader(title = "Backfill metadata")
+    SectionHeader(title = stringResource(R.string.section_backfill_metadata))
 
     GlassCard {
         Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
@@ -307,18 +308,17 @@ private fun BackfillSection(
 @Composable
 private fun QualityInfoRefreshSection(onClick: () -> Unit) {
     val context = LocalContext.current
-    SectionHeader(title = "Quality info")
+    SectionHeader(title = stringResource(R.string.section_quality_info))
     GlassCard {
         Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
             Text(
-                text = "Refresh quality info",
+                text = stringResource(R.string.action_refresh_quality_info),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = "Re-extract bit-depth + sample-rate for FLAC tracks where it's missing. " +
-                    "Runs in the background.",
+                text = stringResource(R.string.desc_re_extract_quality),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedDownloadsScreen.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedDownloadsScreen.kt
@@ -33,9 +33,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stash.core.ui.theme.StashTheme
 import com.stash.feature.sync.components.FailedDownloadsGroupCard
+import com.stash.core.ui.R
 
 /**
  * Top-level screen for the Failed Downloads viewer.
@@ -89,14 +91,14 @@ fun FailedDownloadsScreen(
                     )
                     Spacer(Modifier.height(16.dp))
                     Text(
-                        text = "All caught up!",
+                        text = stringResource(R.string.label_all_caught_up),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
                         color = MaterialTheme.colorScheme.onBackground,
                     )
                     Spacer(Modifier.height(4.dp))
                     Text(
-                        text = "No failed downloads.",
+                        text = stringResource(R.string.label_no_failed_downloads),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -154,7 +156,7 @@ private fun BackChip(onBack: () -> Unit) {
         ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "Back",
+                contentDescription = stringResource(R.string.cd_back),
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }
@@ -187,14 +189,14 @@ private fun Header(
                 .padding(horizontal = 20.dp),
         ) {
             Text(
-                text = "Failed Downloads",
+                text = stringResource(R.string.title_failed_downloads),
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onBackground,
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = "$totalCount track${if (totalCount != 1) "s" else ""} couldn't download.",
+                text = stringResource(R.string.label_failed_downloads_header, totalCount, if (totalCount != 1) "s" else ""),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -206,7 +208,7 @@ private fun Header(
             ) {
                 Icon(Icons.Default.Refresh, null, Modifier.size(20.dp))
                 Spacer(Modifier.width(8.dp))
-                Text("Retry all")
+                Text(stringResource(R.string.action_retry_all))
             }
             Spacer(Modifier.height(16.dp))
         }

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesScreen.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesScreen.kt
@@ -56,10 +56,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.ui.res.stringResource
 import coil3.compose.AsyncImage
 import com.stash.core.data.db.dao.UnmatchedTrackView
 import com.stash.core.media.preview.PreviewState
 import com.stash.core.ui.theme.StashTheme
+import com.stash.core.ui.R
 
 /**
  * Screen displaying tracks that could not be matched on YouTube during sync.
@@ -120,7 +122,7 @@ fun FailedMatchesScreen(
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back",
+                        contentDescription = stringResource(R.string.cd_back),
                         tint = MaterialTheme.colorScheme.onSurface,
                     )
                 }
@@ -142,7 +144,7 @@ fun FailedMatchesScreen(
                     Spacer(modifier = Modifier.height(16.dp))
 
                     Text(
-                        text = "All caught up!",
+                        text = stringResource(R.string.label_all_caught_up),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
                         color = MaterialTheme.colorScheme.onBackground,
@@ -151,7 +153,7 @@ fun FailedMatchesScreen(
                     Spacer(modifier = Modifier.height(4.dp))
 
                     Text(
-                        text = "No unmatched songs.",
+                        text = stringResource(R.string.label_no_unmatched_songs),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -225,14 +227,14 @@ fun FailedMatchesScreen(
                             Spacer(modifier = Modifier.height(16.dp))
                             Column(modifier = Modifier.padding(horizontal = 20.dp)) {
                                 Text(
-                                    text = "You flagged these as wrong",
+                                    text = stringResource(R.string.label_flagged_wrong),
                                     style = MaterialTheme.typography.titleSmall,
                                     fontWeight = FontWeight.SemiBold,
                                     color = MaterialTheme.colorScheme.onBackground,
                                 )
                                 Spacer(modifier = Modifier.height(2.dp))
                                 Text(
-                                    text = "Tap resync above to find replacements, then approve to swap.",
+                                    text = stringResource(R.string.desc_tap_resync),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
@@ -289,14 +291,14 @@ fun FailedMatchesScreen(
             onDismissRequest = { trackToDismiss = null },
             title = {
                 Text(
-                    text = "Stop retrying this song?",
+                    text = stringResource(R.string.dialog_title_stop_retrying),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold,
                 )
             },
             text = {
                 Text(
-                    text = "'${track.artist} \u2014 ${track.title}' won't be downloaded during future syncs. You can find it manually using Search.",
+                    text = stringResource(R.string.dialog_body_stop_retrying, "${track.artist} \u2014 ${track.title}"),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -308,12 +310,12 @@ fun FailedMatchesScreen(
                         trackToDismiss = null
                     },
                 ) {
-                    Text("Confirm")
+                    Text(stringResource(R.string.action_confirm))
                 }
             },
             dismissButton = {
                 OutlinedButton(onClick = { trackToDismiss = null }) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             },
             containerColor = extendedColors.elevatedSurface,
@@ -360,7 +362,7 @@ private fun FailedMatchesHeader(
             ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Back",
+                    contentDescription = stringResource(R.string.cd_back),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }
@@ -584,7 +586,7 @@ private fun UnmatchedTrackRow(
                 )
             } else if (resyncAttempted) {
                 Text(
-                    text = "No match found",
+                    text = stringResource(R.string.label_no_match_found),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                     maxLines = 1,
@@ -607,12 +609,12 @@ private fun UnmatchedTrackRow(
                     )
                     isPreviewPlaying -> Icon(
                         imageVector = Icons.Default.Stop,
-                        contentDescription = "Stop preview",
+                        contentDescription = stringResource(R.string.cd_stop_preview),
                         tint = MaterialTheme.colorScheme.primary,
                     )
                     else -> Icon(
                         imageVector = Icons.Default.PlayArrow,
-                        contentDescription = "Preview match",
+                        contentDescription = stringResource(R.string.cd_preview_match),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
@@ -627,7 +629,7 @@ private fun UnmatchedTrackRow(
             ) {
                 Icon(
                     imageVector = Icons.Default.Check,
-                    contentDescription = "Approve match",
+                    contentDescription = stringResource(R.string.cd_approve_match),
                     tint = Color(0xFF4CAF50),
                 )
             }
@@ -640,7 +642,7 @@ private fun UnmatchedTrackRow(
         ) {
             Icon(
                 imageVector = Icons.Default.Close,
-                contentDescription = "Dismiss",
+                contentDescription = stringResource(R.string.cd_dismiss),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
@@ -727,14 +729,14 @@ private fun FlaggedTrackListItem(
                 )
             } else if (resyncAttempted) {
                 Text(
-                    text = "No replacement found",
+                    text = stringResource(R.string.label_no_replacement),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                     maxLines = 1,
                 )
             } else {
                 Text(
-                    text = "Tap Resync to find replacements",
+                    text = stringResource(R.string.desc_tap_resync_replacements),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                     maxLines = 1,
@@ -756,12 +758,12 @@ private fun FlaggedTrackListItem(
                     )
                     isPreviewPlaying -> Icon(
                         imageVector = Icons.Default.Stop,
-                        contentDescription = "Stop preview",
+                        contentDescription = stringResource(R.string.cd_stop_preview),
                         tint = MaterialTheme.colorScheme.primary,
                     )
                     else -> Icon(
                         imageVector = Icons.Default.PlayArrow,
-                        contentDescription = "Preview replacement",
+                        contentDescription = stringResource(R.string.cd_preview_replacement),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
@@ -775,7 +777,7 @@ private fun FlaggedTrackListItem(
             ) {
                 Icon(
                     imageVector = Icons.Default.Check,
-                    contentDescription = "Swap to this match",
+                    contentDescription = stringResource(R.string.cd_swap_match),
                     tint = Color(0xFF4CAF50),
                 )
             }
@@ -787,7 +789,7 @@ private fun FlaggedTrackListItem(
         ) {
             Icon(
                 imageVector = Icons.Default.Close,
-                contentDescription = "Unflag (keep current match)",
+                contentDescription = stringResource(R.string.cd_unflag_match),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/FailureReasonDisplay.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/FailureReasonDisplay.kt
@@ -7,9 +7,12 @@ import androidx.compose.material.icons.filled.Help
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import com.stash.core.model.DownloadFailureType
+import com.stash.core.ui.R
 
 data class FailureReasonDisplay(
     val icon: ImageVector,
@@ -31,42 +34,43 @@ val FailureReasonDisplayOrder: List<DownloadFailureType> = listOf(
     DownloadFailureType.UNKNOWN,
 )
 
+@Composable
 fun DownloadFailureType.display(): FailureReasonDisplay = when (this) {
     DownloadFailureType.AUTH_EXPIRED -> FailureReasonDisplay(
         icon = Icons.Default.Key,
         tint = Color(0xFFFFAA00),
-        groupTitle = "Sign-in expired",
-        shortLabel = "Sign-in expired",
+        groupTitle = stringResource(R.string.error_signin_expired_group),
+        shortLabel = stringResource(R.string.error_signin_expired_short),
     )
     DownloadFailureType.STORAGE_ERROR -> FailureReasonDisplay(
         icon = Icons.Default.Folder,
         tint = Color(0xFF888888),
-        groupTitle = "Storage unreachable",
-        shortLabel = "Storage error",
+        groupTitle = stringResource(R.string.error_storage_unreachable_group),
+        shortLabel = stringResource(R.string.error_storage_unreachable_short),
     )
     DownloadFailureType.NETWORK -> FailureReasonDisplay(
         icon = Icons.Default.WifiOff,
         tint = Color(0xFF508CFF),
-        groupTitle = "Network errors",
-        shortLabel = "Network error",
+        groupTitle = stringResource(R.string.error_network_errors_group),
+        shortLabel = stringResource(R.string.error_network_errors_short),
     )
     DownloadFailureType.PROVIDER_UNAVAILABLE -> FailureReasonDisplay(
         icon = Icons.Default.CloudOff,
         tint = Color(0xFFAA66CC),
-        groupTitle = "Source unavailable",
-        shortLabel = "Source unavailable",
+        groupTitle = stringResource(R.string.error_source_unavailable_group),
+        shortLabel = stringResource(R.string.error_source_unavailable_short),
     )
     DownloadFailureType.FFMPEG_ERROR -> FailureReasonDisplay(
         icon = Icons.Default.Settings,
         tint = Color(0xFFFF5A5A),
-        groupTitle = "Encoding errors",
-        shortLabel = "Encoding error",
+        groupTitle = stringResource(R.string.error_encoding_errors_group),
+        shortLabel = stringResource(R.string.error_encoding_errors_short),
     )
     DownloadFailureType.UNKNOWN -> FailureReasonDisplay(
         icon = Icons.Default.Help,
         tint = Color(0xFFAAAAAA),
-        groupTitle = "Other errors",
-        shortLabel = "Unknown error",
+        groupTitle = stringResource(R.string.error_other_errors_group),
+        shortLabel = stringResource(R.string.error_unknown_short),
     )
     DownloadFailureType.NONE,
     DownloadFailureType.NO_MATCH -> error("Not surfaced in FailedDownloadsScreen")

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncScreen.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -62,6 +63,7 @@ import com.stash.feature.sync.components.SyncActionProgress
 import com.stash.feature.sync.components.SyncStatusCard
 import com.stash.feature.sync.components.StatusPill
 import com.stash.feature.sync.components.formatRelativeTime
+import com.stash.core.ui.R
 
 /**
  * Main Sync screen.
@@ -120,7 +122,7 @@ fun SyncScreen(
         item {
             Spacer(Modifier.height(8.dp))
             Text(
-                text = "Sync",
+                text = stringResource(R.string.title_sync),
                 style = MaterialTheme.typography.headlineLarge,
                 color = MaterialTheme.colorScheme.onBackground,
                 fontWeight = FontWeight.Bold,
@@ -180,7 +182,7 @@ fun SyncScreen(
         }
 
         // -- Sources section -------------------------------------------------
-        item { SyncSectionLabel("Sources") }
+        item { SyncSectionLabel(stringResource(R.string.section_sources)) }
 
         // -- Spotify Sync Preferences (above schedule) ------------------------
         // Rendered whenever Spotify is connected, even before the first sync
@@ -256,7 +258,7 @@ fun SyncScreen(
         }
 
         // -- Schedule section -------------------------------------------------
-        item { SyncSectionLabel("Schedule") }
+        item { SyncSectionLabel(stringResource(R.string.section_schedule)) }
         item {
             com.stash.feature.sync.components.ScheduleCard(
                 autoSyncEnabled = uiState.syncPreferences.autoSyncEnabled,
@@ -274,7 +276,7 @@ fun SyncScreen(
         // -- Library section --------------------------------------------------
         // Sync-adjacent maintenance: Blocked Songs gate what sync will
         // re-download, so the entry point lives here above Recent Syncs.
-        item { SyncSectionLabel("Library") }
+        item { SyncSectionLabel(stringResource(R.string.section_library)) }
         item {
             LibraryMaintenanceCard(
                 blockedCount = blockedCount,
@@ -284,7 +286,7 @@ fun SyncScreen(
 
         // -- Recent Syncs section ---------------------------------------------
         if (uiState.recentSyncs.isNotEmpty()) {
-            item { SyncSectionLabel("Recent syncs") }
+            item { SyncSectionLabel(stringResource(R.string.section_recent_syncs)) }
             item {
                 val rows = uiState.recentSyncs.map { sync ->
                     RecentSyncRow(
@@ -321,22 +323,15 @@ fun SyncScreen(
     if (uiState.pendingRefreshSource != null) {
         AlertDialog(
             onDismissRequest = viewModel::cancelRefreshMode,
-            title = { Text("Switch to Refresh?") },
+            title = { Text(stringResource(R.string.dialog_title_switch_refresh)) },
             text = {
-                Text(
-                    "Refresh pulls fresh tracks each sync — your auto-generated " +
-                        "daily mixes, weekly discovery, and other rotating playlists. " +
-                        "Tracks that rotate out are removed from the mix and their " +
-                        "downloads deleted to keep your library lean. Cleanup runs once " +
-                        "all sources are set to Refresh — while any source still " +
-                        "accumulates, nothing is deleted. Tracks you added manually are kept."
-                )
+                Text(stringResource(R.string.dialog_body_switch_refresh))
             },
             confirmButton = {
-                TextButton(onClick = viewModel::confirmRefreshMode) { Text("Switch to Refresh") }
+                TextButton(onClick = viewModel::confirmRefreshMode) { Text(stringResource(R.string.action_switch_to_refresh)) }
             },
             dismissButton = {
-                TextButton(onClick = viewModel::cancelRefreshMode) { Text("Cancel") }
+                TextButton(onClick = viewModel::cancelRefreshMode) { Text(stringResource(R.string.action_cancel)) }
             },
         )
     }
@@ -392,15 +387,15 @@ private fun LibraryMaintenanceCard(
             Spacer(modifier = Modifier.width(16.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Blocked Songs",
+                    text = stringResource(R.string.label_blocked_songs),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Text(
                     text = if (blockedCount > 0)
-                        "$blockedCount song${if (blockedCount != 1) "s" else ""} will never re-download"
+                        stringResource(R.string.label_blocked_count, blockedCount, if (blockedCount != 1) "s" else "")
                     else
-                        "No blocked songs",
+                        stringResource(R.string.label_no_blocked_songs),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -558,7 +553,7 @@ private fun FailedDownloadsCard(
             )
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Failed Downloads",
+                    text = stringResource(R.string.label_failed_downloads),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
@@ -594,7 +589,7 @@ private fun SyncModeChipRow(
     accent: Color,
 ) {
     Text(
-        text = "Mix sync mode",
+        text = stringResource(R.string.label_mix_sync_mode),
         style = MaterialTheme.typography.labelMedium,
         color = accent,
         fontWeight = FontWeight.SemiBold,
@@ -606,19 +601,19 @@ private fun SyncModeChipRow(
         FilterChip(
             selected = mode == SyncMode.REFRESH,
             onClick = { onRequestRefresh() },
-            label = { Text("Refresh") },
+            label = { Text(stringResource(R.string.label_refresh)) },
         )
         FilterChip(
             selected = mode == SyncMode.ACCUMULATE,
             onClick = { onChange(SyncMode.ACCUMULATE) },
-            label = { Text("Accumulate") },
+            label = { Text(stringResource(R.string.label_accumulate)) },
         )
     }
     Text(
         text = if (mode == SyncMode.REFRESH)
-            "Mixes update with fresh tracks each sync"
+            stringResource(R.string.desc_mix_refresh)
         else
-            "New tracks stack on top of old ones",
+            stringResource(R.string.desc_mix_accumulate),
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
@@ -680,12 +675,12 @@ private fun StudioOnlyToggleRow(
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = "Studio recordings only",
+                text = stringResource(R.string.label_studio_recordings_only),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
-                text = "Excludes covers, live recordings, and UGC uploads from your Liked Songs. Other YouTube playlists are unaffected.",
+                text = stringResource(R.string.desc_studio_recordings_only),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -743,7 +738,7 @@ private fun SpotifyExpandedContent(
     if (uiState.spotifyPlaylists.isEmpty()) {
         Spacer(modifier = Modifier.height(12.dp))
         Text(
-            text = "Your Spotify playlists and daily mixes will appear here after the first sync. Tap Sync Now to load them — nothing downloads until you toggle it on.",
+            text = stringResource(R.string.desc_empty_spotify),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -790,7 +785,7 @@ private fun SpotifyExpandedContent(
         if (otherMixes.isNotEmpty()) {
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = "Spotify Mixes",
+                text = stringResource(R.string.section_spotify_mixes),
                 style = MaterialTheme.typography.labelMedium,
                 color = purple,
                 fontWeight = FontWeight.SemiBold,
@@ -824,7 +819,7 @@ private fun SpotifyExpandedContent(
         if (custom.isNotEmpty()) {
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = "Your Playlists",
+                text = stringResource(R.string.section_your_playlists),
                 style = MaterialTheme.typography.labelMedium,
                 color = purple,
                 fontWeight = FontWeight.SemiBold,
@@ -868,7 +863,7 @@ private fun <T> SearchablePlaylistList(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 4.dp, bottom = 4.dp),
-        placeholder = { Text("Filter playlists\u2026") },
+        placeholder = { Text(stringResource(R.string.hint_filter_playlists)) },
         singleLine = true,
         leadingIcon = {
             Icon(
@@ -882,7 +877,7 @@ private fun <T> SearchablePlaylistList(
                 IconButton(onClick = { query = "" }) {
                     Icon(
                         imageVector = Icons.Filled.Clear,
-                        contentDescription = "Clear filter",
+                        contentDescription = stringResource(R.string.cd_clear_filter),
                     )
                 }
             }
@@ -895,7 +890,7 @@ private fun <T> SearchablePlaylistList(
     }
     if (filtered.isEmpty()) {
         Text(
-            text = "No playlists matching \u201C${query.trim()}\u201D",
+            text = stringResource(R.string.label_no_playlists_match, query.trim()),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(vertical = 8.dp),
@@ -964,7 +959,7 @@ private fun YouTubeExpandedContent(
     if (!hasPlaylists) {
         Spacer(modifier = Modifier.height(12.dp))
         Text(
-            text = "Your Home Mixes, Liked Songs, and playlists from your YouTube Music library will appear here after the first sync. Nothing downloads until you pick what you want — no surprise downloads.",
+            text = stringResource(R.string.desc_empty_youtube),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -1008,7 +1003,7 @@ private fun YouTubeExpandedContent(
         if (ytMixes.isNotEmpty()) {
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = "Home Mixes",
+                text = stringResource(R.string.section_home_mixes),
                 style = MaterialTheme.typography.labelMedium,
                 color = accent,
                 fontWeight = FontWeight.SemiBold,
@@ -1026,7 +1021,7 @@ private fun YouTubeExpandedContent(
         if (ytOther.isNotEmpty()) {
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = "Other Playlists",
+                text = stringResource(R.string.section_other_playlists),
                 style = MaterialTheme.typography.labelMedium,
                 color = accent,
                 fontWeight = FontWeight.SemiBold,

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/components/AuthExpiredBanner.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/components/AuthExpiredBanner.kt
@@ -18,7 +18,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import com.stash.core.data.sync.AuthExpiryState
+import com.stash.core.ui.R
 
 /**
  * Amber banner mounted at the top of the Sync tab when either Spotify or
@@ -43,21 +45,21 @@ fun AuthExpiredBanner(
     val buttonText: String
     when {
         state.spotifyExpired && state.youtubeExpired -> {
-            headline = "Sign-ins expired"
-            body = "Both Spotify and YouTube need fresh sign-ins to resume sync."
-            buttonText = "Re-authenticate"
+            headline = stringResource(R.string.auth_signins_expired)
+            body = stringResource(R.string.auth_signins_expired_desc)
+            buttonText = stringResource(R.string.action_reauthenticate)
         }
         state.spotifyExpired -> {
-            // Only Spotify is expired \u2014 any other connected source still syncs,
+            // Only Spotify is expired — any other connected source still syncs,
             // so this is NOT a full pause. Copy reflects partial sync.
-            headline = "Spotify session expired"
-            body = "Re-authenticate to include your Spotify library in sync."
-            buttonText = "Re-authenticate Spotify"
+            headline = stringResource(R.string.auth_spotify_expired)
+            body = stringResource(R.string.auth_spotify_expired_desc)
+            buttonText = stringResource(R.string.action_reauthenticate_spotify)
         }
         else -> {
-            headline = "YouTube session expired"
-            body = "Re-authenticate to include your YouTube library in sync."
-            buttonText = "Re-authenticate YouTube"
+            headline = stringResource(R.string.auth_youtube_expired)
+            body = stringResource(R.string.auth_youtube_expired_desc)
+            buttonText = stringResource(R.string.action_reauthenticate_youtube)
         }
     }
 

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/components/DayOfWeekPanel.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/components/DayOfWeekPanel.kt
@@ -24,8 +24,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import com.stash.core.data.sync.DayOfWeekSet
 import com.stash.core.ui.theme.StashTheme
+import com.stash.core.ui.R
 import java.time.DayOfWeek
 
 @Composable
@@ -44,7 +46,7 @@ fun DayOfWeekPanel(
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             Text(
-                text = "REPEAT ON",
+                text = stringResource(R.string.label_repeat_on),
                 style = MaterialTheme.typography.labelSmall,
                 color = StashTheme.extendedColors.purpleLight,
                 fontWeight = FontWeight.SemiBold,
@@ -64,9 +66,9 @@ fun DayOfWeekPanel(
             }
             Spacer(Modifier.height(10.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                PresetChip("Daily", selection.isDaily) { onSelectionChanged(DayOfWeekSet.EVERY_DAY) }
-                PresetChip("Weekdays", selection.isWeekdays) { onSelectionChanged(DayOfWeekSet.WEEKDAYS) }
-                PresetChip("Weekends", selection.isWeekends) { onSelectionChanged(DayOfWeekSet.WEEKENDS) }
+                PresetChip(stringResource(R.string.label_daily), selection.isDaily) { onSelectionChanged(DayOfWeekSet.EVERY_DAY) }
+                PresetChip(stringResource(R.string.label_weekdays), selection.isWeekdays) { onSelectionChanged(DayOfWeekSet.WEEKDAYS) }
+                PresetChip(stringResource(R.string.label_weekends), selection.isWeekends) { onSelectionChanged(DayOfWeekSet.WEEKENDS) }
             }
         }
     }

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/components/RecentSyncsCard.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/components/RecentSyncsCard.kt
@@ -26,8 +26,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import com.stash.core.ui.components.GlassCard
 import com.stash.core.ui.theme.StashTheme
+import com.stash.core.ui.R
 
 /**
  * View-layer row model used by [RecentSyncsCard]. Decouples the card from
@@ -114,7 +116,7 @@ private fun RecentSyncRowItem(row: RecentSyncRow) {
             Spacer(Modifier.height(4.dp))
             if (!row.errorMessage.isNullOrBlank()) {
                 Text(
-                    text = "Error: ${row.errorMessage}",
+                    text = stringResource(R.string.label_error_prefix, row.errorMessage),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
                 )
@@ -122,7 +124,7 @@ private fun RecentSyncRowItem(row: RecentSyncRow) {
             }
             if (!row.diagnostics.isNullOrBlank()) {
                 Text(
-                    text = "Diagnostics:",
+                    text = stringResource(R.string.label_diagnostics),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     fontWeight = FontWeight.SemiBold,
@@ -137,7 +139,7 @@ private fun RecentSyncRowItem(row: RecentSyncRow) {
             }
             if (row.errorMessage.isNullOrBlank() && row.diagnostics.isNullOrBlank()) {
                 Text(
-                    text = "No additional details available",
+                    text = stringResource(R.string.label_no_details),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/components/ScheduleCard.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/components/ScheduleCard.kt
@@ -27,8 +27,10 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import com.stash.core.data.sync.DayOfWeekSet
 import com.stash.core.ui.components.GlassCard
+import com.stash.core.ui.R
 
 @Composable
 fun ScheduleCard(
@@ -57,7 +59,7 @@ fun ScheduleCard(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text("Auto-sync", style = MaterialTheme.typography.bodyLarge)
+                Text(stringResource(R.string.label_auto_sync), style = MaterialTheme.typography.bodyLarge)
                 Switch(
                     checked = autoSyncEnabled,
                     onCheckedChange = { onToggleAutoSync() },
@@ -72,7 +74,7 @@ fun ScheduleCard(
             Column(modifier = Modifier.alpha(if (autoSyncEnabled) 1f else 0.5f)) {
                 if (emptyDays) {
                     Text(
-                        text = "Not scheduled — pick at least one day",
+                        text = stringResource(R.string.label_not_scheduled),
                         style = MaterialTheme.typography.bodyMedium,
                         color = errorColor,
                         modifier = Modifier.clickable { daysExpanded = true },
@@ -93,7 +95,7 @@ fun ScheduleCard(
                         )
                         Text(" on ", style = MaterialTheme.typography.bodyMedium)
                         ScheduleChip(
-                            text = if (wifiOnly) "Wi-Fi only" else "any network",
+                            text = if (wifiOnly) stringResource(R.string.label_wifi_only) else stringResource(R.string.label_any_network),
                             active = false,
                             onClick = { onToggleWifiOnly() },
                             muted = true,
@@ -111,7 +113,7 @@ fun ScheduleCard(
 
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    text = "Tap any chip to change",
+                    text = stringResource(R.string.desc_tap_chip_to_change),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -158,8 +160,9 @@ private fun ScheduleChip(
     )
 }
 
+@Composable
 private fun formatTime(hour: Int, minute: Int): String {
-    val period = if (hour < 12) "AM" else "PM"
+    val period = if (hour < 12) stringResource(R.string.label_am) else stringResource(R.string.label_pm)
     val display = when (hour) {
         0 -> 12
         in 13..23 -> hour - 12

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/components/SyncActionProgress.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/components/SyncActionProgress.kt
@@ -21,8 +21,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stash.core.data.sync.SyncPhase
+import com.stash.core.ui.R
 
 /**
  * Multi-phase sync progress widget shown inside [SyncHeroCard] while a sync
@@ -85,7 +87,7 @@ fun SyncActionProgress(
             )
             Spacer(Modifier.width(8.dp))
             Text(
-                text = "Stop sync",
+                text = stringResource(R.string.action_stop_sync),
                 style = MaterialTheme.typography.labelLarge,
             )
         }
@@ -103,13 +105,14 @@ fun SyncActionProgress(
 }
 
 /** Human-readable label for the current sync phase. */
+@Composable
 internal fun phaseLabel(phase: SyncPhase): String = when (phase) {
-    is SyncPhase.Authenticating -> "Authenticating..."
-    is SyncPhase.FetchingPlaylists -> "Fetching playlists..."
-    is SyncPhase.Diffing -> "Comparing changes..."
-    is SyncPhase.Downloading -> "Downloading ${phase.downloaded}/${phase.total}..."
-    is SyncPhase.Finalizing -> "Finalizing..."
-    is SyncPhase.Completed -> "Complete"
-    is SyncPhase.Error -> "Error"
-    else -> "Syncing..."
+    is SyncPhase.Authenticating -> stringResource(R.string.sync_phase_authenticating)
+    is SyncPhase.FetchingPlaylists -> stringResource(R.string.sync_phase_fetching)
+    is SyncPhase.Diffing -> stringResource(R.string.sync_phase_diffing)
+    is SyncPhase.Downloading -> stringResource(R.string.sync_phase_downloading, phase.downloaded, phase.total)
+    is SyncPhase.Finalizing -> stringResource(R.string.sync_phase_finalizing)
+    is SyncPhase.Completed -> stringResource(R.string.sync_phase_complete)
+    is SyncPhase.Error -> stringResource(R.string.sync_phase_error)
+    else -> stringResource(R.string.status_syncing)
 }

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/components/SyncHeroCard.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/components/SyncHeroCard.kt
@@ -34,7 +34,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import com.stash.core.ui.theme.StashTheme
+import com.stash.core.ui.R
 
 /**
  * Gradient-tinted hero card carrying last-sync metadata + the Sync Now button.
@@ -97,14 +99,14 @@ fun SyncHeroCard(
             ) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = "LAST SYNC",
+                        text = stringResource(R.string.label_last_sync),
                         style = MaterialTheme.typography.labelSmall,
                         color = StashTheme.extendedColors.purpleLight,
                         fontWeight = FontWeight.SemiBold,
                     )
                     Spacer(Modifier.height(2.dp))
                     val body = when {
-                        lastSyncTrackCount == null -> "Never synced"
+                        lastSyncTrackCount == null -> stringResource(R.string.status_never_synced)
                         else -> "$lastSyncRelativeTime · $lastSyncTrackCount tracks"
                     }
                     Text(
@@ -141,7 +143,7 @@ fun SyncHeroCard(
                             modifier = Modifier.size(16.dp),
                         )
                     },
-                    label = { Text("Online") },
+                    label = { Text(stringResource(R.string.mode_online)) },
                 )
                 SegmentedButton(
                     selected = !streamingMode,
@@ -155,7 +157,7 @@ fun SyncHeroCard(
                             modifier = Modifier.size(16.dp),
                         )
                     },
-                    label = { Text("Offline") },
+                    label = { Text(stringResource(R.string.mode_offline)) },
                 )
             }
 
@@ -176,7 +178,7 @@ fun SyncHeroCard(
                     )
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        text = if (streamingMode) "Surface Library for Streaming" else "Download Tracks to Device",
+                        text = if (streamingMode) stringResource(R.string.action_surface_streaming) else stringResource(R.string.action_download_tracks),
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.Bold,
                         maxLines = 1,

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/components/SyncStatusCard.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/components/SyncStatusCard.kt
@@ -25,10 +25,12 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import com.stash.core.model.SyncDisplayStatus
 import com.stash.core.ui.components.GlassCard
 import com.stash.core.ui.theme.StashTheme
 import com.stash.feature.sync.SyncStatusInfo
+import com.stash.core.ui.R
 
 /**
  * Sync status card displayed at the top of the Sync tab.
@@ -74,13 +76,13 @@ fun SyncStatusCard(
             // -- Prompt or stats depending on sync state --
             if (!anyServiceConnected) {
                 Text(
-                    text = "Connect Spotify or YouTube Music in Settings to start syncing your library.",
+                    text = stringResource(R.string.desc_connect_service),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             } else if (!hasEverSynced) {
                 Text(
-                    text = "Tap Sync Now to download your playlists and tracks.",
+                    text = stringResource(R.string.desc_tap_sync_now),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -99,27 +101,27 @@ fun SyncStatusCard(
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
                     StatItem(
-                        label = "Tracks",
+                        label = stringResource(R.string.label_tracks),
                         value = syncStatus.totalTracks.toString(),
                         subValue = if (syncStatus.flacTracks > 0) "${syncStatus.flacTracks} FLAC" else null,
                     )
                     StatItem(
-                        label = "Spotify",
+                        label = stringResource(R.string.label_spotify),
                         value = syncStatus.spotifyTracks.toString(),
                     )
                     StatItem(
-                        label = "YouTube",
+                        label = stringResource(R.string.label_youtube),
                         value = syncStatus.youTubeTracks.toString(),
                     )
                     StatItem(
-                        label = "Storage",
+                        label = stringResource(R.string.label_storage),
                         value = formatBytes(syncStatus.storageUsedBytes),
                         subValue = if (syncStatus.flacStorageBytes > 0) "${formatBytes(syncStatus.flacStorageBytes)} FLAC" else null,
                     )
                 }
                 if (syncStatus.lastSyncTime != null) {
                     Text(
-                        text = "Last sync ${formatRelativeTimeForCard(syncStatus.lastSyncTime)}",
+                        text = stringResource(R.string.label_last_sync_time, formatRelativeTimeForCard(syncStatus.lastSyncTime)),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -140,18 +142,18 @@ private fun syncStatusLabel(
     anyServiceConnected: Boolean,
     hasEverSynced: Boolean,
 ): String = when {
-    !anyServiceConnected -> "No services connected"
-    !hasEverSynced -> "Ready to sync"
+    !anyServiceConnected -> stringResource(R.string.status_no_services_connected)
+    !hasEverSynced -> stringResource(R.string.status_ready_to_sync)
     else -> when (val s = syncStatus.displayStatus) {
-        SyncDisplayStatus.Idle -> "Ready to sync"
-        SyncDisplayStatus.Running -> "Syncing..."
-        SyncDisplayStatus.Success -> "Synced"
+        SyncDisplayStatus.Idle -> stringResource(R.string.status_ready_to_sync)
+        SyncDisplayStatus.Running -> stringResource(R.string.status_syncing)
+        SyncDisplayStatus.Success -> stringResource(R.string.status_synced)
         is SyncDisplayStatus.PartialSuccess ->
-            "Partially synced — ${s.downloaded} saved, ${s.failed} failed"
+            stringResource(R.string.status_partial_sync, s.downloaded, s.failed)
         is SyncDisplayStatus.Interrupted ->
-            if (s.downloaded > 0) "Interrupted — ${s.downloaded} saved"
-            else "Interrupted"
-        is SyncDisplayStatus.Failed -> "Sync failed"
+            if (s.downloaded > 0) stringResource(R.string.status_sync_interrupted_count, s.downloaded)
+            else stringResource(R.string.status_sync_interrupted)
+        is SyncDisplayStatus.Failed -> stringResource(R.string.status_sync_failed)
     }
 }
 

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/components/SyncTimeBottomSheet.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/components/SyncTimeBottomSheet.kt
@@ -20,6 +20,8 @@ import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.stash.core.ui.R
 import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -46,7 +48,7 @@ fun SyncTimeBottomSheet(
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         ) {
             Text(
-                text = "Sync time",
+                text = stringResource(R.string.title_sync_time),
                 style = MaterialTheme.typography.titleLarge,
             )
             Spacer(Modifier.height(16.dp))


### PR DESCRIPTION
Add ~550 string resources in values/strings.xml and values-zh-rCN/strings.xml covering all user-facing UI text across the app.

- Extract hardcoded English strings from 83 Kotlin files into shared string resources in core:ui
- Provide complete Simplified Chinese translations for all resources
- Add per-module zh-CN resource directories (app, core:media)
- Fix Locale.US to Locale.getDefault() for user-facing time/unit formatting in LongExt.kt and GlowingProgressBar.kt
- Bottom navigation labels, sort/filter chips, library tabs, sync phases, EQ presets, quality tiers, and all settings screens fully localized