### PR TITLE
fix: make OPUS downloads and persistence reliable

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/audio/FFmpegBridge.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/audio/FFmpegBridge.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.io.IOException
 import java.io.OutputStream
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -51,13 +52,10 @@ interface FFmpegBridge {
      *
      * Suspends on `Dispatchers.IO` — safe to call from any coroutine.
      *
-     * Throws [java.io.IOException] if the binary cannot be located or the
-     * process cannot be started. Does not throw on non-zero exit codes — a
-     * non-zero exit (e.g. ffmpeg's "Output #0, null" sentinel at the end of
-     * an ebur128 pass still exits 0, but a malformed input might exit 1)
-     * still returns whatever stderr was captured, so the parser can inspect
-     * it. Inspect the returned text for the expected Summary block;
-     * propagate failure from there.
+     * Throws [IOException] if the binary cannot be located, the process cannot
+     * be started, or ffmpeg exits non-zero. Non-zero failures include the
+     * captured stderr in the exception message so callers retain ffmpeg's
+     * diagnostic output while rejecting any partial output file.
      */
     suspend fun runWithStderrCapture(args: List<String>): String
 }
@@ -83,7 +81,7 @@ class FFmpegBridgeImpl @Inject constructor(
         withContext(Dispatchers.IO) {
             val binary = ffmpegBinary()
             if (!binary.exists() || !binary.canExecute()) {
-                throw java.io.IOException(
+                throw IOException(
                     "ffmpeg binary missing or not executable at ${binary.absolutePath}; " +
                         "ensure FFmpeg.getInstance().init(context) has been called",
                 )
@@ -132,6 +130,14 @@ class FFmpegBridgeImpl @Inject constructor(
 
             if (exit != 0) {
                 Log.w(TAG, "ffmpeg exited with code $exit; stderr length=${stderr.length}")
+                throw IOException(
+                    buildString {
+                        append("ffmpeg exited with code "); append(exit)
+                        if (stderr.isNotBlank()) {
+                            append(":\n"); append(stderr)
+                        }
+                    },
+                )
             }
             stderr
         }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
@@ -38,6 +38,10 @@ interface PlaylistDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(playlist: PlaylistEntity): Long
 
+    /** Insert without replacing an existing source_id row. */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertIfAbsent(playlist: PlaylistEntity): Long
+
     /** Insert a cross-reference linking a track to a playlist. */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertCrossRef(crossRef: PlaylistTrackCrossRef)
@@ -53,6 +57,61 @@ interface PlaylistDao {
         WHERE playlist_id = :playlistId AND track_id = :trackId
     """)
     suspend fun getCrossRef(playlistId: Long, trackId: Long): PlaylistTrackCrossRef?
+
+    /**
+     * Atomically returns the existing playlist or inserts it without REPLACE.
+     * Avoiding REPLACE matters because replacing a playlist cascades deletion
+     * to every playlist_tracks membership.
+     */
+    @Transaction
+    suspend fun ensurePlaylist(playlist: PlaylistEntity): Long {
+        findBySourceId(playlist.sourceId)?.let { return it.id }
+        val insertedId = insertIfAbsent(playlist)
+        if (insertedId != -1L) return insertedId
+        return checkNotNull(findBySourceId(playlist.sourceId)) {
+            "Playlist insert was ignored but source_id=${playlist.sourceId} was not found"
+        }.id
+    }
+
+    /**
+     * Atomically ensures [playlist] exists and [trackId] has an active
+     * membership. Unlike the UI-facing repository helper, this operation is
+     * strict: foreign-key/insert failures propagate and a soft-deleted
+     * cross-reference is reactivated before returning.
+     *
+     * This is used for the load-bearing "Your Downloads" membership. Keeping
+     * seeding and linking in one Room transaction prevents concurrent search
+     * downloads from replacing the playlist row between those operations.
+     */
+    @Transaction
+    suspend fun ensurePlaylistAndActiveCrossRef(
+        playlist: PlaylistEntity,
+        trackId: Long,
+    ): Long {
+        val playlistId = ensurePlaylist(playlist)
+        val existing = getCrossRef(playlistId, trackId)
+        if (existing?.removedAt != null || existing == null) {
+            val position = getNextPosition(playlistId)
+            insertCrossRef(
+                existing?.copy(
+                    position = position,
+                    removedAt = null,
+                    locallyAdded = true,
+                ) ?: PlaylistTrackCrossRef(
+                    playlistId = playlistId,
+                    trackId = trackId,
+                    position = position,
+                    locallyAdded = true,
+                ),
+            )
+        }
+
+        val active = getCrossRef(playlistId, trackId)
+        check(active != null && active.removedAt == null) {
+            "Failed to create active playlist membership for trackId=$trackId"
+        }
+        return playlistId
+    }
 
     /**
      * Bulk counterpart to [insertCrossRef] — one INSERT statement covering

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -472,6 +472,7 @@ interface TrackDao {
      * @param downloadedAt  Wall-clock millis the row was marked complete.
      * @param sampleRateHz  Audio sample rate in Hz, or null to preserve existing.
      * @param bitsPerSample Audio bit-depth, or null to preserve existing.
+     * @return Number of rows updated (expected to be exactly one).
      */
     @Query(
         """
@@ -492,7 +493,7 @@ interface TrackDao {
         downloadedAt: Long = System.currentTimeMillis(),
         sampleRateHz: Int? = null,
         bitsPerSample: Int? = null,
-    )
+    ): Int
 
     /**
      * v0.9.26 — fill `album` on a row that previously had no album recorded,

--- a/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
@@ -630,23 +630,26 @@ class MusicRepositoryImpl @Inject constructor(
     }
 
     override suspend fun ensureDownloadsMixSeeded(): Long {
-        val existing = playlistDao.findBySourceId(DOWNLOADS_MIX_SOURCE_ID)
-        if (existing != null) return existing.id
-        val entity = com.stash.core.data.db.entity.PlaylistEntity(
+        return playlistDao.ensurePlaylist(downloadsMixEntity())
+    }
+
+    override suspend fun linkTrackToDownloadsMix(trackId: Long) {
+        val playlistId = playlistDao.ensurePlaylistAndActiveCrossRef(
+            playlist = downloadsMixEntity(),
+            trackId = trackId,
+        )
+        val count = trackDao.getByPlaylist(playlistId, includeStreamable = true).first().size
+        playlistDao.updateTrackCount(playlistId, count)
+    }
+
+    private fun downloadsMixEntity() =
+        com.stash.core.data.db.entity.PlaylistEntity(
             name = "Your Downloads",
             source = com.stash.core.model.MusicSource.BOTH,
             sourceId = DOWNLOADS_MIX_SOURCE_ID,
             type = com.stash.core.model.PlaylistType.DOWNLOADS_MIX,
             syncEnabled = false,
         )
-        return playlistDao.insert(entity)
-    }
-
-    override suspend fun linkTrackToDownloadsMix(trackId: Long) {
-        val playlistId = ensureDownloadsMixSeeded()
-        if (playlistDao.getCrossRef(playlistId, trackId) != null) return
-        addTrackToPlaylist(trackId = trackId, playlistId = playlistId)
-    }
 
     override suspend fun removeTrackFromPlaylist(trackId: Long, playlistId: Long) {
         playlistDao.softDeleteTrackFromPlaylist(playlistId, trackId)

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoDownloadsMixLinkTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoDownloadsMixLinkTest.kt
@@ -1,0 +1,94 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PlaylistDaoDownloadsMixLinkTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var playlistDao: PlaylistDao
+    private lateinit var trackDao: TrackDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        playlistDao = db.playlistDao()
+        trackDao = db.trackDao()
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    @Test
+    fun `strict link reactivates a soft-deleted downloads-mix membership`() = runTest {
+        trackDao.insert(track())
+        val playlist = downloadsMix()
+
+        val playlistId = playlistDao.ensurePlaylistAndActiveCrossRef(playlist, TRACK_ID)
+        val first = playlistDao.getCrossRef(playlistId, TRACK_ID)
+        assertNotNull(first)
+        assertNull(first?.removedAt)
+        assertTrue(first?.locallyAdded == true)
+        val reseededId = playlistDao.ensurePlaylist(playlist)
+        assertEquals(playlistId, reseededId)
+        assertNull(playlistDao.getCrossRef(playlistId, TRACK_ID)?.removedAt)
+
+
+        playlistDao.softDeleteTrackFromPlaylist(playlistId, TRACK_ID)
+        assertNotNull(playlistDao.getCrossRef(playlistId, TRACK_ID)?.removedAt)
+
+        val restoredPlaylistId = playlistDao.ensurePlaylistAndActiveCrossRef(playlist, TRACK_ID)
+        val restored = playlistDao.getCrossRef(restoredPlaylistId, TRACK_ID)
+
+        assertEquals(playlistId, restoredPlaylistId)
+        assertNull(restored?.removedAt)
+        assertTrue(restored?.locallyAdded == true)
+        assertEquals(playlistId, playlistDao.findBySourceId(DOWNLOADS_SOURCE_ID)?.id)
+    }
+
+    private fun track() = TrackEntity(
+        id = TRACK_ID,
+        title = "OPUS track",
+        artist = "Artist",
+        canonicalTitle = "opus track",
+        canonicalArtist = "artist",
+        youtubeId = "video-id",
+        source = MusicSource.YOUTUBE,
+    )
+
+    private fun downloadsMix() = PlaylistEntity(
+        name = "Your Downloads",
+        source = MusicSource.BOTH,
+        sourceId = DOWNLOADS_SOURCE_ID,
+        type = PlaylistType.DOWNLOADS_MIX,
+        syncEnabled = false,
+    )
+
+    private companion object {
+        const val TRACK_ID = 99L
+        const val DOWNLOADS_SOURCE_ID = "stash_downloads_mix"
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/repository/MusicRepositoryDownloadsMixTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/repository/MusicRepositoryDownloadsMixTest.kt
@@ -9,7 +9,6 @@ import com.stash.core.data.db.dao.SyncHistoryDao
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.db.entity.DownloadQueueEntity
 import com.stash.core.data.db.entity.PlaylistEntity
-import com.stash.core.data.db.entity.PlaylistTrackCrossRef
 import com.stash.core.data.db.entity.TrackEntity
 import com.stash.core.data.sync.SingleTrackDownloadEnqueuer
 import com.stash.core.data.sync.SyncPreferencesManager
@@ -31,9 +30,8 @@ class MusicRepositoryDownloadsMixTest {
     @Test
     fun `ensureDownloadsMixSeeded inserts a new playlist when none exists`() = runTest {
         val playlistDao = mockk<PlaylistDao>(relaxed = true)
-        coEvery { playlistDao.findBySourceId("stash_downloads_mix") } returns null
         val inserted = slot<PlaylistEntity>()
-        coEvery { playlistDao.insert(capture(inserted)) } returns 42L
+        coEvery { playlistDao.ensurePlaylist(capture(inserted)) } returns 42L
 
         val repo = buildRepo(playlistDao = playlistDao)
         val id = repo.ensureDownloadsMixSeeded()
@@ -49,59 +47,29 @@ class MusicRepositoryDownloadsMixTest {
     @Test
     fun `ensureDownloadsMixSeeded is idempotent when playlist already exists`() = runTest {
         val playlistDao = mockk<PlaylistDao>(relaxed = true)
-        val existing = PlaylistEntity(
-            id = 7L,
-            name = "Your Downloads",
-            source = MusicSource.BOTH,
-            sourceId = "stash_downloads_mix",
-            type = PlaylistType.DOWNLOADS_MIX,
-        )
-        coEvery { playlistDao.findBySourceId("stash_downloads_mix") } returns existing
+        coEvery { playlistDao.ensurePlaylist(any()) } returns 7L
 
         val repo = buildRepo(playlistDao = playlistDao)
         val id = repo.ensureDownloadsMixSeeded()
 
         assertEquals(7L, id)
-        coVerify(exactly = 0) { playlistDao.insert(any()) }
+        coVerify(exactly = 1) { playlistDao.ensurePlaylist(any()) }
     }
 
     @Test
-    fun `linkTrackToDownloadsMix seeds then adds track when no existing link`() = runTest {
+    fun `linkTrackToDownloadsMix delegates to strict active-link transaction`() = runTest {
         val playlistDao = mockk<PlaylistDao>(relaxed = true)
-        coEvery { playlistDao.findBySourceId("stash_downloads_mix") } returns null
-        coEvery { playlistDao.insert(any()) } returns 42L
-        coEvery { playlistDao.getCrossRef(42L, 99L) } returns null
-        coEvery { playlistDao.getNextPosition(42L) } returns 0
+        coEvery { playlistDao.ensurePlaylistAndActiveCrossRef(any(), 99L) } returns 42L
 
         // addTrackToPlaylist calls trackDao.getByPlaylist(...).first() to update the
         // track count — return an empty list so first() doesn't block.
         val trackDao = mockk<TrackDao>(relaxed = true)
-        coEvery { trackDao.getByPlaylist(42L, includeStreamable = false) } returns flowOf(emptyList())
+        coEvery { trackDao.getByPlaylist(42L, includeStreamable = true) } returns flowOf(emptyList())
 
         val repo = buildRepo(playlistDao = playlistDao, trackDao = trackDao)
         repo.linkTrackToDownloadsMix(trackId = 99L)
 
-        coVerify { playlistDao.insertCrossRef(match { it.playlistId == 42L && it.trackId == 99L }) }
-    }
-
-    @Test
-    fun `linkTrackToDownloadsMix is a no-op when link already exists`() = runTest {
-        val playlistDao = mockk<PlaylistDao>(relaxed = true)
-        val existing = PlaylistEntity(
-            id = 7L,
-            name = "Your Downloads",
-            source = MusicSource.BOTH,
-            sourceId = "stash_downloads_mix",
-            type = PlaylistType.DOWNLOADS_MIX,
-        )
-        coEvery { playlistDao.findBySourceId("stash_downloads_mix") } returns existing
-        coEvery { playlistDao.getCrossRef(7L, 99L) } returns
-            PlaylistTrackCrossRef(playlistId = 7L, trackId = 99L, position = 0)
-
-        val repo = buildRepo(playlistDao = playlistDao)
-        repo.linkTrackToDownloadsMix(trackId = 99L)
-
-        coVerify(exactly = 0) { playlistDao.insertCrossRef(any()) }
+        coVerify { playlistDao.ensurePlaylistAndActiveCrossRef(any(), 99L) }
     }
 
     private fun buildRepo(

--- a/data/download/src/main/kotlin/com/stash/data/download/DownloadExecutor.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/DownloadExecutor.kt
@@ -9,6 +9,7 @@ import com.yausername.youtubedl_android.YoutubeDL
 import com.yausername.youtubedl_android.YoutubeDLException
 import com.yausername.youtubedl_android.YoutubeDLRequest
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -192,6 +193,8 @@ class DownloadExecutor @Inject constructor(
                 Log.w(TAG, "download: no output file (client=${playerClient ?: "default"}). Dir: $dirContents")
                 DownloadResult.NoOutput(stdout.take(2000), stderr.take(2000))
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: YoutubeDLException) {
             // yt-dlp exited with non-zero code. The exception message IS the stderr.
             val errMsg = e.message ?: "Unknown yt-dlp error"

--- a/data/download/src/main/kotlin/com/stash/data/download/files/WebmAudioRemuxer.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/WebmAudioRemuxer.kt
@@ -2,6 +2,7 @@ package com.stash.data.download.files
 
 import android.util.Log
 import com.stash.core.data.audio.FFmpegBridge
+import kotlinx.coroutines.CancellationException
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -32,7 +33,7 @@ class WebmAudioRemuxer @Inject constructor(
     suspend fun toOpusIfWebm(file: File): File {
         if (!needsRemux(file)) return file
         val output = opusTarget(file)
-        return runCatching {
+        return try {
             ffmpeg.runWithStderrCapture(buildRemuxArgs(file, output))
             if (output.exists() && output.length() > 0) {
                 file.delete()
@@ -40,13 +41,22 @@ class WebmAudioRemuxer @Inject constructor(
                 output
             } else {
                 Log.w(TAG, "webm->opus remux produced no output for ${file.name}; keeping original")
-                output.delete()
+                deletePartialOutput(output)
                 file
             }
-        }.getOrElse { e ->
+        } catch (e: CancellationException) {
+            deletePartialOutput(output)
+            throw e
+        } catch (e: Exception) {
             Log.w(TAG, "webm->opus remux failed for ${file.name}: ${e.message}; keeping original")
-            runCatching { output.delete() }
+            deletePartialOutput(output)
             file
+        }
+    }
+
+    private fun deletePartialOutput(output: File) {
+        if (output.exists() && !output.delete()) {
+            Log.w(TAG, "could not delete partial remux output: ${output.absolutePath}")
         }
     }
 

--- a/data/download/src/main/kotlin/com/stash/data/download/search/SearchDownloadCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/search/SearchDownloadCoordinator.kt
@@ -21,6 +21,7 @@ import com.stash.data.download.lossless.TrackQuery
 import com.stash.data.download.lyrics.LyricsFetchTrigger
 import com.stash.data.download.shared.TrackFinalizer
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -120,7 +121,8 @@ class SearchDownloadCoordinator @Inject constructor(
      * explicit user action on a specific track, so the user's fallback
      * preference governs unconditionally.
      *
-     * The flow does not throw; all errors are mapped to [SearchDownloadStatus.Failed].
+     * Operational errors are mapped to [SearchDownloadStatus.Failed].
+     * [CancellationException] still propagates for cooperative cancellation.
      */
     fun download(track: TrackItem): Flow<SearchDownloadStatus> = flow {
         val key = track.videoId
@@ -173,6 +175,7 @@ class SearchDownloadCoordinator @Inject constructor(
 
         val match = runCatching { registry.resolve(track.toQuery()) }
             .onFailure { e ->
+                if (e is CancellationException) throw e
                 Log.w(TAG, "registry.resolve threw for ${track.videoId}: ${e.message}")
             }
             .getOrNull()
@@ -209,6 +212,7 @@ class SearchDownloadCoordinator @Inject constructor(
                     }
                 }
             }.onFailure { e ->
+                if (e is CancellationException) throw e
                 Log.w(TAG, "WAITING_FOR_LOSSLESS DAO write failed for ${track.videoId}: ${e.message}")
             }
             return DownloadJobResult.Deferred
@@ -267,6 +271,7 @@ class SearchDownloadCoordinator @Inject constructor(
             }
         }.onFailure { e ->
             runCatching { dataSource.close() }
+            if (e is CancellationException) throw e
             Log.w(TAG, "lossless cache->file copy failed for $cacheKey: ${e.message}")
             return TrackFinalizer.FinalizeResult.Failed("Cache fill failed: ${e.message}")
         }
@@ -278,36 +283,58 @@ class SearchDownloadCoordinator @Inject constructor(
             format = match.format,
         )
 
-        // Search-specific DB writes — done here, not in TrackFinalizer,
-        // so sync's TrackFinalizer path is unaffected. Wrapped in
-        // runCatching: an exception escaping here would propagate up the
-        // flow and prevent SearchDownloadStatus.Completed from emitting,
-        // leaving the UI's per-row spinner stuck even though the file is
-        // already on disk. The file is the load-bearing artefact; if a DB
-        // write fails the next library scan / sync will reconcile.
+        // TrackFinalizer success proves only that the file was committed.
+        // Completed additionally requires validation and durable library state.
+        var outcome: TrackFinalizer.FinalizeResult = finalized
         if (finalized is TrackFinalizer.FinalizeResult.Success) {
-            runCatching {
-                upsertSearchTrack(track, match.format, finalized, match.coverArtUrl)
-            }.onFailure { e ->
-                Log.e(TAG, "upsertSearchTrack failed for ${track.videoId}: ${e.message}", e)
+            outcome = persistFinalizedTrack(
+                track,
+                match.format,
+                finalized,
+                match.coverArtUrl,
+            )
+            if (outcome is TrackFinalizer.FinalizeResult.Success) {
+                // v0.9.36 lyrics integration: chain the lyrics-fetch enqueue off
+                // the stamp's resolved trackId so we don't repeat findByYoutubeId.
+                // If the stamp lookup failed (returned null), skip lyrics too —
+                // we have no stable id to key the worker on.
+                stampEmbeddedAt(track.videoId)?.let { lyricsFetchTrigger.enqueueFor(it) }
             }
-            // v0.9.36 lyrics integration: chain the lyrics-fetch enqueue off
-            // the stamp's resolved trackId so we don't repeat findByYoutubeId.
-            // If the stamp lookup failed (returned null), skip lyrics too —
-            // we have no stable id to key the worker on.
-            stampEmbeddedAt(track.videoId)?.let { lyricsFetchTrigger.enqueueFor(it) }
         }
 
         // Free preview-cache space now that bytes are on permanent storage.
         runCatching { previewCache.removeResource(cacheKey) }
             .onFailure { e -> Log.w(TAG, "removeResource failed for $cacheKey: ${e.message}") }
 
-        return finalized
+        return outcome
     }
 
     // -------------------------------------------------------------------------
     // YouTube / yt-dlp fallback path
     // -------------------------------------------------------------------------
+
+    /**
+     * Converts file-finalization success into end-to-end success only after
+     * the required database state is durable. Expected validation rejections
+     * and persistence failures become [TrackFinalizer.FinalizeResult.Failed];
+     * cooperative cancellation is never converted into a terminal status.
+     */
+    private suspend fun persistFinalizedTrack(
+        track: TrackItem,
+        format: AudioFormat,
+        finalized: TrackFinalizer.FinalizeResult.Success,
+        coverArtUrl: String?,
+    ): TrackFinalizer.FinalizeResult = try {
+        upsertSearchTrack(track, format, finalized, coverArtUrl)
+        finalized
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Log.e(TAG, "search-track persistence failed for ${track.videoId}: ${e.message}", e)
+        TrackFinalizer.FinalizeResult.Failed(
+            "Failed to save download: ${e.message ?: "unknown persistence error"}",
+        )
+    }
 
     private suspend fun finalizeFromYtDlp(track: TrackItem): TrackFinalizer.FinalizeResult {
         val tempDir = File(context.cacheDir, "search_ytdlp").also { it.mkdirs() }
@@ -321,6 +348,7 @@ class SearchDownloadCoordinator @Inject constructor(
                 qualityArgs = emptyList(),
             )
         }.getOrElse { e ->
+            if (e is CancellationException) throw e
             return TrackFinalizer.FinalizeResult.Failed("yt-dlp threw: ${e.message}")
         }
 
@@ -343,18 +371,15 @@ class SearchDownloadCoordinator @Inject constructor(
             format = format,
         )
 
+        var outcome: TrackFinalizer.FinalizeResult = finalized
         if (finalized is TrackFinalizer.FinalizeResult.Success) {
-            // Same defensive runCatching as the lossless path — DB-write
-            // failures must not prevent Completed from emitting.
-            runCatching {
-                upsertSearchTrack(track, format, finalized, track.thumbnailUrl)
-            }.onFailure { e ->
-                Log.e(TAG, "upsertSearchTrack (yt-dlp) failed for ${track.videoId}: ${e.message}", e)
+            outcome = persistFinalizedTrack(track, format, finalized, track.thumbnailUrl)
+            if (outcome is TrackFinalizer.FinalizeResult.Success) {
+                // v0.9.36 lyrics integration: parity with the lossless branch.
+                stampEmbeddedAt(track.videoId)?.let { lyricsFetchTrigger.enqueueFor(it) }
             }
-            // v0.9.36 lyrics integration: parity with the lossless branch.
-            stampEmbeddedAt(track.videoId)?.let { lyricsFetchTrigger.enqueueFor(it) }
         }
-        return finalized
+        return outcome
     }
 
     /**
@@ -377,6 +402,7 @@ class SearchDownloadCoordinator @Inject constructor(
             trackDao.setMetadataEmbeddedAt(trackId, System.currentTimeMillis())
             trackId
         }.onFailure { e ->
+            if (e is CancellationException) throw e
             Log.w(TAG, "setMetadataEmbeddedAt failed for $videoId: ${e.message}")
         }.getOrNull()
     }
@@ -406,8 +432,14 @@ class SearchDownloadCoordinator @Inject constructor(
                 spotifyUri = null, youtubeId = track.videoId,
             )) {
             android.util.Log.d("SearchDownload", "Refused download of blocked: ${track.artist} - ${track.title}")
-            return
+            throw PersistenceRejectedException("Track is blocked")
         }
+        // Reject a committed file before inserting or mutating library rows.
+        if (!localFileOps.acceptDownloadOrDelete(finalized.committed.filePath)) {
+            Log.w(TAG, "search download: discarded invalid file for videoId=${track.videoId}: ${finalized.committed.filePath}")
+            throw PersistenceRejectedException("Downloaded file failed validation")
+        }
+
 
         val existing = trackDao.findByYoutubeId(track.videoId)
             ?: trackDao.findByCanonicalIdentity(
@@ -451,22 +483,25 @@ class SearchDownloadCoordinator @Inject constructor(
         // would still hide its album from the Library tab.
         if (existing != null && existing.album.isBlank() && albumName.isNotBlank()) {
             runCatching { trackDao.updateAlbumIfEmpty(trackId, albumName) }
-                .onFailure { e -> Log.w(TAG, "updateAlbumIfEmpty failed: ${e.message}") }
+                .onFailure { e ->
+                    if (e is CancellationException) throw e
+                    Log.w(TAG, "updateAlbumIfEmpty failed: ${e.message}")
+                }
         }
         if (existing != null && existing.albumArtist.isBlank() && albumArtistName.isNotBlank()) {
             runCatching { trackDao.updateAlbumArtistIfEmpty(trackId, albumArtistName) }
-                .onFailure { e -> Log.w(TAG, "updateAlbumArtistIfEmpty failed: ${e.message}") }
+                .onFailure { e ->
+                    if (e is CancellationException) throw e
+                    Log.w(TAG, "updateAlbumArtistIfEmpty failed: ${e.message}")
+                }
         }
 
-        // Reject a "successful" download whose file is too small to be audio
-        // (a failed yt-dlp run leaving a tiny error body). Delete it + leave
-        // the track not-downloaded (streamable) rather than mark junk.
-        if (!localFileOps.acceptDownloadOrDelete(finalized.committed.filePath)) {
-            Log.w(TAG, "search download: discarded too-small file for trackId=$trackId: ${finalized.committed.filePath}")
-            return
-        }
+        // Establish orphan-sweep protection before flipping isDownloaded. A
+        // failed link therefore leaves a retryable streamable row rather than
+        // a downloaded row whose file can be deleted on the next cleanup.
+        musicRepository.linkTrackToDownloadsMix(trackId)
 
-        trackDao.markAsDownloaded(
+        val updated = trackDao.markAsDownloaded(
             trackId = trackId,
             filePath = finalized.committed.filePath,
             fileSizeBytes = finalized.committed.sizeBytes,
@@ -474,13 +509,19 @@ class SearchDownloadCoordinator @Inject constructor(
             bitsPerSample = finalized.meta?.bitsPerSample,
         )
 
+        check(updated == 1) {
+            "Track disappeared before download state could be persisted: trackId=$trackId"
+        }
         finalized.meta?.let { meta ->
             // Only write probed values when the probe succeeded and reported
             // a real codec. "unknown" indicates MediaMetadataRetriever returned
             // no MIME type — writing it would corrupt the format column.
             if (meta.format != "unknown") {
                 runCatching { trackDao.setFormatAndQuality(trackId, meta.format, meta.bitrateKbps) }
-                    .onFailure { e -> Log.w(TAG, "setFormatAndQuality failed: ${e.message}") }
+                    .onFailure { e ->
+                        if (e is CancellationException) throw e
+                        Log.w(TAG, "setFormatAndQuality failed: ${e.message}")
+                    }
             }
         }
 
@@ -497,13 +538,12 @@ class SearchDownloadCoordinator @Inject constructor(
 
         coverArtUrl?.let {
             runCatching { trackDao.fillMissingAlbumArtUrl(trackId, it) }
-                .onFailure { e -> Log.w(TAG, "fillMissingAlbumArtUrl failed: ${e.message}") }
+                .onFailure { e ->
+                    if (e is CancellationException) throw e
+                    Log.w(TAG, "fillMissingAlbumArtUrl failed: ${e.message}")
+                }
         }
 
-        // Link to the "Your Downloads" / downloads-mix playlist so orphan
-        // cleanup never deletes this track's file on next sync.
-        runCatching { musicRepository.linkTrackToDownloadsMix(trackId) }
-            .onFailure { e -> Log.e(TAG, "linkTrackToDownloadsMix failed for $trackId", e) }
     }
 
     // -------------------------------------------------------------------------
@@ -575,6 +615,9 @@ class SearchDownloadCoordinator @Inject constructor(
         /** v0.9.17: lossless unavailable + fallback off → WaitingForLossless. */
         data object Deferred : DownloadJobResult
     }
+
+    /** Expected policy/file rejection while converting a committed file into durable library state. */
+    private class PersistenceRejectedException(message: String) : Exception(message)
 
     companion object {
         private const val TAG = "SearchDownloadCoordinator"

--- a/data/download/src/main/kotlin/com/stash/data/download/shared/TrackFinalizer.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/shared/TrackFinalizer.kt
@@ -9,6 +9,7 @@ import com.stash.data.download.files.FileOrganizer
 import com.stash.data.download.files.FileOrganizer.CommittedTrack
 import com.stash.data.download.files.MetadataEmbedder
 import com.stash.data.download.lossless.AudioFormat
+import kotlinx.coroutines.CancellationException
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -56,13 +57,19 @@ class TrackFinalizer @Inject constructor(
         track: Track,
         format: AudioFormat,
         embedMetadata: Boolean = true,
-    ): FinalizeResult = runCatching {
+    ): FinalizeResult = try {
         if (embedMetadata) {
             val art = runCatching { albumArtCache.resolveArt(track) }
-                .onFailure { e -> Log.w(TAG, "art resolve failed: ${e.message}") }
+                .onFailure { e ->
+                    if (e is CancellationException) throw e
+                    Log.w(TAG, "art resolve failed: ${e.message}")
+                }
                 .getOrNull()
             runCatching { metadataEmbedder.embedMetadata(sourceFile, track, art) }
-                .onFailure { e -> Log.w(TAG, "metadata embed failed: ${e.message}") }
+                .onFailure { e ->
+                    if (e is CancellationException) throw e
+                    Log.w(TAG, "metadata embed failed: ${e.message}")
+                }
         }
         val committed: CommittedTrack = fileOrganizer.commitDownload(
             tempFile = sourceFile,
@@ -73,7 +80,9 @@ class TrackFinalizer @Inject constructor(
         )
         val meta: AudioMetadata? = audioExtractor.extract(committed.filePath)
         FinalizeResult.Success(committed, meta)
-    }.getOrElse { e ->
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
         FinalizeResult.Failed(e.message ?: "finalize failed")
     }
 

--- a/data/download/src/test/kotlin/com/stash/data/download/files/WebmAudioRemuxerTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/files/WebmAudioRemuxerTest.kt
@@ -1,13 +1,27 @@
 package com.stash.data.download.files
 
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import com.stash.core.data.audio.FFmpegBridge
+import com.stash.core.data.audio.FFmpegBridgeImpl
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.CancellationException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.ByteArrayInputStream
 import java.io.File
 
 /**
- * Tests for [WebmAudioRemuxer]'s pure decision + arg-building logic.
+ * Tests for [WebmAudioRemuxer]'s decision/arg-building logic and remux-failure
+ * file integrity.
  *
  * Why this exists: YouTube's Opus audio itags (251/250/249) download into a
  * `.webm` *container*. Even though the stream is audio-only, Android's
@@ -19,6 +33,9 @@ import java.io.File
  * and must be left untouched.
  */
 class WebmAudioRemuxerTest {
+
+    @get:Rule
+    val temp = TemporaryFolder()
 
     @Test fun `webm files need remux (case-insensitive)`() {
         assertTrue(WebmAudioRemuxer.needsRemux(File("/tmp/dl_1.webm")))
@@ -54,5 +71,79 @@ class WebmAudioRemuxerTest {
             ),
             WebmAudioRemuxer.buildRemuxArgs(input, output),
         )
+    }
+
+    @Test fun nonZeroFfmpegWithLargePartialOutputKeepsWebmAndDeletesPartialOpus() = runTest {
+        val nativeDir = temp.newFolder("native").also {
+            File(it, "libffmpeg.so").apply {
+                writeText("fake")
+                setExecutable(true)
+            }
+        }
+        val appInfo = ApplicationInfo().apply {
+            nativeLibraryDir = nativeDir.absolutePath
+        }
+        val context = mockk<Context> {
+            every { applicationInfo } returns appInfo
+            every { cacheDir } returns temp.newFolder("cache")
+            every { noBackupFilesDir } returns temp.newFolder("no-backup")
+        }
+        val input = temp.newFile("track.webm").apply {
+            writeBytes(ByteArray(PARTIAL_SIZE_BYTES) { 1 })
+        }
+        val output = WebmAudioRemuxer.opusTarget(input)
+        val process = mockk<Process> {
+            every { inputStream } returns ByteArrayInputStream(ByteArray(0))
+            every { errorStream } returns ByteArrayInputStream("fatal remux error".toByteArray())
+            every { waitFor() } returns 1
+        }
+
+        mockkConstructor(ProcessBuilder::class)
+        try {
+            every { anyConstructed<ProcessBuilder>().environment() } returns mutableMapOf()
+            every { anyConstructed<ProcessBuilder>().redirectErrorStream(false) } answers {
+                self as ProcessBuilder
+            }
+            every { anyConstructed<ProcessBuilder>().start() } answers {
+                output.writeBytes(ByteArray(PARTIAL_SIZE_BYTES) { 2 })
+                process
+            }
+
+            val result = WebmAudioRemuxer(FFmpegBridgeImpl(context)).toOpusIfWebm(input)
+
+            assertEquals(input, result)
+            assertTrue("original WebM must survive ffmpeg failure", input.exists())
+            assertFalse("partial OPUS must be removed", output.exists())
+        } finally {
+            unmockkConstructor(ProcessBuilder::class)
+        }
+    }
+
+    @Test fun cancellationKeepsWebmDeletesPartialOpusAndPropagates() = runTest {
+        val input = temp.newFile("cancelled.webm").apply {
+            writeBytes(ByteArray(PARTIAL_SIZE_BYTES) { 1 })
+        }
+        val output = WebmAudioRemuxer.opusTarget(input)
+        val bridge = object : FFmpegBridge {
+            override suspend fun runWithStderrCapture(args: List<String>): String {
+                output.writeBytes(ByteArray(PARTIAL_SIZE_BYTES) { 2 })
+                throw CancellationException("cancelled")
+            }
+        }
+
+        var cancellationPropagated = false
+        try {
+            WebmAudioRemuxer(bridge).toOpusIfWebm(input)
+        } catch (_: CancellationException) {
+            cancellationPropagated = true
+        }
+
+        assertTrue("cancellation must propagate", cancellationPropagated)
+        assertTrue("original WebM must survive cancellation", input.exists())
+        assertFalse("partial OPUS must be removed on cancellation", output.exists())
+    }
+
+    private companion object {
+        const val PARTIAL_SIZE_BYTES = 32 * 1024
     }
 }

--- a/data/download/src/test/kotlin/com/stash/data/download/search/SearchDownloadCoordinatorCompletionTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/search/SearchDownloadCoordinatorCompletionTest.kt
@@ -1,0 +1,219 @@
+package com.stash.data.download.search
+
+import android.content.Context
+import androidx.media3.datasource.HttpDataSource
+import androidx.media3.datasource.cache.CacheKeyFactory
+import androidx.media3.datasource.cache.SimpleCache
+import com.stash.core.data.audio.AudioMetadata
+import com.stash.core.data.audio.LoudnessMeasurer
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.dao.DownloadQueueDao
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.files.LocalFileOps
+import com.stash.core.data.repository.MusicRepository
+import com.stash.core.model.MusicSource
+import com.stash.core.model.TrackItem
+import com.stash.data.download.DownloadExecutor
+import com.stash.data.download.DownloadResult
+import com.stash.data.download.files.FileOrganizer.CommittedTrack
+import com.stash.data.download.lossless.LosslessSourcePreferences
+import com.stash.data.download.lossless.LosslessSourceRegistry
+import com.stash.data.download.lyrics.LyricsFetchTrigger
+import com.stash.data.download.shared.TrackFinalizer
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+/** Regression coverage for truthful terminal download status. */
+class SearchDownloadCoordinatorCompletionTest {
+
+    private val registry: LosslessSourceRegistry = mockk(relaxed = true)
+    private val previewCache: SimpleCache = mockk(relaxed = true)
+    private val httpDataSourceFactory: HttpDataSource.Factory = mockk(relaxed = true)
+    private val cacheKeyFactory: CacheKeyFactory = mockk(relaxed = true)
+    private val downloadExecutor: DownloadExecutor = mockk()
+    private val trackFinalizer: TrackFinalizer = mockk()
+    private val trackDao: TrackDao = mockk(relaxed = true)
+    private val musicRepository: MusicRepository = mockk(relaxed = true)
+    private val blocklistGuard: BlocklistGuard = mockk(relaxed = true)
+    private val context: Context = mockk(relaxed = true)
+    private val losslessPrefs: LosslessSourcePreferences = mockk(relaxed = true)
+    private val downloadQueueDao: DownloadQueueDao = mockk(relaxed = true)
+    private val localFileOps: LocalFileOps = mockk()
+    private val loudnessMeasurer: LoudnessMeasurer = mockk(relaxed = true)
+    private val lyricsFetchTrigger: LyricsFetchTrigger = mockk(relaxed = true)
+
+    private val tmpCacheDir = File(
+        System.getProperty("java.io.tmpdir"),
+        "stash-search-completion-test-${System.nanoTime()}",
+    ).also { it.mkdirs() }
+
+    private fun newSubject() = SearchDownloadCoordinator(
+        registry = registry,
+        previewCache = previewCache,
+        httpDataSourceFactory = httpDataSourceFactory,
+        cacheKeyFactory = cacheKeyFactory,
+        downloadExecutor = downloadExecutor,
+        trackFinalizer = trackFinalizer,
+        trackDao = trackDao,
+        musicRepository = musicRepository,
+        blocklistGuard = blocklistGuard,
+        context = context,
+        losslessPrefs = losslessPrefs,
+        downloadQueueDao = downloadQueueDao,
+        localFileOps = localFileOps,
+        loudnessMeasurer = loudnessMeasurer,
+        lyricsFetchTrigger = lyricsFetchTrigger,
+    )
+
+    @Before
+    fun setUp() {
+        every { context.cacheDir } returns tmpCacheDir
+        every { localFileOps.acceptDownloadOrDelete(any()) } returns true
+    }
+
+    private fun track() = TrackItem(
+        videoId = "vid42",
+        title = "Sample",
+        artist = "Sample Artist",
+        durationSeconds = 200.0,
+        thumbnailUrl = null,
+    )
+
+    private fun existingTrack() = TrackEntity(
+        id = 7L,
+        title = "Sample",
+        artist = "Sample Artist",
+        youtubeId = "vid42",
+        canonicalTitle = "sample",
+        canonicalArtist = "sample artist",
+        durationMs = 200_000L,
+        source = MusicSource.YOUTUBE,
+        albumArtUrl = null,
+    )
+
+    private fun arrangeFinalizedYtDlpDownload() {
+        coEvery { losslessPrefs.enabledNow() } returns false
+        val tempFile = File.createTempFile("search_yt", ".opus").apply { deleteOnExit() }
+        coEvery {
+            downloadExecutor.download(any(), any(), any(), any(), any())
+        } returns DownloadResult.Success(tempFile)
+        coEvery {
+            trackFinalizer.finalizeFile(any(), any(), any(), any())
+        } returns TrackFinalizer.FinalizeResult.Success(
+            committed = CommittedTrack(
+                filePath = "/library/Sample Artist/Sample.opus",
+                sizeBytes = 4096L,
+            ),
+            meta = AudioMetadata(
+                durationMs = 200_000L,
+                bitrateKbps = 128,
+                format = "opus",
+                sampleRateHz = 48_000,
+                bitsPerSample = 16,
+            ),
+        )
+        coEvery { trackDao.findByYoutubeId("vid42") } returns existingTrack()
+        coEvery {
+            trackDao.markAsDownloaded(any(), any(), any(), any(), any(), any())
+        } returns 1
+    }
+
+    private fun assertFailedNeverCompleted(statuses: List<SearchDownloadStatus>) {
+        assertTrue("terminal status must be Failed, got $statuses", statuses.last() is SearchDownloadStatus.Failed)
+        assertFalse("Completed must never be emitted after persistence failure, got $statuses", statuses.any {
+            it is SearchDownloadStatus.Completed
+        })
+    }
+
+    @Test
+    fun `invalid committed file fails instead of completing`() = runTest {
+        arrangeFinalizedYtDlpDownload()
+        every { localFileOps.acceptDownloadOrDelete(any()) } returns false
+
+        val statuses = newSubject().download(track()).toList()
+
+        assertFailedNeverCompleted(statuses)
+        coVerify(exactly = 0) { trackDao.markAsDownloaded(any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { musicRepository.linkTrackToDownloadsMix(any()) }
+    }
+
+    @Test
+    fun `markAsDownloaded failure fails instead of completing`() = runTest {
+        arrangeFinalizedYtDlpDownload()
+        coEvery {
+            trackDao.markAsDownloaded(any(), any(), any(), any(), any(), any())
+        } throws IllegalStateException("database unavailable")
+
+        val statuses = newSubject().download(track()).toList()
+
+        assertFailedNeverCompleted(statuses)
+        coVerify(exactly = 1) { musicRepository.linkTrackToDownloadsMix(7L) }
+    }
+    @Test
+    fun `zero-row markAsDownloaded fails instead of completing`() = runTest {
+        arrangeFinalizedYtDlpDownload()
+        coEvery {
+            trackDao.markAsDownloaded(any(), any(), any(), any(), any(), any())
+        } returns 0
+
+        val statuses = newSubject().download(track()).toList()
+
+        assertFailedNeverCompleted(statuses)
+    }
+
+
+    @Test
+    fun `downloads-mix link failure fails instead of completing`() = runTest {
+        arrangeFinalizedYtDlpDownload()
+        coEvery { musicRepository.linkTrackToDownloadsMix(7L) } throws
+            IllegalStateException("downloads mix unavailable")
+
+        val statuses = newSubject().download(track()).toList()
+
+        assertFailedNeverCompleted(statuses)
+        coVerify(exactly = 0) { trackDao.markAsDownloaded(any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `persistence cancellation is propagated`() = runTest {
+        arrangeFinalizedYtDlpDownload()
+        coEvery {
+            trackDao.markAsDownloaded(any(), any(), any(), any(), any(), any())
+        } throws CancellationException("cancelled")
+
+        var cancellationPropagated = false
+        try {
+            newSubject().download(track()).toList()
+        } catch (_: CancellationException) {
+            cancellationPropagated = true
+        }
+        assertTrue(cancellationPropagated)
+    }
+    @Test
+    fun `yt-dlp cancellation is propagated`() = runTest {
+        coEvery { losslessPrefs.enabledNow() } returns false
+        coEvery {
+            downloadExecutor.download(any(), any(), any(), any(), any())
+        } throws CancellationException("cancelled")
+
+        var cancellationPropagated = false
+        try {
+            newSubject().download(track()).toList()
+        } catch (_: CancellationException) {
+            cancellationPropagated = true
+        }
+        assertTrue(cancellationPropagated)
+    }
+
+}

--- a/data/download/src/test/kotlin/com/stash/data/download/search/SearchDownloadCoordinatorEmbedStampTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/search/SearchDownloadCoordinatorEmbedStampTest.kt
@@ -128,6 +128,9 @@ class SearchDownloadCoordinatorEmbedStampTest {
         } returns TrackFinalizer.FinalizeResult.Success(committed, meta)
 
         coEvery { trackDao.findByYoutubeId("vid42") } returns stubExistingTrackRow()
+        coEvery {
+            trackDao.markAsDownloaded(any(), any(), any(), any(), any(), any())
+        } returns 1
     }
 
     @Test

--- a/data/download/src/test/kotlin/com/stash/data/download/shared/TrackFinalizerTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/shared/TrackFinalizerTest.kt
@@ -8,6 +8,7 @@ import com.stash.data.download.files.MetadataEmbedder
 import com.stash.data.download.lossless.AudioFormat
 import io.mockk.coEvery
 import io.mockk.coVerify
+import kotlinx.coroutines.CancellationException
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertNull
@@ -90,6 +91,25 @@ class TrackFinalizerTest {
         assertTrue(result is TrackFinalizer.FinalizeResult.Success)
     }
 
+    @Test fun `finalizeFile propagates cancellation from commit`() = runTest {
+        coEvery {
+            fileOrganizer.commitDownload(any(), any(), any(), any(), any())
+        } throws CancellationException("cancelled")
+
+        var cancellationPropagated = false
+        try {
+            subject.finalizeFile(
+                sourceFile = File.createTempFile("src", ".opus"),
+                track = stubTrack(),
+                format = AudioFormat(codec = "opus", bitrateKbps = 128),
+                embedMetadata = false,
+            )
+        } catch (_: CancellationException) {
+            cancellationPropagated = true
+        }
+
+        assertTrue("cancellation must propagate", cancellationPropagated)
+    }
     private fun stubTrack(): Track = Track(
         id = 1L,
         title = "Title",

--- a/feature/library/src/main/kotlin/com/stash/feature/library/AlbumDetailViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/AlbumDetailViewModel.kt
@@ -249,7 +249,7 @@ class AlbumDetailViewModel @Inject constructor(
             var succeeded = 0
             trackIds.forEach { id ->
                 runCatching { musicRepository.queueDownload(id) }
-                    .onSuccess { succeeded++ }
+                    .onSuccess { queued -> if (queued) succeeded++ }
                     .onFailure { e -> if (e is CancellationException) throw e }
             }
             if (succeeded > 0) {

--- a/feature/library/src/main/kotlin/com/stash/feature/library/ArtistDetailViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/ArtistDetailViewModel.kt
@@ -236,7 +236,7 @@ class ArtistDetailViewModel @Inject constructor(
             var succeeded = 0
             trackIds.forEach { id ->
                 runCatching { musicRepository.queueDownload(id) }
-                    .onSuccess { succeeded++ }
+                    .onSuccess { queued -> if (queued) succeeded++ }
                     .onFailure { e -> if (e is CancellationException) throw e }
             }
             if (succeeded > 0) {

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryViewModel.kt
@@ -89,22 +89,6 @@ class LibraryViewModel @Inject constructor(
     /** Local UI controls: tab, search query, and sort order. */
     private val _controls = MutableStateFlow(ControlState())
 
-    init {
-        // Smart-default: if the user already has lossless tracks, open
-        // Library to TRACKS / RECENT / FLAC instead of TRACKS / RECENT
-        // / ALL. One-shot snapshot read at cold start; the user's
-        // mid-session filter changes are honoured (we never fight back).
-        viewModelScope.launch {
-            val firstSnapshot = musicRepository.getAllTracks().first()
-            val hasLossless = firstSnapshot.any {
-                it.fileFormat.lowercase() in LOSSLESS_CODECS
-            }
-            if (hasLossless && _controls.value.sourceFilter == SourceFilter.ALL) {
-                _controls.update { it.copy(sourceFilter = SourceFilter.FLAC) }
-            }
-        }
-    }
-
     /**
      * Derives a pair of (spotifyConnected, youTubeConnected) from TokenManager.
      */
@@ -425,7 +409,7 @@ class LibraryViewModel @Inject constructor(
             var succeeded = 0
             trackIds.forEach { id ->
                 runCatching { musicRepository.queueDownload(id) }
-                    .onSuccess { succeeded++ }
+                    .onSuccess { queued -> if (queued) succeeded++ }
                     .onFailure { e -> if (e is CancellationException) throw e }
             }
             if (succeeded > 0) {

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LikedSongsDetailViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LikedSongsDetailViewModel.kt
@@ -226,7 +226,7 @@ class LikedSongsDetailViewModel @Inject constructor(
             var succeeded = 0
             trackIds.forEach { id ->
                 runCatching { musicRepository.queueDownload(id) }
-                    .onSuccess { succeeded++ }
+                    .onSuccess { queued -> if (queued) succeeded++ }
                     .onFailure { e -> if (e is CancellationException) throw e }
             }
             if (succeeded > 0) {

--- a/feature/library/src/main/kotlin/com/stash/feature/library/PlaylistDetailViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/PlaylistDetailViewModel.kt
@@ -302,8 +302,10 @@ class PlaylistDetailViewModel @Inject constructor(
      */
     fun queueDownload(trackId: Long) {
         viewModelScope.launch {
-            musicRepository.queueDownload(trackId)
-            _userMessages.tryEmit("Queued for download.")
+            val queued = musicRepository.queueDownload(trackId)
+            _userMessages.tryEmit(
+                if (queued) "Queued for download." else "Couldn't queue download.",
+            )
         }
     }
 
@@ -385,7 +387,7 @@ class PlaylistDetailViewModel @Inject constructor(
             var succeeded = 0
             trackIds.forEach { id ->
                 runCatching { musicRepository.queueDownload(id) }
-                    .onSuccess { succeeded++ }
+                    .onSuccess { queued -> if (queued) succeeded++ }
                     .onFailure { e -> if (e is CancellationException) throw e }
             }
             if (succeeded > 0) {

--- a/feature/library/src/test/kotlin/com/stash/feature/library/AlbumDetailViewModelTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/AlbumDetailViewModelTest.kt
@@ -142,6 +142,19 @@ class AlbumDetailViewModelTest {
         assertEquals(listOf("Queued 2 songs for download."), messages)
     }
 
+    @Test
+    fun downloadSelected_counts_only_true_queue_results() = runTest {
+        val musicRepo = musicRepoMock()
+        whenever(musicRepo.queueDownload(eq(2L))).thenReturn(false)
+        val vm = buildVm(musicRepository = musicRepo)
+
+        val messages = collectMessages(vm)
+        vm.downloadSelected(listOf(1L, 2L, 3L))
+        runCurrent()
+
+        assertEquals(listOf("Queued 2 songs for download."), messages)
+    }
+
     // ------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------

--- a/feature/library/src/test/kotlin/com/stash/feature/library/ArtistDetailViewModelTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/ArtistDetailViewModelTest.kt
@@ -142,6 +142,19 @@ class ArtistDetailViewModelTest {
         assertEquals(listOf("Queued 2 songs for download."), messages)
     }
 
+    @Test
+    fun downloadSelected_counts_only_true_queue_results() = runTest {
+        val musicRepo = musicRepoMock()
+        whenever(musicRepo.queueDownload(eq(2L))).thenReturn(false)
+        val vm = buildVm(musicRepository = musicRepo)
+
+        val messages = collectMessages(vm)
+        vm.downloadSelected(listOf(1L, 2L, 3L))
+        runCurrent()
+
+        assertEquals(listOf("Queued 2 songs for download."), messages)
+    }
+
     // ------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelSortTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelSortTest.kt
@@ -58,6 +58,19 @@ class LibraryViewModelSortTest {
         assertThat(state.librarySongCount).isEqualTo(3)
     }
 
+    @Test fun cold_start_keeps_all_tracks_visible_when_library_contains_lossless_audio() = runTest {
+        val mixedFormats = listOf(
+            Track(id = 1L, title = "Lossless", artist = "X", fileFormat = "flac"),
+            Track(id = 2L, title = "New OPUS", artist = "X", fileFormat = "opus"),
+        )
+        val vm = buildVm(musicRepoMock(mixedFormats))
+
+        val state = vm.uiState.first { !it.isLoading }
+
+        assertThat(state.sourceFilter).isEqualTo(SourceFilter.ALL)
+        assertThat(state.tracks.map { it.id }).containsExactly(1L, 2L)
+    }
+
     // ── harness (mirrors LibraryViewModelMixTest) ─────────────────────────
     private fun musicRepoMock(allTracks: List<Track>): MusicRepository = mock {
         on { getAllTracks() } doReturn flowOf(allTracks)

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelTest.kt
@@ -180,6 +180,19 @@ class LibraryViewModelTest {
         assertEquals(listOf("Queued 2 songs for download."), messages)
     }
 
+    @Test
+    fun downloadSelected_counts_only_true_queue_results() = runTest {
+        val musicRepo = musicRepoMock()
+        whenever(musicRepo.queueDownload(eq(2L))).thenReturn(false)
+        val vm = buildVm(musicRepository = musicRepo)
+
+        val messages = collectMessages(vm)
+        vm.downloadSelected(listOf(1L, 2L, 3L))
+        runCurrent()
+
+        assertEquals(listOf("Queued 2 songs for download."), messages)
+    }
+
     // ------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LikedSongsDetailViewModelTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LikedSongsDetailViewModelTest.kt
@@ -218,6 +218,19 @@ class LikedSongsDetailViewModelTest {
         assertEquals(listOf("Queued 2 songs for download."), messages)
     }
 
+    @Test
+    fun downloadSelected_counts_only_true_queue_results() = runTest {
+        val musicRepo = musicRepoMock()
+        whenever(musicRepo.queueDownload(eq(2L))).thenReturn(false)
+        val vm = buildVm(musicRepository = musicRepo)
+
+        val messages = collectMessages(vm)
+        vm.downloadSelected(listOf(1L, 2L, 3L))
+        runCurrent()
+
+        assertEquals(listOf("Queued 2 songs for download."), messages)
+    }
+
     // ------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------

--- a/feature/library/src/test/kotlin/com/stash/feature/library/PlaylistDetailViewModelTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/PlaylistDetailViewModelTest.kt
@@ -201,6 +201,32 @@ class PlaylistDetailViewModelTest {
     }
 
     @Test
+    fun downloadSelected_counts_only_true_queue_results() = runTest {
+        val musicRepo = musicRepoMock()
+        whenever(musicRepo.queueDownload(eq(2L))).thenReturn(false)
+        val vm = buildVm(musicRepository = musicRepo)
+
+        val messages = collectMessages(vm)
+        vm.downloadSelected(listOf(1L, 2L, 3L))
+        runCurrent()
+
+        assertEquals(listOf("Queued 2 songs for download."), messages)
+    }
+
+    @Test
+    fun queueDownload_reports_when_single_item_was_not_queued() = runTest {
+        val musicRepo = musicRepoMock()
+        whenever(musicRepo.queueDownload(eq(1L))).thenReturn(false)
+        val vm = buildVm(musicRepository = musicRepo)
+
+        val messages = collectMessages(vm)
+        vm.queueDownload(1L)
+        runCurrent()
+
+        assertEquals(listOf("Couldn't queue download."), messages)
+    }
+
+    @Test
     fun downloadSelected_rethrows_cancellation_and_aborts_batch() = runTest {
         val musicRepo = musicRepoMock()
         // The FIRST item's repo call is cancelled. The batch methods re-throw


### PR DESCRIPTION
## Summary
- reject non-zero FFmpeg exits, clean partial OPUS outputs, and retain the playable WebM fallback
- report search downloads complete only after file validation, durable database persistence, and an active Your Downloads membership
- keep downloaded OPUS tracks visible by default and make library batch-download feedback reflect actual queue acceptance
- propagate cancellation through download/remux/finalization paths instead of converting it into ordinary failure

Fixes ParaliyzedEvo/Stash#80.

## Verification
- `:app:compileDebugKotlin` — passed
- focused core downloads-mix DAO/repository tests — passed
- focused remux, search persistence, metadata stamp, and finalizer tests — passed
- `:feature:library:testDebugUnitTest` — passed
- independent review wave — no Critical or Important findings remaining

## Baseline test note
The full module runs also reproduce existing upstream failures in three unchanged core-data test classes (4 failures total) and four unrelated data-download tests (three Windows native `.so` harness failures plus one existing source-order assertion). The affected production/test files for the core failures are unchanged from `upstream/master`; all issue-specific regressions pass.