### PR TITLE
fix(downloads): propagate metadata embed failures

### DIFF
--- a/data/download/src/main/kotlin/com/stash/data/download/files/MetadataEmbedder.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/MetadataEmbedder.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -20,7 +21,7 @@ import javax.inject.Singleton
  *
  * The ffmpeg binary is bundled by youtubedl-android as a native .so.
  * If tagging fails for any reason, the original untagged file is
- * preserved — an untagged download is preferable to a missing one.
+ * preserved and the failure is reported to the caller.
  *
  * Vorbis-comment casing: writes each key twice (canonical
  * `ALBUMARTIST` + legacy `album_artist`) so both strict Vorbis
@@ -34,6 +35,10 @@ class MetadataEmbedder @Inject constructor(
     @ApplicationContext private val context: Context,
     private val appVersion: AppVersionProvider,
 ) {
+    internal var renameFile: (File, File) -> Boolean = { source, target ->
+        source.renameTo(target)
+    }
+
     suspend fun embedMetadata(
         audioFile: File,
         track: Track,
@@ -43,6 +48,7 @@ class MetadataEmbedder @Inject constructor(
             audioFile.parent,
             "${audioFile.nameWithoutExtension}_tagged.${audioFile.extension}",
         )
+        var backupFile: File? = null
 
         // Issue #118: realistic album art (300–500KB JPEG → 400–700KB base64)
         // can push a single argv entry near or past Linux's MAX_ARG_STRLEN
@@ -59,7 +65,8 @@ class MetadataEmbedder @Inject constructor(
         )
 
         try {
-            val ffmpegPath = resolveFfmpegBinary() ?: return@withContext audioFile
+            val ffmpegPath = resolveFfmpegBinary()
+                ?: throw IOException("ffmpeg binary not found")
             val pb = ProcessBuilder(listOf(ffmpegPath.absolutePath) + args)
             // Keep stderr separate from stdout so we can log it verbatim on
             // failure — merging via redirectErrorStream(true) and then never
@@ -91,17 +98,40 @@ class MetadataEmbedder @Inject constructor(
                 if (stdout.isNotBlank()) {
                     Log.d(TAG, "ffmpeg stdout: ${stdout.take(200)}")
                 }
+                throw IOException("ffmpeg exited $exit for ${audioFile.absolutePath}")
             }
 
-            if (outputFile.exists() && outputFile.length() > 0) {
-                audioFile.delete()
-                outputFile.renameTo(audioFile)
-            } else {
-                Log.w(TAG, "ffmpeg produced no output for ${audioFile.absolutePath} (exit=$exit)")
+            if (!outputFile.exists() || outputFile.length() <= 0) {
+                throw IOException("ffmpeg produced no output for ${audioFile.absolutePath}")
+            }
+
+            val backup = File.createTempFile(
+                "stash_${audioFile.nameWithoutExtension}_untagged_",
+                ".${audioFile.extension}",
+                audioFile.parentFile,
+            ).apply { delete() }
+            backupFile = backup
+            if (!renameFile(audioFile, backup)) {
+                throw IOException("could not preserve original file ${audioFile.absolutePath}")
+            }
+            if (!renameFile(outputFile, audioFile)) {
+                throw IOException("could not install tagged file ${audioFile.absolutePath}")
+            }
+            if (!backup.delete()) {
+                Log.w(TAG, "could not delete backup file ${backup.absolutePath}")
             }
         } catch (e: Exception) {
             Log.w(TAG, "ffmpeg embed failed for ${audioFile.absolutePath}: ${e.message}", e)
             outputFile.delete()
+            backupFile?.let { backup ->
+                if (backup.exists() && !audioFile.exists()) {
+                    if (!renameFile(backup, audioFile)) {
+                        backup.copyTo(audioFile, overwrite = true)
+                        backup.delete()
+                    }
+                }
+            }
+            throw e
         } finally {
             opusPictureMetadataFile?.delete()
         }

--- a/data/download/src/test/kotlin/com/stash/data/download/backfill/MetadataBackfillWorkerTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/backfill/MetadataBackfillWorkerTest.kt
@@ -114,6 +114,23 @@ class MetadataBackfillWorkerTest {
     }
 
     @Test
+    fun `embed failure stamps 0L instead of a success timestamp`() = runTest {
+        val file = newTempAudio()
+        val rows = listOf(stubEntity(id = 3, filePath = file.absolutePath))
+        every { trackDao.observeTracksNeedingEmbedCount() } returns flowOf(1)
+        coEvery { trackDao.getTracksNeedingEmbed(any(), any()) } returnsMany listOf(rows, emptyList())
+        coEvery { albumArtCache.resolveArt(any()) } returns null
+        coEvery { metadataEmbedder.embedMetadata(any(), any(), any()) } throws
+            IllegalStateException("ffmpeg failed")
+
+        val result = buildSubject().doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+        coVerify(exactly = 1) { trackDao.setMetadataEmbeddedAt(eq(3L), eq(0L)) }
+        coVerify(exactly = 0) { trackDao.setMetadataEmbeddedAt(eq(3L), match { it > 0L }) }
+    }
+
+    @Test
     fun `SAF row stamps 0L and increments safSkipped`() = runTest {
         val rows = listOf(
             stubEntity(id = 5, filePath = "content://com.android.externalstorage.documents/blah"),

--- a/data/download/src/test/kotlin/com/stash/data/download/files/MetadataEmbedderExecutionTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/files/MetadataEmbedderExecutionTest.kt
@@ -1,0 +1,177 @@
+package com.stash.data.download.files
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import com.stash.core.common.AppVersionProvider
+import com.stash.core.model.Track
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+
+class MetadataEmbedderExecutionTest {
+
+    private val root = Files.createTempDirectory("metadata-embedder-test").toFile()
+    private val nativeDir = File(root, "native").apply { mkdirs() }
+    private val noBackupDir = File(root, "no-backup").apply { mkdirs() }
+    private val context: Context = mockk()
+    private val applicationInfo = ApplicationInfo().apply {
+        nativeLibraryDir = nativeDir.absolutePath
+    }
+    private val versionProvider = object : AppVersionProvider {
+        override val versionName: String = "test"
+        override val versionCode: Int = 1
+    }
+    private val track = Track(id = 1, title = "Title", artist = "Artist")
+
+    init {
+        every { context.applicationInfo } returns applicationInfo
+        every { context.noBackupFilesDir } returns noBackupDir
+    }
+
+    @After
+    fun cleanup() {
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun `missing ffmpeg binary fails and preserves original`() = runTest {
+        val audio = newAudio()
+
+        assertFailurePreservesOriginal(audio)
+    }
+
+    @Test
+    fun `non-zero ffmpeg exit fails, removes partial output, and preserves original`() = runTest {
+        installFfmpeg(
+            """#!/bin/sh
+                |for arg do output="${'$'}arg"; done
+                |printf partial > "${'$'}output"
+                |exit 7
+                |""".trimMargin(),
+        )
+        val audio = newAudio()
+
+        assertFailurePreservesOriginal(audio)
+        assertFalse(taggedOutput(audio).exists())
+    }
+
+    @Test
+    fun `zero exit without output fails and preserves original`() = runTest {
+        installFfmpeg("#!/bin/sh\nexit 0\n")
+        val audio = newAudio()
+
+        assertFailurePreservesOriginal(audio)
+    }
+
+    @Test
+    fun `process start exception propagates and preserves original`() = runTest {
+        File(nativeDir, "libffmpeg.so").mkdir()
+        val audio = newAudio()
+
+        assertFailurePreservesOriginal(audio)
+    }
+
+    @Test
+    fun `failure to preserve original propagates and cleans replacement files`() = runTest {
+        installSuccessfulFfmpeg()
+        val audio = newAudio()
+        val embedder = MetadataEmbedder(context, versionProvider).apply {
+            renameFile = { source, target ->
+                if (source == audio) false else source.renameTo(target)
+            }
+        }
+
+        val failure = assertFailurePreservesOriginal(audio, embedder)
+
+        assertTrue(failure is IOException)
+        assertTrue(failure.message.orEmpty().contains("could not preserve original file"))
+        assertReplacementFilesCleaned(audio)
+    }
+
+    @Test
+    fun `failure to install tagged output restores original and cleans replacement files`() = runTest {
+        installSuccessfulFfmpeg()
+        val audio = newAudio()
+        val output = taggedOutput(audio)
+        val embedder = MetadataEmbedder(context, versionProvider).apply {
+            renameFile = { source, target ->
+                if (source == output) false else source.renameTo(target)
+            }
+        }
+
+        val failure = assertFailurePreservesOriginal(audio, embedder)
+
+        assertTrue(failure is IOException)
+        assertTrue(failure.message.orEmpty().contains("could not install tagged file"))
+        assertReplacementFilesCleaned(audio)
+    }
+
+    @Test
+    fun `successful ffmpeg output replaces original and returns original path`() = runTest {
+        installSuccessfulFfmpeg()
+        val audio = newAudio()
+
+        val result = MetadataEmbedder(context, versionProvider).embedMetadata(audio, track)
+
+        assertSame(audio, result)
+        assertEquals("tagged", audio.readText())
+        assertFalse(taggedOutput(audio).exists())
+        assertFalse(root.listFiles().orEmpty().any { "_untagged_" in it.name })
+    }
+
+    private suspend fun assertFailurePreservesOriginal(
+        audio: File,
+        embedder: MetadataEmbedder = MetadataEmbedder(context, versionProvider),
+    ): Throwable {
+        val original = audio.readBytes()
+
+        val result = runCatching {
+            embedder.embedMetadata(audio, track)
+        }
+
+        assertTrue("embedMetadata must propagate failure", result.isFailure)
+        assertTrue("original file must remain at its path", audio.exists())
+        assertArrayEquals(original, audio.readBytes())
+        return result.exceptionOrNull()!!
+    }
+
+    private fun assertReplacementFilesCleaned(audio: File) {
+        assertFalse("tagged output must be removed", taggedOutput(audio).exists())
+        assertFalse(
+            "backup must be removed",
+            root.listFiles().orEmpty().any { "_untagged_" in it.name },
+        )
+    }
+
+    private fun newAudio(): File = File(root, "track.opus").apply {
+        writeText("original")
+    }
+
+    private fun taggedOutput(audio: File): File =
+        File(audio.parent, "${audio.nameWithoutExtension}_tagged.${audio.extension}")
+
+    private fun installSuccessfulFfmpeg() {
+        installFfmpeg(
+            """#!/bin/sh
+                |for arg do output="${'$'}arg"; done
+                |printf tagged > "${'$'}output"
+                |exit 0
+                |""".trimMargin(),
+        )
+    }
+
+    private fun installFfmpeg(script: String) {
+        val binary = File(nativeDir, "libffmpeg.so").apply { writeText(script) }
+        assertTrue("test ffmpeg must be executable", binary.setExecutable(true))
+    }
+}


### PR DESCRIPTION
## Summary

- propagate ffmpeg metadata embedding failures to callers
- preserve and restore the original audio file during tagged-file replacement
- make backup cleanup failures observable
- ensure the backfill worker records failed embeds with the `0L` sentinel

## Testing

- `MetadataEmbedderExecutionTest` with all failure and success paths
- `MetadataBackfillWorkerTest`
- full `assembleDebug`
- `git diff --check`

Closes #96
