### PR TITLE
fix(library): search query now narrows the Liked tab (#293)

### DIFF
--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryViewModel.kt
@@ -42,6 +42,12 @@ import javax.inject.Inject
  */
 private val LOSSLESS_CODECS = setOf("flac", "alac", "wav", "ape", "tta", "wv", "aiff")
 
+/** Shared track search predicate — every Library list matches title/artist/album. */
+private fun Track.matchesQuery(query: String): Boolean =
+    title.lowercase().contains(query) ||
+        artist.lowercase().contains(query) ||
+        album.lowercase().contains(query)
+
 /**
  * ViewModel for the Library screen.
  *
@@ -161,9 +167,7 @@ class LibraryViewModel @Inject constructor(
 
         // -- Apply client-side search filter --
         val filteredTracks = if (query.isEmpty()) sourceFiltered else sourceFiltered.filter {
-            it.title.lowercase().contains(query)
-                    || it.artist.lowercase().contains(query)
-                    || it.album.lowercase().contains(query)
+            it.matchesQuery(query)
         }
         val filteredPlaylists = if (query.isEmpty()) allPlaylists else allPlaylists.filter {
             it.name.lowercase().contains(query)
@@ -269,7 +273,12 @@ class LibraryViewModel @Inject constructor(
             }
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
 
-    /** Liked tracks for the current [likedFilter], de-duped across the liked playlists. */
+    /**
+     * Liked tracks for the current [likedFilter], de-duped across the liked
+     * playlists, then narrowed by the header search query — the Liked tab
+     * used to be the one list [ControlState.searchQuery] never reached
+     * (issue #293: searching on Liked kept showing the full list).
+     */
     @OptIn(ExperimentalCoroutinesApi::class)
     val likedTracks: StateFlow<List<Track>> =
         combine(stashLikedFlow, externalLikedFlow, _likedFilter) { stash, external, filter ->
@@ -286,6 +295,11 @@ class LibraryViewModel @Inject constructor(
                 combine(playlists.map { musicRepository.getTracksByPlaylist(it.id) }) { arrays ->
                     arrays.flatMap { it.toList() }.distinctBy { it.id }
                 }
+            }
+        }.let { likedFlow ->
+            combine(likedFlow, _controls) { tracks, controls ->
+                val query = controls.searchQuery.trim().lowercase()
+                if (query.isEmpty()) tracks else tracks.filter { it.matchesQuery(query) }
             }
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelLikedSearchTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelLikedSearchTest.kt
@@ -1,0 +1,104 @@
+package com.stash.feature.library
+
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.auth.TokenManager
+import com.stash.core.auth.model.AuthState
+import com.stash.core.data.repository.MusicRepository
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlayerState
+import com.stash.core.model.Playlist
+import com.stash.core.model.PlaylistType
+import com.stash.core.model.Track
+import com.stash.data.download.files.LocalImportCoordinator
+import com.stash.data.download.files.LocalImportState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+
+/**
+ * Issue #293: the header search query must narrow the Liked tab too — it
+ * was the one Library list the filter never reached.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LibraryViewModelLikedSearchTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    @Before fun setUp() { Dispatchers.setMain(dispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    private val likedPlaylist = Playlist(
+        id = 42L,
+        name = "Liked Songs",
+        source = MusicSource.SPOTIFY,
+        type = PlaylistType.LIKED_SONGS,
+        trackCount = 3,
+    )
+    private val likedSongs = listOf(
+        Track(id = 1L, title = "Terpukau", artist = "Astrid"),
+        Track(id = 2L, title = "Creep", artist = "Radiohead"),
+        Track(id = 3L, title = "Karma Police", artist = "Radiohead"),
+    )
+
+    @Test fun search_query_narrows_the_liked_list() = runTest {
+        val vm = buildVm()
+
+        // Unfiltered first, so we know the flow is live before querying.
+        assertThat(vm.likedTracks.first { it.isNotEmpty() }).hasSize(3)
+
+        vm.setSearchQuery("terpukau")
+        val filtered = vm.likedTracks.first { it.size < 3 }
+        assertThat(filtered.map { it.title }).containsExactly("Terpukau")
+
+        vm.setSearchQuery("radiohead")
+        val byArtist = vm.likedTracks.first { it.size == 2 }
+        assertThat(byArtist.map { it.id }).containsExactly(2L, 3L)
+    }
+
+    @Test fun clearing_the_query_restores_the_full_liked_list() = runTest {
+        val vm = buildVm()
+        vm.setSearchQuery("terpukau")
+        assertThat(vm.likedTracks.first { it.size == 1 }).hasSize(1)
+
+        vm.setSearchQuery("")
+        assertThat(vm.likedTracks.first { it.size == 3 }).hasSize(3)
+    }
+
+    // ── harness (mirrors LibraryViewModelSortTest) ────────────────────────
+    private fun buildVm(): LibraryViewModel {
+        val musicRepository: MusicRepository = mock {
+            on { getAllTracks() } doReturn flowOf(emptyList())
+            on { getAllPlaylists() } doReturn flowOf(emptyList())
+            on { getAllArtists() } doReturn flowOf(emptyList())
+            on { getAllAlbums() } doReturn flowOf(emptyList())
+            on { getUserCreatedPlaylists() } doReturn flowOf(emptyList())
+            on { getRecentlyAdded(any()) } doReturn flowOf(emptyList())
+            on { getPlaylistsByType(eq(PlaylistType.STASH_LIKED)) } doReturn flowOf(emptyList())
+            on { getPlaylistsByType(eq(PlaylistType.LIKED_SONGS)) } doReturn flowOf(listOf(likedPlaylist))
+            on { getTracksByPlaylist(eq(42L)) } doReturn flowOf(likedSongs)
+        }
+        return LibraryViewModel(
+            musicRepository = musicRepository,
+            playerRepository = mock { on { playerState } doReturn MutableStateFlow(PlayerState()) },
+            tokenManager = mock {
+                on { spotifyAuthState } doReturn MutableStateFlow<AuthState>(AuthState.NotConnected)
+                on { youTubeAuthState } doReturn MutableStateFlow<AuthState>(AuthState.NotConnected)
+            },
+            playlistImageHelper = mock(),
+            localImportCoordinator = mock { on { state } doReturn MutableStateFlow<LocalImportState>(LocalImportState.Idle) },
+            streamingPreference = mock(),
+        )
+    }
+}


### PR DESCRIPTION
The header search filtered every Library list in the uiState combine —
tracks, playlists, artists, albums — but likedTracks is a separate
StateFlow handed raw to LikedTab, so searching on Liked kept showing the
full list (reported with the exact steps on a Samsung A16, v0.9.76).

likedTracks now combines with the controls flow and applies the same
title/artist/album predicate, extracted as a shared Track.matchesQuery
so the Songs tab and Liked tab can't drift apart again.

Unit tests cover the reporter's scenario (query narrows, artist match,
clearing restores); device-verified on the Liked tab live-filtering
mid-keystroke.

Closes #293

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
