### PR TITLE
fix(mixes): freshness guarantee is membership, not position — unfreeze the visible top (#287 round 5)

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -165,11 +165,20 @@ class StashMixRefreshWorker @AssistedInject constructor(
          */
         internal fun rotateSurvivorWindow(pool: List<Long>, cap: Int, seed: Long): List<Long> {
             if (cap <= 0) return emptyList()
-            if (pool.size <= cap) return pool
+            val rnd = kotlin.random.Random(seed)
+            // Small pools rotate their ORDER too — a static order is the same
+            // invisibility bug at smaller scale.
+            if (pool.size <= cap) return pool.shuffled(rnd)
             val freshHead = (cap * FRESH_HEAD_RATIO).roundToInt().coerceIn(0, cap)
             val head = pool.take(freshHead)
-            val rest = pool.drop(freshHead).shuffled(kotlin.random.Random(seed))
-            return head + rest.take(cap - head.size)
+            val rest = pool.drop(freshHead).shuffled(rnd)
+            // The freshness guarantee is MEMBERSHIP, not position: pinning the
+            // newest finds at the top froze positions 0..N (and the cover
+            // mosaic = first 4 positions) across refreshes — users watched the
+            // one part of the mix that never moved and read Refresh as a
+            // no-op. Shuffle the final window so position 0 and the art
+            // rotate every seed while new finds stay guaranteed present.
+            return (head + rest.take(cap - head.size)).shuffled(rnd)
         }
 
         /**

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerRotationTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorkerRotationTest.kt
@@ -16,9 +16,15 @@ class StashMixRefreshWorkerRotationTest {
     private val pool = (1L..100L).toList() // newest-first by contract
 
     @Test
-    fun `pool at or under cap is returned whole and untouched`() {
-        assertEquals(pool.take(10), rotateSurvivorWindow(pool.take(10), cap = 20, seed = 7L))
-        assertEquals(pool.take(20), rotateSurvivorWindow(pool.take(20), cap = 20, seed = 7L))
+    fun `pool at or under cap keeps full membership but rotates order`() {
+        val window = rotateSurvivorWindow(pool.take(10), cap = 20, seed = 7L)
+        assertEquals(pool.take(10).toSet(), window.toSet())
+        // Order itself must rotate across seeds — a static order is the
+        // invisible-refresh bug at small-pool scale.
+        assertNotEquals(
+            rotateSurvivorWindow(pool.take(10), cap = 20, seed = 1L),
+            rotateSurvivorWindow(pool.take(10), cap = 20, seed = 2L),
+        )
     }
 
     @Test
@@ -27,10 +33,18 @@ class StashMixRefreshWorkerRotationTest {
     }
 
     @Test
-    fun `newest head is always preserved`() {
+    fun `newest head is always IN the window — membership, not position`() {
         val window = rotateSurvivorWindow(pool, cap = 20, seed = 42L)
-        // 30% of 20 = 6 newest ids stay pinned at the front.
-        assertEquals(pool.take(6), window.take(6))
+        // 30% of 20 = 6 newest ids are guaranteed present; their position
+        // rotates (pinning them froze the visible top + cover mosaic).
+        assertTrue(window.containsAll(pool.take(6)))
+    }
+
+    @Test
+    fun `position zero rotates across seeds`() {
+        val firsts = (1L..8L).map { rotateSurvivorWindow(pool, cap = 20, seed = it).first() }.toSet()
+        // Eight seeds should not all land the same opener (art mosaic driver).
+        assertTrue(firsts.size > 1)
     }
 
     @Test


### PR DESCRIPTION
The user's three Refresh taps each rotated 32/39 tracks — and the 7 that
never moved were positions 0..6, the only ones visible on the hero and
the first screen of the playlist. The pinned newest-head kept the same
tracks (and therefore the SAME first-4-positions cover mosaic,
byte-identical art URL across taps) at the top of every rotation.
Verified from the device DB: full-membership overlap 7/39 across taps,
top-10 and mosaic URL frozen.

rotateSurvivorWindow now guarantees the newest unheard finds are IN the
window but shuffles the final order with the seed — position 0, the
visible top, and the cover art rotate on every refresh. Small pools
(<= cap) shuffle their order too instead of returning as-is.

Tests updated: head asserted via containsAll (membership), new
position-zero-rotates-across-seeds case, small-pool order rotation.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
