### PR TITLE
fix(lyrics): move save action into the lyrics sheet, drop the jargon

### DIFF
--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
@@ -212,6 +212,9 @@ fun NowPlayingScreen(
             liveLyricsEnabled = liveLyricsEnabled,
             onLiveLyricsToggle = viewModel::setLiveLyricsBarEnabled,
             onSeek = viewModel::onLyricsLineSeek,
+            canSaveToFile = track?.isDownloaded == true,
+            savingToFile = exportingLyricsTrackId != null,
+            onSaveToFile = viewModel::exportLyricsForCurrentTrack,
             onRetry = viewModel::onLyricsRetry,
             onDismiss = viewModel::onDismissLyrics,
         )
@@ -493,18 +496,6 @@ fun NowPlayingScreen(
                             qualityText = qualityText,
                             isStreaming = uiState.isStreaming,
                         )
-                    }
-                    if (track.isDownloaded) {
-                        androidx.compose.material3.TextButton(
-                            enabled = exportingLyricsTrackId == null,
-                            onClick = viewModel::exportLyricsForCurrentTrack,
-                        ) {
-                            Text(when (exportingLyricsTrackId) {
-                                track.id -> "Saving lyrics sidecar"
-                                null -> "Save lyrics sidecar"
-                                else -> "Saving another track’s lyrics sidecar"
-                            })
-                        }
                     }
                 }
 

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingViewModel.kt
@@ -825,13 +825,13 @@ class NowPlayingViewModel @Inject constructor(
                 val message = try {
                     val lyrics = lyricsRepository.get(track.id)
                     if (lyrics == null || lyrics.syncedLrc.isNullOrBlank() && lyrics.plainText.isNullOrBlank()) {
-                        "No cached lyrics to save"
+                        "No lyrics to save yet"
                     } else {
                         lyricsSidecarWriter.write(track.id, lyrics)
-                        "Lyrics sidecar saved"
+                        "Lyrics saved with the song file"
                     }
                 } catch (e: CancellationException) { throw e }
-                catch (e: Exception) { "Couldn't save lyrics sidecar" }
+                catch (e: Exception) { "Couldn't save lyrics" }
                 val suffix = if (_uiState.value.currentTrack?.id != track.id) " for ‘${track.title}’" else ""
                 _userMessages.emit("$message$suffix.")
             } finally {

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/LyricsBottomSheet.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/LyricsBottomSheet.kt
@@ -11,14 +11,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -48,6 +51,12 @@ fun LyricsBottomSheet(
     onSeek: (Long) -> Unit,
     onRetry: () -> Unit,
     onDismiss: () -> Unit,
+    // "Save with song file" footer (writes the .lrc beside the downloaded
+    // audio so external players pick the lyrics up). Shown only for
+    // downloaded tracks while lyrics are actually on screen.
+    canSaveToFile: Boolean = false,
+    savingToFile: Boolean = false,
+    onSaveToFile: () -> Unit = {},
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -98,6 +107,37 @@ fun LyricsBottomSheet(
                         action = if (state.retryable) "Retry" else null,
                         onAction = onRetry,
                     )
+                }
+            }
+
+            // Quiet footer action: only when the track is downloaded AND
+            // lyrics are actually showing — you save what you can see.
+            val lyricsOnScreen =
+                state is LyricsViewState.Synced || state is LyricsViewState.Plain
+            if (canSaveToFile && lyricsOnScreen) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 2.dp),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    TextButton(
+                        enabled = !savingToFile,
+                        onClick = onSaveToFile,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Download,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(Modifier.width(6.dp))
+                        Text(
+                            text = if (savingToFile) "Saving…" else "Save with song file",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
             }
         }

--- a/feature/nowplaying/src/test/kotlin/com/stash/feature/nowplaying/NowPlayingLyricsExportTest.kt
+++ b/feature/nowplaying/src/test/kotlin/com/stash/feature/nowplaying/NowPlayingLyricsExportTest.kt
@@ -77,7 +77,7 @@ class NowPlayingLyricsExportTest {
             coVerify(exactly = 1) { lyricsSidecarWriter.write(42L, any()) }
 
             release.complete(Unit)
-            assertEquals("Lyrics sidecar saved.", awaitItem())
+            assertEquals("Lyrics saved with the song file.", awaitItem())
             assertEquals(null, viewModel.exportingLyricsTrackId.first { it == null })
             cancelAndIgnoreRemainingEvents()
         }
@@ -104,7 +104,7 @@ class NowPlayingLyricsExportTest {
             coVerify(exactly = 0) { lyricsRepository.get(84L) }
 
             release.complete(Unit)
-            assertEquals("Lyrics sidecar saved for ‘Song A’.", awaitItem())
+            assertEquals("Lyrics saved with the song file for ‘Song A’.", awaitItem())
             assertEquals(null, viewModel.exportingLyricsTrackId.first { it == null })
             cancelAndIgnoreRemainingEvents()
         }
@@ -116,7 +116,7 @@ class NowPlayingLyricsExportTest {
 
         viewModel.userMessages.test {
             viewModel.exportLyricsForCurrentTrack()
-            assertEquals("No cached lyrics to save.", awaitItem())
+            assertEquals("No lyrics to save yet.", awaitItem())
             coVerify(exactly = 0) { lyricsSidecarWriter.write(any(), any()) }
             cancelAndIgnoreRemainingEvents()
         }
@@ -129,7 +129,7 @@ class NowPlayingLyricsExportTest {
 
         viewModel.userMessages.test {
             viewModel.exportLyricsForCurrentTrack()
-            assertEquals("Couldn't save lyrics sidecar.", awaitItem())
+            assertEquals("Couldn't save lyrics.", awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -140,7 +140,7 @@ class NowPlayingLyricsExportTest {
 
         viewModel.userMessages.test {
             viewModel.exportLyricsForCurrentTrack()
-            assertEquals("Couldn't save lyrics sidecar.", awaitItem())
+            assertEquals("Couldn't save lyrics.", awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
## Summary
- "Save lyrics sidecar" button relocated from the Now Playing title column into the lyrics sheet as a contextual footer (downloaded track + lyrics visible only)
- Natural language throughout: "Save with song file", "Lyrics saved with the song file", "No lyrics to save yet"
- LyricsSidecarWriter and ViewModel logic untouched; export tests updated for the new strings

## Test Plan
- [x] NowPlayingLyricsExportTest green
- [x] Device: footer shows on downloaded tracks' lyrics sheet, absent for streams; NP body clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)