### PR TITLE
Queue drag-reorder fix, FLAC badge bottom-right, hero refresh/minimize

### DIFF
--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/AlbumSquareCard.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/AlbumSquareCard.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
@@ -61,9 +62,14 @@ fun AlbumSquareCard(
                 modifier = Modifier.size(140.dp).clip(RoundedCornerShape(8.dp)),
             )
             if (isLossless) {
+                // Bottom-right, translucent: the industry-standard corner for a
+                // quality mark, and see-through enough to not block the art.
                 FlacBadge(
                     fileFormat = "flac",
-                    modifier = Modifier.align(Alignment.TopStart).padding(6.dp),
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(6.dp)
+                        .alpha(0.78f),
                 )
             }
         }

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.DownloadDone
 import androidx.compose.material.icons.filled.RemoveCircleOutline
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -144,6 +145,8 @@ fun HomeScreen(
 ) {
     // Long-pressed Stash mix whose action sheet is open (null = closed).
     var actionSheetMixId by remember { mutableStateOf<Long?>(null) }
+    // Long-pressed Daily Discover hero → its own two-row sheet (refresh / minimize).
+    var heroActionSheet by remember { mutableStateOf(false) }
     // Opening a mix = open its materialized playlist + freshen it if stale.
     // A HomeMix's id IS its playlist id, so this reuses the existing playlist nav.
     val openMix: (Long) -> Unit = { id ->
@@ -151,6 +154,7 @@ fun HomeScreen(
         onNavigateToPlaylist(id)
     }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val heroMinimized by viewModel.heroMinimized.collectAsStateWithLifecycle()
     // Master streaming-mode flag. Both the top-bar StreamingModeChip and
     // the sheet (StreamingModeSheet) render from this single source of
     // truth; the chip itself early-returns to nothing while the build-
@@ -329,7 +333,10 @@ fun HomeScreen(
         // Replaces the old "Your mixes" rail.
         item {
             Spacer(Modifier.height(6.dp))
-            val hero = uiState.hero
+            // Minimized (long-press → "Minimize for now") drops the hero page
+            // for the session; the mix pages keep the pager alive. Distinct
+            // from hero == null (not connected), which shows PersonalizeCard.
+            val hero = if (heroMinimized) null else uiState.hero
             val mixPages = uiState.yourMixes
             when {
                 uiState.isLoading -> DiscoverHeroCard(
@@ -342,10 +349,11 @@ fun HomeScreen(
                     loading = true,
                     modifier = Modifier.padding(horizontal = 16.dp),
                 )
-                hero == null && mixPages.isEmpty() -> PersonalizeCard(
+                uiState.hero == null && mixPages.isEmpty() -> PersonalizeCard(
                     onConnect = onNavigateToSettings,
                     modifier = Modifier.padding(horizontal = 16.dp),
                 )
+                hero == null && mixPages.isEmpty() -> Unit // minimized, nothing to page
                 else -> {
                     val heroPages = if (hero != null) 1 else 0
                     val pageCount = heroPages + mixPages.size
@@ -367,6 +375,7 @@ fun HomeScreen(
                                     onPlay = viewModel::playHero,
                                     onOpen = { onNavigateToPlaylist(hero.playlistId) },
                                     onCreateMix = { onNavigateToMixBuilder(null) },
+                                    onLongPress = { heroActionSheet = true },
                                 )
                             } else {
                                 val m = mixPages[page - heroPages]
@@ -629,6 +638,53 @@ fun HomeScreen(
                     onClick = {
                         openMix(id)
                         actionSheetMixId = null
+                    },
+                )
+                Spacer(Modifier.height(12.dp))
+            }
+        }
+    }
+
+    // ── Daily Discover hero action sheet (long-press the hero page) ──────
+    if (heroActionSheet) {
+        val hero = uiState.hero
+        if (hero != null) {
+            val sheetState = rememberModalBottomSheetState()
+            ModalBottomSheet(
+                onDismissRequest = { heroActionSheet = false },
+                sheetState = sheetState,
+                containerColor = MaterialTheme.colorScheme.surface,
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp)
+                        .padding(bottom = 8.dp),
+                ) {
+                    Text(
+                        text = hero.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+
+                MixActionRow(
+                    icon = Icons.Default.Refresh,
+                    label = "Refresh",
+                    onClick = {
+                        viewModel.refreshMix(hero.playlistId)
+                        heroActionSheet = false
+                    },
+                )
+                MixActionRow(
+                    icon = Icons.Default.VisibilityOff,
+                    label = "Minimize for now",
+                    onClick = {
+                        viewModel.setHeroMinimized(true)
+                        heroActionSheet = false
                     },
                 )
                 Spacer(Modifier.height(12.dp))

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
@@ -169,6 +169,18 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Session-scoped "minimize Daily Discover": long-press the hero →
+     * "Minimize for now" drops the hero page until the next app launch.
+     * Deliberately not persisted — it's "hide it for a bit", not a setting.
+     */
+    private val _heroMinimized = MutableStateFlow(false)
+    val heroMinimized: StateFlow<Boolean> = _heroMinimized
+
+    fun setHeroMinimized(minimized: Boolean) {
+        _heroMinimized.value = minimized
+    }
+
     /** Everything derived from the playlists + recipe streams in one holder. */
     private data class HomePlaylistData(
         val hero: DiscoverHeroState?,

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/QueueBottomSheet.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/QueueBottomSheet.kt
@@ -38,12 +38,12 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -78,15 +78,20 @@ fun QueueBottomSheet(
 
     // Local mutable copy of upcoming tracks for drag reordering.
     // Swaps happen here visually during drag; committed to player on drag end.
+    // Each entry carries a uid assigned at sync time. LazyColumn keys MUST NOT
+    // include the position: index-based keys change identity on every swap,
+    // which recreates the dragged row and cancels its pointerInput mid-gesture
+    // (the original "can't reorder" bug). uids stay glued to their entries
+    // across swaps and are only reassigned on resync, when no drag is active.
     val upcomingSource = queue.drop(currentIndex + 1)
-    val localQueue = remember { mutableStateListOf<Track>() }
+    val localQueue = remember { mutableStateListOf<QueueEntry>() }
 
     // Sync local queue with source when not dragging
     var draggedIdx by remember { mutableIntStateOf(-1) }
     LaunchedEffect(upcomingSource) {
         if (draggedIdx < 0) {
             localQueue.clear()
-            localQueue.addAll(upcomingSource)
+            upcomingSource.forEachIndexed { i, t -> localQueue.add(QueueEntry(i, t)) }
         }
     }
 
@@ -135,16 +140,19 @@ fun QueueBottomSheet(
             ) {
                 itemsIndexed(
                     items = localQueue,
-                    key = { idx, track -> "queue-row-$idx-${track.youtubeId ?: track.id}" },
-                ) { idx, track ->
+                    key = { _, entry -> entry.uid },
+                ) { idx, entry ->
+                    val track = entry.track
                     val isDragging = idx == draggedIdx
                     val queueIndex = currentIndex + 1 + idx
-                    val rowKey = "queue-row-$idx-${track.youtubeId ?: track.id}"
+                    // The item's index shifts under an active drag as rows swap;
+                    // pointerInput's coroutine captures values at launch, so it
+                    // reads the live index through this instead.
+                    val currentIdx by rememberUpdatedState(idx)
 
-                    key(rowKey) {
                     // One-shot guard so confirmValueChange can't mass-remove if
                     // Compose's swipe state transitions re-fire during a single
-                    // gesture. Tied to rowKey identity via the surrounding key().
+                    // gesture. Tied to row identity via the LazyColumn item key.
                     val dismissedOnce = remember { mutableStateOf(false) }
 
                     Box(
@@ -244,15 +252,15 @@ fun QueueBottomSheet(
                             Box(
                                 modifier = Modifier
                                     .size(48.dp)
-                                    .pointerInput(idx) {
+                                    .pointerInput(entry.uid) {
                                         detectDragGesturesAfterLongPress(
                                             onDragStart = {
-                                                draggedIdx = idx
+                                                draggedIdx = currentIdx
                                                 dragOffsetY = 0f
                                                 pendingMoves.clear()
                                                 // Measure item height
                                                 val info = listState.layoutInfo.visibleItemsInfo
-                                                    .firstOrNull { it.index == idx }
+                                                    .firstOrNull { it.index == currentIdx }
                                                 if (info != null) itemHeight = info.size
                                             },
                                             onDrag = { change, amount ->
@@ -300,7 +308,9 @@ fun QueueBottomSheet(
                                             onDragCancel = {
                                                 // Revert: resync local queue from source
                                                 localQueue.clear()
-                                                localQueue.addAll(upcomingSource)
+                                                upcomingSource.forEachIndexed { i, t ->
+                                                    localQueue.add(QueueEntry(i, t))
+                                                }
                                                 pendingMoves.clear()
                                                 draggedIdx = -1
                                                 dragOffsetY = 0f
@@ -320,7 +330,6 @@ fun QueueBottomSheet(
                         }
                         } // SwipeToDismissBox
                     }
-                    } // key(rowKey)
                 }
             }
 
@@ -345,6 +354,14 @@ fun QueueBottomSheet(
 }
 
 // ---------------------------------------------------------------------------
+
+/**
+ * A queue row with a drag-stable identity. [uid] is assigned when the local
+ * queue syncs from the player and never changes while rows are swapped, so
+ * LazyColumn item identity (and the active drag gesture) survives reordering.
+ * Also makes duplicate tracks in the queue naturally unique.
+ */
+private class QueueEntry(val uid: Int, val track: Track)
 
 @Composable
 private fun QueueHeader(trackCount: Int, currentIndex: Int, onClose: () -> Unit) {


### PR DESCRIPTION
## Summary
- Queue drag-to-reorder actually works now: rows carry drag-stable uids instead of position-based LazyColumn keys (position keys recreated the row mid-drag and cancelled the gesture — broken since the sheet shipped)
- FLAC badge on album covers: top-left → bottom-right, translucent (alpha .78) so it stops covering art
- Daily Discover hero: long-press → Refresh / Minimize for now (session-scoped)

## Test Plan
- [x] Device-verified drag: move commits to player queue, persists across sheet reopen
- [x] Badge bottom-right on Home New Releases + Library rails
- [x] Hero sheet, minimize, relaunch-restore exercised on device
- [x] HomeViewModelTest green

🤖 Generated with [Claude Code](https://claude.com/claude-code)