### PR TITLE
fix(art): persist streamed-track art upgrades to the DB row

### DIFF
--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -1562,7 +1562,27 @@ class PlayerRepositoryImpl @Inject constructor(
                     com.stash.core.common.ArtUrlUpgrader.isYouTubeVideoThumbnail(currentArt))
         }
         val metaBuilder = item.mediaMetadata.buildUpon().setExtras(newExtras)
-        betterArt?.let { metaBuilder.setArtworkUri(Uri.parse(it)) }
+        betterArt?.let { art ->
+            metaBuilder.setArtworkUri(Uri.parse(art))
+            // #336: persist the upgrade — this stamp used to die with the
+            // session, so Library/queue/playlist rows kept the video
+            // thumbnail forever on queue-driven playback (mixes resolve via
+            // prefetch/LazyResolvingDataSource, which never hit routeStream's
+            // on-stream art swap). Row art re-checked inside the write so a
+            // stale session item can't clobber an already-good row. Same
+            // guard semantics as routeStream (A1) and DownloadManager's
+            // post-download write. Fire-and-forget; cosmetic on failure.
+            scope.launch {
+                runCatching {
+                    val rowArt = trackDao.getById(trackId)?.albumArtUrl
+                    val rowNeedsUpgrade = rowArt.isNullOrBlank() ||
+                        com.stash.core.common.ArtUrlUpgrader.isYouTubeVideoThumbnail(rowArt)
+                    if (rowNeedsUpgrade && rowArt != art) {
+                        trackDao.updateAlbumArtUrl(trackId, art)
+                    }
+                }
+            }
+        }
         val stamped = item.buildUpon()
             .setMediaMetadata(metaBuilder.build())
             .build()


### PR DESCRIPTION
## Summary
- The playing-track stamp already detected video-thumbnail art and swapped in the resolver's real cover — session-only, dying with the session. The two other persistence sites (routeStream's tap-to-play swap, DownloadManager's post-download write) never run for queue-driven mix playback, which is why streaming a whole YT mix fixed nothing (#336: 2194 thumbnail rows on the reporting device).
- The stamp now persists the upgrade to `tracks.album_art_url` with the same blank-or-thumbnail guard as the existing sites, re-checked against the row inside the fire-and-forget write.

## Test Plan
- [x] Device: '00s R&B mix track 1 ("Soldier") flipped `i.ytimg.com` → `static.qobuz.com` cover in the DB on play; prefetched-unplayed next track kept its thumbnail (per spec: browse = thumbnail OK, streamed = real art)
- [x] Residual documented: YouTube-fallback-only tracks have no better art to persist (needs InnerTube catalog lookup — follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)