### PR TITLE
fix(tipjar): stop losing older donations + legacy donors always ride

### DIFF
--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
@@ -269,9 +269,14 @@ fun HomeScreen(
         item {
             val tipJar = uiState.tipJar
             val pillSupporters = remember(tipJar) {
-                tipJar.supporters.map {
+                val live = tipJar.supporters.map {
                     Supporter(name = it.name, amount = "$${it.amountUsd}", message = it.message)
-                }.ifEmpty { HOME_SUPPORTERS }
+                }
+                // Legacy donors pre-date the Ko-fi webhook and exist nowhere
+                // in the Worker's KV — they always ride the tape (deduped in
+                // case they ever re-donate through the live pipeline).
+                val liveNames = live.map { it.name.lowercase() }.toSet()
+                live + LEGACY_SUPPORTERS.filter { it.name.lowercase() !in liveNames }
             }
             // Edge-to-edge: the ticker runs the full screen width, no card
             // chrome — maximum runway for the scrolling messages.
@@ -816,7 +821,7 @@ private const val STASH_ISSUE_URL = "https://github.com/rawnaldclark/Stash/issue
 // browser. Edit when the invite rotates.
 private const val STASH_DISCORD_URL = "https://discord.gg/vcbjEby5PC"
 
-private val HOME_SUPPORTERS = listOf(
+private val LEGACY_SUPPORTERS = listOf(
     Supporter(
         name = "Cedric",
         amount = "$10",

--- a/feature/home/src/main/kotlin/com/stash/feature/home/TickerTape.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/TickerTape.kt
@@ -18,7 +18,7 @@ internal sealed interface TickerSegment {
 internal val TICKER_ANNOUNCEMENTS = listOf(
     "Stash is a community powered open-source project dedicated to the " +
         "love and growth of music. Thank you to our supporters.",
-    "Developers wanted — join the Discord (icon up top) and help build Stash.",
+    "Devs wanted — join the Discord to help build the future of music.",
     "Open source, open to PRs — contributors welcome on GitHub.",
 )
 

--- a/infra/tipjar-worker/src/index.js
+++ b/infra/tipjar-worker/src/index.js
@@ -18,7 +18,10 @@
  * Deploy: see ../README.md.
  */
 
-const SUPPORTERS_LIMIT = 20;
+// 2026-07-19: 20 was destructively truncating — donors pushed past the
+// cap were deleted from KV forever, which is why older donations vanished
+// from the app's ticker. 500 entries is still a trivially small KV value.
+const SUPPORTERS_LIMIT = 500;
 const KV_KEY = "supporters";
 
 export default {


### PR DESCRIPTION
Two leaks were shrinking the tape:

Worker: every Ko-fi webhook sliced the KV list to 20 entries,
PERMANENTLY deleting donors pushed past the cap. Raised to 500
(still a trivially small KV value) and redeployed. Entries already
truncated are gone from KV; the full history remains on Ko-fi.

App: the pre-webhook donors (Cedric, Slowcab, RucaNebas) were only a
fallback for an EMPTY live feed, so they vanished the day the webhook
came alive. They're now LEGACY_SUPPORTERS, always appended to the live
list (name-deduped in case they re-donate through the pipeline).

Also: dev-call announcement copy per user - "Devs wanted - join the
Discord to help build the future of music."

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
