### PR TITLE
fix(library): shuffle keeps the downloaded-only contract, stops failing silently

### DIFF
--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepository.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepository.kt
@@ -138,7 +138,9 @@ interface PlayerRepository {
      * auto-grow watcher so the queue refills from the unused remainder
      * once the user nears the tail. No-op if no tracks are downloaded.
      */
-    suspend fun shuffleLibrary()
+    /** Shuffle-play every downloaded track. Returns false when there is
+     * nothing downloaded to shuffle (caller surfaces the why). */
+    suspend fun shuffleLibrary(): Boolean
 
     /**
      * Insert [track] immediately after the currently-playing track in the queue.

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -657,33 +657,30 @@ class PlayerRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun shuffleLibrary() {
-        val controller = ensureController() ?: return
-        val all = musicRepository.getAllDownloadedTracks()
-        if (all.isEmpty()) return
+    override suspend fun shuffleLibrary(): Boolean {
+        ensureController() ?: return false
+        // #332: Library is downloaded-only BY DESIGN, and so is its shuffle.
+        // The fix here is the failure mode: the old silent return on an
+        // empty pool read as a dead/stuck button — the caller now gets a
+        // Boolean so the Library screen can say why nothing happened.
+        // Routing through setQueueInternal (instead of the old hand-rolled
+        // toMediaItem+setMediaItems) keeps the logical-queue bookkeeping in
+        // one place.
+        val pool = musicRepository.getAllDownloadedTracks()
+        if (pool.isEmpty()) return false
 
-        val shuffled = all.shuffled()
+        val shuffled = pool.shuffled()
         librarySnapshot = shuffled
         libraryShuffleActive = true
         // Mutually exclusive with radio: shuffling the library ends any station.
         radioActive = false
         radioSession = null
         _radioSeedLabel.value = null
-        // Keep the logical queue in lockstep: all-downloaded tracks resolve
-        // 1:1 into the timeline, but a stale logical list from an earlier
-        // setQueue would otherwise hijack the queue display whenever the
-        // playing track happened to be in it.
-        currentQueueTracks = shuffled
-
-        val mediaItems = shuffled.map { it.toMediaItem() }
-        controller.setMediaItems(mediaItems, /* startIndex = */ 0, /* startPositionMs = */ 0L)
-        // Match user expectation: pressing "Shuffle Library" implies shuffle
-        // is on, regardless of the previous toggle state. The Media3 shuffle
-        // mode toggles randomized advance order; we already pre-shuffled the
-        // queue ourselves, so we leave shuffleModeEnabled alone — the queue
-        // we hand to the controller IS the playback order.
-        controller.prepare()
-        controller.play()
+        // setQueueInternal owns the logical-queue bookkeeping and playback
+        // start; the pre-shuffled list IS the playback order, so Media3's
+        // shuffleModeEnabled stays untouched as before.
+        setQueueInternal(shuffled, startIndex = 0, startPositionMs = 0L)
+        return true
     }
 
     override suspend fun startRadio(

--- a/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
@@ -80,7 +80,7 @@ class ListeningRecorderSkipTest {
         override suspend fun seekTo(positionMs: Long) = Unit
         override suspend fun setQueue(tracks: List<Track>, startIndex: Int) = Unit
         override fun resumeLastQueue() = Unit
-        override suspend fun shuffleLibrary() = Unit
+        override suspend fun shuffleLibrary(): Boolean = false
         override suspend fun startRadio(seed: com.stash.core.data.radio.RadioSeed, keepCurrent: Boolean) = false
         override fun stopRadio() = Unit
         override val radioSeedLabel: StateFlow<String?> = MutableStateFlow(null)

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryViewModel.kt
@@ -525,7 +525,9 @@ class LibraryViewModel @Inject constructor(
      */
     fun shuffleLibrary() {
         viewModelScope.launch {
-            playerRepository.shuffleLibrary()
+            if (!playerRepository.shuffleLibrary()) {
+                _userMessages.tryEmit("Nothing downloaded to shuffle yet — download some songs first.")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- #332: Library shuffle is downloaded-only by design (maintainer call) — the defect was the silent failure mode. shuffleLibrary() now returns Boolean and the Library screen says "Nothing downloaded to shuffle yet" instead of dead-tapping; the queue routes through setQueueInternal like every other play path.

## Test Plan
- [x] Device: shuffle tap → instant playback from the downloaded pool (844 tracks)
- [x] ListeningRecorderSkipTest green with the updated fake

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)