### PR TITLE
fix(crossfade): two focus races at the seam + teardown identity logs

### DIFF
--- a/core/media/src/main/kotlin/com/stash/core/media/service/CrossfadeEngine.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/service/CrossfadeEngine.kt
@@ -81,6 +81,11 @@ class CrossfadeEngine(
                 if (pausedForFocusLoss) {
                     pausedForFocusLoss = false
                     playerA.playWhenReady = true
+                    // Mid-fade a transient loss paused BOTH players; the
+                    // incoming (spare) is the audible future master — leaving
+                    // it paused promotes a dead player at the swap (car nav
+                    // prompt during a fade → silence at the seam, #251).
+                    if (transitioning) playerB.playWhenReady = true
                 }
             }
         }
@@ -89,7 +94,13 @@ class CrossfadeEngine(
     /** Requests focus when the master starts; abandons when it stops. */
     private val masterFocusListener = object : Player.Listener {
         override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
-            if (playWhenReady) requestFocus() else if (!pausedForFocusLoss) abandonFocus()
+            // During a fade this listener still sits on the OUTGOING player,
+            // whose pauseAtEndOfMediaItems fires playWhenReady=false if it
+            // runs out mid-ramp (streaming durations drift). The incoming is
+            // still audible — abandoning would drop the whole app out of the
+            // focus stack while music keeps playing (#251 car-route ghost).
+            if (playWhenReady) requestFocus()
+            else if (!pausedForFocusLoss && !transitioning) abandonFocus()
         }
     }
 
@@ -120,9 +131,16 @@ class CrossfadeEngine(
         focusRequest?.let { audioManager.abandonAudioFocusRequest(it); focusRequest = null }
     }
 
+    /** Stable per-instance tag so field logs name WHICH player each stop hit. */
+    private fun tag(p: ExoPlayer) = "p" + Integer.toHexString(System.identityHashCode(p))
+
     /** Prime the spare on [item] (buffered, paused, silent) for an upcoming fade. */
     fun prepareNext(item: MediaItem) {
         val spare = playerB
+        android.util.Log.i(
+            "Crossfade",
+            "prepareNext: stop+prime spare=${tag(spare)} (master=${tag(playerA)}) item=${item.mediaId}",
+        )
         spare.stop()
         spare.clearMediaItems()
         spare.playWhenReady = false
@@ -168,6 +186,10 @@ class CrossfadeEngine(
         transitionJob = scope.launch {
             val outgoing = playerA
             val incoming = playerB
+            android.util.Log.i(
+                "Crossfade",
+                "transition start: out=${tag(outgoing)} in=${tag(incoming)} fadeMs=$fadeMs",
+            )
             incoming.volume = 0f
             incoming.playWhenReady = true
             incoming.play()
@@ -202,6 +224,15 @@ class CrossfadeEngine(
             incoming.pauseAtEndOfMediaItems = false
             playerA = incoming
             playerB = outgoing
+            // The incoming's playWhenReady=true edge fired while it was a
+            // listener-less spare, so no focus request ever ran for it. If
+            // focus was lost/abandoned during the ramp, the new master would
+            // play focusless forever. Idempotent when focus is already held.
+            requestFocus()
+            android.util.Log.i(
+                "Crossfade",
+                "swap: master=${tag(incoming)} spare=${tag(outgoing)} (resetting spare)",
+            )
             onSwap(playerA)
 
             // Reset the old master to a clean spare.
@@ -237,6 +268,13 @@ class CrossfadeEngine(
     fun cancelTransition() {
         transitionJob?.cancel()
         transitionJob = null
+        if (::playerA.isInitialized && ::playerB.isInitialized) {
+            android.util.Log.i(
+                "Crossfade",
+                "cancel: restore master=${tag(playerA)} stop spare=${tag(playerB)} " +
+                    "(wasTransitioning=$transitioning)",
+            )
+        }
         if (::playerA.isInitialized) {
             playerA.volume = 1f
             playerA.pauseAtEndOfMediaItems = false


### PR DESCRIPTION
## Summary
Part of #251 (Android Auto: audio stops, seekbar continues, pause/play recovers). Static analysis of the reporter's diagnostics — full trace in the issue comments — pointed at the crossfade engine's focus layer. Two defects confirmed by code reading, both car-correlated:

- **Mid-ramp end-of-item abandoned focus**: the focus listener rides the *outgoing* player during a fade; its `pauseAtEndOfMediaItems` fires `playWhenReady=false` when the track runs out early (streaming durations drift), which ran `abandonFocus()` while the incoming was audible. The app dropped out of the focus stack and kept playing — undefined car behavior until manual pause/play. Now guarded by `transitioning`.
- **GAIN mid-fade resumed only the outgoing**: a nav prompt (transient loss) pauses both players; GAIN resumed `playerA` only, so the swap promoted a *paused* master — dead audio at the seam, recovered exactly by pause/play. GAIN now resumes the incoming too during a transition.
- Hardening: explicit idempotent `requestFocus()` at the swap (the incoming never produced a `playWhenReady` edge while holding the listener).
- Instrumentation: all player-stopping paths log stable per-instance identity tags under the `Crossfade` tag, so the next field diagnostics name which player each stop hit — targeting the still-unexplained mid-track AudioTrack release.

## Test Plan
- [x] `:core:media:compileDebugKotlin` + `CrossfadeFadeTest`, `AutoBrowseTest`, `AutoBrowseQueueTest` green
- [ ] Field: #251 / Bwangster car reports retest on next release (no car hardware locally; instrumentation makes the next diagnostics decisive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)