### PR TITLE
fix(streaming): skip unconfigured lossless sources and remove parked proxy calls

### DIFF
--- a/core/media/src/main/kotlin/com/stash/core/media/streaming/StreamSourceRegistry.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/streaming/StreamSourceRegistry.kt
@@ -3,6 +3,7 @@ package com.stash.core.media.streaming
 import android.util.Log
 import com.stash.core.data.db.entity.TrackEntity
 import com.stash.core.data.prefs.StreamingPreference
+import com.stash.data.download.BuildConfig  
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -117,33 +118,38 @@ class StreamSourceRegistry @Inject constructor(
                 // both-sources-down outage).
                 if (allowYouTube) add("youtube" to { t: TrackEntity -> youtube.resolve(t, allowYtDlp) })
             } else {
-                // PARKED 2026-07-01: kennyy/squid/arcod hosts are down for us,
-                // so they're commented out of the normal chain (re-enabling is
-                // uncommenting). Kept in sync with
-                // LosslessSourceRegistry.PARKED_SOURCE_IDS (download side).
+                // PARKED 2026-07-01: kennyy/squid hosts are down for us. Kept in
+                // sync with LosslessSourceRegistry.PARKED_SOURCE_IDS (download
+                // side) — re-enabling is uncommenting these two lines.
                 // add("kennyy" to kennyy::resolve)
                 // add("squid" to qobuz::resolve)
-                // if (allowYtDlp) add("arcod" to arcod::resolve)
 
-                // qbdlx (direct Qobuz API, per-account token pool) is now the
+                // qbdlx (direct Qobuz API, per-account token pool) is the
                 // primary lossless source: plain Range-seekable FLAC, no proxy,
-                // no client-side decrypt — the fastest path, so it's tried FIRST
-                // (ahead of amz). Like the parked per-account/slow sources it runs
-                // ONLY on foreground/next-up resolves (allowYtDlp = true), NEVER
-                // on the speculative queue-wide background fill — otherwise one
-                // playlist tap spends a search + the pool account's quota on every
-                // queue track speculatively, not just the ones actually played.
-                if (allowYtDlp) add("qbdlx" to qbdlx::resolve)
+                // no client-side decrypt — the fastest path. Foreground/next-up
+                // only (allowYtDlp = true), never the speculative background
+                // fill, and only when the build actually bundles qbdlx creds —
+                // an unconfigured build can never get a match here, so skipping
+                // the attempt avoids a wasted round-trip.
+                if (allowYtDlp && BuildConfig.QBDLX_CONFIGURED) {
+                    add("qbdlx" to qbdlx::resolve)
+                }
                 // amz (Amazon Music) is the SLOWEST lossless source: its stream
                 // resolver decrypts the whole FLAC to a local cache file before
                 // returning a URL (tens of seconds), serialized behind a single
-                // captcha / per-asin lock. So it sits LAST among lossless and,
-                // like qbdlx, runs ONLY on foreground/next-up resolves
-                // (allowYtDlp = true), NEVER on the speculative background fill —
-                // routing background tracks through the slow decrypt starves the
-                // fast YouTube fallback and leaves the timeline too sparse to skip
-                // (observed on-device 2026-06-21: 52s to resolve one next-up).
-                if (allowYtDlp) add("amz" to amz::resolve)
+                // captcha / per-asin lock. Foreground/next-up only, and skipped
+                // on cellular fast-start so it doesn't starve the YouTube
+                // fallback (observed on-device 2026-06-21: 52s to resolve one
+                // next-up).
+                if (allowYtDlp) {
+                    add("amz" to amz::resolve)
+                }
+                // ARCOD is an authenticated, per-user-account fallback. Foreground/
+                // next-up only, and only when the build bundles the private
+                // stream base — an unconfigured build can never get a match.
+                if (allowYtDlp && BuildConfig.ARCOD_CONFIGURED) {
+                    add("arcod" to arcod::resolve)
+                }
                 if (allowYouTube) add("youtube" to { t: TrackEntity -> youtube.resolve(t, allowYtDlp) })
             }
         }

--- a/data/download/build.gradle.kts
+++ b/data/download/build.gradle.kts
@@ -73,6 +73,9 @@ fun poolFp(plain: String): String =
 val qbdlxTokenPoolEnc = encryptPool(qbdlxTokenPool)
 val qbdlxPoolFp = poolFp(qbdlxTokenPool)
 
+val qbdlxConfigured = qbdlxAppId.isNotBlank() && qbdlxAppSecret.isNotBlank() && qbdlxTokenPool.isNotBlank()
+val arcodConfigured = arcodStreamBase.isNotBlank()
+
 android {
     namespace = "com.stash.data.download"
 
@@ -85,6 +88,8 @@ android {
         buildConfigField("String", "QBDLX_APP_SECRET", "\"$qbdlxAppSecret\"")
         buildConfigField("String", "QBDLX_TOKEN_POOL", "\"$qbdlxTokenPoolEnc\"")
         buildConfigField("String", "QBDLX_POOL_FP", "\"$qbdlxPoolFp\"")
+        buildConfigField("Boolean", "QBDLX_CONFIGURED", "$qbdlxConfigured")
+        buildConfigField("Boolean", "ARCOD_CONFIGURED", "$arcodConfigured")
     }
 
     buildFeatures {

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessSourceRegistry.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessSourceRegistry.kt
@@ -48,10 +48,17 @@ class LosslessSourceRegistry @Inject constructor(
         } else if (streamingPreference.isForceAmzOnly()) {
             orderedSources().filter { it.id == "amz" }
         } else {
-            // Normal chain skips the parked (host-down) sources. Only the
-            // normal path filters — force-X toggles above still reach a parked
+            // Normal chain skips (a) parked (host-down) sources and (b) any
+            // source whose build-time credentials aren't fully configured —
+            // an unconfigured qbdlx or ARCOD can't produce a result, so
+            // skipping it here avoids a wasted HTTP round-trip / rate-limit
+            // spend per resolve() call. Force-X toggles above bypass both
+            // filters so a manual test can still reach a parked/unconfigured
             // source on demand, and orderedSources()/Settings still list them.
-            orderedSources().filterNot { it.id in PARKED_SOURCE_IDS }
+            orderedSources()
+                .filterNot { it.id in PARKED_SOURCE_IDS }
+                .filterNot { it.id == "qbdlx_qobuz" && !com.stash.data.download.BuildConfig.QBDLX_CONFIGURED }
+                .filterNot { it.id == "arcod" && !com.stash.data.download.BuildConfig.ARCOD_CONFIGURED }
         }
         val minQuality = prefs.minQualityNow()
 


### PR DESCRIPTION
## Summary
- **Streaming source reliability** — stream resolution now skips lossless
  sources whose build-time credentials aren't configured instead of wasting
  a network round-trip on them, and no longer double-hits parked (host-down)
  proxies during normal playback.

## Changes
### Streaming source reliability
- `data/download/build.gradle.kts` — expose per-source `QBDLX_CONFIGURED`
  and `ARCOD_CONFIGURED` BuildConfig flags so an unconfigured source is
  skipped independently rather than gating the whole lossless chain
- `data/download/.../lossless/LosslessSourceRegistry.kt` — skip
  unconfigured sources up front on the download-resolve path
- `core/media/.../streaming/StreamSourceRegistry.kt` — same gating for
  streaming resolves; also removed a leftover pair of live (uncommented)
  kennyy/squid calls that were still hitting those parked, host-down
  proxies on every stream resolve despite being documented as disabled,
  and removed duplicate qbdlx/amz entries in the resolver chain

## How was this tested?

<!-- "It compiles" is not testing. Tell us what you actually verified, and on what. -->

- [x] `./gradlew test` passes
- [x] Installed on a device and manually verified the change
- [x] Device / Android version tested: S26u/Android 16
