### PR TITLE
feat(home): ticker resumes mid-tape, plum diamonds, station announcements

### DIFF
--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
@@ -83,6 +83,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.withFrameMillis
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -845,66 +853,90 @@ private fun SupporterTicker(
 
     val ink = MaterialTheme.colorScheme.onSurface
     val dim = MaterialTheme.colorScheme.onSurfaceVariant
-    val gold = Color(0xFFFFC947)
-    // One long styled line; basicMarquee scrolls it forever. Rebuilt only
-    // when the supporter list (or theme inks) change.
-    val line = remember(supporters, ink, dim) {
+    val plum = MaterialTheme.colorScheme.primary
+
+    // Supporters woven with station announcements (mission line, dev and
+    // contributor calls) so the wire carries variety, not just gratitude.
+    // Separator: a small plum diamond — accent-colored, not gold, so the
+    // strip sits inside the app's palette instead of fighting it.
+    val line = remember(supporters, ink, dim, plum) {
+        val segments = buildTickerSegments(
+            supporters.map { TickerSegment.Shoutout(it.name, it.amount, it.message) },
+        )
         buildAnnotatedString {
-            supporters.forEach { s ->
-                withStyle(SpanStyle(color = ink, fontWeight = FontWeight.SemiBold)) {
-                    append("${s.name} · ${s.amount}")
-                }
-                if (s.message.isNotBlank()) {
-                    withStyle(SpanStyle(color = dim, fontStyle = FontStyle.Italic)) {
-                        append("  “${s.message}”")
+            segments.forEach { seg ->
+                when (seg) {
+                    is TickerSegment.Shoutout -> {
+                        withStyle(SpanStyle(color = ink, fontWeight = FontWeight.SemiBold)) {
+                            append("${seg.name} · ${seg.amount}")
+                        }
+                        if (seg.message.isNotBlank()) {
+                            withStyle(SpanStyle(color = dim, fontStyle = FontStyle.Italic)) {
+                                append("  “${seg.message}”")
+                            }
+                        }
+                    }
+                    is TickerSegment.Announcement -> {
+                        withStyle(SpanStyle(color = plum, fontWeight = FontWeight.SemiBold)) {
+                            append(seg.text)
+                        }
                     }
                 }
-                withStyle(SpanStyle(color = gold)) { append("   ✦   ") }
+                withStyle(SpanStyle(color = plum.copy(alpha = 0.55f))) { append("   ◆   ") }
             }
-            // The station voice — once per full cycle, after the last
-            // supporter (plain ink: not a name, not a quote).
-            withStyle(SpanStyle(color = ink)) {
-                append(
-                    "Stash is a community powered open-source project " +
-                        "dedicated to the love and growth of music. " +
-                        "Thank you to our supporters.",
-                )
-            }
-            withStyle(SpanStyle(color = gold)) { append("   ✦   ") }
         }
     }
 
-    // Full-bleed strip: no card, no border, no rounding — just a whisper of
-    // glass tint separating the wire from the ground.
+    // Wall-clock marquee: offset is a pure function of elapsed-since-epoch
+    // (see marqueeOffsetPx), so the tape RESUMES mid-flow after the item
+    // leaves and re-enters composition. basicMarquee restarted from zero on
+    // every return to the top of Home — which is why announcements deep in
+    // the tape were never seen. rememberSaveable pins the epoch across
+    // lazy-item disposal.
+    val epochMs = rememberSaveable { System.currentTimeMillis() }
+    var nowMs by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            withFrameMillis { nowMs = System.currentTimeMillis() }
+        }
+    }
+    val velocityPxPerSec = with(LocalDensity.current) { 28.dp.toPx() }
+    var tapeWidthPx by remember { mutableIntStateOf(0) }
+
+    // Full-bleed strip: no card, no border, no leading icon — every pixel
+    // of width belongs to the tape.
     Surface(
         modifier = modifier.clickable { uriHandler.openUri("https://ko-fi.com/rawnald") },
         color = extendedColors.glassBackground,
     ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 10.dp)
+                .clipToBounds(),
         ) {
-            androidx.compose.material3.Icon(
-                imageVector = androidx.compose.material.icons.Icons.Default.FavoriteBorder,
-                contentDescription = "Supporters on Ko-fi",
-                tint = gold,
-                modifier = Modifier.size(16.dp),
-            )
-            Text(
-                text = line,
-                style = MaterialTheme.typography.labelMedium,
-                maxLines = 1,
-                softWrap = false,
+            Row(
                 modifier = Modifier
-                    .weight(1f)
-                    .basicMarquee(
-                        iterations = Int.MAX_VALUE,
-                        repeatDelayMillis = 0,
-                        initialDelayMillis = 800,
-                        velocity = 28.dp,
-                    ),
-            )
+                    .wrapContentWidth(align = Alignment.Start, unbounded = true)
+                    .graphicsLayer {
+                        translationX = -marqueeOffsetPx(nowMs - epochMs, velocityPxPerSec, tapeWidthPx)
+                    },
+            ) {
+                Text(
+                    text = line,
+                    style = MaterialTheme.typography.labelMedium,
+                    maxLines = 1,
+                    softWrap = false,
+                    modifier = Modifier.onSizeChanged { tapeWidthPx = it.width },
+                )
+                // Second copy of the tape for a seamless wrap.
+                Text(
+                    text = line,
+                    style = MaterialTheme.typography.labelMedium,
+                    maxLines = 1,
+                    softWrap = false,
+                )
+            }
         }
     }
 }

--- a/feature/home/src/main/kotlin/com/stash/feature/home/TickerTape.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/TickerTape.kt
@@ -1,0 +1,64 @@
+package com.stash.feature.home
+
+/**
+ * Content model for the Home supporter ticker: supporter shout-outs woven
+ * with station announcements (mission line, dev/contributor calls). Pure
+ * and separately testable; the composable only styles what this builds.
+ */
+internal sealed interface TickerSegment {
+    data class Shoutout(val name: String, val amount: String, val message: String) : TickerSegment
+    data class Announcement(val text: String) : TickerSegment
+}
+
+/**
+ * The station voice. Order matters — it is the rotation order on the tape.
+ * Edit freely; [buildTickerSegments] guarantees each appears at least once
+ * per cycle regardless of supporter count.
+ */
+internal val TICKER_ANNOUNCEMENTS = listOf(
+    "Stash is a community powered open-source project dedicated to the " +
+        "love and growth of music. Thank you to our supporters.",
+    "Developers wanted — join the Discord (icon up top) and help build Stash.",
+    "Open source, open to PRs — contributors welcome on GitHub.",
+)
+
+/** A shout-out cadence of N supporters between announcements. */
+internal const val ANNOUNCEMENT_EVERY = 3
+
+/**
+ * Weaves [announcements] between [shoutouts]: one announcement after every
+ * [every] supporters (cycling through the list), and any announcements not
+ * yet used are appended at the end so every cycle of the tape carries the
+ * complete station voice even with only a handful of supporters.
+ */
+internal fun buildTickerSegments(
+    shoutouts: List<TickerSegment.Shoutout>,
+    announcements: List<String> = TICKER_ANNOUNCEMENTS,
+    every: Int = ANNOUNCEMENT_EVERY,
+): List<TickerSegment> {
+    val out = mutableListOf<TickerSegment>()
+    var next = 0
+    shoutouts.forEachIndexed { index, shoutout ->
+        out += shoutout
+        if ((index + 1) % every == 0 && announcements.isNotEmpty()) {
+            out += TickerSegment.Announcement(announcements[next % announcements.size])
+            next++
+        }
+    }
+    while (next < announcements.size) {
+        out += TickerSegment.Announcement(announcements[next])
+        next++
+    }
+    return out
+}
+
+/**
+ * Marquee position as a pure function of wall-clock time. Because the
+ * offset depends only on elapsed-since-epoch, the tape RESUMES exactly
+ * where it would have been after the ticker leaves and re-enters
+ * composition — no restart-from-zero on every return to the top of Home.
+ * Double math so hours of uptime don't accumulate float drift.
+ */
+internal fun marqueeOffsetPx(elapsedMs: Long, velocityPxPerSec: Float, tapeWidthPx: Int): Float =
+    if (tapeWidthPx <= 0) 0f
+    else (((elapsedMs / 1000.0) * velocityPxPerSec) % tapeWidthPx).toFloat()

--- a/feature/home/src/test/kotlin/com/stash/feature/home/TickerTapeTest.kt
+++ b/feature/home/src/test/kotlin/com/stash/feature/home/TickerTapeTest.kt
@@ -1,0 +1,61 @@
+package com.stash.feature.home
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class TickerTapeTest {
+
+    private fun shoutouts(n: Int) = (1..n).map {
+        TickerSegment.Shoutout(name = "S$it", amount = "$$it", message = "m$it")
+    }
+
+    @Test
+    fun `announcement lands after every third supporter, cycling`() {
+        val tape = buildTickerSegments(
+            shoutouts(7),
+            announcements = listOf("A", "B", "C"),
+            every = 3,
+        )
+        val kinds = tape.map { if (it is TickerSegment.Announcement) it.text else "s" }
+        // 3 supporters, A, 3 supporters, B, 1 supporter, then C appended so
+        // the full station voice rides every cycle.
+        assertThat(kinds)
+            .containsExactly("s", "s", "s", "A", "s", "s", "s", "B", "s", "C")
+            .inOrder()
+    }
+
+    @Test
+    fun `all announcements appear even with fewer supporters than the cadence`() {
+        val tape = buildTickerSegments(
+            shoutouts(2),
+            announcements = listOf("A", "B", "C"),
+            every = 3,
+        )
+        val announcements = tape.filterIsInstance<TickerSegment.Announcement>().map { it.text }
+        assertThat(announcements).containsExactly("A", "B", "C").inOrder()
+    }
+
+    @Test
+    fun `supporter order is preserved`() {
+        val tape = buildTickerSegments(shoutouts(5))
+        val names = tape.filterIsInstance<TickerSegment.Shoutout>().map { it.name }
+        assertThat(names).containsExactly("S1", "S2", "S3", "S4", "S5").inOrder()
+    }
+
+    @Test
+    fun `offset wraps at tape width and resumes proportionally`() {
+        // 10 px/s over a 100 px tape: 5 s in = 50 px, 12 s in = 20 px (wrapped).
+        assertThat(marqueeOffsetPx(5_000, 10f, 100)).isWithin(0.01f).of(50f)
+        assertThat(marqueeOffsetPx(12_000, 10f, 100)).isWithin(0.01f).of(20f)
+        // Unmeasured tape is safe.
+        assertThat(marqueeOffsetPx(5_000, 10f, 0)).isEqualTo(0f)
+    }
+
+    @Test
+    fun `offset stays precise after hours of uptime`() {
+        val eightHoursMs = 8L * 3600 * 1000
+        val offset = marqueeOffsetPx(eightHoursMs, 28f * 3.5f, 40_000)
+        assertThat(offset).isAtLeast(0f)
+        assertThat(offset).isLessThan(40_000f)
+    }
+}


### PR DESCRIPTION
Three fixes in one rebuild of the supporter ticker:

Resume, not restart: basicMarquee's animation died whenever the lazy
item left composition, so returning to the top of Home restarted the
tape from zero — which is also why the mission line ("once per full
cycle") had never been seen: a cycle never completed. The marquee is now
wall-clock driven (marqueeOffsetPx = pure function of elapsed-since-
epoch, epoch pinned via rememberSaveable across lazy disposal), so the
tape reads as if it kept rolling while you were away. Two tape copies +
clipToBounds for the seamless wrap.

Palette: the gold heart is gone (full-bleed tape, maximum runway) and
the gold sparkle separators are now small plum diamonds at 55% —
accent-colored, inside the app's palette instead of fighting it.

Station voice: announcements woven between supporters every 3 shout-outs
(buildTickerSegments, pure + tested): the mission line, a Discord
developers-wanted call, and a GitHub contributors call — each guaranteed
at least once per cycle regardless of supporter count. Announcements
render plum SemiBold so they read as the station speaking, not a donor.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
