### PR TITLE
feat(lyrics): download lyrics for existing tracks

### DIFF
--- a/data/lyrics/src/main/kotlin/com/stash/data/lyrics/sidecar/LyricsSidecarWriter.kt
+++ b/data/lyrics/src/main/kotlin/com/stash/data/lyrics/sidecar/LyricsSidecarWriter.kt
@@ -12,6 +12,7 @@ import com.stash.data.download.files.FileOrganizerSlugs
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
 import java.io.File
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -36,7 +37,7 @@ import javax.inject.Singleton
  *    same directory the download created.
  *
  * Write failure is non-fatal for the Room state: [LyricsRepository]
- * wraps `write()` in `runCatching`. The contract here is best-effort
+ * wraps the throwing `write()` API in `runCatching`; only that path is best-effort
  * — the lyrics row + `tracks.lyrics_fetched_at` stamp are the source
  * of truth for the in-app reader; the sidecar is a courtesy.
  *
@@ -50,7 +51,7 @@ import javax.inject.Singleton
  * <synced LRC body, or plain text if synced is missing>
  * ```
  *
- * Skipped entirely when both `syncedLrc` and `plainText` are null/blank
+ * Rejected with [IOException] when both bodies are null/blank
  * (the instrumental case). `LyricsRepository` already guards this for
  * the instrumental flag, but `write()` re-checks defensively so callers
  * can't accidentally create a header-only `.lrc` with no body.
@@ -65,21 +66,21 @@ class LyricsSidecarWriter @Inject constructor(
     /**
      * Writes the `.lrc` sidecar for [trackId] using [lyrics].
      *
-     * No-ops when:
+     * Fails when:
      *   - Both `syncedLrc` and `plainText` are null/blank (instrumental).
      *   - The track row is gone (deleted mid-flight).
      *   - The track has no [TrackEntity.filePath] (legacy / sync-only row).
      *   - The SAF tree URI is unset on a `content://` filePath (the user
      *     swapped storage modes; we can't infer the tree root from the
-     *     child URI, so we skip rather than guess).
+     *     child URI, so writing fails rather than guessing).
      *
      * Throws on disk/SAF I/O failure so [LyricsRepository] can
      * `runCatching` it as non-fatal.
      */
     suspend fun write(trackId: Long, lyrics: LyricsEntity) {
-        if (lyrics.syncedLrc.isNullOrBlank() && lyrics.plainText.isNullOrBlank()) return
-        val track = trackDao.getById(trackId) ?: return
-        val path = track.filePath ?: return
+        if (lyrics.syncedLrc.isNullOrBlank() && lyrics.plainText.isNullOrBlank()) fail("No lyrics body for track $trackId")
+        val track = trackDao.getById(trackId) ?: fail("Track $trackId no longer exists")
+        val path = track.filePath ?: fail("Track $trackId has no downloaded file")
         val body = buildLrcBody(track, lyrics)
         if (path.startsWith("content://")) {
             writeSafSidecar(track, body)
@@ -92,7 +93,7 @@ class LyricsSidecarWriter @Inject constructor(
         val audio = File(audioPath)
         val parent = audio.parentFile ?: run {
             Log.w(TAG, "Cannot resolve parent directory for $audioPath; sidecar skipped")
-            return
+            throw IOException("Cannot resolve parent directory for $audioPath")
         }
         val sidecar = File(parent, "${audio.nameWithoutExtension}.lrc")
         sidecar.writeText(body, Charsets.UTF_8)
@@ -104,42 +105,42 @@ class LyricsSidecarWriter @Inject constructor(
         // child's URI would yield "permission denied" or worse. The
         // tree URI lives in [StoragePreference]; if it's unset on a
         // `content://` path the user has swapped storage modes since
-        // download and we can't recover, so we skip.
+        // download and we can't recover, so this writer throws.
         val treeUri: Uri = storagePreference.externalTreeUri.first() ?: run {
             Log.w(
                 TAG,
                 "Track ${track.id} has SAF filePath but no externalTreeUri persisted; sidecar skipped",
             )
-            return
+            throw IOException("Missing SAF tree for track ${track.id}")
         }
         val tree = DocumentFile.fromTreeUri(context, treeUri) ?: run {
             Log.w(TAG, "DocumentFile.fromTreeUri returned null for $treeUri; sidecar skipped")
-            return
+            throw IOException("Invalid SAF tree $treeUri")
         }
         val artistName = track.albumArtist.ifBlank { track.artist }
         val artistDir = findOrCreateDir(tree, FileOrganizerSlugs.slugify(artistName))
-            ?: return
+            ?: fail("Could not create artist directory")
         val albumSlug = if (track.album.isNotBlank()) {
             FileOrganizerSlugs.slugify(track.album)
         } else {
             "singles"
         }
-        val albumDir = findOrCreateDir(artistDir, albumSlug) ?: return
+        val albumDir = findOrCreateDir(artistDir, albumSlug) ?: fail("Could not create album directory")
         val filename = "${FileOrganizerSlugs.slugify(track.title)}.lrc"
         val existing = albumDir.findFile(filename)
         val target = existing ?: albumDir.createFile(LRC_MIME, filename) ?: run {
             Log.w(TAG, "Could not create SAF sidecar '$filename' under ${albumDir.uri}")
-            return
+            throw IOException("Could not create SAF sidecar $filename")
         }
         context.contentResolver.openOutputStream(target.uri, "wt")?.use { out ->
             out.write(body.toByteArray(Charsets.UTF_8))
-        } ?: Log.w(TAG, "Could not open SAF output stream for sidecar ${target.uri}")
+        } ?: fail("Could not open SAF output stream for sidecar ${target.uri}")
     }
 
     /**
      * SAF-side `findOrCreateDir`. Mirrors the helper in `FileOrganizer`
      * but returns `null` (logged) instead of throwing — sidecar failure
-     * must stay non-fatal end-to-end.
+     * is converted to IOException by its caller.
      */
     private fun findOrCreateDir(parent: DocumentFile, name: String): DocumentFile? {
         parent.findFile(name)?.takeIf { it.isDirectory }?.let { return it }
@@ -159,8 +160,10 @@ class LyricsSidecarWriter @Inject constructor(
             appendLine("[length:${sec / 60}:%02d]".format(sec % 60))
         }
         appendLine("[by:Stash]")
-        append(lyrics.syncedLrc ?: lyrics.plainText.orEmpty())
+        append(lyrics.syncedLrc?.takeUnless(String::isBlank) ?: lyrics.plainText.orEmpty())
     }
+
+    private fun fail(message: String): Nothing = throw IOException(message).also { Log.w(TAG, message) }
 
     private companion object {
         private const val TAG = "LyricsSidecarWriter"

--- a/data/lyrics/src/test/kotlin/com/stash/data/lyrics/sidecar/LyricsSidecarWriterTest.kt
+++ b/data/lyrics/src/test/kotlin/com/stash/data/lyrics/sidecar/LyricsSidecarWriterTest.kt
@@ -10,9 +10,11 @@ import com.stash.core.data.prefs.StoragePreference
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -21,6 +23,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.io.File
+import java.io.IOException
 
 /**
  * Robolectric-backed sidecar-writer tests. Internal-storage paths are
@@ -34,8 +37,8 @@ import java.io.File
  *   1. internal-storage write lands `<basename>.lrc` next to the audio
  *      with the canonical header tags + body
  *   2. syncedLrc is preferred when present, plainText is the fallback
- *   3. instrumental (both null) writes nothing
- *   4. a missing track row short-circuits silently
+ *   3. instrumental (both null) is rejected without writing
+ *   4. a missing track row throws
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [33])
@@ -80,42 +83,57 @@ class LyricsSidecarWriterTest {
         assertTrue("plain text written: $body", body.contains("plain text only"))
     }
 
-    @Test fun `does nothing when both syncedLrc and plainText are null - instrumental`() = runTest {
+    @Test fun `blank syncedLrc falls back to nonblank plain text on filesystem`() = runTest {
+        val audio = tmp.newFile("blank-synced.flac")
+        val track = stubTrack(filePath = audio.absolutePath)
+        val writer = makeWriter(track)
+
+        writer.write(track.id, lyricsEntity(syncedLrc = " \n\t ", plainText = "fallback words"))
+
+        val sidecar = File(audio.parent, "blank-synced.lrc")
+        assertTrue("sidecar exists for plain-text fallback", sidecar.exists())
+        assertTrue(
+            "nonblank plain text replaces blank synced text",
+            sidecar.readText(Charsets.UTF_8).endsWith("fallback words"),
+        )
+    }
+
+    @Test fun `blank lyrics throws instead of silently skipping`() = runTest {
         val audio = tmp.newFile("inst.opus")
         val track = stubTrack(filePath = audio.absolutePath)
         val writer = makeWriter(track)
 
-        writer.write(track.id, lyricsEntity(syncedLrc = null, plainText = null, instrumental = true))
-
+        assertThrows(IOException::class.java) {
+            runBlocking { writer.write(track.id, lyricsEntity(instrumental = true)) }
+        }
         val sidecar = File(audio.parent, "inst.lrc")
         assertFalse("sidecar must NOT exist for instrumental", sidecar.exists())
     }
 
-    @Test fun `missing track returns silently without writing`() = runTest {
+    @Test fun `missing track throws instead of silently skipping`() = runTest {
         val trackDao = mockk<TrackDao>()
         coEvery { trackDao.getById(99L) } returns null
         val storagePrefs = mockk<StoragePreference>()
         // Should not even touch storage prefs when the track row is gone.
         val writer = LyricsSidecarWriter(trackDao = trackDao, context = context, storagePreference = storagePrefs)
 
-        // Must not throw; must not write anything.
-        writer.write(99L, lyricsEntity(syncedLrc = "x", plainText = "x"))
-        // No file system assertion possible (no path) — the test passes
-        // by virtue of not throwing.
+        assertThrows(IOException::class.java) {
+            runBlocking { writer.write(99L, lyricsEntity(syncedLrc = "x", plainText = "x")) }
+        }
     }
 
     @Test fun `instrumental short-circuit precedes track lookup`() = runTest {
-        // Defensive check: even if some caller bypasses LyricsRepository's
-        // own instrumental guard, the writer must skip the DAO + write
-        // entirely when both lyric bodies are null.
+        // Even if a caller bypasses LyricsRepository's instrumental guard,
+        // the writer must reject the body before touching the DAO.
         val trackDao = mockk<TrackDao>()
         // No `coEvery` stub for getById — if the writer reaches the DAO
         // it will throw, failing the test.
         val storagePrefs = mockk<StoragePreference>()
         val writer = LyricsSidecarWriter(trackDao = trackDao, context = context, storagePreference = storagePrefs)
 
-        writer.write(1L, lyricsEntity(syncedLrc = null, plainText = null, instrumental = true))
-        // assertion is the lack of MockKException — we never called getById
+        assertThrows(IOException::class.java) {
+            runBlocking { writer.write(1L, lyricsEntity(instrumental = true)) }
+        }
     }
 
     private fun makeWriter(track: TrackEntity): LyricsSidecarWriter {

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
@@ -125,6 +125,7 @@ fun NowPlayingScreen(
     val track = uiState.currentTrack
     val resolvingArtist by viewModel.resolvingArtist.collectAsStateWithLifecycle()
     val isDownloadingCurrent by viewModel.isDownloadingCurrent.collectAsStateWithLifecycle()
+    val exportingLyricsTrackId by viewModel.exportingLyricsTrackId.collectAsStateWithLifecycle()
     val radioLabel by viewModel.radioSeedLabel.collectAsStateWithLifecycle()
     var showQueue by remember { mutableStateOf(false) }
     var showSaveSheet by remember { mutableStateOf(false) }
@@ -456,6 +457,18 @@ fun NowPlayingScreen(
                             qualityText = qualityText,
                             isStreaming = uiState.isStreaming,
                         )
+                    }
+                    if (track.isDownloaded) {
+                        androidx.compose.material3.TextButton(
+                            enabled = exportingLyricsTrackId == null,
+                            onClick = viewModel::exportLyricsForCurrentTrack,
+                        ) {
+                            Text(when (exportingLyricsTrackId) {
+                                track.id -> "Saving lyrics sidecar"
+                                null -> "Save lyrics sidecar"
+                                else -> "Saving another track’s lyrics sidecar"
+                            })
+                        }
                     }
                 }
 

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
@@ -14,6 +14,7 @@ import com.stash.core.model.isFlac
 import com.stash.core.ui.components.PlaylistInfo
 import com.stash.core.model.Track
 import com.stash.data.lyrics.LyricsRepository
+import com.stash.data.lyrics.sidecar.LyricsSidecarWriter
 import com.stash.data.lyrics.source.LyricsQuery
 import com.stash.feature.nowplaying.ui.LyricsViewState
 import com.stash.feature.nowplaying.ui.lyricsViewStateFor
@@ -73,6 +74,7 @@ class NowPlayingViewModel @Inject constructor(
     // codebase (it's not Hilt-injectable in this project).
     private val lyricsRepository: LyricsRepository,
     private val lyricsPreference: com.stash.core.data.prefs.LyricsPreference,
+    private val lyricsSidecarWriter: LyricsSidecarWriter,
     @ApplicationContext private val appContext: Context,
     // Tap-to-artist: resolves the playing track's artist NAME to a YT
     // browseId so Now Playing can open the artist profile.
@@ -152,6 +154,9 @@ class NowPlayingViewModel @Inject constructor(
             downloadKeyFor(t) in keys && !t.isDownloaded
         }.distinctUntilChanged()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000L), false)
+
+    private val _exportingLyricsTrackId = MutableStateFlow<Long?>(null)
+    val exportingLyricsTrackId: StateFlow<Long?> = _exportingLyricsTrackId.asStateFlow()
 
     private fun downloadKeyFor(t: com.stash.core.model.Track): String =
         t.youtubeId?.takeIf { it.isNotBlank() } ?: t.id.toString()
@@ -783,6 +788,29 @@ class NowPlayingViewModel @Inject constructor(
         val track = _uiState.value.currentTrack ?: return
         if (track.id > 0L) fetchLibraryLyrics(track, force = true)
         else fetchStreamingLyrics(track)
+    }
+
+    fun exportLyricsForCurrentTrack() {
+        val track = _uiState.value.currentTrack?.takeIf { it.id > 0L && it.isDownloaded } ?: return
+        if (!_exportingLyricsTrackId.compareAndSet(expect = null, update = track.id)) return
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val message = try {
+                    val lyrics = lyricsRepository.get(track.id)
+                    if (lyrics == null || lyrics.syncedLrc.isNullOrBlank() && lyrics.plainText.isNullOrBlank()) {
+                        "No cached lyrics to save"
+                    } else {
+                        lyricsSidecarWriter.write(track.id, lyrics)
+                        "Lyrics sidecar saved"
+                    }
+                } catch (e: CancellationException) { throw e }
+                catch (e: Exception) { "Couldn't save lyrics sidecar" }
+                val suffix = if (_uiState.value.currentTrack?.id != track.id) " for ‘${track.title}’" else ""
+                _userMessages.emit("$message$suffix.")
+            } finally {
+                _exportingLyricsTrackId.compareAndSet(expect = track.id, update = null)
+            }
+        }
     }
 
     /**

--- a/feature/nowplaying/src/test/kotlin/com/stash/feature/nowplaying/NowPlayingLyricsExportTest.kt
+++ b/feature/nowplaying/src/test/kotlin/com/stash/feature/nowplaying/NowPlayingLyricsExportTest.kt
@@ -1,0 +1,200 @@
+package com.stash.feature.nowplaying
+
+import android.content.Context
+import app.cash.turbine.test
+import com.stash.core.data.db.entity.LyricsEntity
+import com.stash.core.data.lossless.LosslessUpgrader
+import com.stash.core.data.repository.MusicRepository
+import com.stash.core.data.social.LikeCoordinator
+import com.stash.core.media.PlayerRepository
+import com.stash.core.model.PlayerState
+import com.stash.core.model.Track
+import com.stash.data.lyrics.LyricsRepository
+import com.stash.data.lyrics.sidecar.LyricsSidecarWriter
+import com.stash.data.ytmusic.YTMusicApiClient
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NowPlayingLyricsExportTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val playerState = MutableStateFlow(PlayerState())
+    private val playerRepository: PlayerRepository = mockk(relaxed = true) {
+        every { this@mockk.playerState } returns this@NowPlayingLyricsExportTest.playerState
+        every { currentPosition } returns MutableStateFlow(0L)
+    }
+    private val musicRepository: MusicRepository = mockk(relaxed = true) {
+        every { observeTrackById(any()) } returns flowOf(null)
+        every { getUserCreatedPlaylists() } returns flowOf(emptyList())
+    }
+    private val lyricsRepository: LyricsRepository = mockk(relaxed = true)
+    private val lyricsSidecarWriter: LyricsSidecarWriter = mockk()
+    private val likeCoordinator: LikeCoordinator = mockk(relaxed = true) {
+        every { mirrorFailures } returns MutableSharedFlow()
+    }
+
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    @Test fun `double tap is stable single flight and reports confirmed write`() = runTest(dispatcher) {
+        val entered = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        coEvery { lyricsRepository.get(42L) } returns cachedLyrics()
+        coEvery { lyricsSidecarWriter.write(42L, any()) } coAnswers {
+            entered.complete(Unit)
+            release.await()
+        }
+        val viewModel = viewModelWithDownloadedTrack()
+
+        viewModel.userMessages.test {
+            viewModel.exportLyricsForCurrentTrack()
+            viewModel.exportLyricsForCurrentTrack()
+            entered.await()
+            assertEquals(42L, viewModel.exportingLyricsTrackId.value)
+            coVerify(exactly = 1) { lyricsSidecarWriter.write(42L, any()) }
+
+            release.complete(Unit)
+            assertEquals("Lyrics sidecar saved.", awaitItem())
+            assertEquals(null, viewModel.exportingLyricsTrackId.first { it == null })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `A to B switch keeps busy state and names A`() = runTest(dispatcher) {
+        val entered = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        coEvery { lyricsRepository.get(42L) } returns cachedLyrics()
+        coEvery { lyricsSidecarWriter.write(42L, any()) } coAnswers {
+            entered.complete(Unit)
+            release.await()
+        }
+        val viewModel = viewModelWithDownloadedTrack(title = "Song A")
+
+        viewModel.userMessages.test {
+            viewModel.exportLyricsForCurrentTrack()
+            entered.await()
+            playerState.value = playerState.value.copy(currentTrack = downloadedTrack(84L, "Song B"))
+            advanceUntilIdle()
+
+            assertEquals(42L, viewModel.exportingLyricsTrackId.value)
+            viewModel.exportLyricsForCurrentTrack()
+            coVerify(exactly = 0) { lyricsRepository.get(84L) }
+
+            release.complete(Unit)
+            assertEquals("Lyrics sidecar saved for ‘Song A’.", awaitItem())
+            assertEquals(null, viewModel.exportingLyricsTrackId.first { it == null })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `missing cached lyrics reports truthfully`() = runTest(dispatcher) {
+        coEvery { lyricsRepository.get(42L) } returns null
+        val viewModel = viewModelWithDownloadedTrack()
+
+        viewModel.userMessages.test {
+            viewModel.exportLyricsForCurrentTrack()
+            assertEquals("No cached lyrics to save.", awaitItem())
+            coVerify(exactly = 0) { lyricsSidecarWriter.write(any(), any()) }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `write failure reports truthfully`() = runTest(dispatcher) {
+        coEvery { lyricsRepository.get(42L) } returns cachedLyrics()
+        coEvery { lyricsSidecarWriter.write(42L, any()) } throws IOException("disk full")
+        val viewModel = viewModelWithDownloadedTrack()
+
+        viewModel.userMessages.test {
+            viewModel.exportLyricsForCurrentTrack()
+            assertEquals("Couldn't save lyrics sidecar.", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `DAO failure reports write failure truthfully`() = runTest(dispatcher) {
+        coEvery { lyricsRepository.get(42L) } throws IOException("database unavailable")
+        val viewModel = viewModelWithDownloadedTrack()
+
+        viewModel.userMessages.test {
+            viewModel.exportLyricsForCurrentTrack()
+            assertEquals("Couldn't save lyrics sidecar.", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `cancellation is preserved without a failure message`() = runTest(dispatcher) {
+        val entered = CompletableDeferred<Unit>()
+        coEvery { lyricsRepository.get(42L) } coAnswers {
+            entered.complete(Unit)
+            throw CancellationException("cancelled")
+        }
+        val viewModel = viewModelWithDownloadedTrack()
+
+        viewModel.userMessages.test {
+            viewModel.exportLyricsForCurrentTrack()
+            entered.await()
+            assertEquals(null, viewModel.exportingLyricsTrackId.first { it == null })
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun TestScope.viewModelWithDownloadedTrack(title: String = "Song"): NowPlayingViewModel {
+        playerState.value = playerState.value.copy(currentTrack = downloadedTrack(42L, title))
+        return viewModel().also { advanceUntilIdle() }
+    }
+
+    private fun downloadedTrack(id: Long, title: String) = Track(
+        id = id,
+        title = title,
+        artist = "Artist",
+        album = "Album",
+        isDownloaded = true,
+    )
+
+    private fun cachedLyrics() = LyricsEntity(
+        trackId = 42L,
+        plainText = "cached words",
+        syncedLrc = null,
+        instrumental = false,
+        language = null,
+        source = "lrclib",
+        sourceLyricsId = "42",
+        fetchedAt = 1L,
+    )
+
+    private fun viewModel() = NowPlayingViewModel(
+        playerRepository = playerRepository,
+        musicRepository = musicRepository,
+        likeCoordinator = likeCoordinator,
+        losslessUpgrader = mockk<LosslessUpgrader>(relaxed = true),
+        lyricsRepository = lyricsRepository,
+        lyricsPreference = mockk(relaxed = true),
+        lyricsSidecarWriter = lyricsSidecarWriter,
+        appContext = mockk<Context>(relaxed = true),
+        ytMusicApiClient = mockk<YTMusicApiClient>(relaxed = true),
+    )
+}

--- a/feature/nowplaying/src/test/kotlin/com/stash/feature/nowplaying/NowPlayingViewModelTest.kt
+++ b/feature/nowplaying/src/test/kotlin/com/stash/feature/nowplaying/NowPlayingViewModelTest.kt
@@ -211,6 +211,7 @@ class NowPlayingViewModelFindInFlacTest {
         losslessUpgrader = upgrader,
         lyricsRepository = lyricsRepository,
         lyricsPreference = mockk(relaxed = true),
+        lyricsSidecarWriter = mockk(relaxed = true),
         appContext = appContext,
         ytMusicApiClient = mockk(relaxed = true),
     )
@@ -337,6 +338,7 @@ class NowPlayingViewModelLikeRoutingTest {
         losslessUpgrader = upgrader,
         lyricsRepository = lyricsRepository,
         lyricsPreference = mockk(relaxed = true),
+        lyricsSidecarWriter = mockk(relaxed = true),
         appContext = appContext,
         ytMusicApiClient = mockk(relaxed = true),
     )
@@ -409,6 +411,7 @@ class NowPlayingViewModelTrackTapTest {
         losslessUpgrader = upgrader,
         lyricsRepository = lyricsRepository,
         lyricsPreference = mockk(relaxed = true),
+        lyricsSidecarWriter = mockk(relaxed = true),
         appContext = appContext,
         ytMusicApiClient = api,
     )


### PR DESCRIPTION
## What does this PR do?

Adds a **Save lyrics sidecar** action to Now Playing for downloaded tracks. It writes already-cached lyrics beside the downloaded audio so external players can discover them without refetching or changing the in-app lyrics state.

The action reports success only after a confirmed write, distinguishes missing lyrics from storage failures, and prevents concurrent exports. Its visible label reports busy state, and completion messages remain associated with the original track if playback changes during the operation.

## Related issue

Closes #248

## How was this tested?

- 6 sidecar-writer tests cover real temporary-file writes, plain-text fallback, and throwing skip paths.
- 6 Now Playing tests cover cached reads, single-flight behavior, track changes, cancellation, and user messages.
- `:feature:nowplaying:compileDebugKotlin` passes.
- `git diff --check` passes.

- [ ] `./gradlew test` passes
- [ ] Installed on a device and manually verified the change

## Checklist

- [x] My code follows the style of the surrounding code
- [x] This PR does **one thing** (unrelated changes belong in separate PRs)
- [x] I updated comments where the behavior needed explanation
