### PR TITLE
fix(settings): refresh library storage usage on entry

### DIFF
--- a/data/download/src/main/kotlin/com/stash/data/download/files/LibrarySizeHolder.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/LibrarySizeHolder.kt
@@ -6,12 +6,15 @@ import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 
 /**
  * Single source of truth for the music library's on-disk size + lossless
@@ -46,9 +49,12 @@ class LibrarySizeHolder @Inject constructor(
     private val musicRepository: MusicRepository,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val refreshVersion = MutableStateFlow(0L)
 
-    val size: StateFlow<LibrarySizeBreakdown> = musicRepository.getTrackCount()
-        .distinctUntilChanged()
+    val size: StateFlow<LibrarySizeBreakdown> = combine(
+        musicRepository.getTrackCount().distinctUntilChanged(),
+        refreshVersion,
+    ) { _, _ -> Unit }
         .scan(LibrarySizeBreakdown(0L, 0L, 0)) { prev, _ ->
             runCatching { fileOrganizer.computeMusicLibrarySize() }
                 .getOrDefault(prev)
@@ -59,4 +65,9 @@ class LibrarySizeHolder @Inject constructor(
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = LibrarySizeBreakdown(0L, 0L, 0),
         )
+
+    /** Requests a fresh filesystem walk even when the track count is unchanged. */
+    fun refresh() {
+        refreshVersion.update { it + 1 }
+    }
 }

--- a/data/download/src/test/kotlin/com/stash/data/download/files/LibrarySizeHolderTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/files/LibrarySizeHolderTest.kt
@@ -1,0 +1,39 @@
+package com.stash.data.download.files
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.data.repository.MusicRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class LibrarySizeHolderTest {
+
+    @Test
+    fun `refresh recomputes and publishes size without a track count change`() = runTest {
+        val trackCount = MutableStateFlow(7)
+        val initialSize = LibrarySizeBreakdown(100L, 80L, 2)
+        val refreshedSize = LibrarySizeBreakdown(140L, 120L, 3)
+        val fileOrganizer = mockk<FileOrganizer>()
+        val musicRepository = mockk<MusicRepository>()
+        every { musicRepository.getTrackCount() } returns trackCount
+        coEvery { fileOrganizer.computeMusicLibrarySize() } returnsMany
+            listOf(initialSize, refreshedSize)
+        val holder = LibrarySizeHolder(fileOrganizer, musicRepository)
+
+        holder.size.test {
+            assertThat(awaitItem()).isEqualTo(LibrarySizeBreakdown(0L, 0L, 0))
+            assertThat(awaitItem()).isEqualTo(initialSize)
+
+            holder.refresh()
+
+            assertThat(awaitItem()).isEqualTo(refreshedSize)
+            coVerify(exactly = 2) { fileOrganizer.computeMusicLibrarySize() }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsLibraryStorageScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsLibraryStorageScreen.kt
@@ -76,6 +76,10 @@ fun SettingsLibraryStorageScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val extendedColors = StashTheme.extendedColors
 
+    LaunchedEffect(viewModel) {
+        viewModel.refreshStorageUsage()
+    }
+
     SettingsScaffold(title = "Library & Storage", onBack = onBack, modifier = modifier) {
         val context = LocalContext.current
         val contentResolver = context.contentResolver

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -447,6 +447,11 @@ class SettingsViewModel @Inject constructor(
 
     // -- Storage actions ------------------------------------------------------
 
+    /** Recomputes storage usage from the configured library filesystem. */
+    fun refreshStorageUsage() {
+        librarySizeHolder.refresh()
+    }
+
     /**
      * Persists the user's chosen SAF tree URI (or null to revert to
      * internal). Callers MUST have already called

--- a/feature/settings/src/test/kotlin/com/stash/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/stash/feature/settings/SettingsViewModelTest.kt
@@ -1,12 +1,14 @@
 package com.stash.feature.settings
 
 import com.google.common.truth.Truth.assertThat
+import com.stash.data.download.files.LibrarySizeHolder
 import com.stash.data.download.lossless.LosslessSourcePreferences
 import com.stash.data.download.lossless.qbdlx.QbdlxCredentialStore
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,12 +41,13 @@ class SettingsViewModelTest {
     private val qbdlxStore = mockk<QbdlxCredentialStore>(relaxed = true).also {
         coEvery { it.allDead() } returns false
     }
+    private val librarySizeHolder = mockk<LibrarySizeHolder>(relaxed = true)
 
     private fun newVm() = SettingsViewModel(
         appContext = mockk(relaxed = true),
         tokenManager = mockk(relaxed = true),
         musicRepository = mockk(relaxed = true),
-        librarySizeHolder = mockk(relaxed = true),
+        librarySizeHolder = librarySizeHolder,
         qualityPreference = mockk(relaxed = true),
         themePreference = mockk(relaxed = true),
         storagePreference = mockk(relaxed = true),
@@ -80,6 +83,14 @@ class SettingsViewModelTest {
         vm.onQbdlxEnabledChange(false)
         advanceUntilIdle()
         coVerify { losslessPrefs.setQbdlxEnabled(false) }
+    }
+
+    @Test fun `refreshStorageUsage requests a fresh filesystem calculation`() {
+        val vm = newVm()
+
+        vm.refreshStorageUsage()
+
+        verify(exactly = 1) { librarySizeHolder.refresh() }
     }
 
     @Test fun `onQbdlxTokenPaste stores the pasted token`() = runTest {


### PR DESCRIPTION
## What does this PR do?

Refreshes the filesystem-backed library storage total whenever the Library & Storage screen is entered, even when the track count has not changed.

The shared size holder now accepts an explicit refresh signal while preserving its existing track-count updates, IO dispatching, and last-known-value fallback.

## Related issue

Closes #205

## How was this tested?

- Added a holder-level regression test proving `refresh()` performs a second filesystem calculation and publishes the new total while track count stays unchanged.
- Added a focused ViewModel delegation test.
- `:data:download:testDebugUnitTest --tests com.stash.data.download.files.LibrarySizeHolderTest` passes.
- `:feature:settings:testDebugUnitTest --tests com.stash.feature.settings.SettingsViewModelTest` passes.
- `assembleDebug` passes.
- The full `test` task reaches one unrelated `PlaylistTypeTest` failure that reproduces identically on clean `origin/master` at the contribution base.

- [ ] `./gradlew test` passes
- [ ] Installed on a device and manually verified the change
- [ ] Device / Android version tested:

## Checklist

- [x] My code follows the style of the surrounding code
- [x] This PR does **one thing** (unrelated changes belong in separate PRs)
- [x] I updated docs or comments where it made sense
