### PR TITLE
Make Manage Playlists search filter Liked and Mixes sections too

### DIFF
--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/ManagePlaylistsScreen.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/ManagePlaylistsScreen.kt
@@ -97,11 +97,14 @@ fun ManagePlaylistsScreen(
         ManageSegment.SYNCED -> customAll.filter { it.syncEnabled }
         ManageSegment.OFF -> customAll.filter { !it.syncEnabled }
     }
-    val visibleCustom = if (query.isBlank()) {
-        bySegment
-    } else {
-        bySegment.filter { it.name.contains(query.trim(), ignoreCase = true) }
-    }
+    // The query filters every section, not just "Your playlists": accounts can
+    // have 100+ auto mixes, and an unfiltered Liked/Mixes block pushes the
+    // filtered custom results off-screen - making search look broken (#310).
+    val q = query.trim()
+    fun matchesQuery(row: ManageRow) = q.isBlank() || row.name.contains(q, ignoreCase = true)
+    val visibleLiked = liked?.takeIf { matchesQuery(it) }
+    val visibleMixes = mixes.filter { matchesQuery(it) }
+    val visibleCustom = bySegment.filter { matchesQuery(it) }
 
     Scaffold(
         topBar = {
@@ -167,14 +170,14 @@ fun ManagePlaylistsScreen(
                 contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
             ) {
                 // -- Liked ------------------------------------------------------
-                if (liked != null) {
+                if (visibleLiked != null) {
                     item(key = "liked-label") { ManageSectionLabel("Liked") }
                     item(key = "liked-row") {
                         SpotifySyncToggleRow(
-                            name = liked.name,
-                            trackCount = liked.trackCount,
-                            enabled = liked.syncEnabled,
-                            onToggle = { viewModel.onTogglePlaylistSync(liked.id, it) },
+                            name = visibleLiked.name,
+                            trackCount = visibleLiked.trackCount,
+                            enabled = visibleLiked.syncEnabled,
+                            onToggle = { viewModel.onTogglePlaylistSync(visibleLiked.id, it) },
                         )
                     }
                     if (source == SyncSource.YOUTUBE) {
@@ -188,17 +191,17 @@ fun ManagePlaylistsScreen(
                 }
 
                 // -- Mixes (auto) ----------------------------------------------
-                if (mixes.isNotEmpty()) {
+                if (visibleMixes.isNotEmpty()) {
                     item(key = "mixes-label") { ManageSectionLabel("Mixes (auto)") }
                     item(key = "mixes-summary") {
                         Text(
-                            text = "${mixes.size} mixes · surfaced on Home",
+                            text = "${visibleMixes.size} mixes · surfaced on Home",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.padding(bottom = 4.dp),
                         )
                     }
-                    items(mixes, key = { "mix-${it.id}" }) { mix ->
+                    items(visibleMixes, key = { "mix-${it.id}" }) { mix ->
                         MixHideRow(
                             name = mix.name,
                             hideFromHome = mix.hideFromHome,


### PR DESCRIPTION
Closes #310

### Root cause

The search field on the Manage Playlists screen only filtered the custom **"Your playlists"** section. The **Liked** and **Mixes (auto)** sections always rendered unfiltered. The reporter's screenshot shows an account with **129 auto mixes** — so the entire visible screen was the unfiltered Liked + Mixes block, and the (correctly filtered) custom section sat hundreds of rows below the fold. Result: typing in the search bar appeared to do nothing.

### Fix

Apply the query to every section: `Liked` row, `Mixes (auto)` list (including its count in the summary line), and the custom list. Sections collapse when nothing in them matches. One shared `matchesQuery` predicate; the existing segment chips (All/Synced/Off) still only scope the custom section, as before.

Both Spotify and YouTube Music variants share this composable, so both screens are fixed.

### Tested

- `:feature:sync:compileDebugKotlin` — clean
- `:feature:sync:testDebugUnitTest` — all pass
