### PR TITLE
fix(playback): record completed track plays

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/ListeningEventDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/ListeningEventDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.stash.core.data.db.entity.ListeningEventEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -17,6 +18,46 @@ interface ListeningEventDao {
 
     @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insert(event: ListeningEventEntity): Long
+
+    @Query(
+        """
+        UPDATE tracks
+        SET play_count = play_count + 1, last_played = :playedAt
+        WHERE id = :trackId
+        """
+    )
+    suspend fun updateTrackAfterCompletedListen(trackId: Long, playedAt: Long): Int
+
+    /** Atomically persist a completed listen and its denormalized track stats. */
+    @Transaction
+    suspend fun recordCompletedListen(event: ListeningEventEntity): Long {
+        val eventId = insert(event)
+        check(updateTrackAfterCompletedListen(event.trackId, requireNotNull(event.completedAt)) == 1) {
+            "Track ${event.trackId} missing while recording completed listen"
+        }
+        return eventId
+    }
+
+    /** Restore missing denormalized stats for users with existing completed history. */
+    @Query(
+        """
+        UPDATE tracks
+        SET play_count = (
+                SELECT COUNT(*) FROM listening_events
+                WHERE track_id = tracks.id
+            ),
+            last_played = (
+                SELECT MAX(COALESCE(completed_at, started_at)) FROM listening_events
+                WHERE track_id = tracks.id
+            )
+        WHERE play_count = 0
+          AND EXISTS (
+              SELECT 1 FROM listening_events
+              WHERE track_id = tracks.id
+          )
+        """
+    )
+    suspend fun backfillMissingTrackStats()
 
     @Query(
         """

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/ListeningEventDaoCompletedListenTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/ListeningEventDaoCompletedListenTest.kt
@@ -1,0 +1,105 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.ListeningEventEntity
+import com.stash.core.data.db.entity.TrackEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ListeningEventDaoCompletedListenTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: ListeningEventDao
+    private lateinit var trackDao: TrackDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.listeningEventDao()
+        trackDao = db.trackDao()
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    @Test
+    fun `completed listen inserts event and updates track stats atomically`() = runTest {
+        trackDao.insert(track())
+        val completedAt = 123_456L
+
+        dao.recordCompletedListen(event(completedAt))
+
+        assertEquals(listOf(event(completedAt).copy(id = 1L)), dao.pendingScrobbles())
+        val updatedTrack = requireNotNull(trackDao.getById(TRACK_ID))
+        assertEquals(1, updatedTrack.playCount)
+        assertEquals(Instant.ofEpochMilli(completedAt), updatedTrack.lastPlayed)
+    }
+
+    @Test
+    fun `backfill restores stats from existing completed history`() = runTest {
+        trackDao.insert(track())
+        dao.insert(event(123_456L))
+        dao.insert(event(null).copy(startedAt = 234_567L))
+
+        dao.backfillMissingTrackStats()
+        dao.backfillMissingTrackStats()
+
+        val updatedTrack = requireNotNull(trackDao.getById(TRACK_ID))
+        assertEquals(2, updatedTrack.playCount)
+        assertEquals(Instant.ofEpochMilli(234_567L), updatedTrack.lastPlayed)
+    }
+
+    @Test
+    fun `track update failure rolls back listening event`() = runTest {
+        trackDao.insert(track())
+        db.openHelper.writableDatabase.execSQL(
+            """
+            CREATE TRIGGER fail_completed_listen
+            BEFORE UPDATE OF play_count ON tracks
+            BEGIN SELECT RAISE(ABORT, 'forced track update failure'); END
+            """.trimIndent(),
+        )
+
+        val result = runCatching { dao.recordCompletedListen(event(123_456L)) }
+
+        assertTrue(result.isFailure)
+        assertTrue(dao.pendingScrobbles().isEmpty())
+        val unchangedTrack = requireNotNull(trackDao.getById(TRACK_ID))
+        assertEquals(0, unchangedTrack.playCount)
+        assertEquals(null, unchangedTrack.lastPlayed)
+    }
+
+    private fun track() = TrackEntity(
+        id = TRACK_ID,
+        title = "Track",
+        artist = "Artist",
+        canonicalTitle = "track",
+        canonicalArtist = "artist",
+        isDownloaded = true,
+    )
+
+    private fun event(completedAt: Long?) = ListeningEventEntity(
+        trackId = TRACK_ID,
+        startedAt = 100_000L,
+        completedAt = completedAt,
+    )
+
+    private companion object {
+        const val TRACK_ID = 1L
+    }
+}

--- a/core/media/src/main/kotlin/com/stash/core/media/listening/ListeningRecorder.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/listening/ListeningRecorder.kt
@@ -9,6 +9,7 @@ import com.stash.core.data.db.entity.ListeningEventEntity
 import com.stash.core.data.db.entity.TrackSkipEventEntity
 import com.stash.core.media.PlayerRepository
 import com.stash.core.model.RepeatMode
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -86,7 +87,21 @@ class ListeningRecorder @VisibleForTesting internal constructor(
 
     /** Must be called exactly once from Application.onCreate. */
     fun start() {
-        // ── Collector 1: track-change transitions ─────────────────────
+        scope.launch {
+            try {
+                listeningEventDao.backfillMissingTrackStats()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to backfill track play stats", e)
+            }
+            startTrackChangeCollector()
+            startRepeatCollector()
+        }
+    }
+
+    // ── Collector 1: track-change transitions ─────────────────────
+    private fun startTrackChangeCollector() {
         scope.launch {
             // Drop repeats on the SAME track id so we only react to track
             // transitions. Pause/resume mid-track re-emits the same state
@@ -130,8 +145,10 @@ class ListeningRecorder @VisibleForTesting internal constructor(
                     schedulePendingFire(track.id, track.artist, track.title, track.album, track.durationMs)
                 }
         }
+    }
 
-        // ── Collector 2: repeat-one loop detection ────────────────────
+    // ── Collector 2: repeat-one loop detection ────────────────────
+    private fun startRepeatCollector() {
         scope.launch {
             var lastPositionMs = 0L
             var lastTrackId = -1L
@@ -197,18 +214,23 @@ class ListeningRecorder @VisibleForTesting internal constructor(
             // the correct state when it reads .get().
             if (nowPlaying == trackId) {
                 firedFlag.set(true)
-                runCatching {
-                    listeningEventDao.insert(
+                try {
+                    val completedAt = System.currentTimeMillis()
+                    listeningEventDao.recordCompletedListen(
                         ListeningEventEntity(
                             trackId = trackId,
                             startedAt = sessionStart,
                             scrobbled = false,
                             // v0.9.13: insert IS the completion event — recorder only fires
                             // after threshold delay. AutoSaveScrobbler reads completed_at.
-                            completedAt = sessionStart,
+                            completedAt = completedAt,
                         ),
                     )
-                }.onFailure { Log.w(TAG, "Failed to insert listening event", it) }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to record completed listen", e)
+                }
             }
         }
         pending = PendingFire(

--- a/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
@@ -16,13 +16,19 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
@@ -132,9 +138,10 @@ class ListeningRecorderSkipTest {
         runCurrent()
         advanceUntilIdle()
 
+        coVerify(exactly = 1) { listeningDao.backfillMissingTrackStats() }
         coVerify(exactly = 1) { skipDao.insert(any()) }
         assertEquals(trackA.id, skipCapture.captured.trackId)
-        coVerify(exactly = 0) { listeningDao.insert(any()) }
+        coVerify(exactly = 0) { listeningDao.recordCompletedListen(any()) }
     }
 
     @Test
@@ -145,7 +152,7 @@ class ListeningRecorderSkipTest {
         val listeningDao = mockk<ListeningEventDao>(relaxed = true)
         val skipDao = mockk<TrackSkipEventDao>(relaxed = true)
         val listenCapture = slot<ListeningEventEntity>()
-        coEvery { listeningDao.insert(capture(listenCapture)) } returns 1L
+        coEvery { listeningDao.recordCompletedListen(capture(listenCapture)) } returns 1L
 
         val recorder = ListeningRecorder(
             playerRepository = playerRepo,
@@ -164,19 +171,19 @@ class ListeningRecorderSkipTest {
         runCurrent()
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { listeningDao.insert(any()) }
+        coVerify(exactly = 1) { listeningDao.recordCompletedListen(any()) }
         assertEquals(trackA.id, listenCapture.captured.trackId)
         coVerify(exactly = 0) { skipDao.insert(any()) }
     }
 
     @Test
-    fun `repeat-one loop restart schedules a new scrobble session`() = runTest {
+    fun `completed repeat-one loops each record a play`() = runTest {
         val playerRepo = FakePlayerRepository(
             PlayerState(currentTrack = trackA, repeatMode = RepeatMode.ONE, positionMs = 0),
         )
         val listeningDao = mockk<ListeningEventDao>(relaxed = true)
         val capture = slot<ListeningEventEntity>()
-        coEvery { listeningDao.insert(capture(capture)) } returns 1L
+        coEvery { listeningDao.recordCompletedListen(capture(capture)) } returns 1L
 
         val recorder = ListeningRecorder(
             playerRepository = playerRepo,
@@ -190,6 +197,10 @@ class ListeningRecorderSkipTest {
         // the pending fire BEFORE we loop.
         runCurrent()
 
+        // Complete the initial listening session.
+        advanceTimeBy(95_000)
+        runCurrent()
+
         // Simulate playing past 10s then looping back to near zero.
         playerRepo.setPosition(15_000L)
         runCurrent()
@@ -201,7 +212,7 @@ class ListeningRecorderSkipTest {
         runCurrent()
         advanceUntilIdle()
 
-        coVerify(atLeast = 1) { listeningDao.insert(any()) }
+        coVerify(exactly = 2) { listeningDao.recordCompletedListen(any()) }
         assertEquals(trackA.id, capture.captured.trackId)
     }
 
@@ -234,7 +245,7 @@ class ListeningRecorderSkipTest {
 
         // Only the original session's threshold fire — no extra insert
         // from the scrub-back.
-        coVerify(exactly = 1) { listeningDao.insert(any()) }
+        coVerify(exactly = 1) { listeningDao.recordCompletedListen(any()) }
     }
 
     @Test
@@ -245,7 +256,7 @@ class ListeningRecorderSkipTest {
         val listeningDao = mockk<ListeningEventDao>(relaxed = true)
         val skipDao = mockk<TrackSkipEventDao>(relaxed = true)
         val capture = slot<ListeningEventEntity>()
-        coEvery { listeningDao.insert(capture(capture)) } returns 1L
+        coEvery { listeningDao.recordCompletedListen(capture(capture)) } returns 1L
 
         val recorder = ListeningRecorder(
             playerRepository = playerRepo,
@@ -278,7 +289,61 @@ class ListeningRecorderSkipTest {
 
         // Exactly one insert for track B's threshold — no double-schedule
         // from the spurious loop misfire.
-        coVerify(exactly = 1) { listeningDao.insert(any()) }
+        coVerify(exactly = 1) { listeningDao.recordCompletedListen(any()) }
         assertEquals(trackB.id, capture.captured.trackId)
+    }
+
+    @Test
+    fun `playback collectors wait for stats backfill`() = runTest {
+        val playerRepo = FakePlayerRepository(PlayerState(currentTrack = trackA))
+        val listeningDao = mockk<ListeningEventDao>(relaxed = true)
+        val backfill = CompletableDeferred<Unit>()
+        coEvery { listeningDao.backfillMissingTrackStats() } coAnswers { backfill.await() }
+        val recorder = ListeningRecorder(
+            playerRepository = playerRepo,
+            listeningEventDao = listeningDao,
+            trackSkipEventDao = mockk(relaxed = true),
+            scrobbler = mockk(relaxed = true),
+            scope = backgroundScope,
+        )
+
+        recorder.start()
+        runCurrent()
+        advanceTimeBy(95_000)
+        runCurrent()
+        coVerify(exactly = 0) { listeningDao.recordCompletedListen(any()) }
+
+        backfill.complete(Unit)
+        runCurrent()
+        advanceTimeBy(90_000)
+        runCurrent()
+
+        coVerify(exactly = 1) { listeningDao.recordCompletedListen(any()) }
+    }
+
+    @Test
+    fun `completed-listen cancellation cancels the threshold job`() = runTest {
+        val playerRepo = FakePlayerRepository(PlayerState(currentTrack = trackA))
+        val listeningDao = mockk<ListeningEventDao>(relaxed = true)
+        coEvery { listeningDao.recordCompletedListen(any()) } throws CancellationException("cancelled")
+        val parent = SupervisorJob()
+        val recorderScope = CoroutineScope(parent + StandardTestDispatcher(testScheduler))
+        val recorder = ListeningRecorder(
+            playerRepository = playerRepo,
+            listeningEventDao = listeningDao,
+            trackSkipEventDao = mockk(relaxed = true),
+            scrobbler = mockk(relaxed = true),
+            scope = recorderScope,
+        )
+        recorder.start()
+        runCurrent()
+        val initialChildren = parent.children.toList()
+
+        advanceTimeBy(95_000)
+        runCurrent()
+
+        coVerify(exactly = 1) { listeningDao.recordCompletedListen(any()) }
+        assertEquals(1, initialChildren.count { it.isCancelled })
+        recorderScope.cancel()
     }
 }


### PR DESCRIPTION
## What does this PR do?

Records each completed listen in the track's denormalized `play_count` and `last_played` fields, giving the Library's existing Most Played sort meaningful data.

The listening-history insert and track-stat update are performed in one Room transaction. At recorder startup, existing listening history is backfilled for upgraded users, including legacy rows created before `completed_at` was added.

## Related issue

Closes #257

## How was this tested?

- 3 focused DAO tests cover transactional updates, rollback, idempotent backfill, and legacy listening rows.
- 7 recorder tests cover completed plays, skips, repeat-one playback, startup ordering, and cancellation.
- `assembleDebug` passes.
- `git diff --check` passes.
- The repository-wide `core:data` test gate is currently blocked by an unrelated `AlbumCacheTest` compile error that reproduces on clean `origin/master`.

- [ ] `./gradlew test` passes
- [ ] Installed on a device and manually verified the change

## Checklist

- [x] My code follows the style of the surrounding code
- [x] This PR does **one thing** (unrelated changes belong in separate PRs)
- [x] I updated comments where the behavior needed explanation
