### PR TITLE
fix: deactivate missing Spotify playlists after refresh

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
@@ -462,6 +462,19 @@ interface PlaylistDao {
         currentSourceIds: List<String>,
     ): Int
 
+    /** Soft-deactivate only Spotify CUSTOM playlists absent from a complete inventory. */
+    @Query(
+        """
+        UPDATE playlists SET is_active = 0
+        WHERE source = 'SPOTIFY' AND type = 'CUSTOM' AND is_active = 1
+          AND (:hasCurrentIds = 0 OR source_id NOT IN (:currentSourceIds))
+        """
+    )
+    suspend fun deactivateMissingSpotifyCustomPlaylists(
+        currentSourceIds: List<String>,
+        hasCurrentIds: Boolean,
+    ): Int
+
     /** Flip [is_active] back to 1 for a specific playlist id. Paired with
      *  [deactivateMissingForSource] so a rotating home-feed mix that
      *  returns tomorrow re-surfaces on the Home screen instead of

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorker.kt
@@ -11,6 +11,7 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthService
+import com.stash.core.data.db.dao.PlaylistDao
 import com.stash.core.data.db.dao.RemoteSnapshotDao
 import com.stash.core.data.db.dao.SyncHistoryDao
 import com.stash.core.data.db.entity.RemotePlaylistSnapshotEntity
@@ -25,12 +26,14 @@ import com.stash.core.data.sync.auth.YoutubeAuthHealthProbe
 import com.stash.core.model.MusicSource
 import com.stash.core.model.PlaylistType
 import com.stash.core.model.StepStatus
+import com.stash.core.model.SyncMode
 import com.stash.core.model.SyncResult
 import com.stash.core.model.SyncState
 import com.stash.core.model.SyncStepResult
 import com.stash.core.model.SyncTrigger
 import com.stash.data.spotify.SpotifyApiClient
 import com.stash.data.spotify.SpotifyApiException
+import com.stash.data.spotify.SpotifyLibraryPage
 import com.stash.data.ytmusic.InnerTubeClient
 import com.stash.data.ytmusic.YTMusicApiClient
 import com.stash.data.ytmusic.model.MusicVideoType
@@ -40,7 +43,10 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
@@ -53,6 +59,11 @@ internal fun likedPlaylistArtUrl(trackArtUrls: Sequence<String?>): String? =
     com.stash.core.common.ArtUrlUpgrader.upgrade(
         trackArtUrls.firstOrNull { !it.isNullOrBlank() }
     )
+
+internal fun shouldDeactivateMissingSpotifyPlaylists(
+    syncMode: SyncMode,
+    inventoryComplete: Boolean,
+): Boolean = syncMode == SyncMode.REFRESH && inventoryComplete
 
 /**
  * First worker in the sync chain. Authenticates with configured music services,
@@ -69,6 +80,7 @@ class PlaylistFetchWorker @AssistedInject constructor(
     private val spotifyApiClient: SpotifyApiClient,
     private val ytMusicApiClient: YTMusicApiClient,
     private val innerTubeClient: InnerTubeClient,
+    private val playlistDao: PlaylistDao,
     private val syncHistoryDao: SyncHistoryDao,
     private val remoteSnapshotDao: RemoteSnapshotDao,
     private val syncStateManager: SyncStateManager,
@@ -231,6 +243,7 @@ class PlaylistFetchWorker @AssistedInject constructor(
             syncStateManager.onError("Spotify API rate limited, retrying...", e)
             return Result.retry()
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Log.e(TAG, "Playlist fetch failed", e)
             syncHistoryDao.updateDiagnostics(syncId, Json.encodeToString(diagnostics.toList()))
             syncHistoryDao.updateStatus(
@@ -423,6 +436,7 @@ class PlaylistFetchWorker @AssistedInject constructor(
 
         // Fetch user-created/saved playlists from the Spotify library.
         var userPlaylistCount = 0
+        var inventoryComplete = true
         try {
             // v0.9.21: paginate libraryV3 instead of a single 50-item fetch.
             // The previous single-call path silently capped users at ≤50
@@ -450,34 +464,43 @@ class PlaylistFetchWorker @AssistedInject constructor(
             val folderQueue = ArrayDeque<Pair<String, Int>>() // folder uri to depth
             val visitedFolders = mutableSetOf<String>()
 
-            suspend fun pageThrough(folderUri: String?, depth: Int) {
+            suspend fun pageThrough(folderUri: String?, depth: Int): Boolean {
                 var offset = 0
+                var complete = true
                 while (pagesFetched < pageCap) {
                     val page = spotifyApiClient.getUserPlaylists(
                         limit = pageSize,
                         offset = offset,
                         folderUri = folderUri,
                     )
+                    // SpotifyApiClient uses this singleton as its failure/invalid-response
+                    // sentinel. A genuinely empty parsed library is a distinct instance.
+                    currentCoroutineContext().ensureActive()
+                    if (page === SpotifyLibraryPage.EMPTY) return false
+                    if (!page.isComplete) complete = false
                     pagesFetched++
                     userPlaylists += page.playlists
                     for (uri in page.folderUris) {
                         if (visitedFolders.add(uri)) folderQueue.addLast(uri to depth + 1)
                     }
-                    if (page.rawItemCount < pageSize) break // true last page
+                    if (page.rawItemCount < pageSize) return complete
                     offset += pageSize
                 }
+                return false
             }
 
-            pageThrough(folderUri = null, depth = 0)
+            inventoryComplete = pageThrough(folderUri = null, depth = 0)
             while (folderQueue.isNotEmpty() && pagesFetched < pageCap) {
                 val (uri, depth) = folderQueue.removeFirst()
                 if (depth > maxFolderDepth) {
+                    inventoryComplete = false
                     Log.w(TAG, "fetchSpotifyPlaylists: folder '$uri' beyond depth $maxFolderDepth, skipping")
                     continue
                 }
                 foldersWalked++
-                pageThrough(folderUri = uri, depth = depth)
+                if (!pageThrough(folderUri = uri, depth = depth)) inventoryComplete = false
             }
+            if (folderQueue.isNotEmpty()) inventoryComplete = false
 
             Log.i(
                 TAG,
@@ -541,13 +564,25 @@ class PlaylistFetchWorker @AssistedInject constructor(
                         }
                     }
                 } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    inventoryComplete = false
                     Log.w(TAG, "fetchSpotifyPlaylists: failed to fetch tracks for '${playlist.name}'", e)
                 }
+            }
+
+            if (shouldDeactivateMissingSpotifyPlaylists(syncPreferencesManager.spotifySyncMode.first(), inventoryComplete)) {
+                val currentIds = customPlaylists.map { it.id }
+                val hidden = playlistDao.deactivateMissingSpotifyCustomPlaylists(
+                    currentSourceIds = currentIds,
+                    hasCurrentIds = currentIds.isNotEmpty(),
+                )
+                if (hidden > 0) Log.i(TAG, "Deactivated $hidden missing Spotify custom playlist(s)")
             }
             diagnostics.add(SyncStepResult("SPOTIFY", "getUserPlaylists", StepStatus.SUCCESS, userPlaylistCount))
         } catch (e: SpotifyApiException) {
             throw e
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Log.e(TAG, "fetchSpotifyPlaylists: user playlists fetch failed", e)
             diagnostics.add(SyncStepResult("SPOTIFY", "getUserPlaylists", StepStatus.ERROR, errorMessage = e.message))
         }

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoSpotifyDeactivationTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoSpotifyDeactivationTest.kt
@@ -1,0 +1,83 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PlaylistDaoSpotifyDeactivationTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: PlaylistDao
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.playlistDao()
+    }
+
+    @After fun tearDown() = db.close()
+
+    @Test fun `deactivates only active missing Spotify custom playlists`() = runTest {
+        val present = insert("present", MusicSource.SPOTIFY, PlaylistType.CUSTOM)
+        val missing = insert("missing", MusicSource.SPOTIFY, PlaylistType.CUSTOM)
+        val alreadyInactive = insert("inactive", MusicSource.SPOTIFY, PlaylistType.CUSTOM, active = false)
+        val liked = insert("liked", MusicSource.SPOTIFY, PlaylistType.LIKED_SONGS)
+        val daily = insert("daily", MusicSource.SPOTIFY, PlaylistType.DAILY_MIX)
+        val local = insert("local", MusicSource.BOTH, PlaylistType.CUSTOM)
+        val youtube = insert("youtube", MusicSource.YOUTUBE, PlaylistType.CUSTOM)
+
+        assertEquals(1, dao.deactivateMissingSpotifyCustomPlaylists(listOf("present"), true))
+
+        assertTrue(dao.getById(present)!!.isActive)
+        assertFalse(dao.getById(missing)!!.isActive)
+        assertFalse(dao.getById(alreadyInactive)!!.isActive)
+        assertTrue(dao.getById(liked)!!.isActive)
+        assertTrue(dao.getById(daily)!!.isActive)
+        assertTrue(dao.getById(local)!!.isActive)
+        assertTrue(dao.getById(youtube)!!.isActive)
+    }
+
+    @Test fun `complete empty inventory deactivates every eligible playlist`() = runTest {
+        val first = insert("first", MusicSource.SPOTIFY, PlaylistType.CUSTOM)
+        val second = insert("second", MusicSource.SPOTIFY, PlaylistType.CUSTOM)
+        val liked = insert("liked", MusicSource.SPOTIFY, PlaylistType.LIKED_SONGS)
+
+        assertEquals(2, dao.deactivateMissingSpotifyCustomPlaylists(emptyList(), false))
+
+        assertFalse(dao.getById(first)!!.isActive)
+        assertFalse(dao.getById(second)!!.isActive)
+        assertTrue(dao.getById(liked)!!.isActive)
+    }
+
+    private suspend fun insert(
+        sourceId: String,
+        source: MusicSource,
+        type: PlaylistType,
+        active: Boolean = true,
+    ): Long = dao.insert(
+        PlaylistEntity(
+            name = sourceId,
+            source = source,
+            sourceId = sourceId,
+            type = type,
+            isActive = active,
+        )
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/SpotifyPlaylistDeactivationGateTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/SpotifyPlaylistDeactivationGateTest.kt
@@ -1,0 +1,23 @@
+package com.stash.core.data.sync.workers
+
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.model.SyncMode
+import org.junit.Test
+
+class SpotifyPlaylistDeactivationGateTest {
+
+    @Test fun `refresh with complete inventory deactivates missing playlists`() {
+        assertThat(shouldDeactivateMissingSpotifyPlaylists(SyncMode.REFRESH, inventoryComplete = true))
+            .isTrue()
+    }
+
+    @Test fun `accumulate preserves missing playlists`() {
+        assertThat(shouldDeactivateMissingSpotifyPlaylists(SyncMode.ACCUMULATE, inventoryComplete = true))
+            .isFalse()
+    }
+
+    @Test fun `partial or unavailable inventory preserves missing playlists`() {
+        assertThat(shouldDeactivateMissingSpotifyPlaylists(SyncMode.REFRESH, inventoryComplete = false))
+            .isFalse()
+    }
+}

--- a/data/spotify/src/main/kotlin/com/stash/data/spotify/SpotifyLibraryParser.kt
+++ b/data/spotify/src/main/kotlin/com/stash/data/spotify/SpotifyLibraryParser.kt
@@ -38,9 +38,10 @@ data class SpotifyLibraryPage(
     val playlists: List<SpotifyPlaylistItem>,
     val folderUris: List<String>,
     val rawItemCount: Int,
+    val isComplete: Boolean = true,
 ) {
     companion object {
-        val EMPTY = SpotifyLibraryPage(emptyList(), emptyList(), 0)
+        val EMPTY = SpotifyLibraryPage(emptyList(), emptyList(), 0, isComplete = false)
     }
 }
 
@@ -71,13 +72,22 @@ fun parseLibraryPage(responseJson: JsonObject): SpotifyLibraryPage {
 
         val playlists = mutableListOf<SpotifyPlaylistItem>()
         val folderUris = mutableListOf<String>()
+        var isComplete = responseJson["errors"] == null
 
         for (element in items) {
             try {
                 val wrapper = element.jsonObject
-                val item = wrapper["item"]?.jsonObject ?: continue
+                val item = wrapper["item"]?.jsonObject
+                if (item == null) {
+                    isComplete = false
+                    continue
+                }
                 val typeName = item["__typename"]?.jsonPrimitive?.contentOrNull
-                val data = item["data"]?.jsonObject ?: continue
+                val data = item["data"]?.jsonObject
+                if (data == null) {
+                    isComplete = false
+                    continue
+                }
                 val dataTypeName = data["__typename"]?.jsonPrimitive?.contentOrNull
                 val uri = data["uri"]?.jsonPrimitive?.contentOrNull
 
@@ -89,6 +99,7 @@ fun parseLibraryPage(responseJson: JsonObject): SpotifyLibraryPage {
                         folderUris += uri
                         Log.d(TAG, "parseLibraryPage: folder '$uri' queued for descent")
                     } else {
+                        isComplete = false
                         Log.w(TAG, "parseLibraryPage: folder item without uri: $item")
                     }
                     continue
@@ -99,7 +110,10 @@ fun parseLibraryPage(responseJson: JsonObject): SpotifyLibraryPage {
                     continue
                 }
 
-                if (uri == null || !uri.startsWith("spotify:playlist:")) continue
+                if (uri == null || !uri.startsWith("spotify:playlist:")) {
+                    isComplete = false
+                    continue
+                }
 
                 val playlistId = uri.removePrefix("spotify:playlist:")
                 val name = data["name"]?.jsonPrimitive?.contentOrNull ?: "Untitled"
@@ -143,6 +157,7 @@ fun parseLibraryPage(responseJson: JsonObject): SpotifyLibraryPage {
                     )
                 }
             } catch (e: Exception) {
+                isComplete = false
                 Log.w(TAG, "parseLibraryPage: failed to parse item", e)
             }
         }
@@ -156,6 +171,7 @@ fun parseLibraryPage(responseJson: JsonObject): SpotifyLibraryPage {
             playlists = playlists,
             folderUris = folderUris,
             rawItemCount = items.size,
+            isComplete = isComplete,
         )
     } catch (e: Exception) {
         Log.e(TAG, "parseLibraryPage: failed to parse response", e)

--- a/data/spotify/src/test/kotlin/com/stash/data/spotify/SpotifyLibraryParserTest.kt
+++ b/data/spotify/src/test/kotlin/com/stash/data/spotify/SpotifyLibraryParserTest.kt
@@ -3,6 +3,7 @@ package com.stash.data.spotify
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -66,6 +67,7 @@ class SpotifyLibraryParserTest {
         // a paginator using playlists.size (2) would stop a 50-item walk
         // at the first folder-heavy page.
         assertEquals(5, page.rawItemCount)
+        assertTrue(page.isComplete)
     }
 
     @Test
@@ -76,5 +78,23 @@ class SpotifyLibraryParserTest {
         assertEquals(0, page.rawItemCount)
         assertTrue(page.playlists.isEmpty())
         assertTrue(page.folderUris.isEmpty())
+        assertFalse(page.isComplete)
+    }
+
+    @Test
+    fun `GraphQL errors and malformed playlist rows mark inventory incomplete`() {
+        val withErrors = parseLibraryPage(
+            Json.parseToJsonElement(
+                """{"errors":[{"message":"partial"}],"data":{"me":{"libraryV3":{"items":[]}}}}""",
+            ).jsonObject,
+        )
+        val malformedPlaylist = parseLibraryPage(
+            Json.parseToJsonElement(
+                """{"data":{"me":{"libraryV3":{"items":[{"item":{"data":{"__typename":"Playlist"}}}]}}}}""",
+            ).jsonObject,
+        )
+
+        assertFalse(withErrors.isComplete)
+        assertFalse(malformedPlaylist.isComplete)
     }
 }


### PR DESCRIPTION
## What does this PR do?

Deactivates Spotify custom playlists that disappeared from the user's library after a complete Refresh sync, so deleted playlists no longer remain visible locally.

The cleanup is fail-closed: partial GraphQL responses, malformed rows, traversal limits, cancellations, or snapshot failures preserve existing playlists instead of risking false deletion. Accumulate mode and non-custom or non-Spotify playlists are unchanged.

## Related issue

Closes #246

## How was this tested?

- 5 focused Room DAO and refresh-gate tests
- 5 focused Spotify library parser tests
- `assembleDebug`
- `git diff --check`
- The repository-wide test task retains a documented unrelated `PlaylistTypeTest` baseline failure
