### PR TITLE
fix(nowplaying): compact-mode cliff caught the Pixel it was meant to spare

### DIFF
--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
@@ -343,7 +343,14 @@ fun NowPlayingScreen(
                 // halves the decorative spacers. verticalScroll stays as the
                 // net for anything below 180dp of slack.
                 val artSize = (this.maxHeight - 460.dp).coerceIn(180.dp, 280.dp)
-                val compact = artSize < 280.dp
+                // Spacers stay at FULL size while the art alone can absorb
+                // the shortfall — art + spacers then fill the column exactly,
+                // with no dead band. Compact (halved spacers) kicks in only
+                // when the art is genuinely squeezed toward its floor. A
+                // threshold at the design size was a 1dp cliff that dropped
+                // the Pixel itself into compact mode: title crowding the art
+                // and ~200dp of dead space pooling above the lyrics bar.
+                val compact = artSize <= 200.dp
             Column(
                 modifier = Modifier
                     .fillMaxSize()


### PR DESCRIPTION
## Summary
- #349's compact trigger (`artSize < 280.dp`) was a 1dp cliff — the Pixel computes 279dp and fell in, getting halved spacers + a ~200dp dead band. Threshold moved to `artSize <= 200.dp`: full spacing whenever the art alone absorbs the shortfall, compact only for genuinely short geometries.

## Test Plan
- [x] Device (Pixel 6 Pro, native): original spacing restored, no dead band
- [x] Short-geometry compact path unchanged (engages at art ≤ 200dp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)