### PR TITLE
Never classify files on an unmounted volume as MISSING in the repair sweep

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/files/LocalFileOps.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/files/LocalFileOps.kt
@@ -1,6 +1,7 @@
 package com.stash.core.data.files
 
 import android.content.Context
+import android.os.Environment
 import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
 import com.stash.core.common.constants.StashConstants
@@ -43,6 +44,34 @@ enum class LocalFileState {
 class LocalFileOps @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
+    /**
+     * Mount-state probe for the volume containing a plain path. Overridable in
+     * unit tests (Environment is Android framework). Defaults to "is the
+     * volume MOUNTED"; any resolution failure reads as not-mounted so the
+     * sweep never acts on a path it can't attribute to a live volume.
+     */
+    internal var volumeMounted: (File) -> Boolean = { f ->
+        try {
+            Environment.getExternalStorageState(f) == Environment.MEDIA_MOUNTED
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /**
+     * True when [f]'s absence can be trusted as a real deletion. Internal app
+     * storage (`/data/...`) never unmounts, so `exists()` is reliable there.
+     * Any other plain path (`/storage/XXXX-XXXX/...` on an SD card, USB-OTG)
+     * only counts when its volume is currently mounted: with the card ejected
+     * every file on it "doesn't exist", and classifying that as MISSING would
+     * un-mark the user's whole library — permanently, since the sweep result
+     * sticks after the card is reinserted (issue #98).
+     */
+    private fun absenceIsReliable(f: File): Boolean =
+        // File() normalizes to the platform separator; compare with '/' so the
+        // prefix check also holds in JVM unit tests on Windows.
+        f.path.replace(File.separatorChar, '/').startsWith("/data/") || volumeMounted(f)
+
     /** Size of the file behind [path] in bytes; 0 if null/blank/missing/unreadable. */
     fun sizeBytes(path: String?): Long {
         if (path.isNullOrBlank()) return 0L
@@ -78,7 +107,9 @@ class LocalFileOps @Inject constructor(
             } else {
                 val f = File(plainPath(path))
                 when {
-                    !f.exists() -> LocalFileState.MISSING       // internal storage: reliable
+                    !f.exists() ->
+                        if (absenceIsReliable(f)) LocalFileState.MISSING
+                        else LocalFileState.INCONCLUSIVE // volume unmounted (e.g. SD ejected) — don't touch
                     f.length() < minBytes -> LocalFileState.TOO_SMALL // includes a 0-byte present file
                     else -> LocalFileState.OK
                 }

--- a/core/data/src/test/kotlin/com/stash/core/data/files/LocalFileOpsTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/files/LocalFileOpsTest.kt
@@ -70,4 +70,33 @@ class LocalFileOpsTest {
     @Test fun `classify - null path is MISSING`() {
         assertEquals(LocalFileState.MISSING, ops.classify(null, floor))
     }
+
+    // ── Removable-volume safety (issue #98) ──────────────────────────────
+    // A file that "doesn't exist" because its whole volume is unmounted (SD
+    // card ejected) must never classify as MISSING — the sweep would un-mark
+    // the entire external library and the damage would stick after reinsert.
+
+    @Test fun `classify - missing file on an unmounted volume is INCONCLUSIVE`() {
+        ops.volumeMounted = { false }
+        assertEquals(
+            LocalFileState.INCONCLUSIVE,
+            ops.classify("/storage/ABCD-1234/Music/track.flac", floor),
+        )
+    }
+
+    @Test fun `classify - missing file on a mounted volume is MISSING`() {
+        ops.volumeMounted = { true }
+        assertEquals(
+            LocalFileState.MISSING,
+            ops.classify("/storage/ABCD-1234/Music/track.flac", floor),
+        )
+    }
+
+    @Test fun `classify - internal missing file never consults the mount probe`() {
+        ops.volumeMounted = { error("must not be called for /data paths") }
+        assertEquals(
+            LocalFileState.MISSING,
+            ops.classify("/data/user/0/com.stash.app/files/music/nope/missing.flac", floor),
+        )
+    }
 }


### PR DESCRIPTION
Fixes #98

### Scope note

The report predates the current download-integrity sweep (the reporter was on ~v0.9.36, May 24; the sweep landed June 3 in `5afb6ab8`), so I can't prove which code path emptied their library at the time. What I can prove is that **current `master` has exactly this data-loss trap**, and this PR closes it — so this PR is best read as "prevents this class of loss" - if the maintainer prefers to keep #98 open for the historical report, feel free to unlink.

### The trap

`reconcileMissingDownloadedFiles()` runs on **every launch** and un-marks (`bulkResetForReDownload`: `is_downloaded = 0`, `file_path` nulled) every row whose file classifies as `MISSING`. In `LocalFileOps.classify()`, the plain-path branch was:

```kotlin
!f.exists() -> LocalFileState.MISSING       // internal storage: reliable
```

The comment's assumption doesn't hold: plain paths aren't necessarily internal. A path on a removable volume (`/storage/XXXX-XXXX/…` — SD card, USB-OTG) also fails `exists()` **while the volume is ejected**. Sequence:

1. Library lives on SD; rows hold plain paths on the card.
2. User ejects the card, opens the app once.
3. Sweep: every external row → `!exists()` → `MISSING` → un-marked. Whole external library reset in one launch.
4. Card reinserted: files are back, but the DB rows are already cleared — Library stays empty. Permanent.

The SAF (`content://`) branch already had a safety valve for this (`INCONCLUSIVE` = do nothing on ambiguous evidence); the plain-path branch had none.

### Fix

A missing plain file now classifies `MISSING` only when its absence is trustworthy:

- path under `/data/` — internal app storage, never unmounts, `exists()` reliable (sweep's original target: junk/deleted internal downloads — behavior unchanged there), or
- the containing volume currently reports `Environment.MEDIA_MOUNTED`.

Anything else — ejected volume, unresolvable path — returns `INCONCLUSIVE`, the sweep's existing do-nothing valve. Worst case of a false `INCONCLUSIVE` is one skipped cleanup; the next launch with storage healthy re-classifies correctly and true junk still gets swept.

The mount probe (`volumeMounted`) is an injectable seam because `Environment` is Android framework — keeps the branch coverable by plain JVM tests.

### Testing

- 3 new `LocalFileOpsTest` cases: missing file on an unmounted volume → `INCONCLUSIVE`; on a mounted volume → `MISSING`; internal `/data` path never consults the mount probe.
- Full `LocalFileOpsTest` (12) + `DownloadReconcileTest` suites pass; `:core:data:compileDebugKotlin` clean.

Can't resurrect a library that was already reset — restoring those rows would need a re-sync — but after this, ejecting storage can no longer damage the DB.
