### PR TITLE
fix: add artwork to liked playlists

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/social/stash/StashLikedPlaylistRepository.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/social/stash/StashLikedPlaylistRepository.kt
@@ -38,7 +38,11 @@ class StashLikedPlaylistRepository @Inject constructor(
      * leaves the existing timestamp untouched.
      */
     suspend fun add(trackId: Long) {
-        val playlistId = ensureSeeded()
+        val trackArt = trackDao.getById(trackId)?.let { track ->
+            sequenceOf(track.albumArtPath, track.albumArtUrl)
+                .firstOrNull { !it.isNullOrBlank() }
+        }
+        val playlistId = ensureSeeded(trackArt)
         val existing = playlistDao.getCrossRef(playlistId, trackId)
         if (existing != null && existing.removedAt == null) return
         // Order matters: mark the timestamp FIRST so the Room observation
@@ -90,13 +94,19 @@ class StashLikedPlaylistRepository @Inject constructor(
      * liked tracks. Sync pipeline ignores `MusicSource.BOTH`, so this
      * flag only affects visibility, not actual sync behavior.
      */
-    private suspend fun ensureSeeded(): Long {
-        playlistDao.findBySourceId(STASH_LIKED_SOURCE_ID)?.let { return it.id }
+    private suspend fun ensureSeeded(trackArt: String?): Long {
+        playlistDao.findBySourceId(STASH_LIKED_SOURCE_ID)?.let { existing ->
+            if (existing.artUrl.isNullOrBlank() && !trackArt.isNullOrBlank()) {
+                playlistDao.updateArtUrl(existing.id, trackArt)
+            }
+            return existing.id
+        }
         val entity = PlaylistEntity(
             name = "Liked Songs",
             source = MusicSource.BOTH,
             sourceId = STASH_LIKED_SOURCE_ID,
             type = PlaylistType.STASH_LIKED,
+            artUrl = trackArt?.takeUnless { it.isBlank() },
             syncEnabled = true,
         )
         return playlistDao.insert(entity)

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
@@ -243,10 +243,9 @@ class DiffWorker @AssistedInject constructor(
             // Art refresh: ONLY for DAILY_MIX. Daily Mixes (and Spotify's
             // weekly mixes — Discover Weekly, Release Radar, etc., which
             // share the DAILY_MIX type) rotate, so their cover should
-            // follow the tracks. Curated content (LIKED_SONGS, CUSTOM,
-            // STASH_MIX) keeps whatever art was imported on first sync —
-            // overwriting it surprises users whose personal playlists
-            // would otherwise look different every sync.
+            // follow the tracks. Other playlist types never rotate here;
+            // LIKED_SONGS gets only a missing-art repair during metadata
+            // finalization below.
             val rotatesArt = existing.type == PlaylistType.DAILY_MIX
             if (rotatesArt && snapshot.artUrl != null && snapshot.artUrl != existing.artUrl) {
                 playlistDao.updateArtUrl(existing.id, snapshot.artUrl)
@@ -541,6 +540,12 @@ class DiffWorker @AssistedInject constructor(
             if (coverToSet != null && coverToSet != localPlaylist.artUrl) {
                 playlistDao.updateArtUrl(localPlaylist.id, coverToSet)
             }
+        } else if (
+            localPlaylist.type == PlaylistType.LIKED_SONGS &&
+            localPlaylist.artUrl.isNullOrBlank() &&
+            !playlistSnapshot.artUrl.isNullOrBlank()
+        ) {
+            playlistDao.updateArtUrl(localPlaylist.id, playlistSnapshot.artUrl)
         }
     }   
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorker.kt
@@ -49,6 +49,11 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.time.Instant
 
+internal fun likedPlaylistArtUrl(trackArtUrls: Sequence<String?>): String? =
+    com.stash.core.common.ArtUrlUpgrader.upgrade(
+        trackArtUrls.firstOrNull { !it.isNullOrBlank() }
+    )
+
 /**
  * First worker in the sync chain. Authenticates with configured music services,
  * fetches playlist and track metadata, and writes everything to the remote
@@ -379,6 +384,11 @@ class PlaylistFetchWorker @AssistedInject constructor(
                         playlistName = "Liked Songs",
                         playlistType = PlaylistType.LIKED_SONGS,
                         trackCount = allLikedSongs.size,
+                        artUrl = likedPlaylistArtUrl(
+                            allLikedSongs.asSequence().map {
+                                it.track?.album?.images?.firstOrNull()?.url
+                            }
+                        ),
                     )
                 )
 
@@ -757,6 +767,9 @@ class PlaylistFetchWorker @AssistedInject constructor(
                             playlistName = "Liked Songs",
                             playlistType = PlaylistType.LIKED_SONGS,
                             trackCount = likedSongs.size,
+                            artUrl = likedPlaylistArtUrl(
+                                likedSongs.asSequence().map { it.thumbnailUrl }
+                            ),
                             partial = paged.partial,
                             expectedCount = paged.expectedCount,
                         )

--- a/core/data/src/test/kotlin/com/stash/core/data/social/stash/StashLikedPlaylistRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/social/stash/StashLikedPlaylistRepositoryTest.kt
@@ -1,0 +1,107 @@
+package com.stash.core.data.social.stash
+
+import com.stash.core.data.db.dao.PlaylistDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.PlaylistTrackCrossRef
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.repository.MusicRepository
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StashLikedPlaylistRepositoryTest {
+
+    @Test
+    fun `add seeds playlist art from local album art before remote art`() = runTest {
+        val playlistDao = mockk<PlaylistDao>(relaxed = true)
+        val trackDao = mockk<TrackDao>(relaxed = true)
+        val musicRepository = mockk<MusicRepository>(relaxed = true)
+        coEvery { trackDao.getById(11L) } returns track(
+            albumArtPath = "/music/cover.jpg",
+            albumArtUrl = "https://cdn.example/cover.jpg",
+        )
+        coEvery { playlistDao.findBySourceId("stash_liked_songs") } returns null
+        val inserted = slot<PlaylistEntity>()
+        coEvery { playlistDao.insert(capture(inserted)) } returns 7L
+        coEvery { playlistDao.getCrossRef(7L, 11L) } returns null
+
+        StashLikedPlaylistRepository(playlistDao, trackDao, musicRepository).add(11L)
+
+        assertEquals("/music/cover.jpg", inserted.captured.artUrl)
+    }
+
+    @Test
+    fun `re-tapping an existing like repairs blank art from remote fallback`() = runTest {
+        val playlistDao = mockk<PlaylistDao>(relaxed = true)
+        val trackDao = mockk<TrackDao>(relaxed = true)
+        val musicRepository = mockk<MusicRepository>(relaxed = true)
+        coEvery { trackDao.getById(11L) } returns track(
+            albumArtPath = " ",
+            albumArtUrl = "https://cdn.example/cover.jpg",
+        )
+        coEvery { playlistDao.findBySourceId("stash_liked_songs") } returns likedPlaylist(artUrl = "\t")
+        coEvery { playlistDao.getCrossRef(7L, 11L) } returns existingMembership()
+
+        StashLikedPlaylistRepository(playlistDao, trackDao, musicRepository).add(11L)
+
+        coVerify { playlistDao.updateArtUrl(7L, "https://cdn.example/cover.jpg") }
+        coVerify(exactly = 0) { musicRepository.addTrackToPlaylist(any(), any()) }
+    }
+
+    @Test
+    fun `add ignores blank track artwork`() = runTest {
+        val playlistDao = mockk<PlaylistDao>(relaxed = true)
+        val trackDao = mockk<TrackDao>(relaxed = true)
+        coEvery { trackDao.getById(11L) } returns track(albumArtPath = " ", albumArtUrl = "\t")
+        coEvery { playlistDao.findBySourceId("stash_liked_songs") } returns likedPlaylist(artUrl = null)
+        coEvery { playlistDao.getCrossRef(7L, 11L) } returns existingMembership()
+
+        StashLikedPlaylistRepository(playlistDao, trackDao, mockk(relaxed = true)).add(11L)
+
+        coVerify(exactly = 0) { playlistDao.updateArtUrl(any(), any()) }
+    }
+
+    @Test
+    fun `add preserves established playlist artwork`() = runTest {
+        val playlistDao = mockk<PlaylistDao>(relaxed = true)
+        val trackDao = mockk<TrackDao>(relaxed = true)
+        coEvery { trackDao.getById(11L) } returns track(albumArtPath = "/music/new-cover.jpg")
+        coEvery { playlistDao.findBySourceId("stash_liked_songs") } returns
+            likedPlaylist(artUrl = "/music/established-cover.jpg")
+        coEvery { playlistDao.getCrossRef(7L, 11L) } returns existingMembership()
+
+        StashLikedPlaylistRepository(playlistDao, trackDao, mockk(relaxed = true)).add(11L)
+
+        coVerify(exactly = 0) { playlistDao.updateArtUrl(any(), any()) }
+    }
+
+    private fun track(albumArtPath: String? = null, albumArtUrl: String? = null) = TrackEntity(
+        id = 11L,
+        title = "Track",
+        artist = "Artist",
+        albumArtPath = albumArtPath,
+        albumArtUrl = albumArtUrl,
+    )
+
+    private fun likedPlaylist(artUrl: String?) = PlaylistEntity(
+        id = 7L,
+        name = "Liked Songs",
+        source = MusicSource.BOTH,
+        sourceId = "stash_liked_songs",
+        type = PlaylistType.STASH_LIKED,
+        artUrl = artUrl,
+    )
+
+    private fun existingMembership() = PlaylistTrackCrossRef(
+        playlistId = 7L,
+        trackId = 11L,
+        position = 0,
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
@@ -225,6 +225,54 @@ class DiffWorkerTest {
         assertEquals("no new track should be inserted — matched existing", 3, trackDao.getAllForIntegrityScan().size)
     }
 
+    @Test
+    fun `LIKED_SONGS backfills missing art from the snapshot`() = runBlocking {
+        assertEquals(
+            "https://cdn.example/new-cover.jpg",
+            syncLikedPlaylistArt(existingArt = "  ", snapshotArt = "https://cdn.example/new-cover.jpg"),
+        )
+    }
+
+    @Test
+    fun `LIKED_SONGS preserves an existing nonblank cover`() = runBlocking {
+        assertEquals(
+            "https://cdn.example/established-cover.jpg",
+            syncLikedPlaylistArt(
+                existingArt = "https://cdn.example/established-cover.jpg",
+                snapshotArt = "https://cdn.example/new-cover.jpg",
+            ),
+        )
+    }
+
+    private suspend fun syncLikedPlaylistArt(existingArt: String?, snapshotArt: String?): String? {
+        val playlistId = db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Liked Songs",
+                source = MusicSource.SPOTIFY,
+                sourceId = "spotify_liked_songs",
+                type = PlaylistType.LIKED_SONGS,
+                artUrl = existingArt,
+                syncEnabled = true,
+            )
+        )
+        val snapshot = RemotePlaylistSnapshotEntity(
+            id = 4L,
+            syncId = 1L,
+            source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "spotify_liked_songs",
+            playlistName = "Liked Songs",
+            playlistType = PlaylistType.LIKED_SONGS,
+            artUrl = snapshotArt,
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(snapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(4L) } returns emptyList()
+
+        val result = buildWorker().doWork()
+
+        assertTrue("diff must succeed", result is androidx.work.ListenableWorker.Result.Success)
+        return db.playlistDao().getById(playlistId)?.artUrl
+    }
+
     private fun buildWorker(): DiffWorker = TestListenableWorkerBuilder<DiffWorker>(context)
         .setInputData(workDataOf(PlaylistFetchWorker.KEY_SYNC_ID to 1L))
         .setWorkerFactory(object : WorkerFactory() {

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorkerLikedArtTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorkerLikedArtTest.kt
@@ -1,0 +1,32 @@
+package com.stash.core.data.sync.workers
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class PlaylistFetchWorkerLikedArtTest {
+
+    @Test
+    fun `Spotify liked art uses first nonblank track image and upgrades it`() {
+        val smallArt = "https://i.scdn.co/image/ab67616d00001e02abc"
+
+        val result = likedPlaylistArtUrl(sequenceOf(null, "  ", smallArt, "later"))
+
+        assertThat(result).isEqualTo("https://i.scdn.co/image/ab67616d0000b273abc")
+    }
+
+    @Test
+    fun `YouTube liked art uses first nonblank track image and upgrades it`() {
+        val smallArt = "https://lh3.googleusercontent.com/cover=w120-h120-l90-rj"
+
+        val result = likedPlaylistArtUrl(sequenceOf("", smallArt, "later"))
+
+        assertThat(result).isEqualTo(
+            "https://lh3.googleusercontent.com/cover=w1024-h1024-l90-rj"
+        )
+    }
+
+    @Test
+    fun `liked art is absent when every track image is blank`() {
+        assertThat(likedPlaylistArtUrl(sequenceOf(null, "", "\t"))).isNull()
+    }
+}


### PR DESCRIPTION
## Summary

- seed Spotify and YouTube liked-playlist covers from the first available track artwork
- backfill missing external liked-playlist artwork without replacing established covers
- seed or repair the in-app Liked Songs cover from the liked track while preserving later artwork

## Validation

- focused `:core:data:testDebugUnitTest` coverage for artwork selection, sync backfill, and local-liked seeding: 12 tests passed
- `:feature:library:testDebugUnitTest`: 57 tests passed
- `assembleDebug`: passed
- `git diff --check`: passed
- five unrelated core-data failures reproduce identically on clean `origin/master`

## Device testing

- Not run. This is a data-path fix and the existing Library playlist-card UI was unchanged; authenticated Spotify/YouTube seed data was unavailable.

Fixes #67
