### PR TITLE
feat(nowplaying): sleep timer + share song (board issues ParaliyzedEvo#26, #40)

### DIFF
--- a/core/media/src/main/kotlin/com/stash/core/media/SleepTimerController.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/SleepTimerController.kt
@@ -1,0 +1,91 @@
+package com.stash.core.media
+
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * App-wide sleep timer (fork issue ParaliyzedEvo/Stash#26): counts down and
+ * pauses playback, or pauses when the current track finishes. Singleton so
+ * the countdown survives leaving Now Playing; it does NOT survive process
+ * death (an armed timer dies with the app, which is fine — if the process is
+ * gone, nothing is playing).
+ *
+ * Pause, not stop: the user wakes up and resumes exactly where sleep took
+ * them.
+ */
+@Singleton
+class SleepTimerController @VisibleForTesting internal constructor(
+    private val playerRepository: PlayerRepository,
+    private val scope: CoroutineScope,
+) {
+
+    @Inject
+    constructor(playerRepository: PlayerRepository) : this(
+        playerRepository = playerRepository,
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    )
+
+    sealed interface State {
+        data object Off : State
+
+        /** Counting down to [endsAtMs] (epoch millis). */
+        data class Countdown(val endsAtMs: Long) : State
+
+        /** Pausing when the currently-playing track changes or ends. */
+        data object EndOfTrack : State
+    }
+
+    private val _state = MutableStateFlow<State>(State.Off)
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    private var job: Job? = null
+
+    /** Arm (or re-arm) a countdown of [minutes]; replaces any running timer. */
+    fun startMinutes(minutes: Int) {
+        require(minutes > 0)
+        job?.cancel()
+        val durationMs = minutes * 60_000L
+        _state.value = State.Countdown(System.currentTimeMillis() + durationMs)
+        job = scope.launch {
+            delay(durationMs)
+            playerRepository.pause()
+            _state.value = State.Off
+        }
+    }
+
+    /** Pause when the current track transitions (ends or is skipped). */
+    fun stopAtEndOfTrack() {
+        job?.cancel()
+        _state.value = State.EndOfTrack
+        job = scope.launch {
+            playerRepository.playerState
+                .map { it.currentTrack?.id }
+                .distinctUntilChanged()
+                .drop(1) // the value at arm time — wait for the NEXT transition
+                .first()
+            playerRepository.pause()
+            _state.value = State.Off
+        }
+    }
+
+    /** Disarm without touching playback. */
+    fun cancel() {
+        job?.cancel()
+        job = null
+        _state.value = State.Off
+    }
+}

--- a/core/media/src/test/kotlin/com/stash/core/media/SleepTimerControllerTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/SleepTimerControllerTest.kt
@@ -1,0 +1,93 @@
+package com.stash.core.media
+
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.model.PlayerState
+import com.stash.core.model.Track
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SleepTimerControllerTest {
+
+    private val playerState = MutableStateFlow(PlayerState(currentTrack = track(1)))
+    private val playerRepository: PlayerRepository = mockk(relaxed = true) {
+        every { this@mockk.playerState } returns this@SleepTimerControllerTest.playerState
+        coEvery { pause() } returns Unit
+    }
+
+    @Test
+    fun `countdown pauses playback when it elapses`() = runTest {
+        val timer = SleepTimerController(playerRepository, backgroundScope)
+
+        timer.startMinutes(15)
+        assertThat(timer.state.value).isInstanceOf(SleepTimerController.State.Countdown::class.java)
+
+        advanceTimeBy(14 * 60_000L)
+        runCurrent()
+        coVerify(exactly = 0) { playerRepository.pause() }
+
+        advanceTimeBy(60_001L)
+        runCurrent()
+        coVerify(exactly = 1) { playerRepository.pause() }
+        assertThat(timer.state.value).isEqualTo(SleepTimerController.State.Off)
+    }
+
+    @Test
+    fun `re-arming replaces the running countdown`() = runTest {
+        val timer = SleepTimerController(playerRepository, backgroundScope)
+
+        timer.startMinutes(15)
+        advanceTimeBy(10 * 60_000L)
+        timer.startMinutes(30) // re-arm: the old 15m deadline must not fire
+
+        advanceTimeBy(20 * 60_000L)
+        runCurrent()
+        coVerify(exactly = 0) { playerRepository.pause() }
+
+        advanceTimeBy(10 * 60_001L)
+        runCurrent()
+        coVerify(exactly = 1) { playerRepository.pause() }
+    }
+
+    @Test
+    fun `cancel disarms without pausing`() = runTest {
+        val timer = SleepTimerController(playerRepository, backgroundScope)
+
+        timer.startMinutes(15)
+        timer.cancel()
+        assertThat(timer.state.value).isEqualTo(SleepTimerController.State.Off)
+
+        advanceTimeBy(60 * 60_000L)
+        runCurrent()
+        coVerify(exactly = 0) { playerRepository.pause() }
+    }
+
+    @Test
+    fun `end of track pauses on the next track transition only`() = runTest {
+        val timer = SleepTimerController(playerRepository, backgroundScope)
+
+        timer.stopAtEndOfTrack()
+        runCurrent()
+        coVerify(exactly = 0) { playerRepository.pause() }
+
+        // Same track re-emission (pause/resume churn) must not trigger it.
+        playerState.value = PlayerState(currentTrack = track(1), isPlaying = false)
+        runCurrent()
+        coVerify(exactly = 0) { playerRepository.pause() }
+
+        playerState.value = PlayerState(currentTrack = track(2))
+        runCurrent()
+        coVerify(exactly = 1) { playerRepository.pause() }
+        assertThat(timer.state.value).isEqualTo(SleepTimerController.State.Off)
+    }
+
+    private fun track(id: Long) = Track(id = id, title = "T$id", artist = "A")
+}

--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/ShareTrackSheet.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/ShareTrackSheet.kt
@@ -1,0 +1,151 @@
+package com.stash.core.ui.components
+
+import android.content.Intent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.stash.core.ui.theme.StashTheme
+
+/**
+ * Fork issue ParaliyzedEvo/Stash#40: share the song as a link your friends
+ * can actually open — Spotify or YouTube Music when the track carries those
+ * identities, plain "Artist — Title" text always. Fires the system share
+ * chooser; no in-app social plumbing.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ShareTrackSheet(
+    title: String,
+    artist: String,
+    spotifyUri: String?,
+    youtubeId: String?,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val sheetState = rememberModalBottomSheetState()
+    val spotifyUrl = spotifyShareUrl(spotifyUri)
+    val youtubeUrl = youtubeShareUrl(youtubeId)
+
+    fun send(text: String) {
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, text)
+        }
+        context.startActivity(Intent.createChooser(intent, "Share \"$title\""))
+        onDismiss()
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 8.dp),
+        ) {
+            Text(
+                text = "Share \"$title\"",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = artist,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+
+        if (spotifyUrl != null) {
+            ShareRow(
+                label = "Spotify link",
+                tint = StashTheme.extendedColors.spotifyGreen,
+                onClick = { send("$artist — $title\n$spotifyUrl") },
+            )
+        }
+        if (youtubeUrl != null) {
+            ShareRow(
+                label = "YouTube Music link",
+                tint = StashTheme.extendedColors.youtubeRed,
+                onClick = { send("$artist — $title\n$youtubeUrl") },
+            )
+        }
+        ShareRow(
+            label = "Song info only",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            onClick = { send("$artist — $title") },
+        )
+        Spacer(Modifier.height(12.dp))
+    }
+}
+
+@Composable
+private fun ShareRow(label: String, tint: androidx.compose.ui.graphics.Color, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = if (label.startsWith("Song")) Icons.Default.Share else Icons.Default.MusicNote,
+            contentDescription = null,
+            tint = tint,
+            modifier = Modifier.size(22.dp),
+        )
+        Spacer(Modifier.width(16.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+/**
+ * `spotify:track:ID` (or a full open.spotify.com URL, passed through) →
+ * a shareable https link. Null when the track has no Spotify identity.
+ */
+fun spotifyShareUrl(spotifyUri: String?): String? = when {
+    spotifyUri.isNullOrBlank() -> null
+    spotifyUri.startsWith("https://open.spotify.com/") -> spotifyUri
+    spotifyUri.startsWith("spotify:track:") ->
+        "https://open.spotify.com/track/${spotifyUri.removePrefix("spotify:track:")}"
+    else -> null
+}
+
+/** YouTube video id → a YouTube Music watch link. Null when absent. */
+fun youtubeShareUrl(youtubeId: String?): String? =
+    youtubeId?.takeIf { it.isNotBlank() }?.let { "https://music.youtube.com/watch?v=$it" }

--- a/core/ui/src/test/kotlin/com/stash/core/ui/components/ShareLinksTest.kt
+++ b/core/ui/src/test/kotlin/com/stash/core/ui/components/ShareLinksTest.kt
@@ -1,0 +1,34 @@
+package com.stash.core.ui.components
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ShareLinksTest {
+
+    @Test
+    fun `spotify uri converts to open-spotify link`() {
+        assertThat(spotifyShareUrl("spotify:track:4uLU6hMCjMI75M1A2tKUQC"))
+            .isEqualTo("https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC")
+    }
+
+    @Test
+    fun `full spotify url passes through`() {
+        val url = "https://open.spotify.com/track/abc123"
+        assertThat(spotifyShareUrl(url)).isEqualTo(url)
+    }
+
+    @Test
+    fun `unknown or blank spotify identity yields null`() {
+        assertThat(spotifyShareUrl(null)).isNull()
+        assertThat(spotifyShareUrl("")).isNull()
+        assertThat(spotifyShareUrl("spotify:album:xyz")).isNull()
+    }
+
+    @Test
+    fun `youtube id builds a music watch link`() {
+        assertThat(youtubeShareUrl("dQw4w9WgXcQ"))
+            .isEqualTo("https://music.youtube.com/watch?v=dQw4w9WgXcQ")
+        assertThat(youtubeShareUrl(null)).isNull()
+        assertThat(youtubeShareUrl(" ")).isNull()
+    }
+}

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
@@ -19,7 +19,9 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.Radio
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.BookmarkBorder
@@ -77,6 +79,7 @@ import com.stash.feature.nowplaying.ui.AmbientBackground
 import com.stash.feature.nowplaying.ui.GlowingProgressBar
 import com.stash.feature.nowplaying.ui.LiveLyricsBar
 import com.stash.feature.nowplaying.ui.LyricsBottomSheet
+import com.stash.feature.nowplaying.ui.SleepTimerSheet
 import com.stash.feature.nowplaying.ui.QueueBottomSheet
 
 /** Light-ground ink for the pastel-wash Now Playing (the app's plum-black). */
@@ -130,6 +133,9 @@ fun NowPlayingScreen(
     val radioLabel by viewModel.radioSeedLabel.collectAsStateWithLifecycle()
     var showQueue by remember { mutableStateOf(false) }
     var showSaveSheet by remember { mutableStateOf(false) }
+    var showShareSheet by remember { mutableStateOf(false) }
+    var showSleepSheet by remember { mutableStateOf(false) }
+    val sleepTimerState by viewModel.sleepTimerState.collectAsStateWithLifecycle()
     // "This song is wrong" dialog — shown when the flag icon is tapped.
     // Decouples the Flag button (which is just "there's a problem") from
     // the action (find a replacement / delete / delete + block).
@@ -162,6 +168,26 @@ fun NowPlayingScreen(
 
     // Queue bottom sheet
     if (showQueue) {
+        // Share + sleep-timer sheets (fork issues ParaliyzedEvo/Stash#40, #26).
+        val shareTrack = uiState.currentTrack
+        if (showShareSheet && shareTrack != null) {
+            com.stash.core.ui.components.ShareTrackSheet(
+                title = shareTrack.title,
+                artist = shareTrack.artist,
+                spotifyUri = shareTrack.spotifyUri,
+                youtubeId = shareTrack.youtubeId,
+                onDismiss = { showShareSheet = false },
+            )
+        }
+        if (showSleepSheet) {
+            SleepTimerSheet(
+                state = sleepTimerState,
+                onMinutes = { viewModel.onSleepTimerMinutes(it); showSleepSheet = false },
+                onEndOfTrack = { viewModel.onSleepTimerEndOfTrack(); showSleepSheet = false },
+                onCancelTimer = { viewModel.onSleepTimerCancel(); showSleepSheet = false },
+                onDismiss = { showSleepSheet = false },
+            )
+        }
         QueueBottomSheet(
             queue = uiState.queue,
             currentIndex = uiState.currentIndex,
@@ -322,6 +348,9 @@ fun NowPlayingScreen(
                     onFlagWrongMatch = { showWrongMatchDialog = true },
                     onSaveClick = { showSaveSheet = true },
                     onQueueClick = { showQueue = true },
+                    onShareClick = { showShareSheet = true },
+                    sleepTimerActive = sleepTimerState !is com.stash.core.media.SleepTimerController.State.Off,
+                    onSleepTimerClick = { showSleepSheet = true },
                     hasTrack = uiState.hasTrack,
                     queueSize = uiState.queueSize,
                     onDownloadTap = viewModel::toggleDownloadForCurrentTrack,
@@ -541,6 +570,9 @@ private fun TopBar(
     onFlagWrongMatch: () -> Unit,
     onSaveClick: () -> Unit,
     onQueueClick: () -> Unit,
+    onShareClick: () -> Unit,
+    sleepTimerActive: Boolean,
+    onSleepTimerClick: () -> Unit,
     hasTrack: Boolean,
     queueSize: Int,
     onDownloadTap: () -> Unit,
@@ -579,6 +611,28 @@ private fun TopBar(
                     modifier = Modifier.size(24.dp),
                 )
             }
+        }
+
+        // Share the current song as a link (fork issue ParaliyzedEvo/Stash#40).
+        if (hasTrack) {
+            IconButton(onClick = onShareClick) {
+                Icon(
+                    imageVector = Icons.Default.Share,
+                    contentDescription = "Share song",
+                    tint = npInk(),
+                    modifier = Modifier.size(24.dp),
+                )
+            }
+        }
+
+        // Sleep timer (fork issue ParaliyzedEvo/Stash#26) — accent tint while armed.
+        IconButton(onClick = onSleepTimerClick) {
+            Icon(
+                imageVector = Icons.Default.Bedtime,
+                contentDescription = "Sleep timer",
+                tint = if (sleepTimerActive) accentColor else npInk(),
+                modifier = Modifier.size(24.dp),
+            )
         }
 
         // Flag as wrong match — only shown when a track is loaded. Lives

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
@@ -79,7 +79,14 @@ class NowPlayingViewModel @Inject constructor(
     // Tap-to-artist: resolves the playing track's artist NAME to a YT
     // browseId so Now Playing can open the artist profile.
     private val ytMusicApiClient: com.stash.data.ytmusic.YTMusicApiClient,
+    private val sleepTimerController: com.stash.core.media.SleepTimerController,
 ) : ViewModel() {
+
+    // ── Sleep timer (fork issue ParaliyzedEvo/Stash#26) ─────────────────
+    val sleepTimerState = sleepTimerController.state
+    fun onSleepTimerMinutes(minutes: Int) = sleepTimerController.startMinutes(minutes)
+    fun onSleepTimerEndOfTrack() = sleepTimerController.stopAtEndOfTrack()
+    fun onSleepTimerCancel() = sleepTimerController.cancel()
 
     private val _uiState = MutableStateFlow(NowPlayingUiState())
     val uiState: StateFlow<NowPlayingUiState> = _uiState.asStateFlow()

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/SleepTimerSheet.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/SleepTimerSheet.kt
@@ -1,0 +1,137 @@
+package com.stash.feature.nowplaying.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.stash.core.media.SleepTimerController
+
+/**
+ * Sleep-timer picker (fork issue ParaliyzedEvo/Stash#26): duration presets,
+ * end-of-track, and a cancel row while armed. Playback pauses when the
+ * timer fires — nothing is stopped or cleared.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SleepTimerSheet(
+    state: SleepTimerController.State,
+    onMinutes: (Int) -> Unit,
+    onEndOfTrack: () -> Unit,
+    onCancelTimer: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 8.dp),
+        ) {
+            Text(
+                text = "Sleep timer",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold,
+            )
+            // Armed status, computed once at sheet-open — precise enough for
+            // a picker; no per-second ticking.
+            val statusLine = remember(state) {
+                when (state) {
+                    is SleepTimerController.State.Countdown -> {
+                        val minutesLeft =
+                            ((state.endsAtMs - System.currentTimeMillis()) / 60_000L)
+                                .coerceAtLeast(0) + 1
+                        "Music pauses in about $minutesLeft min"
+                    }
+                    SleepTimerController.State.EndOfTrack -> "Music pauses when this track ends"
+                    SleepTimerController.State.Off -> null
+                }
+            }
+            if (statusLine != null) {
+                Text(
+                    text = statusLine,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+
+        listOf(15, 30, 45, 60).forEach { minutes ->
+            TimerRow(
+                icon = Icons.Default.Bedtime,
+                label = "$minutes minutes",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                onClick = { onMinutes(minutes) },
+            )
+        }
+        TimerRow(
+            icon = Icons.Default.SkipNext,
+            label = "End of track",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            onClick = onEndOfTrack,
+        )
+        if (state != SleepTimerController.State.Off) {
+            TimerRow(
+                icon = Icons.Default.Close,
+                label = "Cancel timer",
+                tint = MaterialTheme.colorScheme.error,
+                onClick = onCancelTimer,
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+    }
+}
+
+@Composable
+private fun TimerRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    tint: Color,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(imageVector = icon, contentDescription = null, tint = tint, modifier = Modifier.size(22.dp))
+        Spacer(Modifier.width(16.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}


### PR DESCRIPTION
Sleep timer: SleepTimerController singleton in core:media — 15/30/45/60
minute countdowns or end-of-track, pauses (never stops) playback, armed
state survives leaving Now Playing, dies with the process (nothing is
playing then anyway). Bedtime icon in the NP top bar, accent-tinted while
armed; picker sheet shows the armed status and a cancel row. Unit tests
cover countdown fire, re-arm replacing the deadline, cancel, and the
end-of-track transition (ignoring same-track pause/resume re-emissions).

Share: Share icon on NP opens a sheet offering Spotify and/or YouTube
Music links (whichever identities the track carries) plus a plain
"Artist - Title" text row; fires the system share chooser. Link builders
are pure and tested (spotify:track: conversion, full-URL passthrough,
YouTube watch link). A "Stash app link" per the original request needs
link infra (web landing or app-link domain) - deferred with a note on
the issue.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
