### PR TITLE
Stop passing video url as yt-dlp processId (fixes "Process ID already exists")

### DIFF
--- a/data/download/src/main/kotlin/com/stash/data/download/DownloadExecutor.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/DownloadExecutor.kt
@@ -159,7 +159,12 @@ class DownloadExecutor @Inject constructor(
 
             Log.d(TAG, "download: starting url=$url client=${playerClient ?: "default"} args=$qualityArgs")
 
-            val response = YoutubeDL.getInstance().execute(request, url) { progress, _, _ ->
+            // processId must be null, not `url`: youtubedl-android throws
+            // "Process ID already exists" if two execute() calls share a
+            // non-null id, and a preview prefetch + this download routinely
+            // hit the same video at once. Nothing cancels by id (no
+            // destroyProcessById caller), so the handle was unused anyway. (#210)
+            val response = YoutubeDL.getInstance().execute(request, null) { progress, _, _ ->
                 onProgress((progress / 100f).coerceIn(0f, 1f))
             }
 

--- a/data/download/src/main/kotlin/com/stash/data/download/preview/PreviewUrlExtractor.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/preview/PreviewUrlExtractor.kt
@@ -537,7 +537,10 @@ class PreviewUrlExtractor @Inject constructor(
             }
 
             Log.d(TAG, "yt-dlp: invoking for videoId=$videoId client=${playerClient ?: "default"}")
-            val response = YoutubeDL.getInstance().execute(request, url, null)
+            // null processId: sharing the video url as the id collides with a
+            // concurrent download of the same track ("Process ID already
+            // exists"). The id is never used to cancel. (#210)
+            val response = YoutubeDL.getInstance().execute(request, null, null)
 
             val stdout = response.out.orEmpty()
             val stderr = response.err.orEmpty()

--- a/data/download/src/main/kotlin/com/stash/data/download/ytdlp/YtDlpManager.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/ytdlp/YtDlpManager.kt
@@ -169,8 +169,11 @@ class YtDlpManager @Inject constructor(
                             addOption("--remote-components", "ejs:github")
                         }
                     }
+                    // null processId for the same reason as the download/preview
+                    // paths: a non-null id can collide with a concurrent
+                    // execute() of the same video. (#210)
                     val response = YoutubeDL.getInstance()
-                        .execute(request, WARMUP_VIDEO_URL, null)
+                        .execute(request, null, null)
                     val dt = System.currentTimeMillis() - t0
                     Log.i(
                         TAG,


### PR DESCRIPTION
Addresses #210 — specifically the **"Process ID already exists"** failure.

### Scope

#210 bundles several symptoms, and the attached diagnostics are from **v0.9.55**. The dominant failures there — `Signature solving failed` / `n challenge solving failed` → `Requested format is not available` — are YouTube's JS signature challenge, which current `main` already handles via the QuickJS + EJS wiring in `YtDlpManager`/`DownloadExecutor`. This PR targets the one collision bug that is still present in current code.

### Root cause

`YoutubeDL.execute(request, processId, callback)` throws `YoutubeDLException("Process ID already exists")` when two concurrent calls share the same non-null `processId`. Three call sites passed the bare video **url** as that id:

- `DownloadExecutor.runYtDlp` (the download)
- `PreviewUrlExtractor.runYtDlp` (preview stream extraction)
- `YtDlpManager.warmUp` (startup warmup)

So any two yt-dlp runs on the same video at the same moment collide. The common case is a **preview prefetch racing the actual download of the same track** — visible in the diagnostics, where `PreviewPrefetcher` and the search download both hit `r76d-gZC85M` and the download dies with "Process ID already exists".

### Fix

Pass `null` as `processId` at all three sites. The id is only consumed by `destroyProcessById` for targeted cancellation, and nothing in the app cancels that way (WorkManager tears down via coroutine cancellation). `YouTubeSearchExecutor` already calls the no-id form, so this just makes the other sites consistent. Progress callbacks are unaffected — they're a separate argument.

### Testing

- `:data:download:compileDebugKotlin` — clean (confirms the library accepts a null `processId`)
- `:data:download:testDebugUnitTest` — no new failures. Two suites (`MetadataEmbedderExecutionTest`, `LosslessSourceRegistryTest`) fail **identically on clean `main`** in my environment (native ffmpeg binary unavailable on the dev box); they're unrelated to this change.

No unit test added: the behavior is a native-library interaction (collision inside youtubedl-android's process map) with no seam to assert on without mocking the `YoutubeDL` singleton. Happy to add one if you'd prefer a specific shape.
