### PR TITLE
fix(mixes): unfreeze the discovery pipe, serialize materialization, unplayed-first rotation (#287) + quieter fader cap

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/ListeningEventDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/ListeningEventDao.kt
@@ -234,6 +234,13 @@ interface ListeningEventDao {
     )
     suspend fun getTopArtistsSince(sinceEpochMs: Long, limit: Int = 20): List<ArtistPlayCount>
 
+    /**
+     * Which of [trackIds] the user has ever played. Lets the mix
+     * survivor rotation serve unheard discoveries before repeats.
+     */
+    @Query("SELECT DISTINCT track_id FROM listening_events WHERE track_id IN (:trackIds)")
+    suspend fun getPlayedTrackIdsAmong(trackIds: List<Long>): List<Long>
+
     data class ArtistPlayCount(val artist: String, val plays: Int)
 
     /**

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashDiscoveryWorker.kt
@@ -107,14 +107,16 @@ class StashDiscoveryWorker @AssistedInject constructor(
         private const val WORK_NAME = "stash_discovery"
         private const val ONE_SHOT_WORK_NAME = "stash_discovery_oneshot"
         private const val BATCH_SIZE = 60
-        // Raised from 30 → 100 on 2026-04-22. With Stash Discover at 100%
-        // discovery ratio + targetLength=50, a 30/week drain couldn't
-        // sustain a fresh mix; Last.fm was producing candidates 3× faster
-        // than downloads could complete them. 100/week tracks a steady-
-        // state of "full mix refresh every 10-14 days" — in line with the
-        // 14-day freshness window the recipe filters on.
-        private const val PER_RECIPE_WEEKLY_CAP = 100
-        private const val WEEK_MS = 7L * 24 * 60 * 60 * 1000
+        // #287: was 100/rolling-7-days — a download-era relic (its own
+        // comment sanctioned raising it once storage cost was gone, which
+        // v0.9.37's stream-only stubs delivered). A capped pipe starves
+        // "Daily" Discover: on the reporting device 212 candidates sat
+        // PENDING behind an exhausted weekly window, so every refresh
+        // rotated a frozen backlog. 40/rolling-24h (~280/wk of DB rows,
+        // no files) keeps genuinely-new tracks arriving every day while
+        // still bounding Last.fm/resolver work.
+        private const val PER_RECIPE_DAILY_CAP = 40
+        private val DAY_CAP_WINDOW_MS = TimeUnit.DAYS.toMillis(1)
         /** Age-out cutoff for PENDING discovery rows — 30 days. */
         private const val PENDING_TTL_MS = 30L * 24 * 60 * 60 * 1000
 
@@ -202,8 +204,8 @@ class StashDiscoveryWorker @AssistedInject constructor(
         // cap query was also dead in v0.9.37 — fixed in the DAO by
         // counting both downloaded AND streamable DONE rows.
         val cappedRecipeIds = discoveryQueueDao.findRecipesAtWeeklyCap(
-            sinceMillis = System.currentTimeMillis() - WEEK_MS,
-            cap = PER_RECIPE_WEEKLY_CAP,
+            sinceMillis = System.currentTimeMillis() - DAY_CAP_WINDOW_MS,
+            cap = PER_RECIPE_DAILY_CAP,
         )
         if (cappedRecipeIds.isNotEmpty()) {
             Log.i(TAG, "recipes at cap (excluded from fetch): $cappedRecipeIds")
@@ -235,7 +237,7 @@ class StashDiscoveryWorker @AssistedInject constructor(
             Log.i(TAG, "draining ${pending.size} discovery candidates")
 
             val now = System.currentTimeMillis()
-            val weekAgo = now - WEEK_MS
+            val capWindowStart = now - DAY_CAP_WINDOW_MS
 
             // Per-recipe caps — counted lazily to avoid a DAO hit per candidate.
             val recipeBudget = HashMap<Long, Int>()
@@ -245,15 +247,15 @@ class StashDiscoveryWorker @AssistedInject constructor(
 
             for (entry in pending) {
                 val used = recipeBudget.getOrPut(entry.recipeId) {
-                    discoveryQueueDao.countRecentCompletedForRecipe(entry.recipeId, weekAgo)
+                    discoveryQueueDao.countRecentCompletedForRecipe(entry.recipeId, capWindowStart)
                 }
-                if (used >= PER_RECIPE_WEEKLY_CAP) {
-                    // Leave as PENDING so next week's cycle can pick it up.
+                if (used >= PER_RECIPE_DAILY_CAP) {
+                    // Leave as PENDING so tomorrow's window picks it up.
                     if (cappedRecipesLogged.add(entry.recipeId)) {
                         Log.i(
                             TAG,
                             "recipe ${entry.recipeId} at cap " +
-                                "($used downloaded in last 7d, limit $PER_RECIPE_WEEKLY_CAP) — deferring pending",
+                                "($used completed in last 24h, limit $PER_RECIPE_DAILY_CAP) — deferring pending",
                         )
                     }
                     continue

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -42,6 +42,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -95,6 +96,9 @@ class StashMixRefreshWorker @AssistedInject constructor(
     companion object {
         private const val TAG = "StashMixRefresh"
         private const val WORK_NAME = "stash_mix_refresh"
+
+        /** Serializes [materializeMix] across concurrent worker instances. */
+        private val materializeMutex = kotlinx.coroutines.sync.Mutex()
         const val ONE_SHOT_WORK_NAME = "stash_mix_refresh_oneshot"
         private const val TOP_ARTISTS_LIMIT = 8
         private const val SIMILAR_REQUEST_INTERVAL_MS = 220L
@@ -382,7 +386,15 @@ class StashMixRefreshWorker @AssistedInject constructor(
                 continue
             }
 
-            val result = materializeMix(recipe, tracks, now, excludeSnapshot, rotationSeed)
+            // #287: serialize materialization across worker instances — the
+            // manual single-recipe refresh and the chained batch pass can run
+            // concurrently (separate WorkManager unique chains), and the
+            // clear-then-reinsert membership write is not atomic. Observed on
+            // device: two runs 10s apart interleaved and left Daily Discover
+            // with 25 of 39 rows (and a wrong count) — a torn playlist.
+            val result = materializeMutex.withLock {
+                materializeMix(recipe, tracks, now, excludeSnapshot, rotationSeed)
+            }
             recipeDao.setPlaylistId(recipe.id, result.playlistId)
             recipeDao.setLastRefreshedAt(recipe.id, now)
 
@@ -568,8 +580,19 @@ class StashMixRefreshWorker @AssistedInject constructor(
         // library-only when refreshed after their peers had already grabbed
         // the shared candidates. See conversation 2026-05-12: Deep Cuts had
         // 102 recipe-4 downloaded tracks but 0 discovery survivors.
-        val (preferredIds, sharedIds) = nonLibraryCandidates
+        val (preferredRaw, sharedIds) = nonLibraryCandidates
             .partition { it !in excludeIds }
+        // #287: unheard discoveries outrank repeats — rotation exists to
+        // serve NEW music, so the pool orders unplayed-first (each half
+        // stays newest-first internally; the rotation's guaranteed head is
+        // therefore the newest UNHEARD finds).
+        val playedIds = if (preferredRaw.isEmpty()) {
+            emptySet()
+        } else {
+            listeningEventDao.getPlayedTrackIdsAmong(preferredRaw).toHashSet()
+        }
+        val (unplayedPool, playedPool) = preferredRaw.partition { it !in playedIds }
+        val preferredIds = unplayedPool + playedPool
         val survivorCandidates = if (preferredIds.size >= discoveryCap) {
             rotateSurvivorWindow(preferredIds, discoveryCap, rotationSeed)
         } else {

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/ScrollbarModifier.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/ScrollbarModifier.kt
@@ -26,11 +26,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
+import com.stash.core.ui.theme.StashTheme
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -42,23 +42,21 @@ private class ScrollbarTrackInfo {
     var thumbFraction by mutableStateOf(1f)
 }
 
-/** Fader-cap palette, resolved from the theme like StashSwitch does. */
-private class FaderColors(val fill: Color, val ridge: Color)
+/** Fader-cap palette, resolved from the active theme's own chrome tokens. */
+private class FaderColors(val body: Color, val border: Color, val groove: Color)
 
 /**
- * Plum & cream, matching StashSwitch — the thumb reads as a physical fader
- * cap from the same mixing desk. Cream cap on dark grounds, plum on light.
- * Luminance-driven (not isSystemInDarkTheme) so manual/AMOLED overrides work.
+ * The cap dresses like the rest of the app's chrome — chip surface body,
+ * glass hairline edge, one plum groove — rather than importing its own
+ * palette. surfaceVariant/primary/glassBorderBright all resolve per theme,
+ * so light, dark, and AMOLED each get their native rendering for free.
  */
 @Composable
-private fun faderColors(): FaderColors {
-    val dark = MaterialTheme.colorScheme.background.luminance() < 0.5f
-    return if (dark) {
-        FaderColors(fill = Color(0xFFF2ECE2), ridge = Color(0xFF7E6A90))
-    } else {
-        FaderColors(fill = Color(0xFF6E5A7E), ridge = Color(0xFFF2ECE2))
-    }
-}
+private fun faderColors(): FaderColors = FaderColors(
+    body = MaterialTheme.colorScheme.surfaceVariant,
+    border = StashTheme.extendedColors.glassBorderBright,
+    groove = MaterialTheme.colorScheme.primary,
+)
 
 /** The thumb never shrinks below this — a scrubbable cap, not a sliver. */
 private val MIN_THUMB_HEIGHT = 48.dp
@@ -82,8 +80,9 @@ private fun avgSizeSkippingHeader(items: List<Pair<Int, Int>>): Float {
 }
 
 /**
- * Draws the fader cap: a rounded plum/cream body with a hairline outline and
- * three grip ridges across the middle — analog hardware, not a scroll sliver.
+ * Draws the fader cap: a near-square chip-surface block with a glass
+ * hairline edge and a single plum groove across the middle — the classic
+ * mixer fader cap, in the app's own chrome.
  */
 private fun DrawScope.drawFaderCap(
     info: ScrollbarTrackInfo,
@@ -97,38 +96,34 @@ private fun DrawScope.drawFaderCap(
     val thumbHeight = (trackHeight * info.thumbFraction) + thumbHeightOffset
     val thumbOffsetY = info.progress * (trackHeight - thumbHeight)
     val left = size.width - capWidthPx - 3.dp.toPx()
-    val corner = CornerRadius(capWidthPx / 2f, capWidthPx / 2f)
+    val corner = CornerRadius(3.dp.toPx(), 3.dp.toPx())
 
-    // Cap body.
+    // Cap body — chip surface, faintly translucent so it sits IN the page.
     drawRoundRect(
-        color = colors.fill.copy(alpha = 0.95f * alpha),
+        color = colors.body.copy(alpha = 0.95f * alpha),
         topLeft = Offset(left, thumbOffsetY),
         size = Size(capWidthPx, thumbHeight),
         cornerRadius = corner,
     )
-    // Hairline outline so the cap keeps an edge over any art behind it.
+    // Glass hairline edge (token carries its own low alpha).
     drawRoundRect(
-        color = colors.ridge.copy(alpha = 0.55f * alpha),
+        color = colors.border.copy(alpha = colors.border.alpha * alpha),
         topLeft = Offset(left, thumbOffsetY),
         size = Size(capWidthPx, thumbHeight),
         cornerRadius = corner,
         style = Stroke(width = 1.dp.toPx()),
     )
-    // Grip ridges, centered.
-    val ridgeWidth = capWidthPx * 0.45f
-    val rx = left + (capWidthPx - ridgeWidth) / 2f
+    // Single center groove — the fader-cap signature.
+    val grooveWidth = capWidthPx * 0.6f
+    val gx = left + (capWidthPx - grooveWidth) / 2f
     val cy = thumbOffsetY + thumbHeight / 2f
-    val gap = 5.dp.toPx()
-    for (i in -1..1) {
-        val y = cy + i * gap
-        drawLine(
-            color = colors.ridge.copy(alpha = 0.9f * alpha),
-            start = Offset(rx, y),
-            end = Offset(rx + ridgeWidth, y),
-            strokeWidth = 1.5.dp.toPx(),
-            cap = StrokeCap.Round,
-        )
-    }
+    drawLine(
+        color = colors.groove.copy(alpha = 0.9f * alpha),
+        start = Offset(gx, cy),
+        end = Offset(gx + grooveWidth, cy),
+        strokeWidth = 2.dp.toPx(),
+        cap = StrokeCap.Round,
+    )
 }
 
 /**
@@ -197,7 +192,7 @@ private fun Modifier.thumbGestureExclusion(
 @Composable
 fun BoxScope.VerticalScrollbar(
     state: LazyListState,
-    width: Dp = 14.dp,
+    width: Dp = 12.dp,
     idleDelayMs: Long = 1500L,
     thumbHeightOffset: Float = 0f,
     hitZoneWidth: Dp = 44.dp,
@@ -273,7 +268,7 @@ fun BoxScope.VerticalScrollbar(
 @Composable
 fun BoxScope.VerticalScrollbar(
     state: LazyGridState,
-    width: Dp = 14.dp,
+    width: Dp = 12.dp,
     idleDelayMs: Long = 1500L,
     thumbHeightOffset: Float = 0f,
     hitZoneWidth: Dp = 44.dp,


### PR DESCRIPTION
Round 3 on #287 — the deep diagnosis behind "still not refreshing":

1. Starved pipe: 212 candidates sat PENDING behind the exhausted
   100/rolling-7-days discovery cap (a download-era relic whose own
   comment sanctioned raising it once stream-only landed in v0.9.37).
   Zero new tracks could enter the mix; rotation reshuffled a frozen
   backlog. Now 40/rolling-24h per recipe (~280/wk of DB-row stubs, no
   files) so genuinely-new discoveries arrive every day.

2. Torn writes: the manual single-recipe refresh and the chained batch
   pass run on separate WorkManager unique chains and can interleave
   their non-atomic clear-then-reinsert membership writes. Observed on
   device: two runs 10s apart left Daily Discover with 25 of 39 rows
   and a wrong count. materializeMix is now serialized behind a
   companion Mutex.

3. Repeats before fresh: rotation now orders the survivor pool
   unplayed-first (new ListeningEventDao.getPlayedTrackIdsAmong), so
   the guaranteed window head is the newest UNHEARD finds.

Scrollbar: fader cap restyled into the app's chrome — near-square 3dp
corners, 12dp wide, surfaceVariant body, glass hairline edge, single
plum primary groove; auto-adapts to light/dark/AMOLED via theme tokens.

StashMixRefreshWorker* and StashDiscoveryWorker suites green (2
pre-existing StreamOnlyTest failures unchanged from this morning's
master baseline).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
