### PR TITLE
feat(library,home): swipe between Library pages; Qobuz-on-Home opt-out

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/HomeDiscoveryPreference.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/HomeDiscoveryPreference.kt
@@ -1,0 +1,44 @@
+package com.stash.core.data.prefs
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Dedicated DataStore for the Home Qobuz-discovery opt-out toggle. */
+private val Context.homeDiscoveryDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "home_discovery_preference",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+)
+
+/**
+ * User opt-out for the Qobuz discovery sections on Home (New Releases,
+ * Qobuz Playlists, Top Albums, and the genre chips that steer them).
+ * When `false`, Home keeps only the Stash mix hero/rails and whatever the
+ * user imports from Spotify / YouTube — and the catalog fetches behind the
+ * discovery rows are not made at all. Default `true` preserves current
+ * behavior.
+ */
+@Singleton
+class HomeDiscoveryPreference @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val enabledKey = booleanPreferencesKey("qobuz_discovery_enabled")
+
+    val enabled: Flow<Boolean> = context.homeDiscoveryDataStore.data.map { prefs ->
+        prefs[enabledKey] ?: true
+    }
+
+    suspend fun setEnabled(value: Boolean) {
+        context.homeDiscoveryDataStore.edit { it[enabledKey] = value }
+    }
+}

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
@@ -427,14 +427,17 @@ fun HomeScreen(
         // ── Genre filter chips ───────────────────────────────────────
         // Steer ONLY the Qobuz discovery rows below, so they sit with
         // them — directly under the hero, above New Releases — instead of
-        // topping the whole page (they never affected the hero).
-        item {
-            Spacer(Modifier.height(14.dp))
-            CrispChipRow(
-                chips = uiState.genres.map { it.label },
-                selected = uiState.selectedGenre,
-                onSelect = viewModel::onSelectGenre,
-            )
+        // topping the whole page (they never affected the hero). Hidden
+        // entirely when Qobuz discovery is switched off in Settings.
+        if (uiState.qobuzDiscoveryEnabled) {
+            item {
+                Spacer(Modifier.height(14.dp))
+                CrispChipRow(
+                    chips = uiState.genres.map { it.label },
+                    selected = uiState.selectedGenre,
+                    onSelect = viewModel::onSelectGenre,
+                )
+            }
         }
 
         // ── Qobuz discovery rows (genre-filtered) ─────────────────────

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeUiState.kt
@@ -56,6 +56,9 @@ data class HomeUiState(
     val genres: List<Genre> = GenreCatalog.GENRES,
     /** Currently-selected chip label; drives the three rows below. */
     val selectedGenre: String = "All",
+    /** False when the user opted out of Qobuz discovery on Home — hides the
+     * genre chips (the rows hide themselves via their empty lists). */
+    val qobuzDiscoveryEnabled: Boolean = true,
     val newReleases: List<AlbumSummary> = emptyList(),
     val topAlbums: List<AlbumSummary> = emptyList(),
     val playlists: List<PlaylistSummary> = emptyList(),

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
@@ -78,6 +78,7 @@ class HomeViewModel @Inject constructor(
     private val playlistDao: com.stash.core.data.db.dao.PlaylistDao,
     private val downloadNetworkPreference: DownloadNetworkPreference,
     private val streamingPreference: StreamingPreference,
+    private val homeDiscoveryPreference: com.stash.core.data.prefs.HomeDiscoveryPreference,
     private val metadataBackfillState: MetadataBackfillState,
     private val homeDiscoveryRepository: HomeDiscoveryRepository,
     @ApplicationContext private val context: Context,
@@ -296,6 +297,7 @@ class HomeViewModel @Inject constructor(
         val newReleases: List<AlbumSummary>,
         val topAlbums: List<AlbumSummary>,
         val playlists: List<PlaylistSummary>,
+        val enabled: Boolean = true,
     )
 
     /**
@@ -310,21 +312,32 @@ class HomeViewModel @Inject constructor(
      * content never survives a completed fetch. Fail-soft as before.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    private val discoveryFlow: Flow<DiscoveryUi> = genreFilter
-        .flatMapLatest { label ->
-            flow<Pair<String, DiscoveryUi?>> {
-                val genreId = GenreCatalog.idFor(label)
-                emit(label to null) // loading: re-label, keep previous rows
-                coroutineScope {
-                    val newReleases = async { homeDiscoveryRepository.newReleases(genreId) }
-                    val playlists = async { homeDiscoveryRepository.communityPlaylists(genreId) }
-                    val topAlbums = async { homeDiscoveryRepository.topAlbums(genreId) }
-                    emit(label to DiscoveryUi(label, newReleases.await(), topAlbums.await(), playlists.await()))
-                }
+    private val discoveryFlow: Flow<DiscoveryUi> = homeDiscoveryPreference.enabled
+        .flatMapLatest { qobuzEnabled ->
+            if (!qobuzEnabled) {
+                // Opted out: no Qobuz catalog fetches at all — Home keeps
+                // only the mix rails and imported content.
+                kotlinx.coroutines.flow.flowOf(
+                    DiscoveryUi("All", emptyList(), emptyList(), emptyList(), enabled = false),
+                )
+            } else {
+                genreFilter
+                    .flatMapLatest { label ->
+                        flow<Pair<String, DiscoveryUi?>> {
+                            val genreId = GenreCatalog.idFor(label)
+                            emit(label to null) // loading: re-label, keep previous rows
+                            coroutineScope {
+                                val newReleases = async { homeDiscoveryRepository.newReleases(genreId) }
+                                val playlists = async { homeDiscoveryRepository.communityPlaylists(genreId) }
+                                val topAlbums = async { homeDiscoveryRepository.topAlbums(genreId) }
+                                emit(label to DiscoveryUi(label, newReleases.await(), topAlbums.await(), playlists.await()))
+                            }
+                        }
+                    }
+                    .scan(DiscoveryUi("All", emptyList(), emptyList(), emptyList())) { prev, (label, loaded) ->
+                        loaded ?: prev.copy(selectedGenre = label)
+                    }
             }
-        }
-        .scan(DiscoveryUi("All", emptyList(), emptyList(), emptyList())) { prev, (label, loaded) ->
-            loaded ?: prev.copy(selectedGenre = label)
         }
 
     /** Select a genre chip; re-derives all three discovery rows. */
@@ -344,6 +357,7 @@ class HomeViewModel @Inject constructor(
             tipJar = tipJar,
             metadataBackfillBanner = metadataBackfillBanner,
             selectedGenre = discovery.selectedGenre,
+            qobuzDiscoveryEnabled = discovery.enabled,
             newReleases = discovery.newReleases,
             topAlbums = discovery.topAlbums,
             playlists = discovery.playlists,

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
@@ -72,11 +72,15 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -374,18 +378,18 @@ private fun LibraryContent(
         // landing (scrolls away while the compact header + category chips stay
         // pinned). The old purple shuffle hero is gone — it duplicated the
         // header's shuffle action.
+        // Songs landing only — noise above the other grids. Handed ONLY to
+        // TracksTab: with the pager, neighbor pages compose mid-swipe, so
+        // gating on activeTab here would flash the rail onto other pages.
         val libraryHeader: @Composable () -> Unit = {
-            // Songs landing only — noise above the other grids.
-            if (state.activeTab == LibraryTab.TRACKS) {
-                Column {
-                    if (state.recentlyAdded.isNotEmpty()) {
-                        RecentlyDownloadedRail(
-                            tracks = state.recentlyAdded.take(12),
-                            onTrackClick = onTrackClick,
-                        )
-                    }
-                    Spacer(Modifier.height(4.dp))
+            Column {
+                if (state.recentlyAdded.isNotEmpty()) {
+                    RecentlyDownloadedRail(
+                        tracks = state.recentlyAdded.take(12),
+                        onTrackClick = onTrackClick,
+                    )
                 }
+                Spacer(Modifier.height(4.dp))
             }
         }
 
@@ -476,54 +480,75 @@ private fun LibraryContent(
                 CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
             }
         } else {
-            when (state.activeTab) {
-                LibraryTab.PLAYLISTS -> PlaylistsGrid(
-                    playlists = state.playlists,
-                    anyServiceConnected = anyServiceConnected,
-                    onPlayPlaylist = onPlayPlaylist,
-                    onAddPlaylistToQueue = onAddPlaylistToQueue,
-                    onRemovePlaylist = onRemovePlaylist,
-                    onDeletePlaylist = onDeletePlaylist,
-                    onSetPlaylistImage = onSetPlaylistImage,
-                    onRemovePlaylistImage = onRemovePlaylistImage,
-                    header = libraryHeader,
-                )
-                LibraryTab.TRACKS -> TracksTab(
-                    tracks = state.tracks,
-                    currentlyPlayingTrackId = state.currentlyPlayingTrackId,
-                    onTrackClick = onTrackClick,
-                    onPlayNext = onPlayNext,
-                    onAddToQueue = onAddToQueue,
-                    onDeleteTrack = onDeleteTrack,
-                    anyServiceConnected = anyServiceConnected,
-                    selection = selection,
-                    header = libraryHeader,
-                )
-                LibraryTab.LIKED -> LikedTab(
-                    tracks = likedTracks,
-                    filter = likedFilter,
-                    sources = likedSources,
-                    currentlyPlayingTrackId = state.currentlyPlayingTrackId,
-                    onSelectSource = onSelectLikedSource,
-                    onTrackClick = onPlayLikedTrack,
-                )
-                LibraryTab.ARTISTS -> ArtistsGrid(
-                    artists = state.artists,
-                    singleTrackArtists = state.singleTrackArtists,
-                    anyServiceConnected = anyServiceConnected,
-                    onPlayArtist = onPlayArtist,
-                    onAddArtistToQueue = onAddArtistToQueue,
-                    onDeleteArtist = onDeleteArtist,
-                    header = libraryHeader,
-                )
-                LibraryTab.ALBUMS -> AlbumsGrid(
-                    albums = state.albums,
-                    singleTrackAlbums = state.singleTrackAlbums,
-                    anyServiceConnected = anyServiceConnected,
-                    onPlayAlbum = onPlayAlbum,
-                    onAddAlbumToQueue = onAddAlbumToQueue,
-                    header = libraryHeader,
-                )
+            // Swiping left/right moves between the category pages too — the
+            // pager and the chip row drive the same activeTab state: a chip
+            // tap animates the pager here; a settled swipe pushes the tab
+            // back to the ViewModel (both sync no-ops when already aligned).
+            val pagerState = rememberPagerState(
+                initialPage = chipTabs.indexOfFirst { it.second == state.activeTab }.coerceAtLeast(0),
+            ) { chipTabs.size }
+            LaunchedEffect(state.activeTab) {
+                val idx = chipTabs.indexOfFirst { it.second == state.activeTab }
+                if (idx >= 0 && idx != pagerState.currentPage) pagerState.animateScrollToPage(idx)
+            }
+            LaunchedEffect(pagerState) {
+                snapshotFlow { pagerState.settledPage }.collect { page ->
+                    onTabSelected(chipTabs[page].second)
+                }
+            }
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize(),
+            ) { page ->
+                when (chipTabs[page].second) {
+                    LibraryTab.PLAYLISTS -> PlaylistsGrid(
+                        playlists = state.playlists,
+                        anyServiceConnected = anyServiceConnected,
+                        onPlayPlaylist = onPlayPlaylist,
+                        onAddPlaylistToQueue = onAddPlaylistToQueue,
+                        onRemovePlaylist = onRemovePlaylist,
+                        onDeletePlaylist = onDeletePlaylist,
+                        onSetPlaylistImage = onSetPlaylistImage,
+                        onRemovePlaylistImage = onRemovePlaylistImage,
+                        header = {},
+                    )
+                    LibraryTab.TRACKS -> TracksTab(
+                        tracks = state.tracks,
+                        currentlyPlayingTrackId = state.currentlyPlayingTrackId,
+                        onTrackClick = onTrackClick,
+                        onPlayNext = onPlayNext,
+                        onAddToQueue = onAddToQueue,
+                        onDeleteTrack = onDeleteTrack,
+                        anyServiceConnected = anyServiceConnected,
+                        selection = selection,
+                        header = libraryHeader,
+                    )
+                    LibraryTab.LIKED -> LikedTab(
+                        tracks = likedTracks,
+                        filter = likedFilter,
+                        sources = likedSources,
+                        currentlyPlayingTrackId = state.currentlyPlayingTrackId,
+                        onSelectSource = onSelectLikedSource,
+                        onTrackClick = onPlayLikedTrack,
+                    )
+                    LibraryTab.ARTISTS -> ArtistsGrid(
+                        artists = state.artists,
+                        singleTrackArtists = state.singleTrackArtists,
+                        anyServiceConnected = anyServiceConnected,
+                        onPlayArtist = onPlayArtist,
+                        onAddArtistToQueue = onAddArtistToQueue,
+                        onDeleteArtist = onDeleteArtist,
+                        header = {},
+                    )
+                    LibraryTab.ALBUMS -> AlbumsGrid(
+                        albums = state.albums,
+                        singleTrackAlbums = state.singleTrackAlbums,
+                        anyServiceConnected = anyServiceConnected,
+                        onPlayAlbum = onPlayAlbum,
+                        onAddAlbumToQueue = onAddAlbumToQueue,
+                        header = {},
+                    )
+                }
             }
         }
     }

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsLibraryStorageScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsLibraryStorageScreen.kt
@@ -190,6 +190,18 @@ fun SettingsLibraryStorageScreen(
                         onCheckedChange = viewModel::onStashMixesEnabledChanged,
                     )
                 },
+                {
+                    SettingsToggleRow(
+                        title = "Qobuz discovery on Home",
+                        subtitle = if (uiState.qobuzDiscoveryEnabled) {
+                            "New Releases, Qobuz Playlists, and Top Albums show on Home."
+                        } else {
+                            "Home keeps only your mixes and imported music."
+                        },
+                        checked = uiState.qobuzDiscoveryEnabled,
+                        onCheckedChange = viewModel::onQobuzDiscoveryEnabledChanged,
+                    )
+                },
             ),
         )
 

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
@@ -44,6 +44,9 @@ data class SettingsUiState(
      * built-in mix playlists from Home / Library. See issues #56, #57.
      */
     val stashMixesEnabled: Boolean = true,
+    /** Qobuz discovery sections on Home (New Releases / Qobuz Playlists /
+     * Top Albums + genre chips). False = Home keeps only mixes + imports. */
+    val qobuzDiscoveryEnabled: Boolean = true,
     val ytHistoryHealth: YouTubeScrobblerHealth = YouTubeScrobblerHealth.DISABLED,
     val ytPendingCount: Int = 0,
     /**

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -93,6 +93,7 @@ class SettingsViewModel @Inject constructor(
     private val lastFmScrobbler: LastFmScrobbler,
     private val youTubeHistoryPreference: YouTubeHistoryPreference,
     private val stashMixPreference: com.stash.core.data.prefs.StashMixPreference,
+    private val homeDiscoveryPreference: com.stash.core.data.prefs.HomeDiscoveryPreference,
     private val youTubeHistoryScrobbler: YouTubeHistoryScrobbler,
     private val youTubeScrobblerState: YouTubeScrobblerState,
     private val losslessPrefs: LosslessSourcePreferences,
@@ -347,6 +348,7 @@ class SettingsViewModel @Inject constructor(
         streamingQualityPrefs.cellularTier,
         streamingQualityPrefs.saveData,
         themePreference.amoledDark,
+        homeDiscoveryPreference.enabled,
     ) { values ->
         @Suppress("UNCHECKED_CAST")
         val spotifyAuth = values[0] as AuthState
@@ -383,6 +385,7 @@ class SettingsViewModel @Inject constructor(
         val streamingCellularTier = values[31] as LosslessQualityTier
         val streamingSaveData = values[32] as Boolean
         val amoledDark = values[33] as Boolean
+        val qobuzDiscoveryEnabled = values[34] as Boolean
 
         val lastFmState: LastFmAuthState = local.lastFmAuthOverride
             ?: when {
@@ -419,6 +422,7 @@ class SettingsViewModel @Inject constructor(
             scrobbleDrainResult = local.lastScrobbleDrainResult,
             ytHistoryEnabled = ytHistoryEnabled,
             stashMixesEnabled = stashMixesEnabled,
+            qobuzDiscoveryEnabled = qobuzDiscoveryEnabled,
             ytHistoryHealth = ytHistoryHealth,
             ytPendingCount = ytPendingCount,
             losslessEnabled = losslessEnabled,
@@ -1014,6 +1018,15 @@ class SettingsViewModel @Inject constructor(
                     android.util.Log.e("SettingsVM", "applyStashMixesEnabled failed: ${e.message}", e)
                 }
         }
+    }
+
+    /**
+     * Hide/show the Qobuz discovery sections on Home (New Releases, Qobuz
+     * Playlists, Top Albums + the genre chips). Pref-only — Home's
+     * discovery flow gates its own catalog fetches off this.
+     */
+    fun onQobuzDiscoveryEnabledChanged(enabled: Boolean) {
+        viewModelScope.launch { homeDiscoveryPreference.setEnabled(enabled) }
     }
 
     /** Clear the kill-switch after PROTOCOL_BROKEN. Exposed to the Settings


### PR DESCRIPTION
## Summary
- **Library**: category content moved into a `HorizontalPager` — swipe left/right between Songs / Liked / Playlists / Artists / Albums. Chips and pager drive the same `activeTab`: chip tap animates the pager, settled swipe updates the ViewModel; both no-op when aligned. The recently-downloaded rail is passed only to the Songs page (neighbor pages compose mid-swipe, so the old `activeTab` gate would flash it onto adjacent pages).
- **Home**: "Qobuz discovery on Home" toggle in Settings → Library & Storage, next to Stash Mixes. Off = genre chips + New Releases + Qobuz Playlists + Top Albums vanish and their catalog fetches are skipped entirely (the pref gates the fetch flow, not just rendering). Backed by a dedicated `HomeDiscoveryPreference` DataStore; the flag rides the existing `DiscoveryUi` emission so the Home combine is untouched. Default on.

## Test Plan
- [x] Full app compile clean
- [ ] Device: swipe across all five Library pages both directions; chip taps still animate; Songs rail only on Songs
- [ ] Device: toggle off → Home drops chips + three Qobuz sections live; toggle on → they return (genre refetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)