### PR TITLE
fix: persist streaming tracks before scrobbling

### DIFF
--- a/core/media/src/main/kotlin/com/stash/core/media/listening/ListeningRecorder.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/listening/ListeningRecorder.kt
@@ -7,8 +7,10 @@ import com.stash.core.data.lastfm.LastFmScrobbler
 import com.stash.core.data.db.dao.TrackSkipEventDao
 import com.stash.core.data.db.entity.ListeningEventEntity
 import com.stash.core.data.db.entity.TrackSkipEventEntity
+import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.PlayerRepository
 import com.stash.core.model.RepeatMode
+import com.stash.core.model.Track
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -47,6 +49,7 @@ import javax.inject.Singleton
 @Singleton
 class ListeningRecorder @VisibleForTesting internal constructor(
     private val playerRepository: PlayerRepository,
+    private val musicRepository: MusicRepository,
     private val listeningEventDao: ListeningEventDao,
     private val trackSkipEventDao: TrackSkipEventDao,
     private val scrobbler: LastFmScrobbler,
@@ -56,11 +59,13 @@ class ListeningRecorder @VisibleForTesting internal constructor(
     @Inject
     constructor(
         playerRepository: PlayerRepository,
+        musicRepository: MusicRepository,
         listeningEventDao: ListeningEventDao,
         trackSkipEventDao: TrackSkipEventDao,
         scrobbler: LastFmScrobbler,
     ) : this(
         playerRepository = playerRepository,
+        musicRepository = musicRepository,
         listeningEventDao = listeningEventDao,
         trackSkipEventDao = trackSkipEventDao,
         scrobbler = scrobbler,
@@ -68,18 +73,14 @@ class ListeningRecorder @VisibleForTesting internal constructor(
     )
 
     /**
-     * Pending threshold-fire metadata. We keep the [firedFlag] alongside
-     * the [job] because [Job.cancel] completes the job synchronously —
-     * `isCompleted` cannot distinguish "delay body ran" from "delay was
-     * cancelled mid-flight". The flag is set inside the delay body
-     * BEFORE the listening_events insert, so a track-change collector
-     * reading `firedFlag.get()` after `cancel()` sees the truthful state.
+     * [claimed] is a one-shot handoff between the threshold job and a
+     * transition. Only the side that atomically claims it may act.
      */
     private data class PendingFire(
-        val trackId: Long,
+        val track: Track,
         val sessionStart: Long,
         val job: Job,
-        val firedFlag: AtomicBoolean,
+        val claimed: AtomicBoolean,
         val positionAtScheduleMs: Long,
     )
 
@@ -110,15 +111,13 @@ class ListeningRecorder @VisibleForTesting internal constructor(
             playerRepository.playerState
                 .distinctUntilChangedBy { it.currentTrack?.id }
                 .collect { state ->
-                    // 1. Snapshot previous pending and record a skip if
-                    //    its delayed-fire never completed (cancellation
-                    //    completes the Job either way, so isCompleted is
-                    //    unreliable — we use an AtomicBoolean flag set
-                    //    inside the delay block right before the insert).
+                    // 1. Claim the previous session for this transition.
+                    //    If completion already claimed it, leave its job
+                    //    alive so persistence + listen recording can finish.
                     val previousPending = pending
                     if (previousPending != null) {
-                        previousPending.job.cancel()
-                        if (!previousPending.firedFlag.get()) {
+                        if (previousPending.claimed.compareAndSet(false, true)) {
+                            previousPending.job.cancel()
                             val skipAt = System.currentTimeMillis()
                             val position = previousPending.positionAtScheduleMs
                             // Inline (rather than `scope.launch { ... }`) so
@@ -130,7 +129,7 @@ class ListeningRecorder @VisibleForTesting internal constructor(
                             runCatching {
                                 trackSkipEventDao.insert(
                                     TrackSkipEventEntity(
-                                        trackId = previousPending.trackId,
+                                        trackId = previousPending.track.id,
                                         skippedAt = skipAt,
                                         positionMs = position,
                                     ),
@@ -142,7 +141,7 @@ class ListeningRecorder @VisibleForTesting internal constructor(
 
                     // 2. Schedule the new track's threshold-fire.
                     val track = state.currentTrack ?: return@collect
-                    schedulePendingFire(track.id, track.artist, track.title, track.album, track.durationMs)
+                    schedulePendingFire(track)
                 }
         }
     }
@@ -178,12 +177,9 @@ class ListeningRecorder @VisibleForTesting internal constructor(
 
                     if (isRepeatOne && positionJumpedBack) {
                         Log.d(TAG, "repeat detected for track ${track.id} — scheduling new fire")
-                        pending?.job?.cancel()
+                        pending?.takeIf { it.claimed.compareAndSet(false, true) }?.job?.cancel()
                         pending = null
-                        schedulePendingFire(
-                            track.id, track.artist, track.title,
-                            track.album, track.durationMs,
-                        )
+                        schedulePendingFire(track)
                     }
 
                     lastPositionMs = positionMs
@@ -196,29 +192,20 @@ class ListeningRecorder @VisibleForTesting internal constructor(
      * track-change collector and the repeat-one loop detector so the
      * insert + now-playing logic stays in one place.
      */
-    private fun schedulePendingFire(
-        trackId: Long,
-        artist: String,
-        title: String,
-        album: String,
-        durationMs: Long,
-    ) {
+    private fun schedulePendingFire(track: Track) {
         val sessionStart = System.currentTimeMillis()
-        val threshold = thresholdFor(durationMs)
-        val firedFlag = AtomicBoolean(false)
+        val threshold = thresholdFor(track.durationMs)
+        val claimed = AtomicBoolean(false)
         val job = scope.launch {
             delay(threshold)
             val nowPlaying = playerRepository.playerState.value.currentTrack?.id
-            // Mark fired BEFORE the insert so a race with
-            // the next track-change collector observes
-            // the correct state when it reads .get().
-            if (nowPlaying == trackId) {
-                firedFlag.set(true)
+            if (nowPlaying == track.id && claimed.compareAndSet(false, true)) {
                 try {
+                    val persistedTrackId = musicRepository.ensureTrackPersisted(track)
                     val completedAt = System.currentTimeMillis()
                     listeningEventDao.recordCompletedListen(
                         ListeningEventEntity(
-                            trackId = trackId,
+                            trackId = persistedTrackId,
                             startedAt = sessionStart,
                             scrobbled = false,
                             // v0.9.13: insert IS the completion event — recorder only fires
@@ -234,17 +221,17 @@ class ListeningRecorder @VisibleForTesting internal constructor(
             }
         }
         pending = PendingFire(
-            trackId = trackId,
+            track = track,
             sessionStart = sessionStart,
             job = job,
-            firedFlag = firedFlag,
+            claimed = claimed,
             positionAtScheduleMs = playerRepository.playerState.value.positionMs,
         )
         scope.launch {
             scrobbler.notifyNowPlaying(
-                artist = artist,
-                track = title,
-                album = album.takeIf { it.isNotBlank() },
+                artist = track.artist,
+                track = track.title,
+                album = track.album.takeIf { it.isNotBlank() },
             )
         }
     }

--- a/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
@@ -5,6 +5,7 @@ import com.stash.core.data.db.dao.TrackSkipEventDao
 import com.stash.core.data.lastfm.LastFmScrobbler
 import com.stash.core.data.db.entity.ListeningEventEntity
 import com.stash.core.data.db.entity.TrackSkipEventEntity
+import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.PlayerRepository
 import com.stash.core.media.StreamRoutingResult
 import com.stash.core.media.StreamingHaltedEvent
@@ -34,6 +35,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -110,6 +112,13 @@ class ListeningRecorderSkipTest {
         durationMs = 180_000,
     )
 
+    private fun passthroughMusicRepository(): MusicRepository =
+        mockk<MusicRepository>().also { repository ->
+            coEvery { repository.ensureTrackPersisted(any()) } coAnswers {
+                firstArg<Track>().id
+            }
+        }
+
     @Test
     fun `track id transition before threshold fire records a skip`() = runTest {
         val playerRepo = FakePlayerRepository(
@@ -122,6 +131,7 @@ class ListeningRecorderSkipTest {
 
         val recorder = ListeningRecorder(
             playerRepository = playerRepo,
+            musicRepository = passthroughMusicRepository(),
             listeningEventDao = listeningDao,
             trackSkipEventDao = skipDao,
             scrobbler = mockk(relaxed = true),
@@ -156,6 +166,7 @@ class ListeningRecorderSkipTest {
 
         val recorder = ListeningRecorder(
             playerRepository = playerRepo,
+            musicRepository = passthroughMusicRepository(),
             listeningEventDao = listeningDao,
             trackSkipEventDao = skipDao,
             scrobbler = mockk(relaxed = true),
@@ -164,7 +175,7 @@ class ListeningRecorderSkipTest {
         recorder.start()
         // Threshold for a 180s track = min(90_000, 240_000) coerced into
         // [30s, 4min] = 90_000ms. Advance past it so the delay body runs
-        // and sets firedFlag = true BEFORE we transition to track B.
+        // and claims completion BEFORE we transition to track B.
         advanceTimeBy(95_000)
         runCurrent()
         playerRepo.setState(PlayerState(currentTrack = trackB, positionMs = 0))
@@ -174,6 +185,58 @@ class ListeningRecorderSkipTest {
         coVerify(exactly = 1) { listeningDao.recordCompletedListen(any()) }
         assertEquals(trackA.id, listenCapture.captured.trackId)
         coVerify(exactly = 0) { skipDao.insert(any()) }
+    }
+
+    @Test
+    fun `claimed completion survives transition while synthetic id resolves`() = runTest {
+        val streamingTrack = Track(
+            id = -123L,
+            title = "Stream only",
+            artist = "Artist",
+            durationMs = 60_000L,
+            youtubeId = "video-id",
+        )
+        val playerRepo = FakePlayerRepository(PlayerState(currentTrack = streamingTrack))
+        val musicRepository = mockk<MusicRepository>()
+        val persistedTrack = slot<Track>()
+        val persistenceStarted = CompletableDeferred<Unit>()
+        val releasePersistence = CompletableDeferred<Unit>()
+        coEvery { musicRepository.ensureTrackPersisted(capture(persistedTrack)) } coAnswers {
+            persistenceStarted.complete(Unit)
+            releasePersistence.await()
+            42L
+        }
+        val listeningDao = mockk<ListeningEventDao>(relaxed = true)
+        val skipDao = mockk<TrackSkipEventDao>(relaxed = true)
+        val listen = slot<ListeningEventEntity>()
+        coEvery { listeningDao.recordCompletedListen(capture(listen)) } returns 1L
+
+        val recorder = ListeningRecorder(
+            playerRepository = playerRepo,
+            musicRepository = musicRepository,
+            listeningEventDao = listeningDao,
+            trackSkipEventDao = skipDao,
+            scrobbler = mockk(relaxed = true),
+            scope = backgroundScope,
+        )
+        recorder.start()
+        runCurrent()
+        advanceTimeBy(35_000L)
+        runCurrent()
+        assertTrue(persistenceStarted.isCompleted)
+
+        playerRepo.setState(PlayerState(currentTrack = trackB))
+        runCurrent()
+        coVerify(exactly = 0) { skipDao.insert(any()) }
+        coVerify(exactly = 0) { listeningDao.recordCompletedListen(any()) }
+
+        releasePersistence.complete(Unit)
+        runCurrent()
+
+        coVerify(exactly = 1) { musicRepository.ensureTrackPersisted(streamingTrack) }
+        coVerify(exactly = 1) { listeningDao.recordCompletedListen(any()) }
+        assertEquals("video-id", persistedTrack.captured.youtubeId)
+        assertEquals(42L, listen.captured.trackId)
     }
 
     @Test
@@ -187,6 +250,7 @@ class ListeningRecorderSkipTest {
 
         val recorder = ListeningRecorder(
             playerRepository = playerRepo,
+            musicRepository = passthroughMusicRepository(),
             listeningEventDao = listeningDao,
             trackSkipEventDao = mockk(relaxed = true),
             scrobbler = mockk(relaxed = true),
@@ -225,6 +289,7 @@ class ListeningRecorderSkipTest {
 
         val recorder = ListeningRecorder(
             playerRepository = playerRepo,
+            musicRepository = passthroughMusicRepository(),
             listeningEventDao = listeningDao,
             trackSkipEventDao = mockk(relaxed = true),
             scrobbler = mockk(relaxed = true),
@@ -260,6 +325,7 @@ class ListeningRecorderSkipTest {
 
         val recorder = ListeningRecorder(
             playerRepository = playerRepo,
+            musicRepository = passthroughMusicRepository(),
             listeningEventDao = listeningDao,
             trackSkipEventDao = skipDao,
             scrobbler = mockk(relaxed = true),
@@ -301,6 +367,7 @@ class ListeningRecorderSkipTest {
         coEvery { listeningDao.backfillMissingTrackStats() } coAnswers { backfill.await() }
         val recorder = ListeningRecorder(
             playerRepository = playerRepo,
+            musicRepository = passthroughMusicRepository(),
             listeningEventDao = listeningDao,
             trackSkipEventDao = mockk(relaxed = true),
             scrobbler = mockk(relaxed = true),
@@ -330,6 +397,7 @@ class ListeningRecorderSkipTest {
         val recorderScope = CoroutineScope(parent + StandardTestDispatcher(testScheduler))
         val recorder = ListeningRecorder(
             playerRepository = playerRepo,
+            musicRepository = passthroughMusicRepository(),
             listeningEventDao = listeningDao,
             trackSkipEventDao = mockk(relaxed = true),
             scrobbler = mockk(relaxed = true),


### PR DESCRIPTION
## What does this PR do?

Persists a pure-streaming track before recording its completed listen, then uses the resolved Room primary key for `listening_events`. This prevents synthetic streaming IDs from violating the completed-listen foreign key and silently losing scrobbles.

The recorder retains the full track identity and uses an atomic ownership handoff so a track transition cannot cancel a completed-listen path while persistence is in progress.

## Related issue

Closes #202

## How was this tested?

- 8 focused recorder tests covering synthetic-ID persistence, a blocked-persistence transition race, skips, completed listens, repeat-one playback, startup ordering, and cancellation
- `assembleDebug`
- `git diff --check`
- The repository-wide test task retains a documented unrelated `PlaylistTypeTest` baseline failure
