### PR TITLE
fix(home): ticker announcements murmur instead of shout

### DIFF
--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
@@ -877,7 +877,9 @@ private fun SupporterTicker(
                         }
                     }
                     is TickerSegment.Announcement -> {
-                        withStyle(SpanStyle(color = plum, fontWeight = FontWeight.SemiBold)) {
+                        // Station voice: quiet by design — muted ink, regular
+                        // weight (names are bold, quotes italic; this murmurs).
+                        withStyle(SpanStyle(color = dim)) {
                             append(seg.text)
                         }
                     }


### PR DESCRIPTION
Plum SemiBold read as loud against the tape; the station voice is now
muted ink at regular weight - distinct from bold supporter names and
italic quotes, but quiet. Plum stays only on the diamond separators.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
