### PR TITLE
feat(ui,home): analog fader-cap scrollbar + Qobuz playlist browse search

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/discovery/HomeDiscoveryRepository.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/discovery/HomeDiscoveryRepository.kt
@@ -26,4 +26,11 @@ interface HomeDiscoveryRepository {
      * (null = all). Fail-soft (empty on error). A short page signals the end.
      */
     suspend fun browsePlaylists(genreId: Int?, offset: Int, limit: Int = 30): List<PlaylistSummary>
+
+    /**
+     * One page of catalog-wide playlist search for the browse screen's search
+     * field. Global by nature — Qobuz's catalog/search has no genre filter.
+     * Fail-soft (empty on error). A short page signals the end.
+     */
+    suspend fun searchPlaylists(query: String, offset: Int, limit: Int = 30): List<PlaylistSummary>
 }

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/ScrollbarModifier.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/ScrollbarModifier.kt
@@ -12,14 +12,21 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.systemGestureExclusion
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalDensity
@@ -35,18 +42,169 @@ private class ScrollbarTrackInfo {
     var thumbFraction by mutableStateOf(1f)
 }
 
+/** Fader-cap palette, resolved from the theme like StashSwitch does. */
+private class FaderColors(val fill: Color, val ridge: Color)
+
+/**
+ * Plum & cream, matching StashSwitch — the thumb reads as a physical fader
+ * cap from the same mixing desk. Cream cap on dark grounds, plum on light.
+ * Luminance-driven (not isSystemInDarkTheme) so manual/AMOLED overrides work.
+ */
+@Composable
+private fun faderColors(): FaderColors {
+    val dark = MaterialTheme.colorScheme.background.luminance() < 0.5f
+    return if (dark) {
+        FaderColors(fill = Color(0xFFF2ECE2), ridge = Color(0xFF7E6A90))
+    } else {
+        FaderColors(fill = Color(0xFF6E5A7E), ridge = Color(0xFFF2ECE2))
+    }
+}
+
+/** The thumb never shrinks below this — a scrubbable cap, not a sliver. */
+private val MIN_THUMB_HEIGHT = 48.dp
+
+/** Extra vertical slack around the cap that still counts as grabbing it. */
+private val GRAB_TOLERANCE = 32.dp
+
+/** Clamp the raw viewport fraction so the drawn cap keeps its minimum size. */
+private fun DrawScope.clampedThumbFraction(rawFraction: Float): Float =
+    maxOf(rawFraction, MIN_THUMB_HEIGHT.toPx() / size.height.coerceAtLeast(1f))
+        .coerceAtMost(1f)
+
+/**
+ * Average row height excluding item 0 — every wired list/grid leads with one
+ * oversized full-width header item, and averaging it in makes the position
+ * estimate lurch whenever the header scrolls in or out of the viewport.
+ */
+private fun avgSizeSkippingHeader(items: List<Pair<Int, Int>>): Float {
+    val body = items.filter { it.first != 0 }.ifEmpty { items }
+    return body.sumOf { it.second }.toFloat() / body.size
+}
+
+/**
+ * Draws the fader cap: a rounded plum/cream body with a hairline outline and
+ * three grip ridges across the middle — analog hardware, not a scroll sliver.
+ */
+private fun DrawScope.drawFaderCap(
+    info: ScrollbarTrackInfo,
+    colors: FaderColors,
+    alpha: Float,
+    capWidthPx: Float,
+    thumbHeightOffset: Float,
+) {
+    if (alpha <= 0.001f) return
+    val trackHeight = size.height
+    val thumbHeight = (trackHeight * info.thumbFraction) + thumbHeightOffset
+    val thumbOffsetY = info.progress * (trackHeight - thumbHeight)
+    val left = size.width - capWidthPx - 3.dp.toPx()
+    val corner = CornerRadius(capWidthPx / 2f, capWidthPx / 2f)
+
+    // Cap body.
+    drawRoundRect(
+        color = colors.fill.copy(alpha = 0.95f * alpha),
+        topLeft = Offset(left, thumbOffsetY),
+        size = Size(capWidthPx, thumbHeight),
+        cornerRadius = corner,
+    )
+    // Hairline outline so the cap keeps an edge over any art behind it.
+    drawRoundRect(
+        color = colors.ridge.copy(alpha = 0.55f * alpha),
+        topLeft = Offset(left, thumbOffsetY),
+        size = Size(capWidthPx, thumbHeight),
+        cornerRadius = corner,
+        style = Stroke(width = 1.dp.toPx()),
+    )
+    // Grip ridges, centered.
+    val ridgeWidth = capWidthPx * 0.45f
+    val rx = left + (capWidthPx - ridgeWidth) / 2f
+    val cy = thumbOffsetY + thumbHeight / 2f
+    val gap = 5.dp.toPx()
+    for (i in -1..1) {
+        val y = cy + i * gap
+        drawLine(
+            color = colors.ridge.copy(alpha = 0.9f * alpha),
+            start = Offset(rx, y),
+            end = Offset(rx + ridgeWidth, y),
+            strokeWidth = 1.5.dp.toPx(),
+            cap = StrokeCap.Round,
+        )
+    }
+}
+
+/**
+ * Shared scrub gesture: claims (and scrubs) ONLY when the touch lands on the
+ * VISIBLE cap. Off-thumb or faded-out touches are left unconsumed so the
+ * list/grid underneath scrolls normally — otherwise this full-height strip
+ * would swallow every right-edge drag and freeze scrolling along that edge.
+ */
+private fun Modifier.faderScrubber(
+    stateKey: Any,
+    info: ScrollbarTrackInfo,
+    animatedAlpha: () -> Float,
+    thumbHeightOffset: Float,
+    onWake: () -> Unit,
+    onScrub: (Float) -> Unit,
+): Modifier = pointerInput(stateKey) {
+    val grabTolerance = GRAB_TOLERANCE.toPx()
+    awaitEachGesture {
+        val down = awaitFirstDown(requireUnconsumed = false)
+        val trackHeight = size.height.toFloat()
+        val thumbHeight = (trackHeight * info.thumbFraction) + thumbHeightOffset
+        val thumbOffsetY = info.progress * (trackHeight - thumbHeight)
+        val onThumb = animatedAlpha() > 0.01f && down.position.y in
+            (thumbOffsetY - grabTolerance)..(thumbOffsetY + thumbHeight + grabTolerance)
+        if (!onThumb) return@awaitEachGesture
+        down.consume()
+        onWake()
+        var dragProgress = info.progress
+        val maxOffset = trackHeight - thumbHeight
+        verticalDrag(down.id) { change ->
+            // Read the delta BEFORE consuming — a consumed change reports a
+            // zero positionChange, which would freeze the scrub in place.
+            val deltaY = change.positionChange().y
+            change.consume()
+            if (maxOffset > 0f) {
+                dragProgress = (dragProgress + deltaY / maxOffset).coerceIn(0f, 1f)
+                onScrub(dragProgress)
+            }
+        }
+    }
+}
+
+/**
+ * Excludes ONLY the thumb's current rect (plus grab slack) from the system
+ * back-gesture band. Android silently caps exclusion at 200dp per edge, so
+ * excluding the whole strip is quietly ignored and the system keeps stealing
+ * edge touches — a thumb-sized rect always fits the budget and follows the
+ * cap wherever it sits.
+ */
+private fun Modifier.thumbGestureExclusion(
+    info: ScrollbarTrackInfo,
+    thumbHeightOffset: Float,
+    grabTolerancePx: Float,
+): Modifier = systemGestureExclusion { coords ->
+    val trackHeight = coords.size.height.toFloat()
+    val thumbHeight = (trackHeight * info.thumbFraction) + thumbHeightOffset
+    val thumbOffsetY = info.progress * (trackHeight - thumbHeight)
+    Rect(
+        left = 0f,
+        top = (thumbOffsetY - grabTolerancePx).coerceAtLeast(0f),
+        right = coords.size.width.toFloat(),
+        bottom = (thumbOffsetY + thumbHeight + grabTolerancePx).coerceAtMost(trackHeight),
+    )
+}
+
 @Composable
 fun BoxScope.VerticalScrollbar(
     state: LazyListState,
-    color: Color = Color.White.copy(alpha = 0.5f),
-    width: Dp = 6.dp,
-    idleDelayMs: Long = 800L,
+    width: Dp = 14.dp,
+    idleDelayMs: Long = 1500L,
     thumbHeightOffset: Float = 0f,
-    hitZoneWidth: Dp = 36.dp,
+    hitZoneWidth: Dp = 44.dp,
 ) {
     val info = remember { ScrollbarTrackInfo() }
-    val density = LocalDensity.current
-    val widthPx = with(density) { width.toPx() }
+    val colors = faderColors()
+    val grabTolerancePx = with(LocalDensity.current) { GRAB_TOLERANCE.toPx() }
     var alpha by remember { mutableStateOf(0f) }
     val animatedAlpha by animateFloatAsState(alpha, tween(200), label = "scrollbarAlpha")
     val scope = rememberCoroutineScope()
@@ -63,81 +221,66 @@ fun BoxScope.VerticalScrollbar(
             val totalItems = layout.totalItemsCount
             if (totalItems == 0 || layout.visibleItemsInfo.isEmpty()) return@drawWithContent
             val firstVisible = layout.visibleItemsInfo.first()
-            val avgItemSize = layout.visibleItemsInfo.sumOf { it.size }.toFloat() / layout.visibleItemsInfo.size
+            val avgItemSize = avgSizeSkippingHeader(layout.visibleItemsInfo.map { it.index to it.size })
             val estimatedTotalHeight = avgItemSize * totalItems
             if (estimatedTotalHeight <= layout.viewportEndOffset) return@drawWithContent
 
             val scrolledPx = firstVisible.index * avgItemSize - firstVisible.offset
             val maxScrollPx = estimatedTotalHeight - layout.viewportEndOffset
-            info.thumbFraction = (layout.viewportEndOffset / estimatedTotalHeight).coerceIn(0.05f, 1f)
+            info.thumbFraction = clampedThumbFraction(layout.viewportEndOffset / estimatedTotalHeight)
             info.progress = (scrolledPx / maxScrollPx).coerceIn(0f, 1f)
-            if (animatedAlpha <= 0.001f) return@drawWithContent
-
-            val trackHeight = size.height
-            val thumbHeight = (trackHeight * info.thumbFraction) + thumbHeightOffset
-            val thumbOffsetY = info.progress * (trackHeight - thumbHeight)
-            drawRoundRect(
-                color = color.copy(alpha = color.alpha * animatedAlpha),
-                topLeft = Offset(size.width - widthPx - 2f, thumbOffsetY),
-                size = Size(widthPx, thumbHeight),
-                cornerRadius = CornerRadius(widthPx / 2f, widthPx / 2f),
-            )
+            drawFaderCap(info, colors, animatedAlpha, width.toPx(), thumbHeightOffset)
         },
     )
 
     // Narrow grab strip — ONLY this slice is touchable, everything left of it
-    // passes straight through to the list/grid underneath untouched.
+    // passes straight through to the list underneath untouched.
+    // systemGestureExclusion: the strip lives on the screen's right edge,
+    // which Android's back-gesture nav owns — without the exclusion the
+    // system intercepts edge drags and the cap is randomly ungrabbable.
     Box(
         modifier = Modifier
             .align(Alignment.CenterEnd)
             .fillMaxHeight()
             .width(hitZoneWidth)
-            .pointerInput(state) {
-                val grabTolerance = 24.dp.toPx()
-                // Manual gesture: claim (and scrub) ONLY when the touch lands on
-                // the VISIBLE thumb. Off-thumb or faded-out touches are left
-                // unconsumed so the list underneath scrolls normally — otherwise
-                // this full-height strip would swallow every right-edge drag and
-                // freeze scrolling along that edge.
-                awaitEachGesture {
-                    val down = awaitFirstDown(requireUnconsumed = false)
-                    val trackHeight = size.height.toFloat()
-                    val thumbHeight = (trackHeight * info.thumbFraction) + thumbHeightOffset
-                    val thumbOffsetY = info.progress * (trackHeight - thumbHeight)
-                    val onThumb = animatedAlpha > 0.01f && down.position.y in
-                        (thumbOffsetY - grabTolerance)..(thumbOffsetY + thumbHeight + grabTolerance)
-                    if (!onThumb) return@awaitEachGesture
-                    down.consume()
-                    alpha = 1f
-                    var dragProgress = info.progress
-                    val maxOffset = trackHeight - thumbHeight
-                    verticalDrag(down.id) { change ->
-                        change.consume()
-                        if (maxOffset > 0f) {
-                            dragProgress = (dragProgress + change.positionChange().y / maxOffset)
-                                .coerceIn(0f, 1f)
-                            val targetIndex =
-                                (dragProgress * (state.layoutInfo.totalItemsCount - 1)).roundToInt()
-                            scope.launch { state.scrollToItem(targetIndex) }
-                        }
+            .thumbGestureExclusion(info, thumbHeightOffset, grabTolerancePx)
+            .faderScrubber(
+                stateKey = state,
+                info = info,
+                animatedAlpha = { animatedAlpha },
+                thumbHeightOffset = thumbHeightOffset,
+                onWake = { alpha = 1f },
+                onScrub = { progress ->
+                    // Pixel-granular target: index + intra-item offset. Snapping
+                    // to whole items reads as comically jumpy on tall rows.
+                    val layout = state.layoutInfo
+                    val total = layout.totalItemsCount
+                    if (total > 0 && layout.visibleItemsInfo.isNotEmpty()) {
+                        val avgItemSize =
+                            avgSizeSkippingHeader(layout.visibleItemsInfo.map { it.index to it.size })
+                        val maxScrollPx =
+                            (avgItemSize * total - layout.viewportEndOffset).coerceAtLeast(0f)
+                        val targetPx = progress * maxScrollPx
+                        val index = (targetPx / avgItemSize).toInt().coerceIn(0, total - 1)
+                        val offsetPx = (targetPx - index * avgItemSize).roundToInt()
+                        scope.launch { state.scrollToItem(index, offsetPx) }
                     }
-                }
-            },
+                },
+            ),
     )
 }
 
 @Composable
 fun BoxScope.VerticalScrollbar(
     state: LazyGridState,
-    color: Color = Color.White.copy(alpha = 0.5f),
-    width: Dp = 6.dp,
-    idleDelayMs: Long = 800L,
+    width: Dp = 14.dp,
+    idleDelayMs: Long = 1500L,
     thumbHeightOffset: Float = 0f,
-    hitZoneWidth: Dp = 36.dp,
+    hitZoneWidth: Dp = 44.dp,
 ) {
     val info = remember { ScrollbarTrackInfo() }
-    val density = LocalDensity.current
-    val widthPx = with(density) { width.toPx() }
+    val colors = faderColors()
+    val grabTolerancePx = with(LocalDensity.current) { GRAB_TOLERANCE.toPx() }
     var alpha by remember { mutableStateOf(0f) }
     val animatedAlpha by animateFloatAsState(alpha, tween(200), label = "scrollbarAlpha")
     val scope = rememberCoroutineScope()
@@ -153,7 +296,8 @@ fun BoxScope.VerticalScrollbar(
             val totalItems = layout.totalItemsCount
             if (totalItems == 0 || layout.visibleItemsInfo.isEmpty()) return@drawWithContent
             val firstVisible = layout.visibleItemsInfo.first()
-            val avgItemHeight = layout.visibleItemsInfo.map { it.size.height }.average().toFloat()
+            val avgItemHeight =
+                avgSizeSkippingHeader(layout.visibleItemsInfo.map { it.index to it.size.height })
             val columns = layout.visibleItemsInfo.map { it.column }.distinct().size.coerceAtLeast(1)
             val totalRows = (totalItems + columns - 1) / columns
             val estimatedTotalHeight = avgItemHeight * totalRows
@@ -161,19 +305,9 @@ fun BoxScope.VerticalScrollbar(
 
             val scrolledPx = firstVisible.row * avgItemHeight - firstVisible.offset.y
             val maxScrollPx = estimatedTotalHeight - layout.viewportEndOffset
-            info.thumbFraction = (layout.viewportEndOffset / estimatedTotalHeight).coerceIn(0.05f, 1f)
+            info.thumbFraction = clampedThumbFraction(layout.viewportEndOffset / estimatedTotalHeight)
             info.progress = (scrolledPx / maxScrollPx).coerceIn(0f, 1f)
-            if (animatedAlpha <= 0.001f) return@drawWithContent
-
-            val trackHeight = size.height
-            val thumbHeight = (trackHeight * info.thumbFraction) + thumbHeightOffset
-            val thumbOffsetY = info.progress * (trackHeight - thumbHeight)
-            drawRoundRect(
-                color = color.copy(alpha = color.alpha * animatedAlpha),
-                topLeft = Offset(size.width - widthPx - 2f, thumbOffsetY),
-                size = Size(widthPx, thumbHeight),
-                cornerRadius = CornerRadius(widthPx / 2f, widthPx / 2f),
-            )
+            drawFaderCap(info, colors, animatedAlpha, width.toPx(), thumbHeightOffset)
         },
     )
 
@@ -182,40 +316,33 @@ fun BoxScope.VerticalScrollbar(
             .align(Alignment.CenterEnd)
             .fillMaxHeight()
             .width(hitZoneWidth)
-            .pointerInput(state) {
-                val grabTolerance = 24.dp.toPx()
-                // Manual gesture: claim (and scrub) ONLY when the touch lands on
-                // the VISIBLE thumb. Off-thumb or faded-out touches are left
-                // unconsumed so the grid underneath scrolls normally — otherwise
-                // this full-height strip would swallow every right-edge drag and
-                // freeze scrolling along that edge.
-                awaitEachGesture {
-                    val down = awaitFirstDown(requireUnconsumed = false)
-                    val trackHeight = size.height.toFloat()
-                    val thumbHeight = (trackHeight * info.thumbFraction) + thumbHeightOffset
-                    val thumbOffsetY = info.progress * (trackHeight - thumbHeight)
-                    val onThumb = animatedAlpha > 0.01f && down.position.y in
-                        (thumbOffsetY - grabTolerance)..(thumbOffsetY + thumbHeight + grabTolerance)
-                    if (!onThumb) return@awaitEachGesture
-                    down.consume()
-                    alpha = 1f
-                    var dragProgress = info.progress
-                    val maxOffset = trackHeight - thumbHeight
-                    verticalDrag(down.id) { change ->
-                        change.consume()
-                        if (maxOffset > 0f) {
-                            dragProgress = (dragProgress + change.positionChange().y / maxOffset)
-                                .coerceIn(0f, 1f)
-                            val columns = state.layoutInfo.visibleItemsInfo
-                                .map { it.column }.distinct().size.coerceAtLeast(1)
-                            val totalItems = state.layoutInfo.totalItemsCount
-                            val totalRows = (totalItems + columns - 1) / columns
-                            val targetRow = (dragProgress * (totalRows - 1)).roundToInt()
-                            val targetIndex = (targetRow * columns).coerceIn(0, totalItems - 1)
-                            scope.launch { state.scrollToItem(targetIndex) }
-                        }
+            .thumbGestureExclusion(info, thumbHeightOffset, grabTolerancePx)
+            .faderScrubber(
+                stateKey = state,
+                info = info,
+                animatedAlpha = { animatedAlpha },
+                thumbHeightOffset = thumbHeightOffset,
+                onWake = { alpha = 1f },
+                onScrub = { progress ->
+                    // Pixel-granular target: row + intra-row offset (see list overload).
+                    val layout = state.layoutInfo
+                    val totalItems = layout.totalItemsCount
+                    if (totalItems > 0 && layout.visibleItemsInfo.isNotEmpty()) {
+                        val columns = layout.visibleItemsInfo
+                            .map { it.column }.distinct().size.coerceAtLeast(1)
+                        val totalRows = (totalItems + columns - 1) / columns
+                        val avgRowHeight = avgSizeSkippingHeader(
+                            layout.visibleItemsInfo.map { it.index to it.size.height },
+                        )
+                        val maxScrollPx =
+                            (avgRowHeight * totalRows - layout.viewportEndOffset).coerceAtLeast(0f)
+                        val targetPx = progress * maxScrollPx
+                        val targetRow = (targetPx / avgRowHeight).toInt().coerceAtLeast(0)
+                        val index = (targetRow * columns).coerceIn(0, totalItems - 1)
+                        val offsetPx = (targetPx - targetRow * avgRowHeight).roundToInt()
+                        scope.launch { state.scrollToItem(index, offsetPx) }
                     }
-                }
-            },
+                },
+            ),
     )
 }

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/qbdlx/HomeDiscoveryRepositoryImpl.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/qbdlx/HomeDiscoveryRepositoryImpl.kt
@@ -49,6 +49,12 @@ class HomeDiscoveryRepositoryImpl @Inject constructor(
                 .map { it.toPlaylistSummary() }
         }
 
+    override suspend fun searchPlaylists(query: String, offset: Int, limit: Int): List<PlaylistSummary> =
+        cached("psearch:$query:$offset:$limit") {
+            withToken { tok -> client.searchPlaylists(query, tok, limit, offset) }
+                .map { it.toPlaylistSummary() }
+        }
+
     private suspend fun albums(type: String, genreId: Int?): List<AlbumSummary> =
         cached("$type:$genreId") {
             withToken { tok -> client.getFeaturedAlbums(type, genreId, tok) }.map { it.toAlbumSummary() }

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/qbdlx/QbdlxApiClient.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/qbdlx/QbdlxApiClient.kt
@@ -62,6 +62,25 @@ class QbdlxApiClient @Inject constructor(
             runCatching { json.decodeFromString<QbdlxArtistSearchResponse>(body).artists.items }.getOrDefault(emptyList())
         }
 
+    /**
+     * Search the Qobuz catalog for playlists (read-only metadata). Same
+     * `catalog/search` endpoint as tracks/artists — the playlists bucket
+     * shares the featured-playlists envelope. Search is catalog-global:
+     * the endpoint has no genre filter.
+     */
+    suspend fun searchPlaylists(query: String, token: String, limit: Int = 30, offset: Int = 0): List<QbdlxPlaylistItem> =
+        withContext(Dispatchers.IO) {
+            val url = "$baseUrl/api.json/0.2/catalog/search".toHttpUrl().newBuilder()
+                .addQueryParameter("query", query)
+                .addQueryParameter("type", "playlists")
+                .addQueryParameter("limit", limit.toString())
+                .addQueryParameter("offset", offset.toString())
+                .addQueryParameter("app_id", appId)
+                .build()
+            val body = get(url.toString(), token)
+            runCatching { json.decodeFromString<QbdlxFeaturedPlaylistsResponse>(body).playlists.items }.getOrDefault(emptyList())
+        }
+
     /** Fetch an artist's albums (read-only discography metadata). */
     suspend fun getArtistAlbums(artistId: Long, token: String, limit: Int = 100): List<QbdlxAlbumItem> =
         withContext(Dispatchers.IO) {

--- a/feature/home/src/main/kotlin/com/stash/feature/home/PlaylistBrowseScreen.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/PlaylistBrowseScreen.kt
@@ -2,6 +2,7 @@ package com.stash.feature.home
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,10 +14,14 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -31,15 +36,18 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stash.core.ui.components.AlbumSquareCard
+import com.stash.core.ui.components.VerticalScrollbar
 import com.stash.data.ytmusic.model.AlbumSource
 import com.stash.data.ytmusic.model.AlbumSummary
 import com.stash.data.ytmusic.model.PlaylistSummary
 
 /**
  * "See all" browse of the Qobuz editorial playlist catalog — a paginated
- * 2-column grid that loads more as the user scrolls. Reached from the Home
- * "Qobuz Playlists" row header; tapping a playlist opens it via the shared
- * album-detail screen (QOBUZ_PLAYLIST source).
+ * 2-column grid that loads more as the user scrolls, with a pinned search
+ * field (catalog-wide search — Qobuz search has no genre filter) and the
+ * fader scrollbar for fast travel. Reached from the Home "Qobuz Playlists"
+ * row header; tapping a playlist opens it via the shared album-detail screen
+ * (QOBUZ_PLAYLIST source).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -78,32 +86,73 @@ fun PlaylistBrowseScreen(
             )
         },
     ) { innerPadding ->
-        LazyVerticalGrid(
-            state = gridState,
-            columns = GridCells.Fixed(2),
-            contentPadding = PaddingValues(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.fillMaxSize().padding(innerPadding),
-        ) {
-            items(state.playlists) { playlist ->
-                Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                    AlbumSquareCard(
-                        title = playlist.title,
-                        artist = "${playlist.trackCount} tracks",   // curator is always "Qobuz" — show count instead
-                        thumbnailUrl = playlist.thumbnailUrl,
-                        year = null,
-                        isLossless = true,
-                        onClick = { onNavigateToAlbum(playlist.toAlbumNav()) },
+        Column(Modifier.fillMaxSize().padding(innerPadding)) {
+            // ── Pinned search (stays fixed above the scrolling grid) ────────
+            OutlinedTextField(
+                value = state.query,
+                onValueChange = viewModel::onQueryChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                placeholder = { Text("Search all Qobuz playlists…") },
+                singleLine = true,
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Filled.Search,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
                     )
-                }
-            }
-            if (state.isLoading) {
-                item(span = { GridItemSpan(maxLineSpan) }) {
-                    Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator()
+                },
+                trailingIcon = if (state.query.isNotEmpty()) {
+                    {
+                        IconButton(onClick = { viewModel.onQueryChange("") }) {
+                            Icon(Icons.Filled.Clear, contentDescription = "Clear search")
+                        }
+                    }
+                } else null,
+            )
+
+            Box(Modifier.fillMaxSize()) {
+                LazyVerticalGrid(
+                    state = gridState,
+                    columns = GridCells.Fixed(2),
+                    contentPadding = PaddingValues(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    items(state.playlists) { playlist ->
+                        Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                            AlbumSquareCard(
+                                title = playlist.title,
+                                artist = "${playlist.trackCount} tracks",   // curator is always "Qobuz" — show count instead
+                                thumbnailUrl = playlist.thumbnailUrl,
+                                year = null,
+                                isLossless = true,
+                                onClick = { onNavigateToAlbum(playlist.toAlbumNav()) },
+                            )
+                        }
+                    }
+                    if (state.playlists.isEmpty() && !state.isLoading && state.query.isNotBlank()) {
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            Box(Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
+                                Text(
+                                    text = "No playlists match \"${state.query.trim()}\"",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                    if (state.isLoading) {
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                                CircularProgressIndicator()
+                            }
+                        }
                     }
                 }
+                VerticalScrollbar(state = gridState)
             }
         }
     }

--- a/feature/home/src/main/kotlin/com/stash/feature/home/PlaylistBrowseViewModel.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/PlaylistBrowseViewModel.kt
@@ -7,9 +7,14 @@ import com.stash.core.data.discovery.GenreCatalog
 import com.stash.core.data.discovery.HomeDiscoveryRepository
 import com.stash.data.ytmusic.model.PlaylistSummary
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -19,7 +24,13 @@ import javax.inject.Inject
  * filtered by the genre chip the user came from. Accumulates pages of
  * [PAGE_SIZE] on demand; a short page marks the end. Fail-soft — an empty page
  * (repository swallows errors) simply stops paging.
+ *
+ * A non-blank [PlaylistBrowseUiState.query] switches the SAME accumulation
+ * into catalog-wide playlist search (debounced 300 ms; Qobuz search has no
+ * genre filter). A generation counter discards pages that were in flight
+ * when the query changed, so stale results never splice into a fresh list.
  */
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class PlaylistBrowseViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -32,29 +43,59 @@ class PlaylistBrowseViewModel @Inject constructor(
     private val _state = MutableStateFlow(PlaylistBrowseUiState())
     val state: StateFlow<PlaylistBrowseUiState> = _state.asStateFlow()
 
+    private val queryFlow = MutableStateFlow("")
     private var inFlight = false
+    private var generation = 0
 
-    init { loadMore() }
+    init {
+        loadMore()
+        viewModelScope.launch {
+            queryFlow
+                .debounce(300)
+                .map { it.trim() }
+                .distinctUntilChanged()
+                .drop(1) // the initial "" — the first browse load is already running
+                .collect {
+                    generation++
+                    inFlight = false
+                    _state.update { it.copy(playlists = emptyList(), endReached = false) }
+                    loadMore()
+                }
+        }
+    }
+
+    /** Immediate echo into the text field; the debounced flow drives loading. */
+    fun onQueryChange(query: String) {
+        _state.update { it.copy(query = query) }
+        queryFlow.value = query
+    }
 
     /** Load the next page. No-op while a load is in flight or the end is reached. */
     fun loadMore() {
         if (inFlight || _state.value.endReached) return
         inFlight = true
+        val gen = generation
+        val query = queryFlow.value.trim()
         _state.update { it.copy(isLoading = true) }
         viewModelScope.launch {
-            val page = repository.browsePlaylists(
-                genreId = genreId,
-                offset = _state.value.playlists.size,
-                limit = PAGE_SIZE,
-            )
-            _state.update {
-                it.copy(
-                    playlists = it.playlists + page,
-                    isLoading = false,
-                    endReached = page.size < PAGE_SIZE,
-                )
+            val offset = _state.value.playlists.size
+            val page = if (query.isBlank()) {
+                repository.browsePlaylists(genreId = genreId, offset = offset, limit = PAGE_SIZE)
+            } else {
+                repository.searchPlaylists(query = query, offset = offset, limit = PAGE_SIZE)
             }
-            inFlight = false
+            if (gen == generation) {
+                _state.update {
+                    it.copy(
+                        playlists = it.playlists + page,
+                        isLoading = false,
+                        endReached = page.size < PAGE_SIZE,
+                    )
+                }
+                inFlight = false
+            }
+            // Stale generation: drop the page silently — the reset already
+            // cleared inFlight and kicked off the fresh load.
         }
     }
 
@@ -64,6 +105,7 @@ class PlaylistBrowseViewModel @Inject constructor(
 }
 
 data class PlaylistBrowseUiState(
+    val query: String = "",
     val playlists: List<PlaylistSummary> = emptyList(),
     val isLoading: Boolean = false,
     val endReached: Boolean = false,


### PR DESCRIPTION
Scrollbar becomes a mixer fader cap (plum & cream like StashSwitch, grip
ridges, hairline outline; 14dp wide, 48dp minimum height, 1.5s linger,
32dp grab halo). Three correctness fixes found on-device:
- systemGestureExclusion limited to the thumb's own rect: Android caps
  exclusion at 200dp/edge, so excluding the whole strip was silently
  ignored and the back-gesture band kept stealing grabs entirely.
- Scrub is pixel-granular (scrollToItem index + intra-item offset) —
  whole-item snapping read as comically jumpy.
- Position estimate skips the oversized header item so the thumb no
  longer lurches when the header enters/leaves the viewport. Draw and
  gesture logic factored into shared helpers while in there.

Qobuz Playlists "See all": fader scrollbar on the grid + a pinned search
field. Search is server-side over the full ~6.3k catalog via the same
catalog/search endpoint the client already uses for tracks/artists
(playlists bucket, featured-playlists envelope), paged with the existing
infinite scroll; a generation counter in PlaylistBrowseViewModel keeps
late pages from a superseded query out of fresh results. Search is
catalog-global — the endpoint has no genre filter.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
