### PR TITLE
feat(home): user-arranged section layout + tighter chips seam

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/HomeSectionsPreference.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/HomeSectionsPreference.kt
@@ -1,0 +1,105 @@
+package com.stash.core.data.prefs
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The reorderable/hideable content sections of the Home tab, in default
+ * order. The Discover hero pager is NOT one of these — it's Home's front
+ * door and stays pinned on top.
+ */
+enum class HomeSection(val key: String) {
+    NEW_RELEASES("new_releases"),
+    QOBUZ_PLAYLISTS("qobuz_playlists"),
+    TOP_ALBUMS("top_albums"),
+    MADE_FOR_YOU("made_for_you"),
+    RADIOS("radios"),
+    MOOD_DECADES("mood_decades");
+
+    companion object {
+        fun fromKey(key: String): HomeSection? = entries.firstOrNull { it.key == key }
+    }
+}
+
+/**
+ * Merge a saved order permutation with the app's known sections: unknown
+ * saved keys are dropped (removed in an update), known sections missing
+ * from the saved order are appended in default order (added in an
+ * update) — so a stale preference can never hide a new section.
+ */
+fun resolveHomeSectionOrder(savedKeys: List<String>): List<HomeSection> {
+    val known = savedKeys.mapNotNull(HomeSection::fromKey).distinct()
+    return known + HomeSection.entries.filter { it !in known }
+}
+
+/** Dedicated DataStore for Home section order + visibility. */
+private val Context.homeSectionsDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "home_sections_preference",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+)
+
+/**
+ * User-arranged Home layout: [order] is a full permutation of
+ * [HomeSection]; [hidden] removes sections from Home without forgetting
+ * their position. Defaults preserve today's layout with nothing hidden.
+ */
+@Singleton
+class HomeSectionsPreference @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val orderKey = stringPreferencesKey("home_sections_order")
+    private val hiddenKey = stringPreferencesKey("home_sections_hidden")
+
+    val order: Flow<List<HomeSection>> = context.homeSectionsDataStore.data.map { prefs ->
+        resolveHomeSectionOrder(prefs[orderKey].toKeys())
+    }
+
+    val hidden: Flow<Set<HomeSection>> = context.homeSectionsDataStore.data.map { prefs ->
+        prefs[hiddenKey].toKeys().mapNotNull(HomeSection::fromKey).toSet()
+    }
+
+    /** What Home actually renders: [order] minus [hidden]. */
+    val visibleSections: Flow<List<HomeSection>> = context.homeSectionsDataStore.data.map { prefs ->
+        val hiddenSet = prefs[hiddenKey].toKeys().mapNotNull(HomeSection::fromKey).toSet()
+        resolveHomeSectionOrder(prefs[orderKey].toKeys()).filter { it !in hiddenSet }
+    }
+
+    suspend fun setOrder(order: List<HomeSection>) {
+        context.homeSectionsDataStore.edit { prefs ->
+            prefs[orderKey] = order.joinToString(",") { it.key }
+        }
+    }
+
+    /** Swap [section] one slot up or down in the full order. */
+    suspend fun move(section: HomeSection, up: Boolean) {
+        val current = order.first().toMutableList()
+        val idx = current.indexOf(section)
+        val target = if (up) idx - 1 else idx + 1
+        if (idx < 0 || target !in current.indices) return
+        current[idx] = current[target].also { current[target] = current[idx] }
+        setOrder(current)
+    }
+
+    suspend fun setHidden(section: HomeSection, hide: Boolean) {
+        context.homeSectionsDataStore.edit { prefs ->
+            val current = prefs[hiddenKey].toKeys().mapNotNull(HomeSection::fromKey).toMutableSet()
+            if (hide) current.add(section) else current.remove(section)
+            prefs[hiddenKey] = current.joinToString(",") { it.key }
+        }
+    }
+
+    private fun String?.toKeys(): List<String> =
+        this?.split(',')?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList()
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/prefs/HomeSectionOrderTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/prefs/HomeSectionOrderTest.kt
@@ -1,0 +1,51 @@
+package com.stash.core.data.prefs
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Merge semantics for the saved Home section order (see [resolveHomeSectionOrder]). */
+class HomeSectionOrderTest {
+
+    @Test
+    fun `empty saved order yields the default layout`() {
+        assertEquals(HomeSection.entries.toList(), resolveHomeSectionOrder(emptyList()))
+    }
+
+    @Test
+    fun `saved permutation is honored`() {
+        val saved = listOf(
+            "made_for_you", "radios", "mood_decades",
+            "new_releases", "qobuz_playlists", "top_albums",
+        )
+        assertEquals(
+            listOf(
+                HomeSection.MADE_FOR_YOU, HomeSection.RADIOS, HomeSection.MOOD_DECADES,
+                HomeSection.NEW_RELEASES, HomeSection.QOBUZ_PLAYLISTS, HomeSection.TOP_ALBUMS,
+            ),
+            resolveHomeSectionOrder(saved),
+        )
+    }
+
+    @Test
+    fun `unknown keys are dropped and missing sections appended in default order`() {
+        val saved = listOf("radios", "retired_section", "top_albums")
+        assertEquals(
+            listOf(
+                HomeSection.RADIOS, HomeSection.TOP_ALBUMS,
+                // appended in default order:
+                HomeSection.NEW_RELEASES, HomeSection.QOBUZ_PLAYLISTS,
+                HomeSection.MADE_FOR_YOU, HomeSection.MOOD_DECADES,
+            ),
+            resolveHomeSectionOrder(saved),
+        )
+    }
+
+    @Test
+    fun `duplicate keys keep first occurrence`() {
+        val saved = listOf("radios", "radios", "new_releases")
+        val result = resolveHomeSectionOrder(saved)
+        assertEquals(HomeSection.entries.size, result.size)
+        assertEquals(HomeSection.RADIOS, result[0])
+        assertEquals(HomeSection.NEW_RELEASES, result[1])
+    }
+}

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
@@ -119,6 +119,7 @@ import com.stash.core.model.Track
 import com.stash.core.ui.components.AlbumSquareCard
 import com.stash.core.ui.components.CardRail
 import com.stash.core.ui.components.CrispChipRow
+import com.stash.core.data.prefs.HomeSection
 import com.stash.core.ui.components.DiscoverHeroCard
 import com.stash.core.ui.components.GlassCard
 import com.stash.core.ui.components.RankedAlbumList
@@ -424,127 +425,135 @@ fun HomeScreen(
             }
         }
 
-        // ── Genre filter chips ───────────────────────────────────────
-        // Steer ONLY the Qobuz discovery rows below, so they sit with
-        // them — directly under the hero, above New Releases — instead of
-        // topping the whole page (they never affected the hero). Hidden
-        // entirely when Qobuz discovery is switched off in Settings.
-        if (uiState.qobuzDiscoveryEnabled) {
-            item {
-                Spacer(Modifier.height(14.dp))
-                CrispChipRow(
-                    chips = uiState.genres.map { it.label },
-                    selected = uiState.selectedGenre,
-                    onSelect = viewModel::onSelectGenre,
-                )
-            }
+        // ── User-arranged sections (Settings > Appearance > Home layout) ──
+        // Order + visibility come from uiState.sections. The genre chips
+        // steer only the Qobuz rows, so they ride glued above the FIRST
+        // visible Qobuz section wherever the user placed it — and the old
+        // chips→header seam (16dp spacer stacked on the header's 12dp
+        // padding, 28dp of blank) tightens to 2dp + 12dp for that row.
+        val firstQobuzSection = uiState.sections.firstOrNull {
+            it == HomeSection.NEW_RELEASES ||
+                it == HomeSection.QOBUZ_PLAYLISTS ||
+                it == HomeSection.TOP_ALBUMS
         }
-
-        // ── Qobuz discovery rows (genre-filtered) ─────────────────────
-        // These are what the genre chips at the top actually control, so
-        // they sit directly under the hero; the imported/auto mix rails
-        // follow. Each row renders only when it has content — a failed or
-        // empty row (fail-soft repository) is simply omitted.
-        if (uiState.newReleases.isNotEmpty()) {
-            item {
-                DiscoveryAlbumRow(
-                    title = "New Releases",
-                    albums = uiState.newReleases,
-                    onOpen = onNavigateToAlbum,
-                )
-            }
-        }
-        if (uiState.playlists.isNotEmpty()) {
-            item {
-                DiscoveryPlaylistRow(
-                    title = "Qobuz Playlists",
-                    playlists = uiState.playlists,
-                    onOpen = onNavigateToAlbum,
-                    onSeeAll = { onSeeAllPlaylists(uiState.selectedGenre) },
-                )
-            }
-        }
-        if (uiState.topAlbums.isNotEmpty()) {
-            item {
-                // Collapsed to the top 5 by default; "Show all N" expands the
-                // full best-sellers chart in place. Saveable so the choice
-                // survives the item scrolling out of composition.
-                var topAlbumsExpanded by rememberSaveable { mutableStateOf(false) }
-                val visibleTop =
-                    if (topAlbumsExpanded) uiState.topAlbums else uiState.topAlbums.take(5)
-                Column {
-                    Spacer(Modifier.height(16.dp))
-                    SectionHeader(
-                        title = "Top Albums",
-                        actionText = when {
-                            uiState.topAlbums.size <= 5 -> null
-                            topAlbumsExpanded -> "Show less"
-                            else -> "Show all ${uiState.topAlbums.size}"
-                        },
-                        onActionClick = { topAlbumsExpanded = !topAlbumsExpanded },
+        uiState.sections.forEach { section ->
+            val chipsLead = uiState.qobuzDiscoveryEnabled && section == firstQobuzSection
+            if (chipsLead) {
+                item(key = "section_genre_chips") {
+                    Spacer(Modifier.height(14.dp))
+                    CrispChipRow(
+                        chips = uiState.genres.map { it.label },
+                        selected = uiState.selectedGenre,
+                        onSelect = viewModel::onSelectGenre,
                     )
-                    RankedAlbumList(
-                        items = visibleTop.mapIndexed { i, a ->
-                            RankedAlbumUi(
-                                rank = i + 1,
-                                title = a.title,
-                                artist = a.artist,
-                                artUrl = a.thumbnailUrl,
-                                movement = null,   // Qobuz best-sellers carries no chart delta
+                }
+            }
+            when (section) {
+                HomeSection.NEW_RELEASES -> if (uiState.newReleases.isNotEmpty()) {
+                    item(key = "section_new_releases") {
+                        DiscoveryAlbumRow(
+                            title = "New Releases",
+                            albums = uiState.newReleases,
+                            onOpen = onNavigateToAlbum,
+                            topSpacing = if (chipsLead) 2.dp else 16.dp,
+                        )
+                    }
+                }
+                HomeSection.QOBUZ_PLAYLISTS -> if (uiState.playlists.isNotEmpty()) {
+                    item(key = "section_qobuz_playlists") {
+                        DiscoveryPlaylistRow(
+                            title = "Qobuz Playlists",
+                            playlists = uiState.playlists,
+                            onOpen = onNavigateToAlbum,
+                            onSeeAll = { onSeeAllPlaylists(uiState.selectedGenre) },
+                            topSpacing = if (chipsLead) 2.dp else 16.dp,
+                        )
+                    }
+                }
+                HomeSection.TOP_ALBUMS -> if (uiState.topAlbums.isNotEmpty()) {
+                    item(key = "section_top_albums") {
+                        // Collapsed to the top 5 by default; "Show all N" expands the
+                        // full best-sellers chart in place. Saveable so the choice
+                        // survives the item scrolling out of composition.
+                        var topAlbumsExpanded by rememberSaveable { mutableStateOf(false) }
+                        val visibleTop =
+                            if (topAlbumsExpanded) uiState.topAlbums else uiState.topAlbums.take(5)
+                        Column {
+                            Spacer(Modifier.height(if (chipsLead) 2.dp else 16.dp))
+                            SectionHeader(
+                                title = "Top Albums",
+                                actionText = when {
+                                    uiState.topAlbums.size <= 5 -> null
+                                    topAlbumsExpanded -> "Show less"
+                                    else -> "Show all ${uiState.topAlbums.size}"
+                                },
+                                onActionClick = { topAlbumsExpanded = !topAlbumsExpanded },
                             )
-                        },
-                        onClick = { ranked -> onNavigateToAlbum(uiState.topAlbums[ranked.rank - 1]) },
-                    )
+                            RankedAlbumList(
+                                items = visibleTop.mapIndexed { i, a ->
+                                    RankedAlbumUi(
+                                        rank = i + 1,
+                                        title = a.title,
+                                        artist = a.artist,
+                                        artUrl = a.thumbnailUrl,
+                                        movement = null,   // Qobuz best-sellers carries no chart delta
+                                    )
+                                },
+                                onClick = { ranked -> onNavigateToAlbum(uiState.topAlbums[ranked.rank - 1]) },
+                            )
+                        }
+                    }
                 }
-            }
-        }
-
-        // ── Mix rails (Made for you · Radios · Mood & decades · Your mixes) ──
-        // Derived from the user's playlists + recipes (HomeViewModel.mixRail).
-        // Each rail renders only when non-empty. "Your mixes" (Stash mixes)
-        // additionally long-press → the action sheet below.
-        if (uiState.madeForYou.isNotEmpty()) item {
-            CardRail(
-                title = "Made for you",
-                actionText = "See all",
-                onActionClick = { onSeeAllMixes(MixRail.MADE_FOR_YOU) },
-            ) {
-                items(uiState.madeForYou, key = { it.id }) { m ->
-                    MixRailCard(
-                        title = m.title, artUrl = m.artUrl, source = m.source,
-                        buildState = m.buildState, onClick = { openMix(m.id) },
-                        onLongPress = { actionSheetMixId = m.id },
-                    )
+                HomeSection.MADE_FOR_YOU -> if (uiState.madeForYou.isNotEmpty()) {
+                    item(key = "section_made_for_you") {
+                        CardRail(
+                            title = "Made for you",
+                            actionText = "See all",
+                            onActionClick = { onSeeAllMixes(MixRail.MADE_FOR_YOU) },
+                        ) {
+                            items(uiState.madeForYou, key = { it.id }) { m ->
+                                MixRailCard(
+                                    title = m.title, artUrl = m.artUrl, source = m.source,
+                                    buildState = m.buildState, onClick = { openMix(m.id) },
+                                    onLongPress = { actionSheetMixId = m.id },
+                                )
+                            }
+                        }
+                    }
                 }
-            }
-        }
-        if (uiState.radios.isNotEmpty()) item {
-            CardRail(
-                title = "Radios",
-                actionText = "See all",
-                onActionClick = { onSeeAllMixes(MixRail.RADIOS) },
-            ) {
-                items(uiState.radios, key = { it.id }) { m ->
-                    MixRailCard(
-                        title = m.title, artUrl = m.artUrl, source = m.source,
-                        buildState = m.buildState, onClick = { openMix(m.id) },
-                        onLongPress = { actionSheetMixId = m.id },
-                    )
+                HomeSection.RADIOS -> if (uiState.radios.isNotEmpty()) {
+                    item(key = "section_radios") {
+                        CardRail(
+                            title = "Radios",
+                            actionText = "See all",
+                            onActionClick = { onSeeAllMixes(MixRail.RADIOS) },
+                        ) {
+                            items(uiState.radios, key = { it.id }) { m ->
+                                MixRailCard(
+                                    title = m.title, artUrl = m.artUrl, source = m.source,
+                                    buildState = m.buildState, onClick = { openMix(m.id) },
+                                    onLongPress = { actionSheetMixId = m.id },
+                                )
+                            }
+                        }
+                    }
                 }
-            }
-        }
-        if (uiState.moodDecades.isNotEmpty()) item {
-            CardRail(
-                title = "Mood & decades",
-                actionText = "See all",
-                onActionClick = { onSeeAllMixes(MixRail.MOOD_DECADES) },
-            ) {
-                items(uiState.moodDecades, key = { it.id }) { m ->
-                    MixRailCard(
-                        title = m.title, artUrl = m.artUrl, source = m.source,
-                        buildState = m.buildState, onClick = { openMix(m.id) },
-                        onLongPress = { actionSheetMixId = m.id },
-                    )
+                HomeSection.MOOD_DECADES -> if (uiState.moodDecades.isNotEmpty()) {
+                    item(key = "section_mood_decades") {
+                        CardRail(
+                            title = "Mood & decades",
+                            actionText = "See all",
+                            onActionClick = { onSeeAllMixes(MixRail.MOOD_DECADES) },
+                        ) {
+                            items(uiState.moodDecades, key = { it.id }) { m ->
+                                MixRailCard(
+                                    title = m.title, artUrl = m.artUrl, source = m.source,
+                                    buildState = m.buildState, onClick = { openMix(m.id) },
+                                    onLongPress = { actionSheetMixId = m.id },
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -967,9 +976,10 @@ private fun DiscoveryAlbumRow(
     title: String,
     albums: List<AlbumSummary>,
     onOpen: (AlbumSummary) -> Unit,
+    topSpacing: androidx.compose.ui.unit.Dp = 16.dp,
 ) {
     Column {
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(topSpacing))
         SectionHeader(title = title)
         LazyRow(
             contentPadding = PaddingValues(horizontal = 20.dp),
@@ -1000,9 +1010,10 @@ private fun DiscoveryPlaylistRow(
     playlists: List<PlaylistSummary>,
     onOpen: (AlbumSummary) -> Unit,
     onSeeAll: () -> Unit,
+    topSpacing: androidx.compose.ui.unit.Dp = 16.dp,
 ) {
     Column {
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(topSpacing))
         SectionHeader(title = title, actionText = "See all", onActionClick = onSeeAll)
         LazyRow(
             contentPadding = PaddingValues(horizontal = 20.dp),

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeUiState.kt
@@ -59,6 +59,10 @@ data class HomeUiState(
     /** False when the user opted out of Qobuz discovery on Home — hides the
      * genre chips (the rows hide themselves via their empty lists). */
     val qobuzDiscoveryEnabled: Boolean = true,
+    /** User-arranged visible Home sections, in render order
+     * (Settings > Appearance > Home layout). */
+    val sections: List<com.stash.core.data.prefs.HomeSection> =
+        com.stash.core.data.prefs.HomeSection.entries.toList(),
     val newReleases: List<AlbumSummary> = emptyList(),
     val topAlbums: List<AlbumSummary> = emptyList(),
     val playlists: List<PlaylistSummary> = emptyList(),

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeViewModel.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -79,6 +80,7 @@ class HomeViewModel @Inject constructor(
     private val downloadNetworkPreference: DownloadNetworkPreference,
     private val streamingPreference: StreamingPreference,
     private val homeDiscoveryPreference: com.stash.core.data.prefs.HomeDiscoveryPreference,
+    private val homeSectionsPreference: com.stash.core.data.prefs.HomeSectionsPreference,
     private val metadataBackfillState: MetadataBackfillState,
     private val homeDiscoveryRepository: HomeDiscoveryRepository,
     @ApplicationContext private val context: Context,
@@ -298,6 +300,11 @@ class HomeViewModel @Inject constructor(
         val topAlbums: List<AlbumSummary>,
         val playlists: List<PlaylistSummary>,
         val enabled: Boolean = true,
+        // Rides this emission (instead of a 6th uiState combine source):
+        // the user-arranged visible Home sections, which also gate the
+        // fetches above — a hidden Qobuz section costs zero requests.
+        val sections: List<com.stash.core.data.prefs.HomeSection> =
+            com.stash.core.data.prefs.HomeSection.entries.toList(),
     )
 
     /**
@@ -312,13 +319,24 @@ class HomeViewModel @Inject constructor(
      * content never survives a completed fetch. Fail-soft as before.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    private val discoveryFlow: Flow<DiscoveryUi> = homeDiscoveryPreference.enabled
-        .flatMapLatest { qobuzEnabled ->
-            if (!qobuzEnabled) {
-                // Opted out: no Qobuz catalog fetches at all — Home keeps
-                // only the mix rails and imported content.
+    private val discoveryFlow: Flow<DiscoveryUi> = combine(
+        homeDiscoveryPreference.enabled,
+        homeSectionsPreference.visibleSections,
+    ) { enabled, sections -> enabled to sections }
+        .distinctUntilChanged()
+        .flatMapLatest { (qobuzEnabled, sections) ->
+            // Each Qobuz row fetches only when its section is actually on
+            // Home — hiding a section in Settings > Home layout (or the
+            // global Qobuz opt-out) costs zero catalog requests.
+            val wantReleases = qobuzEnabled && com.stash.core.data.prefs.HomeSection.NEW_RELEASES in sections
+            val wantPlaylists = qobuzEnabled && com.stash.core.data.prefs.HomeSection.QOBUZ_PLAYLISTS in sections
+            val wantTop = qobuzEnabled && com.stash.core.data.prefs.HomeSection.TOP_ALBUMS in sections
+            if (!wantReleases && !wantPlaylists && !wantTop) {
                 kotlinx.coroutines.flow.flowOf(
-                    DiscoveryUi("All", emptyList(), emptyList(), emptyList(), enabled = false),
+                    DiscoveryUi(
+                        "All", emptyList(), emptyList(), emptyList(),
+                        enabled = qobuzEnabled, sections = sections,
+                    ),
                 )
             } else {
                 genreFilter
@@ -327,14 +345,24 @@ class HomeViewModel @Inject constructor(
                             val genreId = GenreCatalog.idFor(label)
                             emit(label to null) // loading: re-label, keep previous rows
                             coroutineScope {
-                                val newReleases = async { homeDiscoveryRepository.newReleases(genreId) }
-                                val playlists = async { homeDiscoveryRepository.communityPlaylists(genreId) }
-                                val topAlbums = async { homeDiscoveryRepository.topAlbums(genreId) }
-                                emit(label to DiscoveryUi(label, newReleases.await(), topAlbums.await(), playlists.await()))
+                                val newReleases = if (wantReleases) async { homeDiscoveryRepository.newReleases(genreId) } else null
+                                val playlists = if (wantPlaylists) async { homeDiscoveryRepository.communityPlaylists(genreId) } else null
+                                val topAlbums = if (wantTop) async { homeDiscoveryRepository.topAlbums(genreId) } else null
+                                emit(
+                                    label to DiscoveryUi(
+                                        label,
+                                        newReleases?.await() ?: emptyList(),
+                                        topAlbums?.await() ?: emptyList(),
+                                        playlists?.await() ?: emptyList(),
+                                        sections = sections,
+                                    ),
+                                )
                             }
                         }
                     }
-                    .scan(DiscoveryUi("All", emptyList(), emptyList(), emptyList())) { prev, (label, loaded) ->
+                    .scan(
+                        DiscoveryUi("All", emptyList(), emptyList(), emptyList(), sections = sections),
+                    ) { prev, (label, loaded) ->
                         loaded ?: prev.copy(selectedGenre = label)
                     }
             }
@@ -358,6 +386,7 @@ class HomeViewModel @Inject constructor(
             metadataBackfillBanner = metadataBackfillBanner,
             selectedGenre = discovery.selectedGenre,
             qobuzDiscoveryEnabled = discovery.enabled,
+            sections = discovery.sections,
             newReleases = discovery.newReleases,
             topAlbums = discovery.topAlbums,
             playlists = discovery.playlists,

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAppearanceScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAppearanceScreen.kt
@@ -18,8 +18,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -118,6 +121,91 @@ fun SettingsAppearanceScreen(
             subtitle = "Animated color wash behind Now Playing — switch off for a still backdrop that saves battery",
             checked = uiState.ambientAnimationEnabled,
             onCheckedChange = viewModel::onAmbientAnimationEnabledChanged,
+        )
+
+        Spacer(Modifier.height(20.dp))
+        SettingsSectionLabel("Home layout")
+        Text(
+            text = "Arrange Home's sections or hide the ones you don't use. The Discover hero stays on top.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+        )
+        uiState.homeSectionOrder.forEachIndexed { index, section ->
+            HomeSectionRow(
+                label = section.displayLabel(),
+                shown = section !in uiState.homeSectionsHidden,
+                canMoveUp = index > 0,
+                canMoveDown = index < uiState.homeSectionOrder.lastIndex,
+                onMoveUp = { viewModel.onHomeSectionMoved(section, up = true) },
+                onMoveDown = { viewModel.onHomeSectionMoved(section, up = false) },
+                onShownChange = { shown -> viewModel.onHomeSectionHiddenChanged(section, hide = !shown) },
+            )
+        }
+    }
+}
+
+private fun com.stash.core.data.prefs.HomeSection.displayLabel(): String = when (this) {
+    com.stash.core.data.prefs.HomeSection.NEW_RELEASES -> "New Releases"
+    com.stash.core.data.prefs.HomeSection.QOBUZ_PLAYLISTS -> "Qobuz Playlists"
+    com.stash.core.data.prefs.HomeSection.TOP_ALBUMS -> "Top Albums"
+    com.stash.core.data.prefs.HomeSection.MADE_FOR_YOU -> "Made for you"
+    com.stash.core.data.prefs.HomeSection.RADIOS -> "Radios"
+    com.stash.core.data.prefs.HomeSection.MOOD_DECADES -> "Mood & decades"
+}
+
+/** One row of the Home layout editor: name, up/down movers, show switch. */
+@Composable
+private fun HomeSectionRow(
+    label: String,
+    shown: Boolean,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+    onShownChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (shown) {
+                MaterialTheme.colorScheme.onSurface
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+            modifier = Modifier.weight(1f),
+        )
+        IconButton(onClick = onMoveUp, enabled = canMoveUp) {
+            Icon(
+                imageVector = Icons.Filled.KeyboardArrowUp,
+                contentDescription = "Move $label up",
+                tint = if (canMoveUp) {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
+                },
+            )
+        }
+        IconButton(onClick = onMoveDown, enabled = canMoveDown) {
+            Icon(
+                imageVector = Icons.Filled.KeyboardArrowDown,
+                contentDescription = "Move $label down",
+                tint = if (canMoveDown) {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
+                },
+            )
+        }
+        com.stash.core.ui.components.StashSwitch(
+            checked = shown,
+            onCheckedChange = onShownChange,
         )
     }
 }

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
@@ -49,6 +49,11 @@ data class SettingsUiState(
     val qobuzDiscoveryEnabled: Boolean = true,
     /** Ambient animated background on the Now Playing screen. */
     val ambientAnimationEnabled: Boolean = true,
+    /** Full Home-section order (including hidden) + the hidden set —
+     * drives the Settings > Appearance > Home layout editor. */
+    val homeSectionOrder: List<com.stash.core.data.prefs.HomeSection> =
+        com.stash.core.data.prefs.HomeSection.entries.toList(),
+    val homeSectionsHidden: Set<com.stash.core.data.prefs.HomeSection> = emptySet(),
     val ytHistoryHealth: YouTubeScrobblerHealth = YouTubeScrobblerHealth.DISABLED,
     val ytPendingCount: Int = 0,
     /**

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -95,6 +95,7 @@ class SettingsViewModel @Inject constructor(
     private val stashMixPreference: com.stash.core.data.prefs.StashMixPreference,
     private val homeDiscoveryPreference: com.stash.core.data.prefs.HomeDiscoveryPreference,
     private val nowPlayingPreference: com.stash.core.data.prefs.NowPlayingPreference,
+    private val homeSectionsPreference: com.stash.core.data.prefs.HomeSectionsPreference,
     private val youTubeHistoryScrobbler: YouTubeHistoryScrobbler,
     private val youTubeScrobblerState: YouTubeScrobblerState,
     private val losslessPrefs: LosslessSourcePreferences,
@@ -351,6 +352,8 @@ class SettingsViewModel @Inject constructor(
         themePreference.amoledDark,
         homeDiscoveryPreference.enabled,
         nowPlayingPreference.ambientAnimationEnabled,
+        homeSectionsPreference.order,
+        homeSectionsPreference.hidden,
     ) { values ->
         @Suppress("UNCHECKED_CAST")
         val spotifyAuth = values[0] as AuthState
@@ -389,6 +392,10 @@ class SettingsViewModel @Inject constructor(
         val amoledDark = values[33] as Boolean
         val qobuzDiscoveryEnabled = values[34] as Boolean
         val ambientAnimationEnabled = values[35] as Boolean
+        @Suppress("UNCHECKED_CAST")
+        val homeSectionOrder = values[36] as List<com.stash.core.data.prefs.HomeSection>
+        @Suppress("UNCHECKED_CAST")
+        val homeSectionsHidden = values[37] as Set<com.stash.core.data.prefs.HomeSection>
 
         val lastFmState: LastFmAuthState = local.lastFmAuthOverride
             ?: when {
@@ -427,6 +434,8 @@ class SettingsViewModel @Inject constructor(
             stashMixesEnabled = stashMixesEnabled,
             qobuzDiscoveryEnabled = qobuzDiscoveryEnabled,
             ambientAnimationEnabled = ambientAnimationEnabled,
+            homeSectionOrder = homeSectionOrder,
+            homeSectionsHidden = homeSectionsHidden,
             ytHistoryHealth = ytHistoryHealth,
             ytPendingCount = ytPendingCount,
             losslessEnabled = losslessEnabled,
@@ -1036,6 +1045,16 @@ class SettingsViewModel @Inject constructor(
     /** Ambient animated background on Now Playing (Settings > Appearance). */
     fun onAmbientAnimationEnabledChanged(enabled: Boolean) {
         viewModelScope.launch { nowPlayingPreference.setAmbientAnimationEnabled(enabled) }
+    }
+
+    /** Move a Home section one slot up/down (Settings > Appearance > Home layout). */
+    fun onHomeSectionMoved(section: com.stash.core.data.prefs.HomeSection, up: Boolean) {
+        viewModelScope.launch { homeSectionsPreference.move(section, up) }
+    }
+
+    /** Show/hide a Home section without forgetting its position. */
+    fun onHomeSectionHiddenChanged(section: com.stash.core.data.prefs.HomeSection, hide: Boolean) {
+        viewModelScope.launch { homeSectionsPreference.setHidden(section, hide) }
     }
 
     /** Clear the kill-switch after PROTOCOL_BROKEN. Exposed to the Settings


### PR DESCRIPTION
## Summary
- Settings > Appearance > **Home layout**: reorder Home's six content sections with up/down movers or hide any of them; the Discover hero stays pinned. Backed by a dedicated `HomeSectionsPreference` (full order permutation + hidden set) whose merge rules are unit-tested — sections added in future updates can never be silently hidden by a stale saved order.
- Hidden Qobuz sections skip their catalog fetches entirely (composes with the global Qobuz opt-out).
- Genre chips attach above the first visible Qobuz section wherever it lands, and the chips→header gap drops from 28dp to 14dp per the wasted-space feedback.

## Test Plan
- [x] `HomeSectionOrderTest` (merge semantics) green; full app compiles
- [ ] Device: reorder sections in Settings and watch Home rearrange live; hide all three Qobuz sections and confirm no catalog requests; verify the tightened chips seam

🤖 Generated with [Claude Code](https://claude.com/claude-code)