### PR TITLE
fix(downloads): preserve non-Latin filenames

### DIFF
--- a/data/download/src/main/kotlin/com/stash/data/download/files/FileOrganizerSlugs.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/FileOrganizerSlugs.kt
@@ -18,21 +18,25 @@ package com.stash.data.download.files
  * `:data:*` modules wiring downloads + sidecars, and the object is
  * intentionally narrow — one pure helper, no state.
  *
- * The body is copied verbatim from the previous
- * `FileOrganizer.slugify` — behaviour is identical.
+ * Download, migration, and sidecar paths share this definition so filename
+ * behavior cannot drift between storage destinations.
  */
 object FileOrganizerSlugs {
 
     /**
      * Converts a human-readable string into a filesystem-safe slug.
      *
-     * Lowercases, strips non-alphanumeric characters (except spaces and hyphens),
-     * collapses whitespace into single hyphens, and truncates to 60 characters.
+     * Lowercases, preserves Unicode letters and numbers, strips other characters
+     * (except spaces and hyphens), collapses whitespace into single hyphens, and
+     * truncates to 60 Unicode code points.
      */
     fun slugify(input: String): String =
         input.lowercase()
-            .replace(Regex("[^a-z0-9\\s-]"), "")
+            .replace(Regex("[^\\p{L}\\p{N}\\s-]"), "")
             .replace(Regex("\\s+"), "-")
             .trim('-')
-            .take(60)
+            .takeCodePoints(60)
+
+    private fun String.takeCodePoints(count: Int): String =
+        substring(0, offsetByCodePoints(0, minOf(count, codePointCount(0, length))))
 }

--- a/data/download/src/main/kotlin/com/stash/data/download/files/MoveLibraryCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/MoveLibraryCoordinator.kt
@@ -166,9 +166,13 @@ class MoveLibraryCoordinator @Inject constructor(
             error("Internal file missing: $path")
         }
 
-        val artistSlug = slugify(track.artist)
-        val albumSlug = if (track.album.isNotBlank()) slugify(track.album) else "singles"
-        val titleSlug = slugify(track.title)
+        val artistSlug = FileOrganizerSlugs.slugify(track.artist)
+        val albumSlug = if (track.album.isNotBlank()) {
+            FileOrganizerSlugs.slugify(track.album)
+        } else {
+            "singles"
+        }
+        val titleSlug = FileOrganizerSlugs.slugify(track.title)
         val format = localFile.extension.ifBlank { "m4a" }
         val filename = "$titleSlug.$format"
 
@@ -210,13 +214,6 @@ class MoveLibraryCoordinator @Inject constructor(
         "wav" -> "audio/wav"
         else -> "audio/*"
     }
-
-    private fun slugify(input: String): String =
-        input.lowercase()
-            .replace(Regex("[^a-z0-9\\s-]"), "")
-            .replace(Regex("\\s+"), "-")
-            .trim('-')
-            .take(60)
 
     companion object {
         private const val TAG = "MoveLibraryCoord"

--- a/data/download/src/test/kotlin/com/stash/data/download/files/FileOrganizerSlugsTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/files/FileOrganizerSlugsTest.kt
@@ -1,0 +1,44 @@
+package com.stash.data.download.files
+
+import java.nio.charset.StandardCharsets
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FileOrganizerSlugsTest {
+
+    @Test
+    fun `slugify preserves existing ASCII behavior`() {
+        assertEquals(
+            "acdc-back-in-black-live",
+            FileOrganizerSlugs.slugify("AC/DC: Back in Black! (Live)"),
+        )
+    }
+
+    @Test
+    fun `slugify keeps Cyrillic names non-empty and filesystem-safe`() {
+        val slug = FileOrganizerSlugs.slugify("Кино — Группа крови")
+
+        assertEquals("кино-группа-крови", slug)
+        assertFalse(slug.isEmpty())
+        assertTrue(slug.matches(Regex("[\\p{L}\\p{N}-]+")))
+    }
+
+    @Test
+    fun `slugify keeps Japanese titles non-empty and filesystem-safe`() {
+        val slug = FileOrganizerSlugs.slugify("夜に駆ける / YOASOBI")
+
+        assertEquals("夜に駆ける-yoasobi", slug)
+        assertFalse(slug.isEmpty())
+        assertTrue(slug.matches(Regex("[\\p{L}\\p{N}-]+")))
+    }
+
+    @Test
+    fun `slugify truncates supplementary-plane letters at complete code points`() {
+        val slug = FileOrganizerSlugs.slugify("a" + "𐐀".repeat(60))
+
+        assertEquals(60, slug.codePointCount(0, slug.length))
+        assertTrue(StandardCharsets.UTF_8.newEncoder().canEncode(slug))
+    }
+}


### PR DESCRIPTION
## Summary

- preserve Unicode letters and numbers when generating download path slugs
- share one slug implementation across downloads, sidecars, and library moves
- truncate at complete Unicode code points to keep filenames valid
- cover existing ASCII, Cyrillic, Japanese, and supplementary-plane behavior

## Testing

- focused `FileOrganizerSlugsTest` with fresh task execution
- full `assembleDebug`
- `git diff --check`

Closes #269
