### PR TITLE
Fix duplicate playback when queueing tracks offline

### DIFF
--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepository.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepository.kt
@@ -145,25 +145,28 @@ interface PlayerRepository {
     /**
      * Insert [track] immediately after the currently-playing track in the queue.
      * Playback continues uninterrupted; the inserted track will play next.
+     * Returns false when the track is not playable in the current mode or the
+     * player controller is unavailable.
      */
-    suspend fun addNext(track: Track)
+    suspend fun addNext(track: Track): Boolean
 
     /**
      * Append [track] to the end of the current queue.
-     * Playback continues uninterrupted.
+     * Playback continues uninterrupted. Returns false when the track is not
+     * playable in the current mode or the player controller is unavailable.
      */
-    suspend fun addToQueue(track: Track)
+    suspend fun addToQueue(track: Track): Boolean
 
     /**
      * Append [tracks] (in order) to the end of the current queue.
      * Single MediaController.addMediaItems round-trip — preferred
      * over looping the single-track variant for known-size batches
      * like an album's full tracklist or an artist's catalog. Empty
-     * list is a no-op.
+     * list is a no-op. Returns true when at least one track was appended.
      *
      * Playback continues uninterrupted.
      */
-    suspend fun addToQueue(tracks: List<Track>)
+    suspend fun addToQueue(tracks: List<Track>): Boolean
 
     /**
      * Start a radio station seeded from an artist or track. Builds a balanced

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -422,12 +422,20 @@ class PlayerRepositoryImpl @Inject constructor(
         // repeat/shuffle are correct because ExoPlayer sees the whole queue.
         // Item building does per-track disk checks (filePathExistsOnDisk), so
         // it runs off the main thread; a 2.6k-track queue must not jank the UI.
-        val playable = tracks.filter { track ->
-            track.isDownloaded || (streamingOn && !track.isUnavailableForDisplay)
+        val builtItems = withContext(Dispatchers.IO) {
+            tracks.mapNotNull { track ->
+                track.takeIf { it.isPlayableForQueueAppend(streamingOn) }
+                    ?.let { it to it.toQueueMediaItem() }
+            }
         }
-        val items = withContext(Dispatchers.IO) {
-            playable.map { it.toQueueMediaItem() }
+        val streamingAtMutation = streamingPreference.current()
+        val acceptedItems = if (streamingAtMutation) {
+            builtItems
+        } else {
+            builtItems.filter { (_, item) -> item.isUsableOfflineQueueItem() }
         }
+        val playable = acceptedItems.map { it.first }
+        val items = acceptedItems.map { it.second }
         if (items.isEmpty()) {
             _userMessages.tryEmit("Nothing in this queue is playable right now.")
             return
@@ -691,6 +699,7 @@ class PlayerRepositoryImpl @Inject constructor(
         val controller = ensureController() ?: return false
         val (session, firstBatch) = radioGenerator.start(seed)
         if (firstBatch.isEmpty()) return false
+        if (!streamingPreference.current()) return false
         radioSession = session
         radioActive = true
         // Only ONE grower may run: startRadio bypasses setQueueInternal (which is
@@ -765,10 +774,18 @@ class PlayerRepositoryImpl @Inject constructor(
     internal suspend fun growRadio() {
         radioGrowMutex.withLock {
             if (!radioActive) return
+            if (!streamingPreference.current()) {
+                stopRadio()
+                return
+            }
             val controller = controllerDeferred ?: return
             val session = radioSession ?: return
             val batch = radioGenerator.nextBatch(session)
             if (batch.isEmpty()) return
+            if (!radioActive || !streamingPreference.current()) {
+                stopRadio()
+                return
+            }
             // Streaming tracks → stash-resolve:// placeholders (see startRadio).
             controller.addMediaItems(batch.map { it.toQueueMediaItem() })
             currentQueueTracks = currentQueueTracks + batch
@@ -812,14 +829,56 @@ class PlayerRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun addNext(track: Track) {
-        val controller = ensureController() ?: return
+    /**
+     * Queue identity is also the Media3 mediaId and StreamUrlCache key.
+     * Native Qobuz rows reach per-track actions without a video id, which
+     * previously mapped every one of them to id=0. Persist those transient
+     * rows before queueing so different songs cannot share one cached URL.
+     */
+    private suspend fun Track.withQueueIdentity(): Track =
+        if (id != 0L) this else copy(id = musicRepository.ensureTrackPersisted(this))
+
+    /**
+     * Applies the queue's Online/Offline contract at the repository boundary.
+     * Offline entries must have a real, usable local file; a stale Room path
+     * must not fall through to a stash-resolve placeholder and hit the network.
+     */
+    private fun Track.isPlayableForQueueAppend(streamingEnabled: Boolean): Boolean {
+        val localPath = filePath
+        return if (streamingEnabled) {
+            !isUnavailableForDisplay
+        } else {
+            isDownloaded &&
+                !localPath.isNullOrBlank() &&
+                filePathExistsOnDisk(localPath)
+        }
+    }
+
+    private fun MediaItem.isUsableOfflineQueueItem(): Boolean {
+        val scheme = localConfiguration?.uri?.scheme
+        return scheme == "file" || scheme == "content"
+    }
+
+    override suspend fun addNext(track: Track): Boolean {
+        val controller = ensureController() ?: return false
+        val playable = track.takeIf {
+            it.isPlayableForQueueAppend(streamingPreference.current())
+        }
+        if (playable == null) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
+        val queueTrack = playable.withQueueIdentity()
+        if (!queueTrack.isPlayableForQueueAppend(streamingPreference.current())) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
         val wasEmpty = controller.mediaItemCount == 0
         // Instant add: stream tracks enter as stash-resolve:// placeholders
         // (resolved at play time), so the queue grows immediately instead of
         // waiting out a slow resolve.
         val insertIndex = controller.currentMediaItemIndex + 1
-        controller.addMediaItem(insertIndex, track.toQueueMediaItem())
+        controller.addMediaItem(insertIndex, queueTrack.toQueueMediaItem())
         // Mirror into the logical queue right after the playing track's
         // logical position (falling back to append) so the queue sheet
         // shows the Play-Next insert where it will actually play.
@@ -827,10 +886,10 @@ class PlayerRepositoryImpl @Inject constructor(
             ?.getLong(EXTRA_TRACK_ID, -1L) ?: -1L
         val logicalPos = currentQueueTracks.indexOfFirst { it.id == currentId }
         currentQueueTracks = when {
-            wasEmpty -> listOf(track)
+            wasEmpty -> listOf(queueTrack)
             logicalPos >= 0 -> currentQueueTracks.toMutableList()
-                .apply { add(logicalPos + 1, track) }
-            else -> currentQueueTracks + track
+                .apply { add(logicalPos + 1, queueTrack) }
+            else -> currentQueueTracks + queueTrack
         }
         // If the queue was empty, the user tapped "Play next" with nothing
         // playing — they expect the song to actually start, not just sit
@@ -839,33 +898,69 @@ class PlayerRepositoryImpl @Inject constructor(
             controller.prepare()
             controller.play()
         }
+        return true
     }
 
-    override suspend fun addToQueue(track: Track) {
-        val controller = ensureController() ?: return
+    override suspend fun addToQueue(track: Track): Boolean {
+        val controller = ensureController() ?: return false
+        val playable = track.takeIf {
+            it.isPlayableForQueueAppend(streamingPreference.current())
+        }
+        if (playable == null) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
+        val queueTrack = playable.withQueueIdentity()
+        if (!queueTrack.isPlayableForQueueAppend(streamingPreference.current())) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
         val wasEmpty = controller.mediaItemCount == 0
-        controller.addMediaItem(track.toQueueMediaItem())
-        currentQueueTracks = if (wasEmpty) listOf(track) else currentQueueTracks + track
+        controller.addMediaItem(queueTrack.toQueueMediaItem())
+        currentQueueTracks = if (wasEmpty) listOf(queueTrack) else currentQueueTracks + queueTrack
         if (wasEmpty) {
             controller.prepare()
             controller.play()
         }
+        return true
     }
 
-    override suspend fun addToQueue(tracks: List<Track>) {
-        if (tracks.isEmpty()) return
-        val controller = ensureController() ?: return
+    override suspend fun addToQueue(tracks: List<Track>): Boolean {
+        if (tracks.isEmpty()) return false
+        val controller = ensureController() ?: return false
+        val streamingEnabled = streamingPreference.current()
+        val playable = tracks.filter { it.isPlayableForQueueAppend(streamingEnabled) }
+        if (playable.isEmpty()) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
+        val persistedTracks = playable.map { it.withQueueIdentity() }
+        val builtItems = withContext(Dispatchers.IO) {
+            persistedTracks.map { it to it.toQueueMediaItem() }
+        }
+        val streamingAtMutation = streamingPreference.current()
+        val acceptedItems = if (streamingAtMutation) {
+            builtItems
+        } else {
+            builtItems.filter { (_, item) -> item.isUsableOfflineQueueItem() }
+        }
+        if (acceptedItems.isEmpty()) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
+        val queueTracks = acceptedItems.map { it.first }
+        val items = acceptedItems.map { it.second }
         val wasEmpty = controller.mediaItemCount == 0
         // Instant batch add: every track becomes a MediaItem now (placeholders
         // for streams), preserving tap order — no resolve fan-out, no dropped
         // rows, "Added N tracks" is finally literally true.
-        val items = withContext(Dispatchers.IO) { tracks.map { it.toQueueMediaItem() } }
-        currentQueueTracks = if (wasEmpty) tracks else currentQueueTracks + tracks
+        currentQueueTracks = if (wasEmpty) queueTracks else currentQueueTracks + queueTracks
         controller.addMediaItems(items)
         if (wasEmpty) {
             controller.prepare()
             controller.play()
         }
+        return true
     }
 
     override suspend fun toggleShuffle() {
@@ -1877,4 +1972,3 @@ internal fun shouldPersistPosition(
 
 /** Minimum position drift before an unforced persist write. */
 internal const val POSITION_PERSIST_MIN_DELTA_MS = 5_000L
-

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -423,12 +423,20 @@ class PlayerRepositoryImpl @Inject constructor(
         // repeat/shuffle are correct because ExoPlayer sees the whole queue.
         // Item building does per-track disk checks (filePathExistsOnDisk), so
         // it runs off the main thread; a 2.6k-track queue must not jank the UI.
-        val playable = tracks.filter { track ->
-            track.isDownloaded || (streamingOn && !track.isUnavailableForDisplay)
+        val builtItems = withContext(Dispatchers.IO) {
+            tracks.mapNotNull { track ->
+                track.takeIf { it.isPlayableForQueueAppend(streamingOn) }
+                    ?.let { it to it.toQueueMediaItem() }
+            }
         }
-        val items = withContext(Dispatchers.IO) {
-            playable.map { it.toQueueMediaItem() }
+        val streamingAtMutation = streamingPreference.current()
+        val acceptedItems = if (streamingAtMutation) {
+            builtItems
+        } else {
+            builtItems.filter { (_, item) -> item.isUsableOfflineQueueItem() }
         }
+        val playable = acceptedItems.map { it.first }
+        val items = acceptedItems.map { it.second }
         if (items.isEmpty()) {
             _userMessages.tryEmit("Nothing in this queue is playable right now.")
             return
@@ -691,7 +699,8 @@ class PlayerRepositoryImpl @Inject constructor(
         if (!streamingPreference.current()) return RadioStartResult.StreamingOff
         val controller = ensureController() ?: return RadioStartResult.PlayerNotReady
         val (session, firstBatch) = radioGenerator.start(seed)
-        if (firstBatch.isEmpty()) return RadioStartResult.NoStation
+        if (firstBatch.isEmpty()) return false
+        if (!streamingPreference.current()) return false
         radioSession = session
         radioActive = true
         // Only ONE grower may run: startRadio bypasses setQueueInternal (which is
@@ -766,10 +775,18 @@ class PlayerRepositoryImpl @Inject constructor(
     internal suspend fun growRadio() {
         radioGrowMutex.withLock {
             if (!radioActive) return
+            if (!streamingPreference.current()) {
+                stopRadio()
+                return
+            }
             val controller = controllerDeferred ?: return
             val session = radioSession ?: return
             val batch = radioGenerator.nextBatch(session)
             if (batch.isEmpty()) return
+            if (!radioActive || !streamingPreference.current()) {
+                stopRadio()
+                return
+            }
             // Streaming tracks → stash-resolve:// placeholders (see startRadio).
             controller.addMediaItems(batch.map { it.toQueueMediaItem() })
             currentQueueTracks = currentQueueTracks + batch
@@ -813,14 +830,56 @@ class PlayerRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun addNext(track: Track) {
-        val controller = ensureController() ?: return
+    /**
+     * Queue identity is also the Media3 mediaId and StreamUrlCache key.
+     * Native Qobuz rows reach per-track actions without a video id, which
+     * previously mapped every one of them to id=0. Persist those transient
+     * rows before queueing so different songs cannot share one cached URL.
+     */
+    private suspend fun Track.withQueueIdentity(): Track =
+        if (id != 0L) this else copy(id = musicRepository.ensureTrackPersisted(this))
+
+    /**
+     * Applies the queue's Online/Offline contract at the repository boundary.
+     * Offline entries must have a real, usable local file; a stale Room path
+     * must not fall through to a stash-resolve placeholder and hit the network.
+     */
+    private fun Track.isPlayableForQueueAppend(streamingEnabled: Boolean): Boolean {
+        val localPath = filePath
+        return if (streamingEnabled) {
+            !isUnavailableForDisplay
+        } else {
+            isDownloaded &&
+                !localPath.isNullOrBlank() &&
+                filePathExistsOnDisk(localPath)
+        }
+    }
+
+    private fun MediaItem.isUsableOfflineQueueItem(): Boolean {
+        val scheme = localConfiguration?.uri?.scheme
+        return scheme == "file" || scheme == "content"
+    }
+
+    override suspend fun addNext(track: Track): Boolean {
+        val controller = ensureController() ?: return false
+        val playable = track.takeIf {
+            it.isPlayableForQueueAppend(streamingPreference.current())
+        }
+        if (playable == null) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
+        val queueTrack = playable.withQueueIdentity()
+        if (!queueTrack.isPlayableForQueueAppend(streamingPreference.current())) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
         val wasEmpty = controller.mediaItemCount == 0
         // Instant add: stream tracks enter as stash-resolve:// placeholders
         // (resolved at play time), so the queue grows immediately instead of
         // waiting out a slow resolve.
         val insertIndex = controller.currentMediaItemIndex + 1
-        controller.addMediaItem(insertIndex, track.toQueueMediaItem())
+        controller.addMediaItem(insertIndex, queueTrack.toQueueMediaItem())
         // Mirror into the logical queue right after the playing track's
         // logical position (falling back to append) so the queue sheet
         // shows the Play-Next insert where it will actually play.
@@ -828,10 +887,10 @@ class PlayerRepositoryImpl @Inject constructor(
             ?.getLong(EXTRA_TRACK_ID, -1L) ?: -1L
         val logicalPos = currentQueueTracks.indexOfFirst { it.id == currentId }
         currentQueueTracks = when {
-            wasEmpty -> listOf(track)
+            wasEmpty -> listOf(queueTrack)
             logicalPos >= 0 -> currentQueueTracks.toMutableList()
-                .apply { add(logicalPos + 1, track) }
-            else -> currentQueueTracks + track
+                .apply { add(logicalPos + 1, queueTrack) }
+            else -> currentQueueTracks + queueTrack
         }
         // If the queue was empty, the user tapped "Play next" with nothing
         // playing — they expect the song to actually start, not just sit
@@ -840,33 +899,69 @@ class PlayerRepositoryImpl @Inject constructor(
             controller.prepare()
             controller.play()
         }
+        return true
     }
 
-    override suspend fun addToQueue(track: Track) {
-        val controller = ensureController() ?: return
+    override suspend fun addToQueue(track: Track): Boolean {
+        val controller = ensureController() ?: return false
+        val playable = track.takeIf {
+            it.isPlayableForQueueAppend(streamingPreference.current())
+        }
+        if (playable == null) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
+        val queueTrack = playable.withQueueIdentity()
+        if (!queueTrack.isPlayableForQueueAppend(streamingPreference.current())) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
         val wasEmpty = controller.mediaItemCount == 0
-        controller.addMediaItem(track.toQueueMediaItem())
-        currentQueueTracks = if (wasEmpty) listOf(track) else currentQueueTracks + track
+        controller.addMediaItem(queueTrack.toQueueMediaItem())
+        currentQueueTracks = if (wasEmpty) listOf(queueTrack) else currentQueueTracks + queueTrack
         if (wasEmpty) {
             controller.prepare()
             controller.play()
         }
+        return true
     }
 
-    override suspend fun addToQueue(tracks: List<Track>) {
-        if (tracks.isEmpty()) return
-        val controller = ensureController() ?: return
+    override suspend fun addToQueue(tracks: List<Track>): Boolean {
+        if (tracks.isEmpty()) return false
+        val controller = ensureController() ?: return false
+        val streamingEnabled = streamingPreference.current()
+        val playable = tracks.filter { it.isPlayableForQueueAppend(streamingEnabled) }
+        if (playable.isEmpty()) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
+        val persistedTracks = playable.map { it.withQueueIdentity() }
+        val builtItems = withContext(Dispatchers.IO) {
+            persistedTracks.map { it to it.toQueueMediaItem() }
+        }
+        val streamingAtMutation = streamingPreference.current()
+        val acceptedItems = if (streamingAtMutation) {
+            builtItems
+        } else {
+            builtItems.filter { (_, item) -> item.isUsableOfflineQueueItem() }
+        }
+        if (acceptedItems.isEmpty()) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
+        val queueTracks = acceptedItems.map { it.first }
+        val items = acceptedItems.map { it.second }
         val wasEmpty = controller.mediaItemCount == 0
         // Instant batch add: every track becomes a MediaItem now (placeholders
         // for streams), preserving tap order — no resolve fan-out, no dropped
         // rows, "Added N tracks" is finally literally true.
-        val items = withContext(Dispatchers.IO) { tracks.map { it.toQueueMediaItem() } }
-        currentQueueTracks = if (wasEmpty) tracks else currentQueueTracks + tracks
+        currentQueueTracks = if (wasEmpty) queueTracks else currentQueueTracks + queueTracks
         controller.addMediaItems(items)
         if (wasEmpty) {
             controller.prepare()
             controller.play()
         }
+        return true
     }
 
     override suspend fun toggleShuffle() {
@@ -1878,4 +1973,3 @@ internal fun shouldPersistPosition(
 
 /** Minimum position drift before an unforced persist write. */
 internal const val POSITION_PERSIST_MIN_DELTA_MS = 5_000L
-

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -699,8 +699,8 @@ class PlayerRepositoryImpl @Inject constructor(
         if (!streamingPreference.current()) return RadioStartResult.StreamingOff
         val controller = ensureController() ?: return RadioStartResult.PlayerNotReady
         val (session, firstBatch) = radioGenerator.start(seed)
-        if (firstBatch.isEmpty()) return false
-        if (!streamingPreference.current()) return false
+        if (firstBatch.isEmpty()) return RadioStartResult.NoStation
+        if (!streamingPreference.current()) return RadioStartResult.StreamingOff
         radioSession = session
         radioActive = true
         // Only ONE grower may run: startRadio bypasses setQueueInternal (which is

--- a/core/media/src/main/kotlin/com/stash/core/media/actions/TrackActionsDelegate.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/actions/TrackActionsDelegate.kt
@@ -387,8 +387,12 @@ class TrackActionsDelegate @Inject constructor(
     fun playNext(item: TrackItem) {
         scope().launch {
             try {
-                playerRepository.addNext(item.toDomainTrack())
-                _userMessages.tryEmit("Playing next")
+                if (!streamingPreference.current()) {
+                    _userMessages.tryEmit("Turn on Online mode to queue this track.")
+                    return@launch
+                }
+                val added = playerRepository.addNext(item.toDomainTrack())
+                _userMessages.tryEmit(if (added) "Playing next" else "Couldn't add to queue")
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -415,8 +419,12 @@ class TrackActionsDelegate @Inject constructor(
     fun addToQueue(item: TrackItem) {
         scope().launch {
             try {
-                playerRepository.addToQueue(item.toDomainTrack())
-                _userMessages.tryEmit("Added to queue")
+                if (!streamingPreference.current()) {
+                    _userMessages.tryEmit("Turn on Online mode to queue this track.")
+                    return@launch
+                }
+                val added = playerRepository.addToQueue(item.toDomainTrack())
+                _userMessages.tryEmit(if (added) "Added to queue" else "Couldn't add to queue")
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/core/media/src/main/kotlin/com/stash/core/media/actions/TrackActionsDelegate.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/actions/TrackActionsDelegate.kt
@@ -388,8 +388,12 @@ class TrackActionsDelegate @Inject constructor(
     fun playNext(item: TrackItem) {
         scope().launch {
             try {
-                playerRepository.addNext(item.toDomainTrack())
-                _userMessages.tryEmit("Playing next")
+                if (!streamingPreference.current()) {
+                    _userMessages.tryEmit("Turn on Online mode to queue this track.")
+                    return@launch
+                }
+                val added = playerRepository.addNext(item.toDomainTrack())
+                _userMessages.tryEmit(if (added) "Playing next" else "Couldn't add to queue")
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -416,8 +420,12 @@ class TrackActionsDelegate @Inject constructor(
     fun addToQueue(item: TrackItem) {
         scope().launch {
             try {
-                playerRepository.addToQueue(item.toDomainTrack())
-                _userMessages.tryEmit("Added to queue")
+                if (!streamingPreference.current()) {
+                    _userMessages.tryEmit("Turn on Online mode to queue this track.")
+                    return@launch
+                }
+                val added = playerRepository.addToQueue(item.toDomainTrack())
+                _userMessages.tryEmit(if (added) "Added to queue" else "Couldn't add to queue")
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryFullTimelineTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryFullTimelineTest.kt
@@ -79,6 +79,200 @@ class PlayerRepositoryFullTimelineTest {
     }
 
     @Test
+    fun `offline addToQueue rejects consecutive stream-only tracks without starting playback`() = runTest {
+        coEvery { streamingPreference.current() } returns false
+        every { controller.mediaItemCount } returns 0
+        val first = Track(
+            id = 101L,
+            title = "First",
+            artist = "Artist",
+            youtubeId = "first-video",
+            isStreamable = true,
+        )
+        val second = first.copy(
+            id = 202L,
+            title = "Second",
+            youtubeId = "second-video",
+        )
+
+        repo.addToQueue(first)
+        repo.addToQueue(second)
+
+        verify(exactly = 0) { controller.addMediaItem(any()) }
+        verify(exactly = 0) { controller.prepare() }
+        verify(exactly = 0) { controller.play() }
+    }
+
+    @Test
+    fun `offline addToQueue rejects a downloaded row whose local file is unusable`() = runTest {
+        coEvery { streamingPreference.current() } returns false
+        repo.filePathExistsOnDisk = { false }
+        val staleDownload = Track(
+            id = 303L,
+            title = "Missing",
+            artist = "Artist",
+            filePath = "/storage/music/missing.flac",
+            isDownloaded = true,
+            isStreamable = true,
+        )
+
+        repo.addToQueue(staleDownload)
+
+        verify(exactly = 0) { controller.addMediaItem(any()) }
+    }
+
+    @Test
+    fun `addToQueue rejects a stream when Online mode turns off during persistence`() = runTest {
+        coEvery { streamingPreference.current() } returnsMany listOf(true, false)
+        coEvery { musicRepository.ensureTrackPersisted(any()) } returns 404L
+        val transientStream = Track(
+            id = 0L,
+            title = "Transient",
+            artist = "Artist",
+            isStreamable = true,
+        )
+
+        val added = repo.addToQueue(transientStream)
+
+        assertThat(added).isFalse()
+        verify(exactly = 0) { controller.addMediaItem(any()) }
+    }
+
+    @Test
+    fun `offline setQueue rejects a downloaded row whose local file is unusable`() = runTest {
+        coEvery { streamingPreference.current() } returns false
+        repo.filePathExistsOnDisk = { false }
+        val staleDownload = Track(
+            id = 505L,
+            title = "Missing",
+            artist = "Artist",
+            filePath = "/storage/music/missing.flac",
+            isDownloaded = true,
+            isStreamable = true,
+        )
+
+        repo.setQueue(listOf(staleDownload))
+
+        verify(exactly = 0) {
+            controller.setMediaItems(any<List<MediaItem>>(), any<Int>(), any<Long>())
+        }
+    }
+
+    @Test
+    fun `setQueue drops streams when Online mode turns off while items are built`() = runTest {
+        var online = true
+        coEvery { streamingPreference.current() } answers { online }
+        repo.filePathExistsOnDisk = {
+            online = false
+            true
+        }
+        val local = Track(
+            id = 606L,
+            title = "Local",
+            artist = "Artist",
+            filePath = "/storage/music/local.flac",
+            isDownloaded = true,
+        )
+        val remote = Track(
+            id = 707L,
+            title = "Remote",
+            artist = "Artist",
+            isStreamable = true,
+        )
+        val items = slot<List<MediaItem>>()
+        every { controller.setMediaItems(capture(items), any<Int>(), any<Long>()) } returns Unit
+
+        repo.setQueue(listOf(local, remote))
+
+        assertThat(items.captured.map { it.mediaId }).containsExactly("606")
+    }
+
+    @Test
+    fun `batch addToQueue drops streams when Online mode turns off while items are built`() = runTest {
+        var online = true
+        coEvery { streamingPreference.current() } answers { online }
+        repo.filePathExistsOnDisk = {
+            online = false
+            true
+        }
+        every { controller.mediaItemCount } returns 1
+        val local = Track(
+            id = 808L,
+            title = "Local",
+            artist = "Artist",
+            filePath = "/storage/music/local.flac",
+            isDownloaded = true,
+        )
+        val remote = Track(
+            id = 909L,
+            title = "Remote",
+            artist = "Artist",
+            isStreamable = true,
+        )
+        val items = slot<List<MediaItem>>()
+        every { controller.addMediaItems(capture(items)) } returns Unit
+
+        val added = repo.addToQueue(listOf(local, remote))
+
+        assertThat(added).isTrue()
+        assertThat(items.captured.map { it.mediaId }).containsExactly("808")
+    }
+
+    @Test
+    fun `offline batch addToQueue accepts a usable SAF content download`() = runTest {
+        coEvery { streamingPreference.current() } returns false
+        repo.filePathExistsOnDisk = { true }
+        every { controller.mediaItemCount } returns 1
+        val safDownload = Track(
+            id = 1001L,
+            title = "SAF Local",
+            artist = "Artist",
+            filePath = "content://com.android.externalstorage.documents/document/music%3Asong.flac",
+            isDownloaded = true,
+        )
+        val items = slot<List<MediaItem>>()
+        every { controller.addMediaItems(capture(items)) } returns Unit
+
+        val added = repo.addToQueue(listOf(safDownload))
+
+        assertThat(added).isTrue()
+        assertThat(items.captured.single().localConfiguration?.uri?.scheme)
+            .isEqualTo("content")
+    }
+
+    @Test
+    fun `addToQueue persists zero-id stream tracks before building media items`() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        every { controller.mediaItemCount } returns 1
+        coEvery {
+            musicRepository.ensureTrackPersisted(match { it.title == "First" })
+        } returns 101L
+        coEvery {
+            musicRepository.ensureTrackPersisted(match { it.title == "Second" })
+        } returns 202L
+        val first = Track(
+            id = 0L,
+            title = "First",
+            artist = "Artist",
+            isStreamable = true,
+        )
+        val second = first.copy(title = "Second")
+        val items = mutableListOf<MediaItem>()
+        every { controller.addMediaItem(capture(items)) } returns Unit
+
+        repo.addToQueue(first)
+        repo.addToQueue(second)
+
+        assertThat(items.map { it.mediaId }).containsExactly("101", "202").inOrder()
+        assertThat(items.map { it.localConfiguration?.uri?.toString() })
+            .containsExactly(
+                "stash-resolve://track/101?t=First&a=Artist",
+                "stash-resolve://track/202?t=Second&a=Artist",
+            )
+            .inOrder()
+    }
+
+    @Test
     fun `skipNext is always a native seek`() = runTest {
         every { controller.hasNextMediaItem() } returns true
 

--- a/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryRadioTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryRadioTest.kt
@@ -104,6 +104,24 @@ class PlayerRepositoryRadioTest {
         assertThat(repo.radioSeedLabel.value).isNull()
     }
 
+    @Test fun `startRadio rejects a batch when Online mode turns off during generation`() = runTest {
+        var online = true
+        coEvery { streamingPreference.current() } answers { online }
+        val session = mockk<RadioSession>(relaxed = true)
+        coEvery { radioGenerator.start(any()) } answers {
+            online = false
+            session to listOf(track(1))
+        }
+
+        val started = repo.startRadio(RadioSeed.Artist("MBV", "id"))
+
+        assertThat(started).isFalse()
+        assertThat(repo.radioSeedLabel.value).isNull()
+        verify(exactly = 0) {
+            controller.setMediaItems(any<List<MediaItem>>(), any<Int>(), any<Long>())
+        }
+    }
+
     @Test fun `setQueue disarms the station`() = runTest {
         coEvery { streamingPreference.current() } returns true
         val session = mockk<RadioSession>(relaxed = true)
@@ -165,6 +183,38 @@ class PlayerRepositoryRadioTest {
 
         coVerify { radioGenerator.nextBatch(session) }
         verify { controller.addMediaItems(any<List<MediaItem>>()) }
+    }
+
+    @Test fun `growRadio disarms without appending when Online mode was turned off`() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        val session = mockk<RadioSession>(relaxed = true)
+        coEvery { radioGenerator.start(any()) } returns (session to listOf(track(1)))
+        coEvery { radioGenerator.nextBatch(session) } returns listOf(track(2))
+        repo.startRadio(RadioSeed.Artist("MBV", "id"))
+        coEvery { streamingPreference.current() } returns false
+
+        repo.growRadio()
+
+        assertThat(repo.radioSeedLabel.value).isNull()
+        coVerify(exactly = 0) { radioGenerator.nextBatch(session) }
+        verify(exactly = 0) { controller.addMediaItems(any<List<MediaItem>>()) }
+    }
+
+    @Test fun `growRadio disarms when Online mode turns off during generation`() = runTest {
+        var online = true
+        coEvery { streamingPreference.current() } answers { online }
+        val session = mockk<RadioSession>(relaxed = true)
+        coEvery { radioGenerator.start(any()) } returns (session to listOf(track(1)))
+        coEvery { radioGenerator.nextBatch(session) } answers {
+            online = false
+            listOf(track(2))
+        }
+        repo.startRadio(RadioSeed.Artist("MBV", "id"))
+
+        repo.growRadio()
+
+        assertThat(repo.radioSeedLabel.value).isNull()
+        verify(exactly = 0) { controller.addMediaItems(any<List<MediaItem>>()) }
     }
 
     @Test fun `growRadio is a no-op when no station is active`() = runTest {

--- a/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryRadioTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryRadioTest.kt
@@ -137,6 +137,24 @@ class PlayerRepositoryRadioTest {
         assertThat(repo.radioSeedLabel.value).isNull()
     }
 
+    @Test fun `startRadio rejects a batch when Online mode turns off during generation`() = runTest {
+        var online = true
+        coEvery { streamingPreference.current() } answers { online }
+        val session = mockk<RadioSession>(relaxed = true)
+        coEvery { radioGenerator.start(any()) } answers {
+            online = false
+            session to listOf(track(1))
+        }
+
+        val started = repo.startRadio(RadioSeed.Artist("MBV", "id"))
+
+        assertThat(started).isFalse()
+        assertThat(repo.radioSeedLabel.value).isNull()
+        verify(exactly = 0) {
+            controller.setMediaItems(any<List<MediaItem>>(), any<Int>(), any<Long>())
+        }
+    }
+
     @Test fun `setQueue disarms the station`() = runTest {
         coEvery { streamingPreference.current() } returns true
         val session = mockk<RadioSession>(relaxed = true)
@@ -198,6 +216,38 @@ class PlayerRepositoryRadioTest {
 
         coVerify { radioGenerator.nextBatch(session) }
         verify { controller.addMediaItems(any<List<MediaItem>>()) }
+    }
+
+    @Test fun `growRadio disarms without appending when Online mode was turned off`() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        val session = mockk<RadioSession>(relaxed = true)
+        coEvery { radioGenerator.start(any()) } returns (session to listOf(track(1)))
+        coEvery { radioGenerator.nextBatch(session) } returns listOf(track(2))
+        repo.startRadio(RadioSeed.Artist("MBV", "id"))
+        coEvery { streamingPreference.current() } returns false
+
+        repo.growRadio()
+
+        assertThat(repo.radioSeedLabel.value).isNull()
+        coVerify(exactly = 0) { radioGenerator.nextBatch(session) }
+        verify(exactly = 0) { controller.addMediaItems(any<List<MediaItem>>()) }
+    }
+
+    @Test fun `growRadio disarms when Online mode turns off during generation`() = runTest {
+        var online = true
+        coEvery { streamingPreference.current() } answers { online }
+        val session = mockk<RadioSession>(relaxed = true)
+        coEvery { radioGenerator.start(any()) } returns (session to listOf(track(1)))
+        coEvery { radioGenerator.nextBatch(session) } answers {
+            online = false
+            listOf(track(2))
+        }
+        repo.startRadio(RadioSeed.Artist("MBV", "id"))
+
+        repo.growRadio()
+
+        assertThat(repo.radioSeedLabel.value).isNull()
+        verify(exactly = 0) { controller.addMediaItems(any<List<MediaItem>>()) }
     }
 
     @Test fun `growRadio is a no-op when no station is active`() = runTest {

--- a/core/media/src/test/kotlin/com/stash/core/media/actions/TrackActionsDelegateQueueActionsTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/actions/TrackActionsDelegateQueueActionsTest.kt
@@ -28,6 +28,7 @@ class TrackActionsDelegateQueueActionsTest {
     private val musicRepository: com.stash.core.data.repository.MusicRepository = mockk(relaxed = true)
     private val blocklistGuard: com.stash.core.data.blocklist.BlocklistGuard = mockk(relaxed = true)
     private val trackDao: com.stash.core.data.db.dao.TrackDao = mockk(relaxed = true)
+    private val streamingPreference: com.stash.core.data.prefs.StreamingPreference = mockk(relaxed = true)
 
     // Real flows, not relaxed stubs: bindToScope collects playerErrors, and a
     // relaxed mock's `collect` (returns Nothing) throws, killing the scope.
@@ -36,18 +37,21 @@ class TrackActionsDelegateQueueActionsTest {
         every { playerErrors } returns MutableSharedFlow()
     }
 
-    private fun delegate() = TrackActionsDelegate(
-        previewPlayer = previewPlayer,
-        searchPreviewMediaSource = mockk(relaxed = true),
-        previewUrlExtractor = mockk(relaxed = true),
-        previewUrlCache = mockk(relaxed = true),
-        trackDao = trackDao,
-        searchDownloadCoordinator = mockk(relaxed = true),
-        playerRepository = playerRepository,
-        streamingPreference = mockk(relaxed = true),
-        musicRepository = musicRepository,
-        blocklistGuard = blocklistGuard,
-    )
+    private fun delegate(online: Boolean = true): TrackActionsDelegate {
+        coEvery { streamingPreference.current() } returns online
+        return TrackActionsDelegate(
+            previewPlayer = previewPlayer,
+            searchPreviewMediaSource = mockk(relaxed = true),
+            previewUrlExtractor = mockk(relaxed = true),
+            previewUrlCache = mockk(relaxed = true),
+            trackDao = trackDao,
+            searchDownloadCoordinator = mockk(relaxed = true),
+            playerRepository = playerRepository,
+            streamingPreference = streamingPreference,
+            musicRepository = musicRepository,
+            blocklistGuard = blocklistGuard,
+        )
+    }
 
     private val item = TrackItem(
         videoId = "abc123", title = "Song", artist = "Artist",
@@ -58,7 +62,7 @@ class TrackActionsDelegateQueueActionsTest {
     fun `addToQueue maps TrackItem and calls repo with streamable Track`() = runTest {
         val d = delegate().apply { bindToScope(backgroundScope) }
         val slot = slot<Track>()
-        coEvery { playerRepository.addToQueue(capture(slot)) } returns Unit
+        coEvery { playerRepository.addToQueue(capture(slot)) } returns true
 
         val messages = mutableListOf<String>()
         backgroundScope.launch { d.userMessages.collect { messages.add(it) } }
@@ -78,8 +82,37 @@ class TrackActionsDelegateQueueActionsTest {
     }
 
     @Test
+    fun `offline addToQueue refuses stream track with an Online mode hint`() = runTest {
+        val d = delegate(online = false).apply { bindToScope(backgroundScope) }
+        val messages = mutableListOf<String>()
+        backgroundScope.launch { d.userMessages.collect { messages.add(it) } }
+        runCurrent()
+
+        d.addToQueue(item)
+        runCurrent()
+
+        assertThat(messages).containsExactly("Turn on Online mode to queue this track.")
+        coVerify(exactly = 0) { playerRepository.addToQueue(any<Track>()) }
+    }
+
+    @Test
+    fun `addToQueue reports failure when repository rejects after the mode precheck`() = runTest {
+        val d = delegate().apply { bindToScope(backgroundScope) }
+        coEvery { playerRepository.addToQueue(any<Track>()) } returns false
+        val messages = mutableListOf<String>()
+        backgroundScope.launch { d.userMessages.collect { messages.add(it) } }
+        runCurrent()
+
+        d.addToQueue(item)
+        runCurrent()
+
+        assertThat(messages).containsExactly("Couldn't add to queue")
+    }
+
+    @Test
     fun `playNext calls addNext and emits message`() = runTest {
         val d = delegate().apply { bindToScope(backgroundScope) }
+        coEvery { playerRepository.addNext(any<Track>()) } returns true
 
         val messages = mutableListOf<String>()
         backgroundScope.launch { d.userMessages.collect { messages.add(it) } }
@@ -90,6 +123,20 @@ class TrackActionsDelegateQueueActionsTest {
 
         assertThat(messages).containsExactly("Playing next")
         coVerify(exactly = 1) { playerRepository.addNext(any<Track>()) }
+    }
+
+    @Test
+    fun `playNext reports failure when repository rejects after the mode precheck`() = runTest {
+        val d = delegate().apply { bindToScope(backgroundScope) }
+        coEvery { playerRepository.addNext(any<Track>()) } returns false
+        val messages = mutableListOf<String>()
+        backgroundScope.launch { d.userMessages.collect { messages.add(it) } }
+        runCurrent()
+
+        d.playNext(item)
+        runCurrent()
+
+        assertThat(messages).containsExactly("Couldn't add to queue")
     }
 
     @Test

--- a/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
@@ -84,9 +84,9 @@ class ListeningRecorderSkipTest {
         override suspend fun startRadio(seed: com.stash.core.data.radio.RadioSeed, keepCurrent: Boolean) = false
         override fun stopRadio() = Unit
         override val radioSeedLabel: StateFlow<String?> = MutableStateFlow(null)
-        override suspend fun addNext(track: Track) = Unit
-        override suspend fun addToQueue(track: Track) = Unit
-        override suspend fun addToQueue(tracks: List<Track>) = Unit
+        override suspend fun addNext(track: Track) = false
+        override suspend fun addToQueue(track: Track) = false
+        override suspend fun addToQueue(tracks: List<Track>) = false
         override suspend fun toggleShuffle() = Unit
         override suspend fun cycleRepeatMode() = Unit
         override suspend fun removeFromQueue(index: Int) = Unit

--- a/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
@@ -85,9 +85,9 @@ class ListeningRecorderSkipTest {
             com.stash.core.model.RadioStartResult.StreamingOff
         override fun stopRadio() = Unit
         override val radioSeedLabel: StateFlow<String?> = MutableStateFlow(null)
-        override suspend fun addNext(track: Track) = Unit
-        override suspend fun addToQueue(track: Track) = Unit
-        override suspend fun addToQueue(tracks: List<Track>) = Unit
+        override suspend fun addNext(track: Track) = false
+        override suspend fun addToQueue(track: Track) = false
+        override suspend fun addToQueue(tracks: List<Track>) = false
         override suspend fun toggleShuffle() = Unit
         override suspend fun cycleRepeatMode() = Unit
         override suspend fun removeFromQueue(index: Int) = Unit

--- a/feature/search/src/main/kotlin/com/stash/feature/search/AlbumDiscoveryViewModel.kt
+++ b/feature/search/src/main/kotlin/com/stash/feature/search/AlbumDiscoveryViewModel.kt
@@ -295,11 +295,14 @@ class AlbumDiscoveryViewModel @Inject constructor(
         viewModelScope.launch {
             val tracks = buildQueueTracks()
             if (tracks.isEmpty()) return@launch
-            // Emit immediately — URL resolution can take ~20-30s for 15
-            // streaming tracks against a degraded Kennyy/Squid. Without this
-            // optimistic toast the user gets zero feedback during the wait.
-            _userMessages.emit("Adding ${tracks.size} tracks to queue...")
-            playerRepository.addToQueue(tracks)
+            val added = playerRepository.addToQueue(tracks)
+            _userMessages.emit(
+                if (added) {
+                    "Added album to queue"
+                } else {
+                    "Couldn't add album to queue"
+                },
+            )
         }
     }
 

--- a/feature/search/src/test/kotlin/com/stash/feature/search/AlbumDiscoveryViewModelTest.kt
+++ b/feature/search/src/test/kotlin/com/stash/feature/search/AlbumDiscoveryViewModelTest.kt
@@ -293,6 +293,7 @@ class AlbumDiscoveryViewModelTest {
             whenever(it.get(any(), any())).thenReturn(detail)
         }
         val player = mock<PlayerRepository>()
+        whenever(player.addToQueue(any<List<Track>>())).thenReturn(true)
 
         val vm = vmWith(cache = cache, playerRepository = player)
         advanceUntilIdle()
@@ -300,7 +301,29 @@ class AlbumDiscoveryViewModelTest {
         vm.userMessages.test {
             vm.addAlbumToQueue()
             advanceUntilIdle()
-            assertEquals("Adding 3 tracks to queue...", awaitItem())
+            assertEquals("Added album to queue", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `addAlbumToQueue reports when the repository rejects the album`() = runTest {
+        val detail = albumDetail(
+            tracks = listOf("v1", "v2", "v3").map(::trackSummary),
+        )
+        val cache = mock<AlbumCache>().also {
+            whenever(it.get(any(), any())).thenReturn(detail)
+        }
+        val player = mock<PlayerRepository>()
+        whenever(player.addToQueue(any<List<Track>>())).thenReturn(false)
+
+        val vm = vmWith(cache = cache, playerRepository = player)
+        advanceUntilIdle()
+
+        vm.userMessages.test {
+            vm.addAlbumToQueue()
+            advanceUntilIdle()
+            assertEquals("Couldn't add album to queue", awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
## Summary
- persist transient zero-ID Qobuz tracks before queueing so each track gets a distinct MediaItem and stream-cache key
- enforce Online/Offline playability at queue mutation time, including valid local file and SAF content downloads, mode-change races, and radio growth
- return queue append outcomes to UI callers and provide accurate success/failure feedback

## Testing
- [x] Focused `core:media` regression suite: 40 tests, 0 failures
- [x] `:feature:search:compileDebugKotlin`
- [x] `git diff --check`

## Known local verification limitations
- The full `:core:media:testDebugUnitTest` task timed out locally after 10 minutes without reporting a test failure; the focused affected classes pass.
- `:feature:search:testDebugUnitTest` is independently blocked on current master by a missing `sharedTrackLinkHolder` argument in `SearchViewModelTest.kt:306`.

Closes https://github.com/ParaliyzedEvo/Stash/issues/72