### PR TITLE
feat: add now playing animation toggle

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/NowPlayingPreference.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/NowPlayingPreference.kt
@@ -1,0 +1,27 @@
+package com.stash.core.data.prefs
+
+import android.content.Context
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.nowPlayingDataStore by preferencesDataStore(
+    name = "now_playing_preference",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+)
+
+@Singleton
+class NowPlayingPreference @Inject constructor(@ApplicationContext private val context: Context) {
+    private val ambientAnimationKey = booleanPreferencesKey("ambient_animation_enabled")
+    val ambientAnimationEnabled = context.nowPlayingDataStore.data.map { it[ambientAnimationKey] ?: true }
+
+    suspend fun setAmbientAnimationEnabled(enabled: Boolean) {
+        context.nowPlayingDataStore.edit { it[ambientAnimationKey] = enabled }
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/prefs/NowPlayingPreferenceTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/prefs/NowPlayingPreferenceTest.kt
@@ -1,0 +1,44 @@
+package com.stash.core.data.prefs
+
+import android.content.Context
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class NowPlayingPreferenceTest {
+    private lateinit var context: Context
+    private lateinit var preference: NowPlayingPreference
+    private lateinit var file: File
+
+    @Before fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        file = context.preferencesDataStoreFile("now_playing_preference")
+        if (file.exists()) file.delete()
+        preference = NowPlayingPreference(context)
+    }
+
+    @After fun tearDown() {
+        if (file.exists()) file.delete()
+    }
+
+    @Test fun ambientAnimation_defaultsToTrue() = runTest {
+        assertTrue(preference.ambientAnimationEnabled.first())
+    }
+
+    @Test fun ambientAnimation_persistsFalseAndTrue() = runTest {
+        preference.setAmbientAnimationEnabled(false)
+        assertFalse(preference.ambientAnimationEnabled.first())
+        preference.setAmbientAnimationEnabled(true)
+        assertTrue(preference.ambientAnimationEnabled.first())
+    }
+}

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
@@ -1,7 +1,6 @@
 package com.stash.feature.nowplaying
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.clickable
@@ -15,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -30,8 +28,6 @@ import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.DownloadDone
 import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.MotionPhotosOff
-import androidx.compose.material.icons.filled.MotionPhotosOn
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Repeat
@@ -364,8 +360,6 @@ fun NowPlayingScreen(
                     albumArtUrl = track?.albumArtUrl,
                     albumArtPath = track?.albumArtPath,
                     accentColor = npAccent(uiState.vibrantColor),
-                    ambientAnimationEnabled = ambientAnimationEnabled,
-                    onAmbientAnimationToggle = { viewModel.setAmbientAnimationEnabled(!ambientAnimationEnabled) },
                     onBitmapLoaded = viewModel::onAlbumArtLoaded,
                 )
 
@@ -699,8 +693,6 @@ private fun AlbumArtSection(
     albumArtUrl: String?,
     albumArtPath: String?,
     accentColor: Color,
-    ambientAnimationEnabled: Boolean,
-    onAmbientAnimationToggle: () -> Unit,
     onBitmapLoaded: (android.graphics.Bitmap?) -> Unit,
 ) {
     val context = LocalContext.current
@@ -715,18 +707,11 @@ private fun AlbumArtSection(
             .build()
     }
 
-    Box(
-        modifier = Modifier
-            .widthIn(max = if (ambientAnimationEnabled) 280.dp else 360.dp)
-            .fillMaxWidth()
-            .aspectRatio(1f),
-        contentAlignment = Alignment.Center,
-    ) {
+    Box(contentAlignment = Alignment.Center) {
         // Glow behind the artwork.
         Box(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(10.dp)
+                .size(260.dp)
                 .shadow(
                     elevation = 40.dp,
                     shape = RoundedCornerShape(20.dp),
@@ -751,25 +736,9 @@ private fun AlbumArtSection(
                 }
             },
             modifier = Modifier
-                .fillMaxSize()
+                .size(280.dp)
                 .clip(RoundedCornerShape(20.dp)),
         )
-
-        IconButton(
-            onClick = onAmbientAnimationToggle,
-            modifier = Modifier
-                .align(Alignment.TopEnd)
-                .padding(8.dp)
-                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.82f), CircleShape),
-        ) {
-            Icon(
-                imageVector =
-                    if (ambientAnimationEnabled) Icons.Default.MotionPhotosOn else Icons.Default.MotionPhotosOff,
-                contentDescription =
-                    if (ambientAnimationEnabled) "Turn off ambient animation" else "Turn on ambient animation",
-                tint = MaterialTheme.colorScheme.onSurface,
-            )
-        }
     }
 }
 

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
@@ -1,6 +1,7 @@
 package com.stash.feature.nowplaying
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.clickable
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -28,6 +30,8 @@ import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.DownloadDone
 import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.MotionPhotosOff
+import androidx.compose.material.icons.filled.MotionPhotosOn
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Repeat
@@ -129,6 +133,7 @@ fun NowPlayingScreen(
     val isDownloadingCurrent by viewModel.isDownloadingCurrent.collectAsStateWithLifecycle()
     val exportingLyricsTrackId by viewModel.exportingLyricsTrackId.collectAsStateWithLifecycle()
     val radioLabel by viewModel.radioSeedLabel.collectAsStateWithLifecycle()
+    val ambientAnimationEnabled = viewModel.ambientAnimationEnabled.collectAsStateWithLifecycle().value ?: return
     var showQueue by remember { mutableStateOf(false) }
     var showSaveSheet by remember { mutableStateOf(false) }
     val shareTrack by viewModel.shareTrack.collectAsStateWithLifecycle()
@@ -309,11 +314,11 @@ fun NowPlayingScreen(
         )
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
         // Ambient animated background behind everything — dark canvas, the
         // light pastel wash, or a dead-black AMOLED ground, following the
         // resolved app theme.
-        AmbientBackground(
+        if (ambientAnimationEnabled) AmbientBackground(
             dominantColor = uiState.dominantColor,
             vibrantColor = uiState.vibrantColor,
             mutedColor = uiState.mutedColor,
@@ -359,6 +364,8 @@ fun NowPlayingScreen(
                     albumArtUrl = track?.albumArtUrl,
                     albumArtPath = track?.albumArtPath,
                     accentColor = npAccent(uiState.vibrantColor),
+                    ambientAnimationEnabled = ambientAnimationEnabled,
+                    onAmbientAnimationToggle = { viewModel.setAmbientAnimationEnabled(!ambientAnimationEnabled) },
                     onBitmapLoaded = viewModel::onAlbumArtLoaded,
                 )
 
@@ -692,6 +699,8 @@ private fun AlbumArtSection(
     albumArtUrl: String?,
     albumArtPath: String?,
     accentColor: Color,
+    ambientAnimationEnabled: Boolean,
+    onAmbientAnimationToggle: () -> Unit,
     onBitmapLoaded: (android.graphics.Bitmap?) -> Unit,
 ) {
     val context = LocalContext.current
@@ -706,11 +715,18 @@ private fun AlbumArtSection(
             .build()
     }
 
-    Box(contentAlignment = Alignment.Center) {
+    Box(
+        modifier = Modifier
+            .widthIn(max = if (ambientAnimationEnabled) 280.dp else 360.dp)
+            .fillMaxWidth()
+            .aspectRatio(1f),
+        contentAlignment = Alignment.Center,
+    ) {
         // Glow behind the artwork.
         Box(
             modifier = Modifier
-                .size(260.dp)
+                .fillMaxSize()
+                .padding(10.dp)
                 .shadow(
                     elevation = 40.dp,
                     shape = RoundedCornerShape(20.dp),
@@ -735,9 +751,25 @@ private fun AlbumArtSection(
                 }
             },
             modifier = Modifier
-                .size(280.dp)
+                .fillMaxSize()
                 .clip(RoundedCornerShape(20.dp)),
         )
+
+        IconButton(
+            onClick = onAmbientAnimationToggle,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(8.dp)
+                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.82f), CircleShape),
+        ) {
+            Icon(
+                imageVector =
+                    if (ambientAnimationEnabled) Icons.Default.MotionPhotosOn else Icons.Default.MotionPhotosOff,
+                contentDescription =
+                    if (ambientAnimationEnabled) "Turn off ambient animation" else "Turn on ambient animation",
+                tint = MaterialTheme.colorScheme.onSurface,
+            )
+        }
     }
 }
 

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.palette.graphics.Palette
 import com.stash.core.data.lossless.LosslessUpgrader
+import com.stash.core.data.prefs.NowPlayingPreference
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.PlayerRepository
 import com.stash.core.model.UpgradeResult
@@ -75,6 +76,7 @@ class NowPlayingViewModel @Inject constructor(
     // codebase (it's not Hilt-injectable in this project).
     private val lyricsRepository: LyricsRepository,
     private val lyricsPreference: com.stash.core.data.prefs.LyricsPreference,
+    private val nowPlayingPreference: NowPlayingPreference,
     private val lyricsSidecarWriter: LyricsSidecarWriter,
     @ApplicationContext private val appContext: Context,
     // Tap-to-artist: resolves the playing track's artist NAME to a YT
@@ -114,6 +116,14 @@ class NowPlayingViewModel @Inject constructor(
 
     fun setLiveLyricsBarEnabled(enabled: Boolean) {
         viewModelScope.launch { lyricsPreference.setLiveBarEnabled(enabled) }
+    }
+
+    val ambientAnimationEnabled: StateFlow<Boolean?> = nowPlayingPreference.ambientAnimationEnabled
+        .map<Boolean, Boolean?> { it }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    fun setAmbientAnimationEnabled(enabled: Boolean) {
+        viewModelScope.launch { nowPlayingPreference.setAmbientAnimationEnabled(enabled) }
     }
 
     private val _userMessages = MutableSharedFlow<String>(
@@ -1097,4 +1107,3 @@ internal fun overlayDisplayTrack(
         )
     } else baseTrack
 }
-

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
@@ -122,9 +122,6 @@ class NowPlayingViewModel @Inject constructor(
         .map<Boolean, Boolean?> { it }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
-    fun setAmbientAnimationEnabled(enabled: Boolean) {
-        viewModelScope.launch { nowPlayingPreference.setAmbientAnimationEnabled(enabled) }
-    }
 
     private val _userMessages = MutableSharedFlow<String>(
         // v0.9.18: bumped from 1 → 8. The Find-in-FLAC action emits TWO

--- a/feature/nowplaying/src/test/kotlin/com/stash/feature/nowplaying/NowPlayingLyricsExportTest.kt
+++ b/feature/nowplaying/src/test/kotlin/com/stash/feature/nowplaying/NowPlayingLyricsExportTest.kt
@@ -193,6 +193,7 @@ class NowPlayingLyricsExportTest {
         losslessUpgrader = mockk<LosslessUpgrader>(relaxed = true),
         lyricsRepository = lyricsRepository,
         lyricsPreference = mockk(relaxed = true),
+        nowPlayingPreference = mockk(relaxed = true),
         lyricsSidecarWriter = lyricsSidecarWriter,
         appContext = mockk<Context>(relaxed = true),
         ytMusicApiClient = mockk<YTMusicApiClient>(relaxed = true),

--- a/feature/nowplaying/src/test/kotlin/com/stash/feature/nowplaying/NowPlayingViewModelTest.kt
+++ b/feature/nowplaying/src/test/kotlin/com/stash/feature/nowplaying/NowPlayingViewModelTest.kt
@@ -5,6 +5,7 @@ import app.cash.turbine.test
 import app.cash.turbine.testIn
 import app.cash.turbine.turbineScope
 import com.stash.core.data.lossless.LosslessUpgrader
+import com.stash.core.data.prefs.NowPlayingPreference
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.data.social.LikeCoordinator
 import com.stash.core.media.PlayerRepository
@@ -20,10 +21,12 @@ import io.mockk.slot
 import io.mockk.verify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.yield
@@ -204,13 +207,16 @@ class NowPlayingViewModelFindInFlacTest {
     private val lyricsRepository: LyricsRepository = mockk(relaxed = true)
     private val appContext: Context = mockk(relaxed = true)
 
-    private fun newViewModel(): NowPlayingViewModel = NowPlayingViewModel(
+    private fun newViewModel(
+        nowPlayingPreference: NowPlayingPreference = mockk(relaxed = true),
+    ): NowPlayingViewModel = NowPlayingViewModel(
         playerRepository = playerRepository,
         musicRepository = musicRepository,
         likeCoordinator = likeCoordinator,
         losslessUpgrader = upgrader,
         lyricsRepository = lyricsRepository,
         lyricsPreference = mockk(relaxed = true),
+        nowPlayingPreference = nowPlayingPreference,
         lyricsSidecarWriter = mockk(relaxed = true),
         appContext = appContext,
         ytMusicApiClient = mockk(relaxed = true),
@@ -223,6 +229,24 @@ class NowPlayingViewModelFindInFlacTest {
         fileFormat = "opus",
     )
     private val flacTrack = nonFlacTrack.copy(id = 99L, fileFormat = "flac")
+
+    @Test fun `cold persisted false stays unloaded until preference emits`() = runTest(dispatcher) {
+        val releasePreference = CompletableDeferred<Unit>()
+        val preference = mockk<NowPlayingPreference> {
+            every { ambientAnimationEnabled } returns flow {
+                releasePreference.await()
+                emit(false)
+            }
+        }
+        val vm = newViewModel(preference)
+
+        vm.ambientAnimationEnabled.test {
+            assertEquals(null, awaitItem())
+            releasePreference.complete(Unit)
+            assertEquals(false, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 
     /**
      * The action's body emits "Looking for FLAC…", calls `upgradeToLossless`,
@@ -338,6 +362,7 @@ class NowPlayingViewModelLikeRoutingTest {
         losslessUpgrader = upgrader,
         lyricsRepository = lyricsRepository,
         lyricsPreference = mockk(relaxed = true),
+        nowPlayingPreference = mockk(relaxed = true),
         lyricsSidecarWriter = mockk(relaxed = true),
         appContext = appContext,
         ytMusicApiClient = mockk(relaxed = true),
@@ -411,6 +436,7 @@ class NowPlayingViewModelTrackTapTest {
         losslessUpgrader = upgrader,
         lyricsRepository = lyricsRepository,
         lyricsPreference = mockk(relaxed = true),
+        nowPlayingPreference = mockk(relaxed = true),
         lyricsSidecarWriter = mockk(relaxed = true),
         appContext = appContext,
         ytMusicApiClient = api,

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAppearanceScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAppearanceScreen.kt
@@ -109,6 +109,16 @@ fun SettingsAppearanceScreen(
             checked = uiState.amoledDark,
             onCheckedChange = viewModel::onAmoledDarkChanged,
         )
+
+        Spacer(Modifier.height(20.dp))
+        SettingsSectionLabel("Now Playing")
+
+        SettingsToggleRow(
+            title = "Ambient motion",
+            subtitle = "Animated color wash behind Now Playing — switch off for a still backdrop that saves battery",
+            checked = uiState.ambientAnimationEnabled,
+            onCheckedChange = viewModel::onAmbientAnimationEnabledChanged,
+        )
     }
 }
 

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
@@ -47,6 +47,8 @@ data class SettingsUiState(
     /** Qobuz discovery sections on Home (New Releases / Qobuz Playlists /
      * Top Albums + genre chips). False = Home keeps only mixes + imports. */
     val qobuzDiscoveryEnabled: Boolean = true,
+    /** Ambient animated background on the Now Playing screen. */
+    val ambientAnimationEnabled: Boolean = true,
     val ytHistoryHealth: YouTubeScrobblerHealth = YouTubeScrobblerHealth.DISABLED,
     val ytPendingCount: Int = 0,
     /**

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -94,6 +94,7 @@ class SettingsViewModel @Inject constructor(
     private val youTubeHistoryPreference: YouTubeHistoryPreference,
     private val stashMixPreference: com.stash.core.data.prefs.StashMixPreference,
     private val homeDiscoveryPreference: com.stash.core.data.prefs.HomeDiscoveryPreference,
+    private val nowPlayingPreference: com.stash.core.data.prefs.NowPlayingPreference,
     private val youTubeHistoryScrobbler: YouTubeHistoryScrobbler,
     private val youTubeScrobblerState: YouTubeScrobblerState,
     private val losslessPrefs: LosslessSourcePreferences,
@@ -349,6 +350,7 @@ class SettingsViewModel @Inject constructor(
         streamingQualityPrefs.saveData,
         themePreference.amoledDark,
         homeDiscoveryPreference.enabled,
+        nowPlayingPreference.ambientAnimationEnabled,
     ) { values ->
         @Suppress("UNCHECKED_CAST")
         val spotifyAuth = values[0] as AuthState
@@ -386,6 +388,7 @@ class SettingsViewModel @Inject constructor(
         val streamingSaveData = values[32] as Boolean
         val amoledDark = values[33] as Boolean
         val qobuzDiscoveryEnabled = values[34] as Boolean
+        val ambientAnimationEnabled = values[35] as Boolean
 
         val lastFmState: LastFmAuthState = local.lastFmAuthOverride
             ?: when {
@@ -423,6 +426,7 @@ class SettingsViewModel @Inject constructor(
             ytHistoryEnabled = ytHistoryEnabled,
             stashMixesEnabled = stashMixesEnabled,
             qobuzDiscoveryEnabled = qobuzDiscoveryEnabled,
+            ambientAnimationEnabled = ambientAnimationEnabled,
             ytHistoryHealth = ytHistoryHealth,
             ytPendingCount = ytPendingCount,
             losslessEnabled = losslessEnabled,
@@ -1027,6 +1031,11 @@ class SettingsViewModel @Inject constructor(
      */
     fun onQobuzDiscoveryEnabledChanged(enabled: Boolean) {
         viewModelScope.launch { homeDiscoveryPreference.setEnabled(enabled) }
+    }
+
+    /** Ambient animated background on Now Playing (Settings > Appearance). */
+    fun onAmbientAnimationEnabledChanged(enabled: Boolean) {
+        viewModelScope.launch { nowPlayingPreference.setAmbientAnimationEnabled(enabled) }
     }
 
     /** Clear the kill-switch after PROTOCOL_BROKEN. Exposed to the Settings


### PR DESCRIPTION
## Summary

- persist a Now Playing ambient-animation toggle that defaults on
- omit the animated ambient background and expand album art when animation is disabled
- add an accessible motion toggle directly on the album artwork

## Validation

- `NowPlayingPreferenceTest`: 2 tests passed
- `:feature:nowplaying:testDebugUnitTest`: 46 tests passed
- `:app:assembleDebug`: passed
- latest debug APK installed and cold-launched on a Medium Phone API 36 emulator
- `git diff --check`: passed

## Device testing

- Install and cold launch passed. The fresh emulator profile had no connected service, library, or playing track, so the two Now Playing visual modes could not be exercised without personal provider credentials.

Fixes #65
