### PR TITLE
Parse the flat InnerTube search shape so results appear for all regions

### DIFF
--- a/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/FlatSearchResponseParser.kt
+++ b/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/FlatSearchResponseParser.kt
@@ -1,0 +1,152 @@
+package com.stash.data.ytmusic
+
+import com.stash.data.ytmusic.model.AlbumSummary
+import com.stash.data.ytmusic.model.ArtistSummary
+import com.stash.data.ytmusic.model.SearchResultSection
+import com.stash.data.ytmusic.model.TrackSummary
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Parser for the "flat" InnerTube search response shape.
+ *
+ * The titled `musicShelfRenderer` shape ("Songs"/"Artists"/"Albums") that
+ * [parseSongsShelf] / [parseArtistsShelf] / [parseAlbumsShelf] expect is only
+ * served to authenticated YouTube-Music clients in supported regions. In other
+ * cases — unauthenticated, or a region where the request is treated as plain
+ * YouTube — InnerTube returns a FLAT list instead: `sectionListRenderer.contents`
+ * holds a run of `itemSectionRenderer` wrappers, each carrying a single
+ * `musicResponsiveListItemRenderer` row, with no titled shelves at all.
+ *
+ * The legacy parser finds no `musicShelfRenderer` in that shape and yields zero
+ * sections, so the Search screen shows "No results found" even though the
+ * response is full of real songs/artists/albums (issue #268). This parser
+ * recovers those rows: it classifies each `musicResponsiveListItemRenderer` by
+ * its navigation target — a videoId → song, `MUSIC_PAGE_TYPE_ARTIST` → artist,
+ * `MUSIC_PAGE_TYPE_ALBUM` → album — and groups them into the same
+ * [SearchResultSection]s the UI already renders.
+ */
+
+private const val PAGE_TYPE_ARTIST = "MUSIC_PAGE_TYPE_ARTIST"
+private const val PAGE_TYPE_ALBUM = "MUSIC_PAGE_TYPE_ALBUM"
+
+/** Max song rows to surface, matching the titled-"Songs"-shelf cap in searchAll. */
+private const val FLAT_SONGS_CAP = 4
+
+/**
+ * Walks the flat `itemSectionRenderer` rows of a search response and groups them
+ * into Songs / Artists / Albums sections. Returns an empty list when [shelves]
+ * carries no recognisable flat rows (e.g. it was the titled-shelf shape, already
+ * handled by the caller).
+ */
+internal fun parseFlatSearchSections(shelves: JsonArray): List<SearchResultSection> {
+    val songs = mutableListOf<TrackSummary>()
+    val artists = mutableListOf<ArtistSummary>()
+    val albums = mutableListOf<AlbumSummary>()
+
+    for (shelf in shelves) {
+        val rows = shelf.asObject()
+            ?.get("itemSectionRenderer")?.asObject()
+            ?.get("contents")?.asArray()
+            ?: continue
+        for (row in rows) {
+            val renderer = row.asObject()
+                ?.get("musicResponsiveListItemRenderer")?.asObject()
+                ?: continue
+
+            // A row that resolves to a videoId is a song, regardless of any
+            // browse endpoint it may also carry.
+            val track = parseTrackSummaryFromListItem(renderer)
+            if (track != null) {
+                songs.add(track)
+                continue
+            }
+
+            val pageType = renderer.navigatePath(
+                "navigationEndpoint", "browseEndpoint",
+                "browseEndpointContextSupportedConfigs",
+                "browseEndpointContextMusicConfig", "pageType",
+            )?.asString()
+            when (pageType) {
+                PAGE_TYPE_ARTIST -> parseArtistFromListItem(renderer)?.let { artists.add(it) }
+                PAGE_TYPE_ALBUM -> parseAlbumFromListItem(renderer)?.let { albums.add(it) }
+            }
+        }
+    }
+
+    return buildList {
+        if (songs.isNotEmpty()) add(SearchResultSection.Songs(songs.take(FLAT_SONGS_CAP)))
+        if (artists.isNotEmpty()) add(SearchResultSection.Artists(artists))
+        if (albums.isNotEmpty()) add(SearchResultSection.Albums(albums))
+    }
+}
+
+/** Parses a flat `musicResponsiveListItemRenderer` artist row into an [ArtistSummary]. */
+internal fun parseArtistFromListItem(renderer: JsonObject): ArtistSummary? {
+    val id = renderer.navigatePath(
+        "navigationEndpoint", "browseEndpoint", "browseId",
+    )?.asString() ?: return null
+    val name = renderer["flexColumns"]?.asArray()
+        ?.getOrNull(0)?.asObject()
+        ?.navigatePath("musicResponsiveListItemFlexColumnRenderer", "text", "runs")
+        ?.firstArray()?.firstOrNull()?.asObject()
+        ?.get("text")?.asString()
+        ?: return null
+    val thumbnails = renderer.navigatePath(
+        "thumbnail", "musicThumbnailRenderer", "thumbnail", "thumbnails",
+    )?.firstArray()
+    val avatarUrl = com.stash.core.common.ArtUrlUpgrader.upgrade(
+        thumbnails?.maxByOrNull {
+            it.asObject()?.get("width")?.asString()?.toIntOrNull() ?: 0
+        }?.asObject()?.get("url")?.asString()
+    )
+    return ArtistSummary(id = id, name = name, avatarUrl = avatarUrl)
+}
+
+/**
+ * Parses a flat `musicResponsiveListItemRenderer` album row into an
+ * [AlbumSummary]. Unlike the titled "Albums" shelf (which ships
+ * `musicTwoRowItemRenderer` cards), flat album rows are list items whose
+ * subtitle reads like "Album • <artist> • <year>".
+ */
+internal fun parseAlbumFromListItem(renderer: JsonObject): AlbumSummary? {
+    val id = renderer.navigatePath(
+        "navigationEndpoint", "browseEndpoint", "browseId",
+    )?.asString() ?: return null
+    val flexColumns = renderer["flexColumns"]?.asArray() ?: return null
+    val title = flexColumns.getOrNull(0)?.asObject()
+        ?.navigatePath("musicResponsiveListItemFlexColumnRenderer", "text", "runs")
+        ?.firstArray()?.firstOrNull()?.asObject()
+        ?.get("text")?.asString()
+        ?: return null
+
+    val subtitleTexts = flexColumns.getOrNull(1)?.asObject()
+        ?.navigatePath("musicResponsiveListItemFlexColumnRenderer", "text", "runs")
+        ?.asArray()
+        ?.mapNotNull { it.asObject()?.get("text")?.asString() }
+        ?.filterNot { it == " • " || it == " & " || it == ", " || it == " x " }
+        ?: emptyList()
+    // Drop the leading type label ("Album"/"EP"/"Single") if present.
+    val dataTokens = if (
+        subtitleTexts.firstOrNull()?.let { ALBUM_TYPE_LABELS.contains(it) } == true
+    ) subtitleTexts.drop(1) else subtitleTexts
+    val year = dataTokens.firstOrNull { it.matches(YEAR_REGEX) }
+    val artist = dataTokens.firstOrNull { !it.matches(YEAR_REGEX) } ?: ""
+
+    val thumbnails = renderer.navigatePath(
+        "thumbnail", "musicThumbnailRenderer", "thumbnail", "thumbnails",
+    )?.firstArray()
+    val thumbnailUrl = com.stash.core.common.ArtUrlUpgrader.upgrade(
+        thumbnails?.maxByOrNull {
+            it.asObject()?.get("width")?.asString()?.toIntOrNull() ?: 0
+        }?.asObject()?.get("url")?.asString()
+    )
+
+    return AlbumSummary(
+        id = id,
+        title = title,
+        artist = artist,
+        thumbnailUrl = thumbnailUrl,
+        year = year,
+    )
+}

--- a/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/ResponseParserHelpers.kt
+++ b/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/ResponseParserHelpers.kt
@@ -38,6 +38,13 @@ internal val PLAY_COUNT_REGEX =
     Regex("""^[\d.,]+\s*[KMB]?\s*plays?$""", RegexOption.IGNORE_CASE)
 
 /**
+ * Leading content-type labels that flat search rows (issue #268) put before the
+ * artist in a song row's subtitle ("Song • <artist>"). The titled "Songs" shelf
+ * omits these, so stripping a single leading match is safe for both shapes.
+ */
+internal val SONG_ROW_TYPE_LABELS = setOf("Song", "Video", "Music video", "Episode")
+
+/**
  * Parses a `musicResponsiveListItemRenderer` into a [TrackSummary].
  *
  * Expected shape:
@@ -88,15 +95,19 @@ internal fun parseTrackSummaryFromListItem(
     // without an artist). The caller — typically AlbumResponseParser —
     // passes the album header's artist as fallbackArtist so per-row
     // artists default to that when the shelf row carries none.
-    val artistRuns = flexColumns.getOrNull(1)?.asObject()
+    val artistTexts = flexColumns.getOrNull(1)?.asObject()
         ?.navigatePath("musicResponsiveListItemFlexColumnRenderer", "text", "runs")
         ?.asArray()
-    val parsedArtist = artistRuns
         ?.mapNotNull { it.asObject()?.get("text")?.asString() }
-        ?.filterNot { it == " & " || it == ", " || it == " x " }
-        ?.joinToString(", ")
-        .orEmpty()
-    val artist = parsedArtist.ifBlank { fallbackArtist.orEmpty() }
+        ?.filterNot { it == " & " || it == ", " || it == " x " || it == " • " }
+        ?: emptyList()
+    // Flat search rows (issue #268) prefix the subtitle with a content-type
+    // label — "Song • <artist>" — that the titled "Songs" shelf omits. Drop a
+    // single leading label so it doesn't pollute the artist string; harmless
+    // for legacy rows, whose first token is already the artist.
+    val cleanedArtistTexts =
+        if (artistTexts.firstOrNull() in SONG_ROW_TYPE_LABELS) artistTexts.drop(1) else artistTexts
+    val artist = cleanedArtistTexts.joinToString(", ").ifBlank { fallbackArtist.orEmpty() }
 
     // flexColumns[2] is the album ONLY on album-page tracklists (a different
     // parser). This helper's callers are the search "Songs" shelf and the artist

--- a/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/YTMusicApiClient.kt
+++ b/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/YTMusicApiClient.kt
@@ -342,6 +342,21 @@ class YTMusicApiClient @Inject constructor(
             }
         }
 
+        // The titled musicShelfRenderer shape above is only served to
+        // authenticated YT-Music clients in supported regions. Unauthenticated
+        // / region-limited requests get a FLAT itemSectionRenderer list with no
+        // titled shelves, which the loop above skips entirely — the user then
+        // sees "No results found" over a response full of hits (issue #268).
+        // Recover those rows when no list shelf matched.
+        val hasListSections = sections.any {
+            it is SearchResultSection.Songs ||
+                it is SearchResultSection.Artists ||
+                it is SearchResultSection.Albums
+        }
+        if (!hasListSections) {
+            sections.addAll(parseFlatSearchSections(shelves))
+        }
+
         Log.d(TAG, "searchAll('$query'): ${sections.size} sections")
         return SearchAllResults(sections)
     }

--- a/data/ytmusic/src/test/kotlin/com/stash/data/ytmusic/FlatSearchResponseParserTest.kt
+++ b/data/ytmusic/src/test/kotlin/com/stash/data/ytmusic/FlatSearchResponseParserTest.kt
@@ -1,0 +1,100 @@
+package com.stash.data.ytmusic
+
+import com.stash.data.ytmusic.model.SearchResultSection
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #268: unauthenticated / region-limited InnerTube search returns a FLAT
+ * `itemSectionRenderer` list instead of the titled `musicShelfRenderer` shelves,
+ * so the legacy parser produced zero sections and the UI showed "No results
+ * found" over a response full of hits. [parseFlatSearchSections] recovers those
+ * rows. The fixture below mirrors the real shape captured from the live API.
+ */
+class FlatSearchResponseParserTest {
+    private fun shelves(json: String) = Json.parseToJsonElement(json).jsonArray
+
+    // One song, one artist, one album — the three flat row kinds interleaved,
+    // each an itemSectionRenderer wrapping a single musicResponsiveListItemRenderer.
+    private val flatResponse = """
+        [
+          {"itemSectionRenderer":{"contents":[
+            {"musicResponsiveListItemRenderer":{
+              "playlistItemData":{"videoId":"vidSong1"},
+              "flexColumns":[
+                {"musicResponsiveListItemFlexColumnRenderer":{"text":{"runs":[{"text":"Pagan Poetry"}]}}},
+                {"musicResponsiveListItemFlexColumnRenderer":{"text":{"runs":[
+                  {"text":"Song"},{"text":" • "},{"text":"Bjork"}]}}}
+              ]
+            }}
+          ]}},
+          {"itemSectionRenderer":{"contents":[
+            {"musicResponsiveListItemRenderer":{
+              "navigationEndpoint":{"browseEndpoint":{
+                "browseId":"UCartist1",
+                "browseEndpointContextSupportedConfigs":{"browseEndpointContextMusicConfig":{
+                  "pageType":"MUSIC_PAGE_TYPE_ARTIST"}}}},
+              "flexColumns":[
+                {"musicResponsiveListItemFlexColumnRenderer":{"text":{"runs":[{"text":"Sunna Bjork"}]}}}
+              ]
+            }}
+          ]}},
+          {"itemSectionRenderer":{"contents":[
+            {"musicResponsiveListItemRenderer":{
+              "navigationEndpoint":{"browseEndpoint":{
+                "browseId":"MPREb_album1",
+                "browseEndpointContextSupportedConfigs":{"browseEndpointContextMusicConfig":{
+                  "pageType":"MUSIC_PAGE_TYPE_ALBUM"}}}},
+              "flexColumns":[
+                {"musicResponsiveListItemFlexColumnRenderer":{"text":{"runs":[{"text":"Debut"}]}}},
+                {"musicResponsiveListItemFlexColumnRenderer":{"text":{"runs":[
+                  {"text":"Album"},{"text":" • "},{"text":"Bjork"},{"text":" • "},{"text":"1993"}]}}}
+              ]
+            }}
+          ]}}
+        ]
+    """.trimIndent()
+
+    @Test fun `flat response yields Songs, Artists and Albums sections`() {
+        val sections = parseFlatSearchSections(shelves(flatResponse))
+        assertEquals(3, sections.size)
+        assertTrue(sections.any { it is SearchResultSection.Songs })
+        assertTrue(sections.any { it is SearchResultSection.Artists })
+        assertTrue(sections.any { it is SearchResultSection.Albums })
+    }
+
+    @Test fun `song row strips the leading Song label from the artist`() {
+        val songs = parseFlatSearchSections(shelves(flatResponse))
+            .filterIsInstance<SearchResultSection.Songs>().single().tracks
+        assertEquals(1, songs.size)
+        assertEquals("Pagan Poetry", songs[0].title)
+        assertEquals("vidSong1", songs[0].videoId)
+        // "Song • Bjork" must not leak the type label / separator into the artist.
+        assertEquals("Bjork", songs[0].artist)
+    }
+
+    @Test fun `artist row carries browseId and name`() {
+        val artists = parseFlatSearchSections(shelves(flatResponse))
+            .filterIsInstance<SearchResultSection.Artists>().single().artists
+        assertEquals(1, artists.size)
+        assertEquals("UCartist1", artists[0].id)
+        assertEquals("Sunna Bjork", artists[0].name)
+    }
+
+    @Test fun `album row parses id, artist and year from the subtitle`() {
+        val albums = parseFlatSearchSections(shelves(flatResponse))
+            .filterIsInstance<SearchResultSection.Albums>().single().albums
+        assertEquals(1, albums.size)
+        assertEquals("MPREb_album1", albums[0].id)
+        assertEquals("Debut", albums[0].title)
+        assertEquals("Bjork", albums[0].artist)
+        assertEquals("1993", albums[0].year)
+    }
+
+    @Test fun `empty shelves yield no sections`() {
+        assertTrue(parseFlatSearchSections(shelves("[]")).isEmpty())
+    }
+}


### PR DESCRIPTION
Closes #268

### Root cause

The reporter (and a commenter) suspected regional blocking, but the app already pins `gl=US` / `hl=en` on every InnerTube request — so I captured a live response with the exact context the app sends. YouTube serves **two search response shapes**:

- **Titled shape** (authenticated YT-Music clients in supported regions): `sectionListRenderer.contents` holds `musicShelfRenderer` shelves titled "Songs" / "Artists" / "Albums". This is the only shape `searchAll` parsed.
- **Flat shape** (unauthenticated or region-limited requests — the reporter's case): the same path instead holds a run of `itemSectionRenderer` wrappers, each carrying one `musicResponsiveListItemRenderer` row, with **no titled shelves at all**.

On the flat shape `searchAll` found no `musicShelfRenderer`, produced zero sections, and the UI rendered "No results found" — over a response full of hits. My captured `bjork` response in that shape contained 11 songs, 3 artists, and 3 albums, all silently discarded. This also explains why VPN location changes toggled the bug: the account/IP combination decides which shape you get, not whether results exist.

### Fix

- **`FlatSearchResponseParser.kt`** (new): walks the flat `itemSectionRenderer` rows and classifies each by its navigation target — a `videoId` → song, `MUSIC_PAGE_TYPE_ARTIST` → artist, `MUSIC_PAGE_TYPE_ALBUM` → album — then groups them into the existing `SearchResultSection` types (songs capped at 4, matching the titled-shelf cap).
- **`searchAll`**: falls back to the flat parser **only when no titled list shelf matched**, so the authenticated path is untouched.
- **`parseTrackSummaryFromListItem`**: flat song rows subtitle as `"Song • <artist>"`; a single leading content-type label is now dropped so it can't pollute the artist string. Legacy titled-shelf rows carry no such label and are unaffected (existing separator filtering already covered `" • "`).

The top-result card (`musicCardShelfRenderer`) is present in both shapes and keeps working unchanged.

### Testing

- Captured a real flat-shape response from the live endpoint and validated the classification extracts all 17 entities before writing the Kotlin.
- `FlatSearchResponseParserTest` (new): 5 tests over a fixture mirroring the real shape — section grouping, song label-stripping, artist browseId, album artist/year subtitle parsing, empty input.
- `:data:ytmusic:compileDebugKotlin` clean; new tests pass.
- Pre-existing note: the whole `YTMusicApiClientTest` class currently fails on `master` in my environment with `InvalidUseOfMatchersException` (a Mockito matcher misuse in the test's own fake) — unrelated to this change, identical failure count with the change stashed.

### Possible follow-up

The issue's second screenshot (tapping a saved artist → empty profile page) goes through the artist `browse` path, which may need the same flat-shape treatment — I kept this PR scoped to search. Happy to look at that separately if wanted.
