### PR TITLE
feat(settings): prefer GitHub Sponsors in the Support banner

### DIFF
--- a/app/src/main/kotlin/com/stash/app/navigation/StashNavHost.kt
+++ b/app/src/main/kotlin/com/stash/app/navigation/StashNavHost.kt
@@ -133,8 +133,11 @@ fun StashNavHost(
                 onOpenLibraryStorage = { navController.navigate(SettingsLibraryStorageRoute) },
                 onOpenAppearance = { navController.navigate(SettingsAppearanceRoute) },
                 onOpenAbout = { navController.navigate(SettingsAboutRoute) },
-                onDonate = { runCatching { uriHandler.openUri("https://ko-fi.com/rawnald") } },
+                // GitHub Sponsors is the preferred path — 0% platform fee, so
+                // 100% reaches the maintainer (Ko-fi skims a few percent).
+                onSponsor = { runCatching { uriHandler.openUri("https://github.com/sponsors/rawnaldclark") } },
                 onStar = { runCatching { uriHandler.openUri("https://github.com/rawnaldclark/Stash") } },
+                onKofi = { runCatching { uriHandler.openUri("https://ko-fi.com/rawnald") } },
             )
         }
 

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsHubScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsHubScreen.kt
@@ -38,7 +38,7 @@ import com.stash.feature.settings.components.SupportBanner
  * "spoke" screens (built in later tasks) via the `onOpen*` callbacks.
  *
  * Pure host: it owns no navigation itself — the caller wires every `onOpen*`,
- * [onDonate], and [onStar]. It shares the existing [SettingsViewModel] so the
+ * [onSponsor], [onStar], and [onKofi]. It shares the existing [SettingsViewModel] so the
  * subtitles reflect live playback/quality/account/library/appearance/version
  * state.
  */
@@ -50,8 +50,9 @@ fun SettingsHubScreen(
     onOpenLibraryStorage: () -> Unit,
     onOpenAppearance: () -> Unit,
     onOpenAbout: () -> Unit,
-    onDonate: () -> Unit,
+    onSponsor: () -> Unit,
     onStar: () -> Unit,
+    onKofi: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
@@ -94,7 +95,7 @@ fun SettingsHubScreen(
             style = MaterialTheme.typography.headlineSmall,
             color = MaterialTheme.colorScheme.onSurface,
         )
-        SupportBanner(onDonate = onDonate, onStar = onStar)
+        SupportBanner(onSponsor = onSponsor, onStar = onStar, onKofi = onKofi)
         SettingsSearchField()
         SettingsGroupCard(
             rows = listOf(

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SupportBanner.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SupportBanner.kt
@@ -3,6 +3,7 @@ package com.stash.feature.settings.components
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -31,14 +32,20 @@ import com.stash.core.ui.theme.StashPurple
 import com.stash.core.ui.theme.StashPurpleLight
 
 /**
- * A premium gradient Support card for the Settings hub. Renders a one-line pitch
- * and two actions (Donate / Star). Pure presentation — the hub screen wires the
- * actual donate/star URL handlers via [onDonate] and [onStar].
+ * A premium gradient Support card for the Settings hub. Renders a one-line pitch,
+ * two primary actions (Sponsor / Star), and a secondary Ko-fi link. Pure
+ * presentation — the hub screen wires the URL handlers via [onSponsor], [onStar],
+ * and [onKofi].
+ *
+ * GitHub Sponsors is the preferred path (0% platform fee, so 100% reaches the
+ * maintainer); Ko-fi stays available as a lower-friction option for donors
+ * without a GitHub account.
  */
 @Composable
 fun SupportBanner(
-    onDonate: () -> Unit,
+    onSponsor: () -> Unit,
     onStar: () -> Unit,
+    onKofi: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -75,7 +82,7 @@ fun SupportBanner(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             Button(
-                onClick = onDonate,
+                onClick = onSponsor,
                 modifier = Modifier.weight(1f),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = MaterialTheme.colorScheme.primary,
@@ -87,7 +94,7 @@ fun SupportBanner(
                     modifier = Modifier.size(16.dp),
                 )
                 Spacer(modifier = Modifier.width(6.dp))
-                Text(text = "Donate", style = MaterialTheme.typography.labelMedium)
+                Text(text = "Sponsor", style = MaterialTheme.typography.labelMedium)
             }
             OutlinedButton(
                 onClick = onStar,
@@ -105,5 +112,13 @@ fun SupportBanner(
                 Text(text = "Star", style = MaterialTheme.typography.labelMedium)
             }
         }
+        Text(
+            text = "also on Ko-fi ↗",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .clickable(onClick = onKofi)
+                .padding(vertical = 2.dp),
+        )
     }
 }


### PR DESCRIPTION
## What & why

Makes **GitHub Sponsors** the preferred support path in the Settings hub banner. Sponsors has a **0% platform fee** (100% reaches the maintainer), whereas Ko-fi skims a few percent.

## Changes
- **Primary button** relabeled `Donate → Sponsor`, now opens `github.com/sponsors/rawnaldclark` (was `ko-fi.com/rawnald`).
- **Ko-fi kept as a secondary link** (`also on Ko-fi ↗`) for donors without a GitHub account or who prefer card/PayPal — nobody's turned away, but the 0%-fee path is the default.
- **Star** button unchanged.
- Renamed the callback `onDonate → onSponsor` and added `onKofi`, threaded through `SupportBanner` → `SettingsHubScreen` → `StashNavHost`.

```
Support Stash
If Stash replaced a subscription for you, consider supporting the project.

[ ♥ Sponsor ]  [ ★ Star ]
also on Ko-fi ↗
```

## Verification
`:feature:settings` + `:app` `compileDebugKotlin` → **BUILD SUCCESSFUL**. No stale `onDonate` references remain.

## Out of scope
The Home tip-jar / supporters strip still points at Ko-fi (that's where the supporter list is tracked) — intentionally left as-is.
