### PR TITLE
fix(home): tipjar ticker goes true black on AMOLED

### DIFF
--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
@@ -916,7 +916,13 @@ private fun SupporterTicker(
     // of width belongs to the tape.
     Surface(
         modifier = modifier.clickable { uriHandler.openUri("https://ko-fi.com/rawnald") },
-        color = extendedColors.glassBackground,
+        // AMOLED: the glass tint would keep the strip's pixels lit — let the
+        // pure-black ground show through instead.
+        color = if (com.stash.core.ui.theme.LocalIsAmoledTheme.current) {
+            Color.Transparent
+        } else {
+            extendedColors.glassBackground
+        },
     ) {
         Box(
             modifier = Modifier


### PR DESCRIPTION
The strip's glass tint (translucent white) kept its pixels lit on the
pure-black theme. On AMOLED the Surface is now transparent - the black
ground shows through and only the tape's text lights up.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
