### PR TITLE
fix(mixes): drain discovery candidates newest-first (#287 round 4)

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/DiscoveryQueueDao.kt
@@ -73,16 +73,24 @@ interface DiscoveryQueueDao {
     suspend fun getRecipesWithPending(cappedRecipeIds: List<Long>): List<Long>
 
     /**
-     * PENDING rows for a single recipe, oldest first. Used by the
+     * PENDING rows for a single recipe, NEWEST first. Used by the
      * round-robin scheduler to pull a bounded per-recipe quota out of the
      * queue so no one recipe can starve the others — v0.9.38 fairness fix.
+     *
+     * #287: was oldest-first (FIFO). With a deep backlog that meant the
+     * daily completion budget got spent on candidates from weeks-old
+     * seeds while TODAY's recent-listening candidates waited days at the
+     * back of the line — observed on device as Motown-era completions
+     * while fresh Panda Bear/Dan Deacon candidates sat pending. Newest
+     * seeds complete first; the stale tail drains with leftover budget
+     * and ages out via the 30-day PENDING TTL.
      */
     @Query(
         """
         SELECT * FROM discovery_queue
         WHERE status = 'PENDING'
           AND recipe_id = :recipeId
-        ORDER BY queued_at ASC
+        ORDER BY queued_at DESC
         LIMIT :limit
         """
     )


### PR DESCRIPTION
Full-chain audit on the reporting device: Last.fm alive (115 candidates
per refresh), local listening tracked (105 events/48h), seeds correctly
personalized (newest queued candidates = Panda Bear / Dan Deacon / Avey
Tare — direct neighbors of the last-48h listening). But the newest
COMPLETIONS were The Four Tops and The Marvelettes: the pending queue
drained oldest-first, so the daily completion budget was spent on
candidates from weeks-old seeds while today's on-taste candidates waited
~5 days behind a 208-row backlog.

getPendingForRecipe now orders queued_at DESC: fresh seeds' candidates
complete first, the stale tail drains with leftover budget and ages out
via the existing 30-day PENDING TTL.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
