### PR TITLE
Pure black (AMOLED) dark theme + fast-scroll scrollbars (supersedes #215)

### DIFF
--- a/app/src/main/kotlin/com/stash/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/stash/app/MainActivity.kt
@@ -46,6 +46,7 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             val themeMode by themeModeFlow.collectAsState(initial = ThemeMode.SYSTEM)
+            val amoledDark by themePreference.amoledDark.collectAsState(initial = false)
             val systemDark = isSystemInDarkTheme()
             val darkTheme = when (themeMode) {
                 ThemeMode.LIGHT -> false
@@ -53,7 +54,7 @@ class MainActivity : ComponentActivity() {
                 ThemeMode.SYSTEM -> systemDark
             }
 
-            StashTheme(darkTheme = darkTheme) {
+            StashTheme(darkTheme = darkTheme, amoled = amoledDark) {
                 StashScaffold(
                     pendingDeepLink = pendingDeepLink.value,
                     onDeepLinkConsumed = { pendingDeepLink.value = null },

--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/ThemePreference.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/ThemePreference.kt
@@ -17,4 +17,13 @@ interface ThemePreference {
 
     /** Persists the selected [mode] for the next app session and beyond. */
     suspend fun setThemeMode(mode: ThemeMode)
+
+    /**
+     * Emits whether dark theme should use pure-black (AMOLED) backgrounds.
+     * Dormant while the effective theme is light. Defaults to false.
+     */
+    val amoledDark: Flow<Boolean>
+
+    /** Persists the pure-black dark preference. */
+    suspend fun setAmoledDark(enabled: Boolean)
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/ThemePreferencesManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/ThemePreferencesManager.kt
@@ -6,6 +6,7 @@ import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.stash.core.model.ThemeMode
@@ -44,6 +45,20 @@ class ThemePreferencesManager @Inject constructor(
     override suspend fun setThemeMode(mode: ThemeMode) {
         context.themeDataStore.edit { prefs ->
             prefs[themeKey] = mode.name
+        }
+    }
+
+    private val amoledKey = booleanPreferencesKey("amoled_dark")
+
+    /** Emits the pure-black (AMOLED) dark preference, defaulting to false. */
+    override val amoledDark: Flow<Boolean> = context.themeDataStore.data.map { prefs ->
+        prefs[amoledKey] ?: false
+    }
+
+    /** Persists the pure-black dark preference. */
+    override suspend fun setAmoledDark(enabled: Boolean) {
+        context.themeDataStore.edit { prefs ->
+            prefs[amoledKey] = enabled
         }
     }
 }

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/ScrollbarModifier.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/ScrollbarModifier.kt
@@ -1,0 +1,221 @@
+package com.stash.core.ui.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.verticalDrag
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+/** Shared snapshot written by the draw layer, read by the drag-handle layer. */
+private class ScrollbarTrackInfo {
+    var progress by mutableStateOf(0f)
+    var thumbFraction by mutableStateOf(1f)
+}
+
+@Composable
+fun BoxScope.VerticalScrollbar(
+    state: LazyListState,
+    color: Color = Color.White.copy(alpha = 0.5f),
+    width: Dp = 6.dp,
+    idleDelayMs: Long = 800L,
+    thumbHeightOffset: Float = 0f,
+    hitZoneWidth: Dp = 36.dp,
+) {
+    val info = remember { ScrollbarTrackInfo() }
+    val density = LocalDensity.current
+    val widthPx = with(density) { width.toPx() }
+    var alpha by remember { mutableStateOf(0f) }
+    val animatedAlpha by animateFloatAsState(alpha, tween(200), label = "scrollbarAlpha")
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(state.isScrollInProgress) {
+        if (state.isScrollInProgress) alpha = 1f else { delay(idleDelayMs); alpha = 0f }
+    }
+
+    // Draw-only layer — fillMaxSize but NO pointerInput, so it never blocks touches.
+    Box(
+        modifier = Modifier.fillMaxSize().drawWithContent {
+            drawContent()
+            val layout = state.layoutInfo
+            val totalItems = layout.totalItemsCount
+            if (totalItems == 0 || layout.visibleItemsInfo.isEmpty()) return@drawWithContent
+            val firstVisible = layout.visibleItemsInfo.first()
+            val avgItemSize = layout.visibleItemsInfo.sumOf { it.size }.toFloat() / layout.visibleItemsInfo.size
+            val estimatedTotalHeight = avgItemSize * totalItems
+            if (estimatedTotalHeight <= layout.viewportEndOffset) return@drawWithContent
+
+            val scrolledPx = firstVisible.index * avgItemSize - firstVisible.offset
+            val maxScrollPx = estimatedTotalHeight - layout.viewportEndOffset
+            info.thumbFraction = (layout.viewportEndOffset / estimatedTotalHeight).coerceIn(0.05f, 1f)
+            info.progress = (scrolledPx / maxScrollPx).coerceIn(0f, 1f)
+            if (animatedAlpha <= 0.001f) return@drawWithContent
+
+            val trackHeight = size.height
+            val thumbHeight = (trackHeight * info.thumbFraction) + thumbHeightOffset
+            val thumbOffsetY = info.progress * (trackHeight - thumbHeight)
+            drawRoundRect(
+                color = color.copy(alpha = color.alpha * animatedAlpha),
+                topLeft = Offset(size.width - widthPx - 2f, thumbOffsetY),
+                size = Size(widthPx, thumbHeight),
+                cornerRadius = CornerRadius(widthPx / 2f, widthPx / 2f),
+            )
+        },
+    )
+
+    // Narrow grab strip — ONLY this slice is touchable, everything left of it
+    // passes straight through to the list/grid underneath untouched.
+    Box(
+        modifier = Modifier
+            .align(Alignment.CenterEnd)
+            .fillMaxHeight()
+            .width(hitZoneWidth)
+            .pointerInput(state) {
+                val grabTolerance = 24.dp.toPx()
+                // Manual gesture: claim (and scrub) ONLY when the touch lands on
+                // the VISIBLE thumb. Off-thumb or faded-out touches are left
+                // unconsumed so the list underneath scrolls normally — otherwise
+                // this full-height strip would swallow every right-edge drag and
+                // freeze scrolling along that edge.
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    val trackHeight = size.height.toFloat()
+                    val thumbHeight = (trackHeight * info.thumbFraction) + thumbHeightOffset
+                    val thumbOffsetY = info.progress * (trackHeight - thumbHeight)
+                    val onThumb = animatedAlpha > 0.01f && down.position.y in
+                        (thumbOffsetY - grabTolerance)..(thumbOffsetY + thumbHeight + grabTolerance)
+                    if (!onThumb) return@awaitEachGesture
+                    down.consume()
+                    alpha = 1f
+                    var dragProgress = info.progress
+                    val maxOffset = trackHeight - thumbHeight
+                    verticalDrag(down.id) { change ->
+                        change.consume()
+                        if (maxOffset > 0f) {
+                            dragProgress = (dragProgress + change.positionChange().y / maxOffset)
+                                .coerceIn(0f, 1f)
+                            val targetIndex =
+                                (dragProgress * (state.layoutInfo.totalItemsCount - 1)).roundToInt()
+                            scope.launch { state.scrollToItem(targetIndex) }
+                        }
+                    }
+                }
+            },
+    )
+}
+
+@Composable
+fun BoxScope.VerticalScrollbar(
+    state: LazyGridState,
+    color: Color = Color.White.copy(alpha = 0.5f),
+    width: Dp = 6.dp,
+    idleDelayMs: Long = 800L,
+    thumbHeightOffset: Float = 0f,
+    hitZoneWidth: Dp = 36.dp,
+) {
+    val info = remember { ScrollbarTrackInfo() }
+    val density = LocalDensity.current
+    val widthPx = with(density) { width.toPx() }
+    var alpha by remember { mutableStateOf(0f) }
+    val animatedAlpha by animateFloatAsState(alpha, tween(200), label = "scrollbarAlpha")
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(state.isScrollInProgress) {
+        if (state.isScrollInProgress) alpha = 1f else { delay(idleDelayMs); alpha = 0f }
+    }
+
+    Box(
+        modifier = Modifier.fillMaxSize().drawWithContent {
+            drawContent()
+            val layout = state.layoutInfo
+            val totalItems = layout.totalItemsCount
+            if (totalItems == 0 || layout.visibleItemsInfo.isEmpty()) return@drawWithContent
+            val firstVisible = layout.visibleItemsInfo.first()
+            val avgItemHeight = layout.visibleItemsInfo.map { it.size.height }.average().toFloat()
+            val columns = layout.visibleItemsInfo.map { it.column }.distinct().size.coerceAtLeast(1)
+            val totalRows = (totalItems + columns - 1) / columns
+            val estimatedTotalHeight = avgItemHeight * totalRows
+            if (estimatedTotalHeight <= layout.viewportEndOffset) return@drawWithContent
+
+            val scrolledPx = firstVisible.row * avgItemHeight - firstVisible.offset.y
+            val maxScrollPx = estimatedTotalHeight - layout.viewportEndOffset
+            info.thumbFraction = (layout.viewportEndOffset / estimatedTotalHeight).coerceIn(0.05f, 1f)
+            info.progress = (scrolledPx / maxScrollPx).coerceIn(0f, 1f)
+            if (animatedAlpha <= 0.001f) return@drawWithContent
+
+            val trackHeight = size.height
+            val thumbHeight = (trackHeight * info.thumbFraction) + thumbHeightOffset
+            val thumbOffsetY = info.progress * (trackHeight - thumbHeight)
+            drawRoundRect(
+                color = color.copy(alpha = color.alpha * animatedAlpha),
+                topLeft = Offset(size.width - widthPx - 2f, thumbOffsetY),
+                size = Size(widthPx, thumbHeight),
+                cornerRadius = CornerRadius(widthPx / 2f, widthPx / 2f),
+            )
+        },
+    )
+
+    Box(
+        modifier = Modifier
+            .align(Alignment.CenterEnd)
+            .fillMaxHeight()
+            .width(hitZoneWidth)
+            .pointerInput(state) {
+                val grabTolerance = 24.dp.toPx()
+                // Manual gesture: claim (and scrub) ONLY when the touch lands on
+                // the VISIBLE thumb. Off-thumb or faded-out touches are left
+                // unconsumed so the grid underneath scrolls normally — otherwise
+                // this full-height strip would swallow every right-edge drag and
+                // freeze scrolling along that edge.
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    val trackHeight = size.height.toFloat()
+                    val thumbHeight = (trackHeight * info.thumbFraction) + thumbHeightOffset
+                    val thumbOffsetY = info.progress * (trackHeight - thumbHeight)
+                    val onThumb = animatedAlpha > 0.01f && down.position.y in
+                        (thumbOffsetY - grabTolerance)..(thumbOffsetY + thumbHeight + grabTolerance)
+                    if (!onThumb) return@awaitEachGesture
+                    down.consume()
+                    alpha = 1f
+                    var dragProgress = info.progress
+                    val maxOffset = trackHeight - thumbHeight
+                    verticalDrag(down.id) { change ->
+                        change.consume()
+                        if (maxOffset > 0f) {
+                            dragProgress = (dragProgress + change.positionChange().y / maxOffset)
+                                .coerceIn(0f, 1f)
+                            val columns = state.layoutInfo.visibleItemsInfo
+                                .map { it.column }.distinct().size.coerceAtLeast(1)
+                            val totalItems = state.layoutInfo.totalItemsCount
+                            val totalRows = (totalItems + columns - 1) / columns
+                            val targetRow = (dragProgress * (totalRows - 1)).roundToInt()
+                            val targetIndex = (targetRow * columns).coerceIn(0, totalItems - 1)
+                            scope.launch { state.scrollToItem(targetIndex) }
+                        }
+                    }
+                }
+            },
+    )
+}

--- a/core/ui/src/main/kotlin/com/stash/core/ui/theme/Color.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/theme/Color.kt
@@ -21,6 +21,11 @@ val StashSuccess = Color(0xFF10B981)
 val StashBackground = Color(0xFF06060C)
 val StashSurface = Color(0xFF0D0D18)
 val StashElevatedSurface = Color(0xFF1A1A2E)
+
+// ── AMOLED (pure-black dark) ───────────────────────────────────────────────
+// Backgrounds and surfaces go to true #000000 so OLED pixels switch off;
+// only the raised-container tier keeps a dim lift for hierarchy.
+val StashAmoledSurfaceHigh = Color(0xFF14141E)
 val StashTextPrimary = Color(0xFFE8E8F0)
 val StashTextSecondary = Color(0xFFA0A0B8)
 val StashTextTertiary = Color(0xFF606078)

--- a/core/ui/src/main/kotlin/com/stash/core/ui/theme/Theme.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/theme/Theme.kt
@@ -62,9 +62,41 @@ val StashLightColorScheme = lightColorScheme(
     outlineVariant = StashGlassBorderBrightLight,
 )
 
+/**
+ * AMOLED variant of the dark scheme: every ground the eye reads as "the app's
+ * canvas" is pure #000000 so OLED panels switch those pixels off entirely.
+ *
+ * Beyond background/surface, the whole M3 surface-container family and
+ * [androidx.compose.material3.ColorScheme.surfaceTint] are forced black —
+ * components that default to `surfaceContainerLow` (ModalBottomSheet) or
+ * apply tonal elevation would otherwise render M3's baseline dark gray on
+ * top of our black. With surfaceTint black, `surfaceColorAtElevation()` is
+ * a no-op by construction. Raised tiers (surfaceVariant, containerHigh /
+ * Highest) keep a dim lift so chips, thumbnails, and drag targets stay
+ * distinguishable on true black — hierarchy on AMOLED is carried by the
+ * glass borders, not by big tonal fills.
+ */
+val StashAmoledColorScheme = StashDarkColorScheme.copy(
+    background = Color.Black,
+    surface = Color.Black,
+    surfaceTint = Color.Black,
+    surfaceDim = Color.Black,
+    surfaceBright = StashElevatedSurface,
+    surfaceContainerLowest = Color.Black,
+    surfaceContainerLow = Color.Black,
+    surfaceContainer = Color.Black,
+    surfaceContainerHigh = StashAmoledSurfaceHigh,
+    surfaceContainerHighest = StashElevatedSurface,
+)
+
 // ── LocalIsDarkTheme — queried by composables that need theme-aware assets
 //    (e.g. the wordmark drawable selection in HomeScreen). ────────────────
 val LocalIsDarkTheme = staticCompositionLocalOf { true }
+
+// ── LocalIsAmoledTheme — true only when the pure-black dark theme is
+//    active. Queried by surfaces that paint their own canvas (e.g. Now
+//    Playing's AmbientBackground) instead of sniffing colorScheme values. ──
+val LocalIsAmoledTheme = staticCompositionLocalOf { false }
 
 /**
  * Root theme for the Stash app.
@@ -73,6 +105,10 @@ val LocalIsDarkTheme = staticCompositionLocalOf { true }
  * preference (Light/Dark/System) instead of always following the OS.
  * When the caller wants to mirror the system, pass
  * `isSystemInDarkTheme()` — that's also the default for safety.
+ *
+ * [amoled] upgrades the DARK scheme to pure black ([StashAmoledColorScheme]);
+ * it composes with any mode — on light (or system-day) it is dormant and
+ * kicks in whenever the effective theme is dark.
  *
  * Switching between schemes is done purely in Compose state — no activity
  * recreation, no resource configuration override — so the flip is instant
@@ -84,9 +120,15 @@ val LocalIsDarkTheme = staticCompositionLocalOf { true }
 @Composable
 fun StashTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
+    amoled: Boolean = false,
     content: @Composable () -> Unit,
 ) {
-    val colorScheme = if (darkTheme) StashDarkColorScheme else StashLightColorScheme
+    val useAmoled = darkTheme && amoled
+    val colorScheme = when {
+        useAmoled -> StashAmoledColorScheme
+        darkTheme -> StashDarkColorScheme
+        else -> StashLightColorScheme
+    }
     val extendedColors = if (darkTheme) StashExtendedColorsDark else StashExtendedColorsLight
 
     val view = LocalView.current
@@ -105,6 +147,7 @@ fun StashTheme(
     CompositionLocalProvider(
         LocalStashColors provides extendedColors,
         LocalIsDarkTheme provides darkTheme,
+        LocalIsAmoledTheme provides useAmoled,
     ) {
         MaterialTheme(
             colorScheme = colorScheme,

--- a/core/ui/src/test/kotlin/com/stash/core/ui/theme/AmoledSchemeTest.kt
+++ b/core/ui/src/test/kotlin/com/stash/core/ui/theme/AmoledSchemeTest.kt
@@ -1,0 +1,51 @@
+package com.stash.core.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The AMOLED contract: every color a full-screen ground can resolve to must
+ * be pure #000000, or OLED pixels stay lit and the whole point is lost.
+ * Guards against someone later "warming up" a surface token or forgetting
+ * that M3 components fall back to the surfaceContainer family / tonal
+ * elevation (surfaceTint) rather than plain `surface`.
+ */
+class AmoledSchemeTest {
+
+    @Test
+    fun `all canvas-level surfaces are pure black`() {
+        val s = StashAmoledColorScheme
+        assertThat(s.background).isEqualTo(Color.Black)
+        assertThat(s.surface).isEqualTo(Color.Black)
+        assertThat(s.surfaceDim).isEqualTo(Color.Black)
+        assertThat(s.surfaceContainerLowest).isEqualTo(Color.Black)
+        assertThat(s.surfaceContainerLow).isEqualTo(Color.Black)
+        assertThat(s.surfaceContainer).isEqualTo(Color.Black)
+    }
+
+    @Test
+    fun `tonal elevation cannot tint surfaces away from black`() {
+        // surfaceColorAtElevation lerps surface toward surfaceTint; with a
+        // black tint the lerp is a no-op at every elevation.
+        assertThat(StashAmoledColorScheme.surfaceTint).isEqualTo(Color.Black)
+    }
+
+    @Test
+    fun `raised tiers keep a visible lift for hierarchy`() {
+        // Deliberately NOT black: chips/thumbnails must stay distinguishable.
+        assertThat(StashAmoledColorScheme.surfaceVariant).isNotEqualTo(Color.Black)
+        assertThat(StashAmoledColorScheme.surfaceContainerHigh).isNotEqualTo(Color.Black)
+        assertThat(StashAmoledColorScheme.surfaceContainerHighest).isNotEqualTo(Color.Black)
+    }
+
+    @Test
+    fun `non-surface identity is inherited from the dark scheme`() {
+        val amoled = StashAmoledColorScheme
+        val dark = StashDarkColorScheme
+        assertThat(amoled.primary).isEqualTo(dark.primary)
+        assertThat(amoled.onBackground).isEqualTo(dark.onBackground)
+        assertThat(amoled.onSurface).isEqualTo(dark.onSurface)
+        assertThat(amoled.outline).isEqualTo(dark.outline)
+    }
+}

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
@@ -24,10 +24,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -94,6 +96,7 @@ import com.stash.core.model.Track
 import com.stash.core.ui.components.GlassCard
 import com.stash.core.ui.components.SourceIndicator
 import com.stash.core.ui.components.TrackListItem
+import com.stash.core.ui.components.VerticalScrollbar
 import com.stash.core.ui.selection.SelectionAction
 import com.stash.core.ui.selection.SelectionScaffoldOverlay
 import com.stash.core.ui.selection.SelectionState
@@ -575,32 +578,36 @@ private fun LikedTab(
         if (LikedFilter.SPOTIFY in sources) add("Spotify" to LikedFilter.SPOTIFY)
         if (LikedFilter.YOUTUBE in sources) add("YouTube" to LikedFilter.YOUTUBE)
     }
-    LazyColumn {
-        // Only offer the sift when there's more than one origin to pick between.
-        if (sift.size > 2) {
-            item {
-                com.stash.core.ui.components.CrispChipRow(
-                    chips = sift.map { it.first },
-                    selected = sift.firstOrNull { it.second == filter }?.first ?: "All",
-                    onSelect = { label -> onSelectSource(sift.first { it.first == label }.second) },
-                    modifier = Modifier.padding(vertical = 4.dp),
+    val listState = rememberLazyListState()
+    Box(Modifier.fillMaxSize()) {
+        LazyColumn(state = listState) {
+            // Only offer the sift when there's more than one origin to pick between.
+            if (sift.size > 2) {
+                item {
+                    com.stash.core.ui.components.CrispChipRow(
+                        chips = sift.map { it.first },
+                        selected = sift.firstOrNull { it.second == filter }?.first ?: "All",
+                        onSelect = { label -> onSelectSource(sift.first { it.first == label }.second) },
+                        modifier = Modifier.padding(vertical = 4.dp),
+                    )
+                }
+            }
+            if (tracks.isEmpty()) {
+                item { EmptyTabMessage("No liked songs yet — tap the heart on a track to like it") }
+            }
+            items(tracks, key = { it.id }) { track ->
+                TrackListItem(
+                    track = track,
+                    onClick = { onTrackClick(track) },
+                    isPlaying = track.id == currentlyPlayingTrackId,
+                    onLongPress = {},
+                    selectionActive = false,
+                    selected = false,
+                    onMoreClick = {},
                 )
             }
         }
-        if (tracks.isEmpty()) {
-            item { EmptyTabMessage("No liked songs yet — tap the heart on a track to like it") }
-        }
-        items(tracks, key = { it.id }) { track ->
-            TrackListItem(
-                track = track,
-                onClick = { onTrackClick(track) },
-                isPlaying = track.id == currentlyPlayingTrackId,
-                onLongPress = {},
-                selectionActive = false,
-                selected = false,
-                onMoreClick = {},
-            )
-        }
+        VerticalScrollbar(state = listState)
     }
 }
 
@@ -783,117 +790,122 @@ private fun PlaylistsGrid(
         playlistForImagePick = null
     }
 
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(2),
-        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        // Full-width leading header (Shuffle hero + recent rail, Songs-tab only).
-        item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
-            header()
-        }
-        if (playlists.isEmpty()) {
+    val gridState = rememberLazyGridState()
+    Box(Modifier.fillMaxSize()) {
+        LazyVerticalGrid(
+            state = gridState,
+            columns = GridCells.Fixed(2),
+            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // Full-width leading header (Shuffle hero + recent rail, Songs-tab only).
             item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
-                EmptyTabMessage(
-                    if (anyServiceConnected) "Sync your playlists to see them here"
-                    else "Connect a service in Settings to see your playlists",
-                )
+                header()
             }
-        }
-        items(playlists, key = { it.id }) { playlist ->
-            if (playlist.artUrl != null) {
-                // Playlist with artwork: image background + dark overlay
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(140.dp)
-                        .clip(RoundedCornerShape(16.dp))
-                        .combinedClickable(
-                            onClick = { onPlayPlaylist(playlist) },
-                            onLongClick = { selectedPlaylist = playlist },
-                        ),
-                ) {
-                    AsyncImage(
-                        model = playlist.artUrl,
-                        contentDescription = "${playlist.name} artwork",
-                        modifier = Modifier.fillMaxSize(),
-                        contentScale = ContentScale.Crop,
+            if (playlists.isEmpty()) {
+                item(span = { androidx.compose.foundation.lazy.grid.GridItemSpan(maxLineSpan) }) {
+                    EmptyTabMessage(
+                        if (anyServiceConnected) "Sync your playlists to see them here"
+                        else "Connect a service in Settings to see your playlists",
                     )
-                    // Dark scrim overlay for text legibility
+                }
+            }
+            items(playlists, key = { it.id }) { playlist ->
+                if (playlist.artUrl != null) {
+                    // Playlist with artwork: image background + dark overlay
                     Box(
                         modifier = Modifier
-                            .fillMaxSize()
-                            .background(
-                                Brush.verticalGradient(
-                                    colors = listOf(
-                                        Color.Transparent,
-                                        Color.Black.copy(alpha = 0.7f),
-                                    ),
-                                    startY = 40f,
-                                ),
+                            .fillMaxWidth()
+                            .height(140.dp)
+                            .clip(RoundedCornerShape(16.dp))
+                            .combinedClickable(
+                                onClick = { onPlayPlaylist(playlist) },
+                                onLongClick = { selectedPlaylist = playlist },
                             ),
-                    )
-                    // Text pinned to bottom
-                    Column(
-                        modifier = Modifier
-                            .align(Alignment.BottomStart)
-                            .padding(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(4.dp),
                     ) {
-                        Text(
-                            text = playlist.name,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = Color.White,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
+                        AsyncImage(
+                            model = playlist.artUrl,
+                            contentDescription = "${playlist.name} artwork",
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop,
                         )
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(6.dp),
-                            verticalAlignment = Alignment.CenterVertically,
+                        // Dark scrim overlay for text legibility
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(
+                                    Brush.verticalGradient(
+                                        colors = listOf(
+                                            Color.Transparent,
+                                            Color.Black.copy(alpha = 0.7f),
+                                        ),
+                                        startY = 40f,
+                                    ),
+                                ),
+                        )
+                        // Text pinned to bottom
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.BottomStart)
+                                .padding(12.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
                         ) {
-                            SourceIndicator(source = playlist.source)
                             Text(
-                                text = "${playlist.trackCount} tracks",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = Color.White.copy(alpha = 0.8f),
+                                text = playlist.name,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = Color.White,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
                             )
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                SourceIndicator(source = playlist.source)
+                                Text(
+                                    text = "${playlist.trackCount} tracks",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = Color.White.copy(alpha = 0.8f),
+                                )
+                            }
                         }
                     }
-                }
-            } else {
-                // No artwork: keep the original GlassCard look
-                GlassCard(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .combinedClickable(
-                            onClick = { onPlayPlaylist(playlist) },
-                            onLongClick = { selectedPlaylist = playlist },
-                        ),
-                ) {
-                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                        Text(
-                            text = playlist.name,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onBackground,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(6.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            SourceIndicator(source = playlist.source)
+                } else {
+                    // No artwork: keep the original GlassCard look
+                    GlassCard(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .combinedClickable(
+                                onClick = { onPlayPlaylist(playlist) },
+                                onLongClick = { selectedPlaylist = playlist },
+                            ),
+                    ) {
+                        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                             Text(
-                                text = "${playlist.trackCount} tracks",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                text = playlist.name,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onBackground,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
                             )
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                SourceIndicator(source = playlist.source)
+                                Text(
+                                    text = "${playlist.trackCount} tracks",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
                         }
                     }
                 }
             }
         }
+        VerticalScrollbar(state = gridState)
     }
 
     // ── Context-menu bottom sheet ───────────────────────────────────────
@@ -1082,27 +1094,32 @@ private fun TracksTab(
     // Track pending delete confirmation.
     var trackToDelete by remember { mutableStateOf<Track?>(null) }
 
-    LazyColumn(
-        // While selecting, the mini-player hides (Task 7) but the bottom
-        // selection bar takes its place — pad enough that the last row clears
-        // it in either state.
-        contentPadding = PaddingValues(bottom = if (selection.isActive) 140.dp else 0.dp),
-    ) {
-        item { header() }
-        items(tracks, key = { it.id }) { track ->
-            TrackListItem(
-                track = track,
-                onClick = {
-                    if (selection.isActive) selection.toggle(track.id)
-                    else onTrackClick(track)
-                },
-                isPlaying = track.id == currentlyPlayingTrackId,
-                onLongPress = { if (!selection.isActive) selection.enter(track.id) },
-                selectionActive = selection.isActive,
-                selected = selection.isSelected(track.id),
-                onMoreClick = { selectedTrack = track },
-            )
+    val listState = rememberLazyListState()
+    Box(Modifier.fillMaxSize()) {
+        LazyColumn(
+            state = listState,
+            // While selecting, the mini-player hides (Task 7) but the bottom
+            // selection bar takes its place — pad enough that the last row clears
+            // it in either state.
+            contentPadding = PaddingValues(bottom = if (selection.isActive) 140.dp else 0.dp),
+        ) {
+            item { header() }
+            items(tracks, key = { it.id }) { track ->
+                TrackListItem(
+                    track = track,
+                    onClick = {
+                        if (selection.isActive) selection.toggle(track.id)
+                        else onTrackClick(track)
+                    },
+                    isPlaying = track.id == currentlyPlayingTrackId,
+                    onLongPress = { if (!selection.isActive) selection.enter(track.id) },
+                    selectionActive = selection.isActive,
+                    selected = selection.isSelected(track.id),
+                    onMoreClick = { selectedTrack = track },
+                )
+            }
         }
+        VerticalScrollbar(state = listState)
     }
 
     // ── Context-menu bottom sheet ───────────────────────────────────────
@@ -1307,107 +1324,112 @@ private fun ArtistsGrid(
 
     val displayList = if (showSingleTrack) artists + singleTrackArtists else artists
 
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(2),
-        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        item(span = { GridItemSpan(maxLineSpan) }) { header() }
-        items(displayList, key = { it.name }) { artist ->
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp)
-                    .combinedClickable(
-                        onClick = { onPlayArtist(artist.name) },
-                        onLongClick = { selectedArtist = artist },
-                    ),
-            ) {
-                // Album art proxy or gradient circle fallback
-                if (artist.artUrl != null) {
-                    coil3.compose.AsyncImage(
-                        model = artist.artUrl,
-                        contentDescription = null,
-                        modifier = Modifier
-                            .size(72.dp)
-                            .clip(CircleShape),
-                        contentScale = androidx.compose.ui.layout.ContentScale.Crop,
-                    )
-                } else {
-                    val gradientColors = remember(artist.name) {
-                        artistGradient(artist.name)
-                    }
-                    Box(
-                        modifier = Modifier
-                            .size(72.dp)
-                            .clip(CircleShape)
-                            .background(Brush.linearGradient(gradientColors)),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = artist.name.firstOrNull()
-                                ?.uppercaseChar()?.toString() ?: "?",
-                            style = MaterialTheme.typography.headlineMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = Color.White,
-                        )
-                    }
-                }
-                Text(
-                    text = artist.name,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onBackground,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    textAlign = TextAlign.Center,
-                )
-                Text(
-                    text = "${artist.trackCount} tracks",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-
-        // Collapsible section for single-track artists
-        if (singleTrackArtists.isNotEmpty()) {
-            item(span = { GridItemSpan(2) }) {
-                Surface(
+    val gridState = rememberLazyGridState()
+    Box(Modifier.fillMaxSize()) {
+        LazyVerticalGrid(
+            state = gridState,
+            columns = GridCells.Fixed(2),
+            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item(span = { GridItemSpan(maxLineSpan) }) { header() }
+            items(displayList, key = { it.name }) { artist ->
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(vertical = 8.dp)
-                        .clickable { showSingleTrack = !showSingleTrack },
-                    color = StashTheme.extendedColors.glassBackground,
-                    shape = RoundedCornerShape(12.dp),
-                    border = androidx.compose.foundation.BorderStroke(
-                        1.dp, StashTheme.extendedColors.glassBorder,
-                    ),
+                        .combinedClickable(
+                            onClick = { onPlayArtist(artist.name) },
+                            onLongClick = { selectedArtist = artist },
+                        ),
                 ) {
-                    Row(
-                        modifier = Modifier.padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        Text(
-                            text = if (showSingleTrack) "Hide single-track artists"
-                            else "${singleTrackArtists.size} artists with 1 track",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.weight(1f),
-                        )
-                        Icon(
-                            imageVector = if (showSingleTrack) Icons.Default.ExpandLess
-                            else Icons.Default.ExpandMore,
+                    // Album art proxy or gradient circle fallback
+                    if (artist.artUrl != null) {
+                        coil3.compose.AsyncImage(
+                            model = artist.artUrl,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier
+                                .size(72.dp)
+                                .clip(CircleShape),
+                            contentScale = androidx.compose.ui.layout.ContentScale.Crop,
                         )
+                    } else {
+                        val gradientColors = remember(artist.name) {
+                            artistGradient(artist.name)
+                        }
+                        Box(
+                            modifier = Modifier
+                                .size(72.dp)
+                                .clip(CircleShape)
+                                .background(Brush.linearGradient(gradientColors)),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = artist.name.firstOrNull()
+                                    ?.uppercaseChar()?.toString() ?: "?",
+                                style = MaterialTheme.typography.headlineMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.White,
+                            )
+                        }
+                    }
+                    Text(
+                        text = artist.name,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onBackground,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        text = "${artist.trackCount} tracks",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            // Collapsible section for single-track artists
+            if (singleTrackArtists.isNotEmpty()) {
+                item(span = { GridItemSpan(2) }) {
+                    Surface(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp)
+                            .clickable { showSingleTrack = !showSingleTrack },
+                        color = StashTheme.extendedColors.glassBackground,
+                        shape = RoundedCornerShape(12.dp),
+                        border = androidx.compose.foundation.BorderStroke(
+                            1.dp, StashTheme.extendedColors.glassBorder,
+                        ),
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                        ) {
+                            Text(
+                                text = if (showSingleTrack) "Hide single-track artists"
+                                else "${singleTrackArtists.size} artists with 1 track",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.weight(1f),
+                            )
+                            Icon(
+                                imageVector = if (showSingleTrack) Icons.Default.ExpandLess
+                                else Icons.Default.ExpandMore,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                     }
                 }
             }
         }
+        VerticalScrollbar(state = gridState)
     }
 
     // ── Context-menu bottom sheet ───────────────────────────────────────
@@ -1524,114 +1546,119 @@ private fun AlbumsGrid(
 
     val displayList = if (showSingleTrack) albums + singleTrackAlbums else albums
 
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(2),
-        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        item(span = { GridItemSpan(maxLineSpan) }) { header() }
-        items(displayList, key = { "${it.name}|${it.artist}" }) { album ->
-            Column(
-                verticalArrangement = Arrangement.spacedBy(6.dp),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 4.dp)
-                    .combinedClickable(
-                        onClick = { onPlayAlbum(album.name, album.artist) },
-                        onLongClick = { selectedAlbum = album },
-                    ),
-            ) {
-                // Album art: try local path, then remote URL, then fallback icon
-                val artModel = album.artPath ?: album.artUrl
-                Box(
+    val gridState = rememberLazyGridState()
+    Box(Modifier.fillMaxSize()) {
+        LazyVerticalGrid(
+            state = gridState,
+            columns = GridCells.Fixed(2),
+            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item(span = { GridItemSpan(maxLineSpan) }) { header() }
+            items(displayList, key = { "${it.name}|${it.artist}" }) { album ->
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(120.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(StashTheme.extendedColors.elevatedSurface),
-                    contentAlignment = Alignment.Center,
+                        .padding(vertical = 4.dp)
+                        .combinedClickable(
+                            onClick = { onPlayAlbum(album.name, album.artist) },
+                            onLongClick = { selectedAlbum = album },
+                        ),
                 ) {
-                    if (artModel != null) {
-                        AsyncImage(
-                            model = artModel,
-                            contentDescription = "${album.name} album art",
-                            modifier = Modifier.fillMaxSize(),
-                            contentScale = ContentScale.Crop,
-                        )
-                    } else {
-                        Icon(
-                            imageVector = Icons.Default.Album,
-                            contentDescription = null,
-                            tint = StashTheme.extendedColors.textTertiary,
-                            modifier = Modifier.size(40.dp),
-                        )
+                    // Album art: try local path, then remote URL, then fallback icon
+                    val artModel = album.artPath ?: album.artUrl
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(120.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(StashTheme.extendedColors.elevatedSurface),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (artModel != null) {
+                            AsyncImage(
+                                model = artModel,
+                                contentDescription = "${album.name} album art",
+                                modifier = Modifier.fillMaxSize(),
+                                contentScale = ContentScale.Crop,
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Default.Album,
+                                contentDescription = null,
+                                tint = StashTheme.extendedColors.textTertiary,
+                                modifier = Modifier.size(40.dp),
+                            )
+                        }
                     }
-                }
-                Text(
-                    text = album.name,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onBackground,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
                     Text(
-                        text = album.artist,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        text = album.name,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onBackground,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f, fill = false),
                     )
-                    Text(
-                        text = "· ${album.trackCount}",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-        }
-
-        // Collapsible section for single-track albums
-        if (singleTrackAlbums.isNotEmpty()) {
-            item(span = { GridItemSpan(2) }) {
-                Surface(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 8.dp)
-                        .clickable { showSingleTrack = !showSingleTrack },
-                    color = StashTheme.extendedColors.glassBackground,
-                    shape = RoundedCornerShape(12.dp),
-                    border = androidx.compose.foundation.BorderStroke(
-                        1.dp, StashTheme.extendedColors.glassBorder,
-                    ),
-                ) {
                     Row(
-                        modifier = Modifier.padding(16.dp),
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
                     ) {
                         Text(
-                            text = if (showSingleTrack) "Hide single-track albums"
-                            else "${singleTrackAlbums.size} albums with 1 track",
-                            style = MaterialTheme.typography.bodyMedium,
+                            text = album.artist,
+                            style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.weight(1f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false),
                         )
-                        Icon(
-                            imageVector = if (showSingleTrack) Icons.Default.ExpandLess
-                            else Icons.Default.ExpandMore,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        Text(
+                            text = "· ${album.trackCount}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }
             }
+
+            // Collapsible section for single-track albums
+            if (singleTrackAlbums.isNotEmpty()) {
+                item(span = { GridItemSpan(2) }) {
+                    Surface(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp)
+                            .clickable { showSingleTrack = !showSingleTrack },
+                        color = StashTheme.extendedColors.glassBackground,
+                        shape = RoundedCornerShape(12.dp),
+                        border = androidx.compose.foundation.BorderStroke(
+                            1.dp, StashTheme.extendedColors.glassBorder,
+                        ),
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                        ) {
+                            Text(
+                                text = if (showSingleTrack) "Hide single-track albums"
+                                else "${singleTrackAlbums.size} albums with 1 track",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.weight(1f),
+                            )
+                            Icon(
+                                imageVector = if (showSingleTrack) Icons.Default.ExpandLess
+                                else Icons.Default.ExpandMore,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
         }
+        VerticalScrollbar(state = gridState)
     }
 
     // ── Context-menu bottom sheet ───────────────────────────────────────

--- a/feature/library/src/main/kotlin/com/stash/feature/library/PlaylistDetailScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/PlaylistDetailScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -75,6 +76,7 @@ import com.stash.core.data.mix.MixBuildState
 import com.stash.core.media.BulkPlayAction
 import com.stash.core.model.PlaylistType
 import com.stash.core.model.Track
+import com.stash.core.ui.components.VerticalScrollbar
 import com.stash.core.ui.components.DetailTrackRow
 import com.stash.core.ui.components.SearchFilterBar
 import com.stash.core.ui.components.SourceIndicator
@@ -143,6 +145,7 @@ fun PlaylistDetailScreen(
         }
     }
 
+    val listState = rememberLazyListState()
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -156,6 +159,7 @@ fun PlaylistDetailScreen(
             )
         } else {
             LazyColumn(
+                state = listState,
                 modifier = Modifier.fillMaxSize(),
                 // Task 7 hides the mini-player while selecting, but the bottom
                 // selection bar (~100dp + nav insets) then takes its place. Pad
@@ -293,6 +297,7 @@ fun PlaylistDetailScreen(
                     }
                 }
             }
+            VerticalScrollbar(state = listState)
         }
 
         // ── Selection chrome (overlaid contextual top + bottom bars) ────────

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
@@ -72,6 +72,7 @@ import coil3.toBitmap
 import com.stash.core.model.RepeatMode
 import com.stash.core.model.isFlac
 import com.stash.core.ui.components.SaveToPlaylistSheet
+import com.stash.core.ui.theme.LocalIsAmoledTheme
 import com.stash.feature.nowplaying.ui.AmbientBackground
 import com.stash.feature.nowplaying.ui.GlowingProgressBar
 import com.stash.feature.nowplaying.ui.LiveLyricsBar
@@ -292,13 +293,15 @@ fun NowPlayingScreen(
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        // Ambient animated background behind everything — dark canvas or the
-        // light pastel wash, following the resolved app theme.
+        // Ambient animated background behind everything — dark canvas, the
+        // light pastel wash, or a dead-black AMOLED ground, following the
+        // resolved app theme.
         AmbientBackground(
             dominantColor = uiState.dominantColor,
             vibrantColor = uiState.vibrantColor,
             mutedColor = uiState.mutedColor,
             lightMode = MaterialTheme.colorScheme.background.luminance() >= 0.5f,
+            amoledMode = LocalIsAmoledTheme.current,
             modifier = Modifier.fillMaxSize(),
         )
 

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/AmbientBackground.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/AmbientBackground.kt
@@ -39,6 +39,9 @@ private const val CROSSFADE_MS = 800
  * @param vibrantColor  Secondary palette color.
  * @param mutedColor    Tertiary palette color (lowest alpha gradient).
  * @param lightMode     Pastel wash on lavender paper instead of the dark canvas.
+ * @param amoledMode    Pure #000000 canvas, no orbs — and no animation
+ *   infrastructure at all: the point of AMOLED is pixels (and the GPU)
+ *   doing nothing. Wins over [lightMode].
  * @param modifier      Standard Compose [Modifier].
  */
 @Composable
@@ -47,8 +50,13 @@ fun AmbientBackground(
     vibrantColor: Color,
     mutedColor: Color,
     lightMode: Boolean = false,
+    amoledMode: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
+    if (amoledMode) {
+        Canvas(modifier = modifier) { drawRect(color = Color.Black) }
+        return
+    }
     // Animate colors so track changes produce a smooth 800 ms crossfade.
     val animDominant by animateColorAsState(
         targetValue = dominantColor,

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAppearanceScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAppearanceScreen.kt
@@ -42,12 +42,15 @@ import com.stash.core.ui.theme.StashTextSecondaryLight
 import com.stash.core.ui.theme.StashTheme
 import com.stash.feature.settings.components.SettingsScaffold
 import com.stash.feature.settings.components.SettingsSectionLabel
+import com.stash.feature.settings.components.SettingsToggleRow
 
 /**
  * Appearance category screen. Replaces the old RadioButton theme list
  * (SettingsScreen.kt:1089-1139) with three tappable T1 theme-preview thumbnails
  * (Dark / Light / Follow system). The underlying control is the SAME existing
- * callback: [SettingsViewModel.onThemeChanged].
+ * callback: [SettingsViewModel.onThemeChanged]. Below the thumbnails, a
+ * "Pure black (AMOLED)" switch upgrades whichever dark theme is in effect
+ * to true #000000 backgrounds.
  */
 @Composable
 fun SettingsAppearanceScreen(
@@ -95,6 +98,16 @@ fun SettingsAppearanceScreen(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(start = 4.dp, end = 4.dp, top = 4.dp),
+        )
+
+        Spacer(Modifier.height(20.dp))
+        SettingsSectionLabel("Dark theme")
+
+        SettingsToggleRow(
+            title = "Pure black (AMOLED)",
+            subtitle = "True-black backgrounds whenever dark theme is active — OLED pixels switch off",
+            checked = uiState.amoledDark,
+            onCheckedChange = viewModel::onAmoledDarkChanged,
         )
     }
 }

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsHubSummaries.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsHubSummaries.kt
@@ -60,6 +60,9 @@ fun settingsHubSummaries(
         ThemeMode.LIGHT -> "Light"
         ThemeMode.DARK -> "Dark"
         ThemeMode.SYSTEM -> "Follow system"
+    }.let { base ->
+        // AMOLED only ever applies to dark; a forced-light picker hides it.
+        if (state.amoledDark && state.themeMode != ThemeMode.LIGHT) "$base · Pure black" else base
     }
 
     val about = "v$versionName"

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
@@ -28,6 +28,8 @@ data class SettingsUiState(
     val youTubeAuthState: AuthState = AuthState.NotConnected,
     val audioQuality: QualityTier = QualityTier.MAX,
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
+    /** Pure-black (AMOLED) backgrounds whenever the effective theme is dark. */
+    val amoledDark: Boolean = false,
     /**
      * Network + power conditions under which Stash runs background
      * downloads (Stash Discover, tag enrichment). Changing this in

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -345,6 +345,7 @@ class SettingsViewModel @Inject constructor(
         streamingQualityPrefs.wifiTier,
         streamingQualityPrefs.cellularTier,
         streamingQualityPrefs.saveData,
+        themePreference.amoledDark,
     ) { values ->
         @Suppress("UNCHECKED_CAST")
         val spotifyAuth = values[0] as AuthState
@@ -380,6 +381,7 @@ class SettingsViewModel @Inject constructor(
         val streamingWifiTier = values[30] as LosslessQualityTier
         val streamingCellularTier = values[31] as LosslessQualityTier
         val streamingSaveData = values[32] as Boolean
+        val amoledDark = values[33] as Boolean
 
         val lastFmState: LastFmAuthState = local.lastFmAuthOverride
             ?: when {
@@ -396,6 +398,7 @@ class SettingsViewModel @Inject constructor(
             youTubeAuthState = youTubeAuth,
             audioQuality = quality,
             themeMode = theme,
+            amoledDark = amoledDark,
             downloadNetworkMode = downloadNetworkMode,
             totalStorageBytes = storageBytes,
             totalTracks = trackCount,
@@ -949,6 +952,13 @@ class SettingsViewModel @Inject constructor(
     fun onThemeChanged(mode: ThemeMode) {
         viewModelScope.launch {
             themePreference.setThemeMode(mode)
+        }
+    }
+
+    /** Persists the pure-black (AMOLED) dark preference. */
+    fun onAmoledDarkChanged(enabled: Boolean) {
+        viewModelScope.launch {
+            themePreference.setAmoledDark(enabled)
         }
     }
 

--- a/feature/settings/src/test/kotlin/com/stash/feature/settings/SettingsHubSummariesTest.kt
+++ b/feature/settings/src/test/kotlin/com/stash/feature/settings/SettingsHubSummariesTest.kt
@@ -164,6 +164,26 @@ class SettingsHubSummariesTest {
         assertEquals("Dark", s.appearance)
     }
 
+    @Test fun `appearance DARK plus AMOLED → Dark · Pure black`() {
+        val s = settingsHubSummaries(
+            state = SettingsUiState(themeMode = ThemeMode.DARK, amoledDark = true),
+            versionName = "0.9.51",
+            streamingEnabled = true,
+            streamOnCellular = false,
+        )
+        assertEquals("Dark · Pure black", s.appearance)
+    }
+
+    @Test fun `appearance LIGHT hides dormant AMOLED flag`() {
+        val s = settingsHubSummaries(
+            state = SettingsUiState(themeMode = ThemeMode.LIGHT, amoledDark = true),
+            versionName = "0.9.51",
+            streamingEnabled = true,
+            streamOnCellular = false,
+        )
+        assertEquals("Light", s.appearance)
+    }
+
     // --- about ------------------------------------------------------------
 
     @Test fun `about prefixes v to versionName`() {


### PR DESCRIPTION
## Summary
- **Pure black (AMOLED)**: new switch under Settings → Appearance → Dark theme. Composes with Light/Dark/Follow-system; forces background/surface + the whole M3 surfaceContainer family + surfaceTint to #000000 (tonal elevation and defaulting sheets can't go gray). Now Playing paints dead black and skips the orb animations entirely in this mode.
- **Fast-scroll scrollbars** on Library songs/Liked/playlists/artists/albums + playlist detail, with the fixed thumb-only gesture (right-edge drags never freeze).
- Modern rebuild of the surviving pieces of #215 (which predates two redesigns); streaming fast-start, theme-pref data layer, mini-player hiding, and yt-dlp changes dropped as obsolete/regressive. Credit: @ParaliyzedEvo (co-authored).

## Test Plan
- [x] AmoledSchemeTest pins pixels-off invariants (all canvas surfaces + surfaceTint == #000)
- [x] SettingsHubSummariesTest covers the "Dark · Pure black" summary
- [x] Device-verified: backgrounds sample (0,0,0) on Home/Library/Now Playing; instant flip; thumb scrub jumps an 844-track list; off-thumb edge drags scroll normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)