### PR TITLE
fix(sync): Refresh mode can no longer destroy playlists on failed fetches

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
@@ -310,7 +310,29 @@ class DiffWorker @AssistedInject constructor(
         streamingMode: Boolean,
     ): Int {
         if (syncMode == SyncMode.REFRESH) {
-            playlistDao.clearSyncedPlaylistTracks(localPlaylist.id)
+            // #343: NEVER mirror-clear against a fetch that admits (or looks
+            // like) incompleteness — one flaky API call was emptying whole
+            // playlists, and the orphan cleaner then deleted the files.
+            //  - partial: the fetch worker marked this snapshot incomplete
+            //    (track fetch threw/errored, or pagination hit its cap — the
+            //    long-standing YT truncation loss is this same hole).
+            //  - suspiciousEmpty: zero tracks fetched while the playlist
+            //    LISTING claimed some exist — an unmarked failure shape.
+            // In both cases we fall through and merge additions only
+            // (accumulate semantics); a later clean fetch re-mirrors fully.
+            if (snapshotUnreliable(playlistSnapshot, trackSnapshots)) {
+                Log.w(
+                    TAG,
+                    "REFRESH: keeping local tracks for '${playlistSnapshot.playlistName}' — " +
+                        if (playlistSnapshot.partial) {
+                            "fetch marked partial (${trackSnapshots.size} snapshot tracks)"
+                        } else {
+                            "snapshot empty but listing claims ${playlistSnapshot.trackCount} tracks"
+                        },
+                )
+            } else {
+                playlistDao.clearSyncedPlaylistTracks(localPlaylist.id)
+            }
         }
 
         if (trackSnapshots.isEmpty()) {
@@ -517,6 +539,19 @@ class DiffWorker @AssistedInject constructor(
     }
 
     /**
+     * A snapshot that must NOT be treated as the full remote truth (#343):
+     * either the fetch worker marked it partial (track fetch errored, or
+     * pagination hit a cap), or it fetched zero tracks while the playlist
+     * LISTING claims some exist — an unmarked failure shape. Shared by the
+     * REFRESH clear guard and [finalizePlaylistMetadata] so the "don't
+     * mirror" and "don't record mirrored state" decisions can't drift.
+     */
+    private fun snapshotUnreliable(
+        snapshot: RemotePlaylistSnapshotEntity,
+        trackSnapshots: List<RemoteTrackSnapshotEntity>,
+    ): Boolean = snapshot.partial || (trackSnapshots.isEmpty() && snapshot.trackCount > 0)
+
+    /**
      * Playlist metadata bookkeeping shared by every processPlaylist exit
      * path (including the early-return-on-empty branches). Unchanged from
      * the original inline tail of processPlaylist.
@@ -527,6 +562,14 @@ class DiffWorker @AssistedInject constructor(
         trackSnapshots: List<RemoteTrackSnapshotEntity>,
     ) {
         playlistDao.updateLastSynced(localPlaylist.id, System.currentTimeMillis())
+        if (snapshotUnreliable(playlistSnapshot, trackSnapshots)) {
+            // #343: an unreliable fetch was NOT mirrored (see processPlaylist).
+            // Recording its snapshot_id would make the next sync skip this
+            // playlist as "unchanged" and the missing tracks would never
+            // re-sync; stamping trackSnapshots.size would show a lying track
+            // count over retained content. Leave both as they were.
+            return
+        }
         if (playlistSnapshot.snapshotId != null) {
             playlistDao.updateSnapshotId(localPlaylist.id, playlistSnapshot.snapshotId)
         }

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorker.kt
@@ -368,6 +368,11 @@ class PlaylistFetchWorker @AssistedInject constructor(
             val allLikedSongs = mutableListOf<com.stash.data.spotify.model.SpotifyTrackItem>()
             var likedOffset = 0
             val likedPageSize = 50
+            // #343: an error mid-pagination used to break out and snapshot
+            // the truncated pile as if it were the complete library —
+            // REFRESH then mirrored Liked Songs DOWN to it. Track the
+            // failure so the snapshot admits incompleteness.
+            var likedFetchPartial = false
 
             while (true) {
                 when (val result = spotifyApiClient.getLikedSongs(limit = likedPageSize, offset = likedOffset)) {
@@ -379,6 +384,7 @@ class PlaylistFetchWorker @AssistedInject constructor(
                     }
                     is SyncResult.Empty -> break
                     is SyncResult.Error -> {
+                        likedFetchPartial = true
                         Log.e(TAG, "fetchSpotifyPlaylists: liked songs page error at offset=$likedOffset: ${result.message}")
                         break
                     }
@@ -402,6 +408,7 @@ class PlaylistFetchWorker @AssistedInject constructor(
                                 it.track?.album?.images?.firstOrNull()?.url
                             }
                         ),
+                        partial = likedFetchPartial,
                     )
                 )
 
@@ -518,6 +525,31 @@ class PlaylistFetchWorker @AssistedInject constructor(
 
             for (playlist in customPlaylists) {
                 try {
+                    // #343: fetch tracks FIRST (like the YouTube paths) so
+                    // the snapshot row can carry an HONEST partial flag. The
+                    // old order inserted the snapshot, then a failed track
+                    // fetch left it present-but-empty with partial=false —
+                    // which REFRESH mode mirror-cleared into real data loss.
+                    var fetchFailed = false
+                    val fetchedItems = try {
+                        when (val tracksResult = spotifyApiClient.getPlaylistTracks(playlist.id)) {
+                            is SyncResult.Success -> tracksResult.data
+                            is SyncResult.Empty -> emptyList()
+                            is SyncResult.Error -> {
+                                fetchFailed = true
+                                inventoryComplete = false
+                                Log.w(TAG, "fetchSpotifyPlaylists: '${playlist.name}' — error: ${tracksResult.message}")
+                                emptyList()
+                            }
+                        }
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
+                        fetchFailed = true
+                        inventoryComplete = false
+                        Log.w(TAG, "fetchSpotifyPlaylists: failed to fetch tracks for '${playlist.name}'", e)
+                        emptyList()
+                    }
+
                     val playlistSnapshotId = remoteSnapshotDao.insertPlaylistSnapshot(
                         RemotePlaylistSnapshotEntity(
                             syncId = syncId,
@@ -529,44 +561,38 @@ class PlaylistFetchWorker @AssistedInject constructor(
                             artUrl = com.stash.core.common.ArtUrlUpgrader.upgrade(
                                 playlist.images?.firstOrNull()?.url,
                             ),
+                            partial = fetchFailed,
+                            expectedCount = playlist.tracks?.total,
                         )
                     )
 
-                    when (val tracksResult = spotifyApiClient.getPlaylistTracks(playlist.id)) {
-                        is SyncResult.Success -> {
-                            val trackSnapshots = tracksResult.data.mapIndexedNotNull { index, item ->
-                                val track = item.track ?: return@mapIndexedNotNull null
-                                RemoteTrackSnapshotEntity(
-                                    syncId = syncId,
-                                    snapshotPlaylistId = playlistSnapshotId,
-                                    title = track.name,
-                                    artist = track.artists.joinToString(", ") { it.name },
-                                    album = track.album?.name,
-                                    durationMs = track.duration_ms,
-                                    spotifyUri = track.uri,
-                                    albumArtUrl = com.stash.core.common.ArtUrlUpgrader.upgrade(track.album?.images?.firstOrNull()?.url),
-                                    position = index,
-                                    isrc = track.isrc,
-                                    explicit = track.explicit,
-                                )
-                            }
-                            if (trackSnapshots.isNotEmpty()) {
-                                remoteSnapshotDao.insertTrackSnapshots(trackSnapshots)
-                            }
-                            userPlaylistCount++
-                            Log.d(TAG, "fetchSpotifyPlaylists: '${playlist.name}' — ${trackSnapshots.size} tracks")
-                        }
-                        is SyncResult.Empty -> {
-                            Log.d(TAG, "fetchSpotifyPlaylists: '${playlist.name}' — empty")
-                        }
-                        is SyncResult.Error -> {
-                            Log.w(TAG, "fetchSpotifyPlaylists: '${playlist.name}' — error: ${tracksResult.message}")
-                        }
+                    val trackSnapshots = fetchedItems.mapIndexedNotNull { index, item ->
+                        val track = item.track ?: return@mapIndexedNotNull null
+                        RemoteTrackSnapshotEntity(
+                            syncId = syncId,
+                            snapshotPlaylistId = playlistSnapshotId,
+                            title = track.name,
+                            artist = track.artists.joinToString(", ") { it.name },
+                            album = track.album?.name,
+                            durationMs = track.duration_ms,
+                            spotifyUri = track.uri,
+                            albumArtUrl = com.stash.core.common.ArtUrlUpgrader.upgrade(track.album?.images?.firstOrNull()?.url),
+                            position = index,
+                            isrc = track.isrc,
+                            explicit = track.explicit,
+                        )
+                    }
+                    if (trackSnapshots.isNotEmpty()) {
+                        remoteSnapshotDao.insertTrackSnapshots(trackSnapshots)
+                    }
+                    if (!fetchFailed) {
+                        userPlaylistCount++
+                        Log.d(TAG, "fetchSpotifyPlaylists: '${playlist.name}' — ${trackSnapshots.size} tracks")
                     }
                 } catch (e: Exception) {
                     if (e is CancellationException) throw e
                     inventoryComplete = false
-                    Log.w(TAG, "fetchSpotifyPlaylists: failed to fetch tracks for '${playlist.name}'", e)
+                    Log.w(TAG, "fetchSpotifyPlaylists: snapshot failed for '${playlist.name}'", e)
                 }
             }
 

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
@@ -273,6 +273,120 @@ class DiffWorkerTest {
         return db.playlistDao().getById(playlistId)?.artUrl
     }
 
+    // ── #343: REFRESH must never mirror-clear against unreliable fetches ──
+
+    private suspend fun seedSyncedPlaylist(
+        snapshotId: String? = "old-snap",
+    ): Pair<Long, Long> {
+        val trackId = db.trackDao().insert(
+            TrackEntity(
+                title = "Keeper", artist = "Artist",
+                canonicalTitle = "keeper", canonicalArtist = "artist",
+                spotifyUri = "spotify:track:keeper",
+            )
+        )
+        val playlistId = db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Jams", source = MusicSource.SPOTIFY,
+                sourceId = "pl1", type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        db.playlistDao().insertCrossRef(
+            PlaylistTrackCrossRef(playlistId = playlistId, trackId = trackId, position = 0)
+        )
+        snapshotId?.let { db.playlistDao().updateSnapshotId(playlistId, it) }
+        db.playlistDao().updateTrackCount(playlistId, 1)
+        return playlistId to trackId
+    }
+
+    private fun stubSnapshot(
+        partial: Boolean,
+        listedTrackCount: Int,
+        trackSnapshots: List<RemoteTrackSnapshotEntity> = emptyList(),
+    ) {
+        val snapshot = RemotePlaylistSnapshotEntity(
+            id = 4L, syncId = 1L, source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "pl1", playlistName = "Jams",
+            playlistType = PlaylistType.CUSTOM, trackCount = listedTrackCount,
+            partial = partial, snapshotId = "new-snap",
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(snapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(4L) } returns trackSnapshots
+    }
+
+    private suspend fun activeTrackCount(playlistId: Long): Int =
+        db.playlistDao().getCrossRefsForPlaylist(playlistId).count { it.removedAt == null }
+
+    @Test
+    fun `REFRESH keeps local tracks when the snapshot is marked partial`() = runBlocking {
+        val (playlistId, _) = seedSyncedPlaylist()
+        stubSnapshot(partial = true, listedTrackCount = 12)
+
+        val result = buildWorker().doWork()
+
+        assertTrue("diff must succeed", result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals("local track survives a partial fetch", 1, activeTrackCount(playlistId))
+    }
+
+    @Test
+    fun `REFRESH keeps local tracks when the snapshot is empty but the listing claims tracks`() = runBlocking {
+        val (playlistId, _) = seedSyncedPlaylist()
+        stubSnapshot(partial = false, listedTrackCount = 12)
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals("unmarked failure shape must not clear", 1, activeTrackCount(playlistId))
+    }
+
+    @Test
+    fun `REFRESH mirrors a genuinely emptied playlist`() = runBlocking {
+        val (playlistId, _) = seedSyncedPlaylist()
+        stubSnapshot(partial = false, listedTrackCount = 0)
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals("clean empty fetch mirrors the empty remote", 0, activeTrackCount(playlistId))
+    }
+
+    @Test
+    fun `partial fetch does not advance snapshot id or track count`() = runBlocking {
+        val (playlistId, _) = seedSyncedPlaylist(snapshotId = "old-snap")
+        stubSnapshot(partial = true, listedTrackCount = 12)
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals(
+            "snapshot id must stay stale so the next sync re-diffs this playlist",
+            "old-snap", db.playlistDao().getSnapshotId(playlistId),
+        )
+        assertEquals("track count must not lie over retained tracks", 1, db.playlistDao().getById(playlistId)?.trackCount)
+    }
+
+    @Test
+    fun `partial fetch still merges the additions it did return`() = runBlocking {
+        val (playlistId, _) = seedSyncedPlaylist()
+        stubSnapshot(
+            partial = true, listedTrackCount = 12,
+            trackSnapshots = listOf(
+                RemoteTrackSnapshotEntity(
+                    id = 9L, syncId = 1L, snapshotPlaylistId = 4L,
+                    title = "Newcomer", artist = "Artist",
+                    durationMs = 200_000, spotifyUri = "spotify:track:new",
+                    position = 0,
+                )
+            ),
+        )
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals("existing track kept AND the fetched addition merged", 2, activeTrackCount(playlistId))
+    }
+
     private fun buildWorker(): DiffWorker = TestListenableWorkerBuilder<DiffWorker>(context)
         .setInputData(workDataOf(PlaylistFetchWorker.KEY_SYNC_ID to 1L))
         .setWorkerFactory(object : WorkerFactory() {


### PR DESCRIPTION
## Summary
- **Root cause of #343 / zero-song playlists**: Refresh cleared playlist tracks *before* checking the fetch succeeded. Spotify customs wrote their snapshot before fetching (failures left present-but-empty snapshots), Liked Songs pagination passed truncated piles off as complete, and the diff ignored the `partial` flag the YouTube paths were already writing (= the long-standing YT truncation loss).
- Fetch side: Spotify customs fetch-first with honest `partial` stamping; liked pagination marks partial on page errors; `SyncResult.Error` now vetoes #331's deactivation gate.
- Diff side: `snapshotUnreliable()` (partial OR empty-with-claimed-tracks) guards the clear — unreliable fetches merge additions only; finalize skips `snapshot_id`/track-count writes so the next sync re-diffs and counts never lie.

## Test Plan
- [x] 5 new Robolectric tests: partial retains / unmarked-empty retains / clean-empty mirrors / partial merges additions / partial never advances snapshot_id or count — full DiffWorkerTest green
- [ ] Device: mid-sync network kill in Refresh mode → playlists retain tracks, logcat shows the retention guard, next clean sync re-mirrors

🤖 Generated with [Claude Code](https://claude.com/claude-code)