### PR TITLE
fix(mixes): discovery-led mixes lead with discoveries so Refresh is visible (#287)

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -597,7 +597,18 @@ class StashMixRefreshWorker @AssistedInject constructor(
         )
         // The full ordered membership we are about to write: library slice
         // (generator order) followed by discovery survivors.
-        val finalOrderedIds = tracks.map { it.id } + discoveryTrackIds
+        // #287 follow-up: a discovery-led mix leads WITH its discoveries —
+        // fresh finds own the top of the list, the cover mosaic (built from
+        // the first 4 positions), and the first tap of Play. Under the old
+        // library-first order a successful rotation was visually invisible:
+        // same openers, same art, same count — users read Refresh as a no-op.
+        // Library-led mixes keep their library-first order.
+        val discoveryFirst = recipe.discoveryRatio >= 0.5f
+        val finalOrderedIds = if (discoveryFirst) {
+            discoveryTrackIds + tracks.map { it.id }
+        } else {
+            tracks.map { it.id } + discoveryTrackIds
+        }
         val totalCount = finalOrderedIds.size
 
         // v0.9.42: idempotency short-circuit. If the playlist already exists
@@ -639,24 +650,14 @@ class StashMixRefreshWorker @AssistedInject constructor(
             playlistDao.insert(newPlaylist)
         }
 
-        // Rebuild track membership in generator order (library slice first).
+        // Rebuild track membership in the final order computed above.
         val nowInstant = Instant.ofEpochMilli(now)
-        tracks.forEachIndexed { position, track ->
-            playlistDao.insertCrossRef(
-                PlaylistTrackCrossRef(
-                    playlistId = playlistId,
-                    trackId = track.id,
-                    position = position,
-                    addedAt = nowInstant,
-                )
-            )
-        }
-        discoveryTrackIds.forEachIndexed { offset, trackId ->
+        finalOrderedIds.forEachIndexed { position, trackId ->
             playlistDao.insertCrossRef(
                 PlaylistTrackCrossRef(
                     playlistId = playlistId,
                     trackId = trackId,
-                    position = tracks.size + offset,
+                    position = position,
                     addedAt = nowInstant,
                 )
             )


### PR DESCRIPTION
The rotation fix worked — logcat + DB confirmed every Refresh tap rotated
29+ of 39 tracks — but users read it as a no-op anyway: the library slice
owned positions 0..4 AND the cover mosaic is built from the first 4
positions, so the hero art, the subtitle, and the visible top of the
playlist were byte-identical after every rotation. The fresh tracks hid
below familiar openers.

Mixes with discoveryRatio >= 0.5 now write discovery survivors FIRST:
fresh finds own the top of the list, the mosaic, and the first tap of
Play. Library-led mixes keep library-first order. The two-loop cross-ref
insert collapses into one loop over the final ordered ids.

Device-verified: one Refresh tap took Daily Discover's top-6 from five
pinned library tracks to six fresh discoveries and changed the cover
mosaic. All StashMixRefreshWorker suites green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
