### PR TITLE
fix(sync): prevent FK failures for duplicate playlist tracks

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -1357,6 +1357,7 @@ interface TrackDao {
         """
         UPDATE tracks SET youtube_id = :youtubeId
         WHERE id = :trackId
+          AND (youtube_id IS NULL OR TRIM(youtube_id) = '')
           AND NOT EXISTS (
               SELECT 1 FROM tracks WHERE youtube_id = :youtubeId AND id != :trackId
           )

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
@@ -89,6 +89,12 @@ class DiffWorker @AssistedInject constructor(
         private const val NEVER_MATCH_SENTINEL = "\u0000__stash_never_match__"
     }
 
+    private class BatchTrack(
+        var entity: TrackEntity,
+        val isNew: Boolean,
+        var persistedId: Long? = entity.id.takeUnless { isNew },
+    )
+
     override suspend fun doWork(): Result {
         val syncId = inputData.getLong(PlaylistFetchWorker.KEY_SYNC_ID, -1L)
         if (syncId == -1L) {
@@ -368,22 +374,76 @@ class DiffWorker @AssistedInject constructor(
         val canonicalOf = allowedSnapshots.associateWith {
             trackMatcher.canonicalTitle(it.title) to trackMatcher.canonicalArtist(it.artist)
         }
-        val spotifyUris = allowedSnapshots.mapNotNull { it.spotifyUri }.distinct()
+        val spotifyUris = allowedSnapshots.mapNotNull { it.spotifyUri?.takeIf(String::isNotBlank) }.distinct()
             .ifEmpty { listOf(NEVER_MATCH_SENTINEL) }
-        val youtubeIds = allowedSnapshots.mapNotNull { it.youtubeId }.distinct()
+        val youtubeIds = allowedSnapshots.mapNotNull { it.youtubeId?.takeIf(String::isNotBlank) }.distinct()
             .ifEmpty { listOf(NEVER_MATCH_SENTINEL) }
         val canonicalKeys = canonicalOf.values.map { (t, a) -> "$t|$a" }.distinct()
 
         val candidates = trackDao.findExistingForBatch(spotifyUris, youtubeIds, canonicalKeys)
-        val bySpotifyUri = candidates.filter { it.spotifyUri != null }.associateBy { it.spotifyUri }
-        val byYoutubeId = candidates.filter { it.youtubeId != null }.associateBy { it.youtubeId }
-        val byCanonical = candidates.associateBy { "${it.canonicalTitle}|${it.canonicalArtist}" }
+        val candidateTracks = candidates.associate { candidate ->
+            candidate.id to BatchTrack(candidate, isNew = false)
+        }
+        val bySpotifyUri = mutableMapOf<String, BatchTrack>()
+        val byYoutubeId = mutableMapOf<String, BatchTrack>()
+        val byCanonical = mutableMapOf<String, MutableList<BatchTrack>>()
 
-        fun matchExisting(snapshot: RemoteTrackSnapshotEntity): TrackEntity? {
-            snapshot.spotifyUri?.let { uri -> bySpotifyUri[uri]?.let { return it } }
-            snapshot.youtubeId?.let { yid -> byYoutubeId[yid]?.let { return it } }
+        fun registerBatchTrack(track: BatchTrack) {
+            track.entity.spotifyUri?.takeIf(String::isNotBlank)?.let { bySpotifyUri[it] = track }
+            track.entity.youtubeId?.takeIf(String::isNotBlank)?.let { byYoutubeId[it] = track }
+            val canonicalKey = "${track.entity.canonicalTitle}|${track.entity.canonicalArtist}"
+            val canonicalMatches = byCanonical.getOrPut(canonicalKey) { mutableListOf() }
+            if (canonicalMatches.none { it === track }) {
+                canonicalMatches.add(track)
+            }
+        }
+
+        candidateTracks.values.forEach(::registerBatchTrack)
+
+        fun strongIdsCompatible(
+            track: BatchTrack,
+            snapshot: RemoteTrackSnapshotEntity,
+        ): Boolean {
+            fun compatible(stored: String?, incoming: String?): Boolean =
+                stored.isNullOrBlank() || incoming.isNullOrBlank() || stored == incoming
+
+            return compatible(track.entity.spotifyUri, snapshot.spotifyUri) &&
+                compatible(track.entity.youtubeId, snapshot.youtubeId)
+        }
+
+        fun matchBatchTrack(snapshot: RemoteTrackSnapshotEntity): BatchTrack? {
+            snapshot.spotifyUri?.takeIf(String::isNotBlank)?.let { uri -> bySpotifyUri[uri]?.let { return it } }
+            snapshot.youtubeId?.takeIf(String::isNotBlank)?.let { yid -> byYoutubeId[yid]?.let { return it } }
             val (ct, ca) = canonicalOf.getValue(snapshot)
-            return byCanonical["$ct|$ca"]
+            return byCanonical["$ct|$ca"]?.firstOrNull {
+                strongIdsCompatible(it, snapshot)
+            }
+        }
+
+        suspend fun enrichExistingBatchTrack(
+            batchTrack: BatchTrack,
+            snapshot: RemoteTrackSnapshotEntity,
+        ) {
+            val existingTrack = batchTrack.entity
+            val snapshotYtId = snapshot.youtubeId?.takeIf(String::isNotBlank)
+            if (!snapshotYtId.isNullOrBlank() && existingTrack.youtubeId.isNullOrBlank()) {
+                val youtubeOwner = byYoutubeId[snapshotYtId]
+                if (youtubeOwner == null || youtubeOwner === batchTrack) {
+                    val applied = trackDao.updateYoutubeIdIfUnclaimed(existingTrack.id, snapshotYtId)
+                    if (applied == 1) {
+                        batchTrack.entity = batchTrack.entity.copy(youtubeId = snapshotYtId)
+                        byYoutubeId[snapshotYtId] = batchTrack
+                        val ytUrl = "https://music.youtube.com/watch?v=$snapshotYtId"
+                        downloadQueueDao.fillMissingYoutubeUrlForTrack(existingTrack.id, ytUrl)
+                    }
+                }
+            }
+
+            val snapshotArt = snapshot.albumArtUrl
+            if (!snapshotArt.isNullOrBlank() && snapshotArt != batchTrack.entity.albumArtUrl) {
+                trackDao.updateAlbumArtUrl(existingTrack.id, snapshotArt)
+                batchTrack.entity = batchTrack.entity.copy(albumArtUrl = snapshotArt)
+            }
         }
 
         // Preload every current cross-ref for this playlist ONCE instead of
@@ -391,87 +451,111 @@ class DiffWorker @AssistedInject constructor(
         val existingCrossRefs = playlistDao.getCrossRefsForPlaylist(localPlaylist.id)
             .associateBy { it.trackId }
 
-        val newSnapshots = mutableListOf<RemoteTrackSnapshotEntity>()
-        val newEntities = mutableListOf<TrackEntity>()
-        val existingPairs = mutableListOf<Pair<TrackEntity, RemoteTrackSnapshotEntity>>()
+        val newTracks = mutableListOf<BatchTrack>()
+        val newOccurrences = mutableListOf<Pair<BatchTrack, RemoteTrackSnapshotEntity>>()
+        val existingPairs = mutableListOf<Pair<BatchTrack, RemoteTrackSnapshotEntity>>()
 
         for (snapshot in allowedSnapshots) {
-            val existing = matchExisting(snapshot)
-            if (existing != null) {
-                existingPairs.add(existing to snapshot)
-            } else {
+            val batchTrack = matchBatchTrack(snapshot) ?: run {
                 val (ct, ca) = canonicalOf.getValue(snapshot)
-                newEntities.add(
-                    TrackEntity(
+                BatchTrack(
+                    entity = TrackEntity(
                         title = snapshot.title,
                         artist = snapshot.artist,
                         album = snapshot.album ?: "",
                         durationMs = snapshot.durationMs,
                         source = playlistSnapshot.source,
-                        spotifyUri = snapshot.spotifyUri,
-                        youtubeId = snapshot.youtubeId,
+                        spotifyUri = snapshot.spotifyUri?.takeIf(String::isNotBlank),
+                        youtubeId = snapshot.youtubeId?.takeIf(String::isNotBlank),
                         albumArtUrl = snapshot.albumArtUrl,
                         canonicalTitle = ct,
                         canonicalArtist = ca,
                         isDownloaded = false,
                         isrc = snapshot.isrc,
                         explicit = snapshot.explicit,
-                    )
-                )
-                newSnapshots.add(snapshot)
+                    ),
+                    isNew = true,
+                ).also {
+                    newTracks.add(it)
+                    registerBatchTrack(it)
+                }
+            }
+
+            if (batchTrack.isNew) {
+                val snapshotYtId = snapshot.youtubeId?.takeIf(String::isNotBlank)
+                val youtubeOwner = snapshotYtId?.let(byYoutubeId::get)
+                if (!snapshotYtId.isNullOrBlank() &&
+                    batchTrack.entity.youtubeId.isNullOrBlank() &&
+                    (youtubeOwner == null || youtubeOwner === batchTrack)
+                ) {
+                    batchTrack.entity = batchTrack.entity.copy(youtubeId = snapshotYtId)
+                    byYoutubeId[snapshotYtId] = batchTrack
+                }
+
+                val snapshotArt = snapshot.albumArtUrl
+                if (!snapshotArt.isNullOrBlank() && snapshotArt != batchTrack.entity.albumArtUrl) {
+                    batchTrack.entity = batchTrack.entity.copy(albumArtUrl = snapshotArt)
+                }
+                newOccurrences.add(batchTrack to snapshot)
+            } else {
+                enrichExistingBatchTrack(batchTrack, snapshot)
+                existingPairs.add(batchTrack to snapshot)
             }
         }
 
         // ── Bulk insert new tracks ───────────────────────────────────────
         // Room's insertAll returns generated row ids in the same order as
         // the input list.
-        val newTrackIds = if (newEntities.isNotEmpty()) trackDao.insertAll(newEntities) else emptyList()
+        val newTrackIds = if (newTracks.isNotEmpty()) {
+            trackDao.insertAll(newTracks.map { it.entity })
+        } else {
+            emptyList()
+        }
+        check(newTrackIds.size == newTracks.size) {
+            "Expected ${newTracks.size} generated track ids, got ${newTrackIds.size}"
+        }
+        newTracks.zip(newTrackIds).forEach { (track, trackId) ->
+            track.persistedId = trackId
+        }
 
-        val crossRefsToInsert = mutableListOf<PlaylistTrackCrossRef>()
+        val crossRefsToInsert = linkedMapOf<Long, PlaylistTrackCrossRef>()
         val downloadEntries = mutableListOf<DownloadQueueEntity>()
-        var newTrackCount = 0
 
-        newTrackIds.forEachIndexed { index, trackId ->
-            val snapshot = newSnapshots[index]
-            addCrossRefIfNotSoftDeleted(localPlaylist.id, trackId, snapshot.position, existingCrossRefs, crossRefsToInsert)
-            if (!streamingMode) {
+        for ((batchTrack, snapshot) in newOccurrences) {
+            val trackId = checkNotNull(batchTrack.persistedId)
+            addCrossRefIfNotSoftDeleted(
+                localPlaylist.id,
+                trackId,
+                snapshot.position,
+                existingCrossRefs,
+                crossRefsToInsert,
+            )
+        }
+
+        if (!streamingMode) {
+            for (batchTrack in newTracks) {
+                val trackId = checkNotNull(batchTrack.persistedId)
                 downloadEntries.add(
                     DownloadQueueEntity(
                         trackId = trackId,
                         syncId = syncId,
-                        searchQuery = "${snapshot.artist} - ${snapshot.title}",
-                        youtubeUrl = snapshot.youtubeId?.let { "https://music.youtube.com/watch?v=$it" },
+                        searchQuery = "${batchTrack.entity.artist} - ${batchTrack.entity.title}",
+                        youtubeUrl = batchTrack.entity.youtubeId?.let {
+                            "https://music.youtube.com/watch?v=$it"
+                        },
                     )
                 )
             }
-            newTrackCount++
         }
+        val newTrackCount = newTracks.size
 
         // ── Existing-track path: membership + enrichment ─────────────────
         // Enrichment writes (youtubeId backfill, art refresh, auto-
         // reconciliation) stay per-row — they're targeted single-column
         // UPDATEs, not the insert flood that caused the slowdown.
-        for ((existingTrack, snapshot) in existingPairs) {
+        for ((batchTrack, snapshot) in existingPairs) {
+            val existingTrack = batchTrack.entity
             addCrossRefIfNotSoftDeleted(localPlaylist.id, existingTrack.id, snapshot.position, existingCrossRefs, crossRefsToInsert)
-
-            val snapshotYtId = snapshot.youtubeId
-            if (!snapshotYtId.isNullOrBlank() && existingTrack.youtubeId.isNullOrBlank()) {
-                // Guarded: a DIFFERENT track can already own this youtube_id
-                // (UNIQUE column) — e.g. one snapshot matching separate rows
-                // by spotifyUri and youtubeId. The unguarded UPDATE threw
-                // SQLiteConstraintException and failed the entire diff.
-                val applied = trackDao.updateYoutubeIdIfUnclaimed(existingTrack.id, snapshotYtId)
-                if (applied == 1) {
-                    val ytUrl = "https://music.youtube.com/watch?v=$snapshotYtId"
-                    downloadQueueDao.fillMissingYoutubeUrlForTrack(existingTrack.id, ytUrl)
-                }
-            }
-
-            val snapshotArt = snapshot.albumArtUrl
-            if (!snapshotArt.isNullOrBlank() && snapshotArt != existingTrack.albumArtUrl) {
-                trackDao.updateAlbumArtUrl(existingTrack.id, snapshotArt)
-            }
-
             if (!existingTrack.isDownloaded && !existingTrack.matchDismissed) {
                 val downloadedMatch = trackDao.findDownloadedByCanonical(
                     canonicalTitle = existingTrack.canonicalTitle.lowercase(),
@@ -489,7 +573,7 @@ class DiffWorker @AssistedInject constructor(
 
         // ── Flush batched writes ─────────────────────────────────────────
         if (crossRefsToInsert.isNotEmpty()) {
-            playlistDao.insertAllCrossRefs(crossRefsToInsert)
+            playlistDao.insertAllCrossRefs(crossRefsToInsert.values.toList())
         }
         if (downloadEntries.isNotEmpty()) {
             downloadQueueDao.insertAll(downloadEntries)
@@ -521,20 +605,19 @@ class DiffWorker @AssistedInject constructor(
         trackId: Long,
         position: Int,
         existingByTrackId: Map<Long, PlaylistTrackCrossRef>,
-        out: MutableList<PlaylistTrackCrossRef>,
+        out: MutableMap<Long, PlaylistTrackCrossRef>,
     ) {
-        val prior = existingByTrackId[trackId]
-        if (prior != null && prior.removedAt != null) {
+        val storedPrior = existingByTrackId[trackId]
+        if (storedPrior != null && storedPrior.removedAt != null) {
             Log.d(TAG, "Skipping re-link for soft-deleted track $trackId in playlist $playlistId (user removed it)")
             return
         }
-        out.add(
-            PlaylistTrackCrossRef(
-                playlistId = playlistId,
-                trackId = trackId,
-                position = position,
-                addedAt = prior?.addedAt ?: java.time.Instant.now(),
-            )
+        val batchPrior = out[trackId]
+        out[trackId] = PlaylistTrackCrossRef(
+            playlistId = playlistId,
+            trackId = trackId,
+            position = position,
+            addedAt = batchPrior?.addedAt ?: storedPrior?.addedAt ?: java.time.Instant.now(),
         )
     }
 

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
@@ -25,6 +25,7 @@ import com.stash.core.model.MusicSource
 import com.stash.core.model.PlaylistType
 import com.stash.core.model.SyncMode
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
@@ -120,7 +121,8 @@ class DiffWorkerTest {
             )
         )
 
-        buildWorker().doWork()
+        val result = buildWorker().doWork()
+        assertTrue("diff must succeed", result is androidx.work.ListenableWorker.Result.Success)
 
         val crossRefs = db.playlistDao().getCrossRefsForPlaylist(playlistId)
         assertEquals("expected exactly one cross-ref row (the tombstone)", 1, crossRefs.size)
@@ -172,7 +174,8 @@ class DiffWorkerTest {
             )
         )
 
-        buildWorker().doWork()
+        val result = buildWorker().doWork()
+        assertTrue("diff must succeed", result is androidx.work.ListenableWorker.Result.Success)
 
         val crossRef = db.playlistDao().getCrossRef(playlistId, trackId)
         assertEquals(originalAddedAt, crossRef?.addedAt)
@@ -223,6 +226,357 @@ class DiffWorkerTest {
         assertEquals(1, crossRefs.size)
         assertEquals("spotifyUri match must win", bySpotify, crossRefs.single().trackId)
         assertEquals("no new track should be inserted — matched existing", 3, trackDao.getAllForIntegrityScan().size)
+    }
+
+    @Test
+    fun `duplicate Spotify URI in one custom playlist reuses a valid track row`() = runBlocking {
+        db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Duplicates",
+                source = MusicSource.SPOTIFY,
+                sourceId = "spotify:playlist:duplicates",
+                type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val playlistSnapshot = RemotePlaylistSnapshotEntity(
+            id = 4L,
+            syncId = 1L,
+            source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "spotify:playlist:duplicates",
+            playlistName = "Duplicates",
+            playlistType = PlaylistType.CUSTOM,
+        )
+        val duplicateSnapshots = listOf(
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 4L,
+                title = "Repeat",
+                artist = "Artist",
+                spotifyUri = "spotify:track:repeat",
+                position = 0,
+            ),
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 4L,
+                title = "Repeat",
+                artist = "Artist",
+                spotifyUri = "spotify:track:repeat",
+                position = 7,
+            ),
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(playlistSnapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(4L) } returns duplicateSnapshots
+        coEvery { streamingPreference.current() } returns true
+
+        val result = buildWorker().doWork()
+
+        assertTrue("duplicate playlist entries must not fail the sync", result is androidx.work.ListenableWorker.Result.Success)
+        val output = (result as androidx.work.ListenableWorker.Result.Success).outputData
+        assertEquals(1L, output.getLong(DiffWorker.KEY_SYNC_ID, -1L))
+        assertEquals(1, output.getInt(DiffWorker.KEY_NEW_TRACKS, -1))
+        assertEquals(1, output.getInt(DiffWorker.KEY_PLAYLISTS_CHECKED, -1))
+        val playlist = requireNotNull(db.playlistDao().findBySourceId("spotify:playlist:duplicates"))
+        val tracks = db.trackDao().getAllForIntegrityScan()
+        val crossRefs = db.playlistDao().getCrossRefsForPlaylist(playlist.id)
+        assertEquals("duplicate identity must create one track row", 1, tracks.size)
+        assertEquals("local membership model stores one row per track", 1, crossRefs.size)
+        assertEquals(tracks.single().id, crossRefs.single().trackId)
+        assertEquals("last occurrence keeps the pre-batching position semantics", 7, crossRefs.single().position)
+        assertNull(crossRefs.single().removedAt)
+        assertEquals("spotify:track:repeat", tracks.single().spotifyUri)
+        assertEquals("remote occurrence count remains visible in metadata", 2, playlist.trackCount)
+    }
+
+    @Test
+    fun `duplicate YouTube ID queues one valid track offline`() = runBlocking {
+        db.playlistDao().insert(
+            PlaylistEntity(
+                name = "YouTube Duplicates",
+                source = MusicSource.YOUTUBE,
+                sourceId = "youtube:playlist:duplicates",
+                type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val playlistSnapshot = RemotePlaylistSnapshotEntity(
+            id = 5L,
+            syncId = 1L,
+            source = MusicSource.YOUTUBE,
+            sourcePlaylistId = "youtube:playlist:duplicates",
+            playlistName = "YouTube Duplicates",
+            playlistType = PlaylistType.CUSTOM,
+        )
+        val duplicateSnapshots = listOf(
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 5L,
+                title = "Repeat",
+                artist = "Artist",
+                youtubeId = "repeat-video-id",
+                position = 0,
+            ),
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 5L,
+                title = "Repeat",
+                artist = "Artist",
+                youtubeId = "repeat-video-id",
+                position = 7,
+            ),
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(playlistSnapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(5L) } returns duplicateSnapshots
+
+        val result = buildWorker().doWork()
+
+        assertTrue("duplicate YouTube entries must not fail the sync", result is androidx.work.ListenableWorker.Result.Success)
+        val output = (result as androidx.work.ListenableWorker.Result.Success).outputData
+        assertEquals(1, output.getInt(DiffWorker.KEY_NEW_TRACKS, -1))
+        val playlist = requireNotNull(db.playlistDao().findBySourceId("youtube:playlist:duplicates"))
+        val tracks = db.trackDao().getAllForIntegrityScan()
+        val crossRefs = db.playlistDao().getCrossRefsForPlaylist(playlist.id)
+        assertEquals(1, tracks.size)
+        assertEquals("repeat-video-id", tracks.single().youtubeId)
+        assertEquals(1, crossRefs.size)
+        assertEquals(tracks.single().id, crossRefs.single().trackId)
+        assertEquals(7, crossRefs.single().position)
+        assertEquals(2, playlist.trackCount)
+        coVerify(exactly = 1) {
+            downloadQueueDao.insertAll(
+                match { entries ->
+                    entries.size == 1 &&
+                        entries.single().trackId == tracks.single().id &&
+                        entries.single().youtubeUrl ==
+                        "https://music.youtube.com/watch?v=repeat-video-id"
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `distinct YouTube IDs with the same canonical metadata stay separate`() = runBlocking {
+        db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Strong IDs",
+                source = MusicSource.YOUTUBE,
+                sourceId = "youtube:playlist:strong-ids",
+                type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val playlistSnapshot = RemotePlaylistSnapshotEntity(
+            id = 6L,
+            syncId = 1L,
+            source = MusicSource.YOUTUBE,
+            sourcePlaylistId = "youtube:playlist:strong-ids",
+            playlistName = "Strong IDs",
+            playlistType = PlaylistType.CUSTOM,
+        )
+        val snapshots = listOf(
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 6L,
+                title = "Same Song",
+                artist = "Artist",
+                youtubeId = "video-one",
+                position = 0,
+            ),
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 6L,
+                title = "Same Song",
+                artist = "Artist",
+                youtubeId = "video-two",
+                position = 1,
+            ),
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(playlistSnapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(6L) } returns snapshots
+        coEvery { streamingPreference.current() } returns true
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals(2, db.trackDao().getAllForIntegrityScan().size)
+        assertEquals(
+            setOf("video-one", "video-two"),
+            db.trackDao().getAllForIntegrityScan().mapNotNull { it.youtubeId }.toSet(),
+        )
+        val playlist = requireNotNull(db.playlistDao().findBySourceId("youtube:playlist:strong-ids"))
+        assertEquals(2, db.playlistDao().getCrossRefsForPlaylist(playlist.id).size)
+    }
+
+    @Test
+    fun `existing canonical match reserves its first YouTube identity`() = runBlocking {
+        val existingId = db.trackDao().insert(
+            TrackEntity(
+                title = "Same Song",
+                artist = "Artist",
+                canonicalTitle = "same song",
+                canonicalArtist = "artist",
+                source = MusicSource.SPOTIFY,
+                spotifyUri = "spotify:track:existing",
+            )
+        )
+        db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Identity Backfill",
+                source = MusicSource.YOUTUBE,
+                sourceId = "youtube:playlist:identity-backfill",
+                type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val playlistSnapshot = RemotePlaylistSnapshotEntity(
+            id = 7L,
+            syncId = 1L,
+            source = MusicSource.YOUTUBE,
+            sourcePlaylistId = "youtube:playlist:identity-backfill",
+            playlistName = "Identity Backfill",
+            playlistType = PlaylistType.CUSTOM,
+        )
+        val snapshots = listOf(
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 7L,
+                title = "Same Song",
+                artist = "Artist",
+                youtubeId = "video-one",
+                position = 0,
+            ),
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 7L,
+                title = "Same Song",
+                artist = "Artist",
+                youtubeId = "video-two",
+                position = 1,
+            ),
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(playlistSnapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(7L) } returns snapshots
+        coEvery { streamingPreference.current() } returns true
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals("video-one", db.trackDao().getById(existingId)?.youtubeId)
+        assertEquals(
+            setOf("video-one", "video-two"),
+            db.trackDao().getAllForIntegrityScan().mapNotNull { it.youtubeId }.toSet(),
+        )
+        val playlist = requireNotNull(db.playlistDao().findBySourceId("youtube:playlist:identity-backfill"))
+        assertEquals(2, db.playlistDao().getCrossRefsForPlaylist(playlist.id).size)
+    }
+
+    @Test
+    fun `duplicate existing track keeps the last nonblank artwork`() = runBlocking {
+        val trackId = db.trackDao().insert(
+            TrackEntity(
+                title = "Artwork",
+                artist = "Artist",
+                canonicalTitle = "artwork",
+                canonicalArtist = "artist",
+                source = MusicSource.SPOTIFY,
+                spotifyUri = "spotify:track:artwork",
+                albumArtUrl = "https://cdn.example/old.jpg",
+            )
+        )
+        db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Artwork Order",
+                source = MusicSource.SPOTIFY,
+                sourceId = "spotify:playlist:artwork-order",
+                type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val playlistSnapshot = RemotePlaylistSnapshotEntity(
+            id = 8L,
+            syncId = 1L,
+            source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "spotify:playlist:artwork-order",
+            playlistName = "Artwork Order",
+            playlistType = PlaylistType.CUSTOM,
+        )
+        val snapshots = listOf(
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 8L,
+                title = "Artwork",
+                artist = "Artist",
+                spotifyUri = "spotify:track:artwork",
+                albumArtUrl = "https://cdn.example/first.jpg",
+                position = 0,
+            ),
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 8L,
+                title = "Artwork",
+                artist = "Artist",
+                spotifyUri = "spotify:track:artwork",
+                albumArtUrl = "https://cdn.example/last.jpg",
+                position = 1,
+            ),
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(playlistSnapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(8L) } returns snapshots
+        coEvery { streamingPreference.current() } returns true
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals("https://cdn.example/last.jpg", db.trackDao().getById(trackId)?.albumArtUrl)
+    }
+
+    @Test
+    fun `blank provider IDs do not merge distinct canonical tracks`() = runBlocking {
+        db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Blank IDs",
+                source = MusicSource.SPOTIFY,
+                sourceId = "spotify:playlist:blank-ids",
+                type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val playlistSnapshot = RemotePlaylistSnapshotEntity(
+            id = 9L,
+            syncId = 1L,
+            source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "spotify:playlist:blank-ids",
+            playlistName = "Blank IDs",
+            playlistType = PlaylistType.CUSTOM,
+        )
+        val snapshots = listOf(
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 9L,
+                title = "First",
+                artist = "One",
+                spotifyUri = "",
+                position = 0,
+            ),
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 9L,
+                title = "Second",
+                artist = "Two",
+                spotifyUri = "",
+                position = 1,
+            ),
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(playlistSnapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(9L) } returns snapshots
+        coEvery { streamingPreference.current() } returns true
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals(2, db.trackDao().getAllForIntegrityScan().size)
+        val playlist = requireNotNull(db.playlistDao().findBySourceId("spotify:playlist:blank-ids"))
+        assertEquals(2, db.playlistDao().getCrossRefsForPlaylist(playlist.id).size)
     }
 
     @Test

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepository.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepository.kt
@@ -145,25 +145,28 @@ interface PlayerRepository {
     /**
      * Insert [track] immediately after the currently-playing track in the queue.
      * Playback continues uninterrupted; the inserted track will play next.
+     * Returns false when the track is not playable in the current mode or the
+     * player controller is unavailable.
      */
-    suspend fun addNext(track: Track)
+    suspend fun addNext(track: Track): Boolean
 
     /**
      * Append [track] to the end of the current queue.
-     * Playback continues uninterrupted.
+     * Playback continues uninterrupted. Returns false when the track is not
+     * playable in the current mode or the player controller is unavailable.
      */
-    suspend fun addToQueue(track: Track)
+    suspend fun addToQueue(track: Track): Boolean
 
     /**
      * Append [tracks] (in order) to the end of the current queue.
      * Single MediaController.addMediaItems round-trip — preferred
      * over looping the single-track variant for known-size batches
      * like an album's full tracklist or an artist's catalog. Empty
-     * list is a no-op.
+     * list is a no-op. Returns true when at least one track was appended.
      *
      * Playback continues uninterrupted.
      */
-    suspend fun addToQueue(tracks: List<Track>)
+    suspend fun addToQueue(tracks: List<Track>): Boolean
 
     /**
      * Start a radio station seeded from an artist or track. Builds a balanced

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -422,12 +422,20 @@ class PlayerRepositoryImpl @Inject constructor(
         // repeat/shuffle are correct because ExoPlayer sees the whole queue.
         // Item building does per-track disk checks (filePathExistsOnDisk), so
         // it runs off the main thread; a 2.6k-track queue must not jank the UI.
-        val playable = tracks.filter { track ->
-            track.isDownloaded || (streamingOn && !track.isUnavailableForDisplay)
+        val builtItems = withContext(Dispatchers.IO) {
+            tracks.mapNotNull { track ->
+                track.takeIf { it.isPlayableForQueueAppend(streamingOn) }
+                    ?.let { it to it.toQueueMediaItem() }
+            }
         }
-        val items = withContext(Dispatchers.IO) {
-            playable.map { it.toQueueMediaItem() }
+        val streamingAtMutation = streamingPreference.current()
+        val acceptedItems = if (streamingAtMutation) {
+            builtItems
+        } else {
+            builtItems.filter { (_, item) -> item.isUsableOfflineQueueItem() }
         }
+        val playable = acceptedItems.map { it.first }
+        val items = acceptedItems.map { it.second }
         if (items.isEmpty()) {
             _userMessages.tryEmit("Nothing in this queue is playable right now.")
             return
@@ -691,6 +699,7 @@ class PlayerRepositoryImpl @Inject constructor(
         val controller = ensureController() ?: return false
         val (session, firstBatch) = radioGenerator.start(seed)
         if (firstBatch.isEmpty()) return false
+        if (!streamingPreference.current()) return false
         radioSession = session
         radioActive = true
         // Only ONE grower may run: startRadio bypasses setQueueInternal (which is
@@ -765,10 +774,18 @@ class PlayerRepositoryImpl @Inject constructor(
     internal suspend fun growRadio() {
         radioGrowMutex.withLock {
             if (!radioActive) return
+            if (!streamingPreference.current()) {
+                stopRadio()
+                return
+            }
             val controller = controllerDeferred ?: return
             val session = radioSession ?: return
             val batch = radioGenerator.nextBatch(session)
             if (batch.isEmpty()) return
+            if (!radioActive || !streamingPreference.current()) {
+                stopRadio()
+                return
+            }
             // Streaming tracks → stash-resolve:// placeholders (see startRadio).
             controller.addMediaItems(batch.map { it.toQueueMediaItem() })
             currentQueueTracks = currentQueueTracks + batch
@@ -812,14 +829,56 @@ class PlayerRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun addNext(track: Track) {
-        val controller = ensureController() ?: return
+    /**
+     * Queue identity is also the Media3 mediaId and StreamUrlCache key.
+     * Native Qobuz rows reach per-track actions without a video id, which
+     * previously mapped every one of them to id=0. Persist those transient
+     * rows before queueing so different songs cannot share one cached URL.
+     */
+    private suspend fun Track.withQueueIdentity(): Track =
+        if (id != 0L) this else copy(id = musicRepository.ensureTrackPersisted(this))
+
+    /**
+     * Applies the queue's Online/Offline contract at the repository boundary.
+     * Offline entries must have a real, usable local file; a stale Room path
+     * must not fall through to a stash-resolve placeholder and hit the network.
+     */
+    private fun Track.isPlayableForQueueAppend(streamingEnabled: Boolean): Boolean {
+        val localPath = filePath
+        return if (streamingEnabled) {
+            !isUnavailableForDisplay
+        } else {
+            isDownloaded &&
+                !localPath.isNullOrBlank() &&
+                filePathExistsOnDisk(localPath)
+        }
+    }
+
+    private fun MediaItem.isUsableOfflineQueueItem(): Boolean {
+        val scheme = localConfiguration?.uri?.scheme
+        return scheme == "file" || scheme == "content"
+    }
+
+    override suspend fun addNext(track: Track): Boolean {
+        val controller = ensureController() ?: return false
+        val playable = track.takeIf {
+            it.isPlayableForQueueAppend(streamingPreference.current())
+        }
+        if (playable == null) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
+        val queueTrack = playable.withQueueIdentity()
+        if (!queueTrack.isPlayableForQueueAppend(streamingPreference.current())) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
         val wasEmpty = controller.mediaItemCount == 0
         // Instant add: stream tracks enter as stash-resolve:// placeholders
         // (resolved at play time), so the queue grows immediately instead of
         // waiting out a slow resolve.
         val insertIndex = controller.currentMediaItemIndex + 1
-        controller.addMediaItem(insertIndex, track.toQueueMediaItem())
+        controller.addMediaItem(insertIndex, queueTrack.toQueueMediaItem())
         // Mirror into the logical queue right after the playing track's
         // logical position (falling back to append) so the queue sheet
         // shows the Play-Next insert where it will actually play.
@@ -827,10 +886,10 @@ class PlayerRepositoryImpl @Inject constructor(
             ?.getLong(EXTRA_TRACK_ID, -1L) ?: -1L
         val logicalPos = currentQueueTracks.indexOfFirst { it.id == currentId }
         currentQueueTracks = when {
-            wasEmpty -> listOf(track)
+            wasEmpty -> listOf(queueTrack)
             logicalPos >= 0 -> currentQueueTracks.toMutableList()
-                .apply { add(logicalPos + 1, track) }
-            else -> currentQueueTracks + track
+                .apply { add(logicalPos + 1, queueTrack) }
+            else -> currentQueueTracks + queueTrack
         }
         // If the queue was empty, the user tapped "Play next" with nothing
         // playing — they expect the song to actually start, not just sit
@@ -839,33 +898,69 @@ class PlayerRepositoryImpl @Inject constructor(
             controller.prepare()
             controller.play()
         }
+        return true
     }
 
-    override suspend fun addToQueue(track: Track) {
-        val controller = ensureController() ?: return
+    override suspend fun addToQueue(track: Track): Boolean {
+        val controller = ensureController() ?: return false
+        val playable = track.takeIf {
+            it.isPlayableForQueueAppend(streamingPreference.current())
+        }
+        if (playable == null) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
+        val queueTrack = playable.withQueueIdentity()
+        if (!queueTrack.isPlayableForQueueAppend(streamingPreference.current())) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
         val wasEmpty = controller.mediaItemCount == 0
-        controller.addMediaItem(track.toQueueMediaItem())
-        currentQueueTracks = if (wasEmpty) listOf(track) else currentQueueTracks + track
+        controller.addMediaItem(queueTrack.toQueueMediaItem())
+        currentQueueTracks = if (wasEmpty) listOf(queueTrack) else currentQueueTracks + queueTrack
         if (wasEmpty) {
             controller.prepare()
             controller.play()
         }
+        return true
     }
 
-    override suspend fun addToQueue(tracks: List<Track>) {
-        if (tracks.isEmpty()) return
-        val controller = ensureController() ?: return
+    override suspend fun addToQueue(tracks: List<Track>): Boolean {
+        if (tracks.isEmpty()) return false
+        val controller = ensureController() ?: return false
+        val streamingEnabled = streamingPreference.current()
+        val playable = tracks.filter { it.isPlayableForQueueAppend(streamingEnabled) }
+        if (playable.isEmpty()) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
+        val persistedTracks = playable.map { it.withQueueIdentity() }
+        val builtItems = withContext(Dispatchers.IO) {
+            persistedTracks.map { it to it.toQueueMediaItem() }
+        }
+        val streamingAtMutation = streamingPreference.current()
+        val acceptedItems = if (streamingAtMutation) {
+            builtItems
+        } else {
+            builtItems.filter { (_, item) -> item.isUsableOfflineQueueItem() }
+        }
+        if (acceptedItems.isEmpty()) {
+            _userMessages.tryEmit("Nothing in this queue is playable right now.")
+            return false
+        }
+        val queueTracks = acceptedItems.map { it.first }
+        val items = acceptedItems.map { it.second }
         val wasEmpty = controller.mediaItemCount == 0
         // Instant batch add: every track becomes a MediaItem now (placeholders
         // for streams), preserving tap order — no resolve fan-out, no dropped
         // rows, "Added N tracks" is finally literally true.
-        val items = withContext(Dispatchers.IO) { tracks.map { it.toQueueMediaItem() } }
-        currentQueueTracks = if (wasEmpty) tracks else currentQueueTracks + tracks
+        currentQueueTracks = if (wasEmpty) queueTracks else currentQueueTracks + queueTracks
         controller.addMediaItems(items)
         if (wasEmpty) {
             controller.prepare()
             controller.play()
         }
+        return true
     }
 
     override suspend fun toggleShuffle() {
@@ -1877,4 +1972,3 @@ internal fun shouldPersistPosition(
 
 /** Minimum position drift before an unforced persist write. */
 internal const val POSITION_PERSIST_MIN_DELTA_MS = 5_000L
-

--- a/core/media/src/main/kotlin/com/stash/core/media/actions/TrackActionsDelegate.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/actions/TrackActionsDelegate.kt
@@ -387,8 +387,12 @@ class TrackActionsDelegate @Inject constructor(
     fun playNext(item: TrackItem) {
         scope().launch {
             try {
-                playerRepository.addNext(item.toDomainTrack())
-                _userMessages.tryEmit("Playing next")
+                if (!streamingPreference.current()) {
+                    _userMessages.tryEmit("Turn on Online mode to queue this track.")
+                    return@launch
+                }
+                val added = playerRepository.addNext(item.toDomainTrack())
+                _userMessages.tryEmit(if (added) "Playing next" else "Couldn't add to queue")
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -415,8 +419,12 @@ class TrackActionsDelegate @Inject constructor(
     fun addToQueue(item: TrackItem) {
         scope().launch {
             try {
-                playerRepository.addToQueue(item.toDomainTrack())
-                _userMessages.tryEmit("Added to queue")
+                if (!streamingPreference.current()) {
+                    _userMessages.tryEmit("Turn on Online mode to queue this track.")
+                    return@launch
+                }
+                val added = playerRepository.addToQueue(item.toDomainTrack())
+                _userMessages.tryEmit(if (added) "Added to queue" else "Couldn't add to queue")
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryFullTimelineTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryFullTimelineTest.kt
@@ -79,6 +79,200 @@ class PlayerRepositoryFullTimelineTest {
     }
 
     @Test
+    fun `offline addToQueue rejects consecutive stream-only tracks without starting playback`() = runTest {
+        coEvery { streamingPreference.current() } returns false
+        every { controller.mediaItemCount } returns 0
+        val first = Track(
+            id = 101L,
+            title = "First",
+            artist = "Artist",
+            youtubeId = "first-video",
+            isStreamable = true,
+        )
+        val second = first.copy(
+            id = 202L,
+            title = "Second",
+            youtubeId = "second-video",
+        )
+
+        repo.addToQueue(first)
+        repo.addToQueue(second)
+
+        verify(exactly = 0) { controller.addMediaItem(any()) }
+        verify(exactly = 0) { controller.prepare() }
+        verify(exactly = 0) { controller.play() }
+    }
+
+    @Test
+    fun `offline addToQueue rejects a downloaded row whose local file is unusable`() = runTest {
+        coEvery { streamingPreference.current() } returns false
+        repo.filePathExistsOnDisk = { false }
+        val staleDownload = Track(
+            id = 303L,
+            title = "Missing",
+            artist = "Artist",
+            filePath = "/storage/music/missing.flac",
+            isDownloaded = true,
+            isStreamable = true,
+        )
+
+        repo.addToQueue(staleDownload)
+
+        verify(exactly = 0) { controller.addMediaItem(any()) }
+    }
+
+    @Test
+    fun `addToQueue rejects a stream when Online mode turns off during persistence`() = runTest {
+        coEvery { streamingPreference.current() } returnsMany listOf(true, false)
+        coEvery { musicRepository.ensureTrackPersisted(any()) } returns 404L
+        val transientStream = Track(
+            id = 0L,
+            title = "Transient",
+            artist = "Artist",
+            isStreamable = true,
+        )
+
+        val added = repo.addToQueue(transientStream)
+
+        assertThat(added).isFalse()
+        verify(exactly = 0) { controller.addMediaItem(any()) }
+    }
+
+    @Test
+    fun `offline setQueue rejects a downloaded row whose local file is unusable`() = runTest {
+        coEvery { streamingPreference.current() } returns false
+        repo.filePathExistsOnDisk = { false }
+        val staleDownload = Track(
+            id = 505L,
+            title = "Missing",
+            artist = "Artist",
+            filePath = "/storage/music/missing.flac",
+            isDownloaded = true,
+            isStreamable = true,
+        )
+
+        repo.setQueue(listOf(staleDownload))
+
+        verify(exactly = 0) {
+            controller.setMediaItems(any<List<MediaItem>>(), any<Int>(), any<Long>())
+        }
+    }
+
+    @Test
+    fun `setQueue drops streams when Online mode turns off while items are built`() = runTest {
+        var online = true
+        coEvery { streamingPreference.current() } answers { online }
+        repo.filePathExistsOnDisk = {
+            online = false
+            true
+        }
+        val local = Track(
+            id = 606L,
+            title = "Local",
+            artist = "Artist",
+            filePath = "/storage/music/local.flac",
+            isDownloaded = true,
+        )
+        val remote = Track(
+            id = 707L,
+            title = "Remote",
+            artist = "Artist",
+            isStreamable = true,
+        )
+        val items = slot<List<MediaItem>>()
+        every { controller.setMediaItems(capture(items), any<Int>(), any<Long>()) } returns Unit
+
+        repo.setQueue(listOf(local, remote))
+
+        assertThat(items.captured.map { it.mediaId }).containsExactly("606")
+    }
+
+    @Test
+    fun `batch addToQueue drops streams when Online mode turns off while items are built`() = runTest {
+        var online = true
+        coEvery { streamingPreference.current() } answers { online }
+        repo.filePathExistsOnDisk = {
+            online = false
+            true
+        }
+        every { controller.mediaItemCount } returns 1
+        val local = Track(
+            id = 808L,
+            title = "Local",
+            artist = "Artist",
+            filePath = "/storage/music/local.flac",
+            isDownloaded = true,
+        )
+        val remote = Track(
+            id = 909L,
+            title = "Remote",
+            artist = "Artist",
+            isStreamable = true,
+        )
+        val items = slot<List<MediaItem>>()
+        every { controller.addMediaItems(capture(items)) } returns Unit
+
+        val added = repo.addToQueue(listOf(local, remote))
+
+        assertThat(added).isTrue()
+        assertThat(items.captured.map { it.mediaId }).containsExactly("808")
+    }
+
+    @Test
+    fun `offline batch addToQueue accepts a usable SAF content download`() = runTest {
+        coEvery { streamingPreference.current() } returns false
+        repo.filePathExistsOnDisk = { true }
+        every { controller.mediaItemCount } returns 1
+        val safDownload = Track(
+            id = 1001L,
+            title = "SAF Local",
+            artist = "Artist",
+            filePath = "content://com.android.externalstorage.documents/document/music%3Asong.flac",
+            isDownloaded = true,
+        )
+        val items = slot<List<MediaItem>>()
+        every { controller.addMediaItems(capture(items)) } returns Unit
+
+        val added = repo.addToQueue(listOf(safDownload))
+
+        assertThat(added).isTrue()
+        assertThat(items.captured.single().localConfiguration?.uri?.scheme)
+            .isEqualTo("content")
+    }
+
+    @Test
+    fun `addToQueue persists zero-id stream tracks before building media items`() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        every { controller.mediaItemCount } returns 1
+        coEvery {
+            musicRepository.ensureTrackPersisted(match { it.title == "First" })
+        } returns 101L
+        coEvery {
+            musicRepository.ensureTrackPersisted(match { it.title == "Second" })
+        } returns 202L
+        val first = Track(
+            id = 0L,
+            title = "First",
+            artist = "Artist",
+            isStreamable = true,
+        )
+        val second = first.copy(title = "Second")
+        val items = mutableListOf<MediaItem>()
+        every { controller.addMediaItem(capture(items)) } returns Unit
+
+        repo.addToQueue(first)
+        repo.addToQueue(second)
+
+        assertThat(items.map { it.mediaId }).containsExactly("101", "202").inOrder()
+        assertThat(items.map { it.localConfiguration?.uri?.toString() })
+            .containsExactly(
+                "stash-resolve://track/101?t=First&a=Artist",
+                "stash-resolve://track/202?t=Second&a=Artist",
+            )
+            .inOrder()
+    }
+
+    @Test
     fun `skipNext is always a native seek`() = runTest {
         every { controller.hasNextMediaItem() } returns true
 

--- a/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryRadioTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryRadioTest.kt
@@ -104,6 +104,24 @@ class PlayerRepositoryRadioTest {
         assertThat(repo.radioSeedLabel.value).isNull()
     }
 
+    @Test fun `startRadio rejects a batch when Online mode turns off during generation`() = runTest {
+        var online = true
+        coEvery { streamingPreference.current() } answers { online }
+        val session = mockk<RadioSession>(relaxed = true)
+        coEvery { radioGenerator.start(any()) } answers {
+            online = false
+            session to listOf(track(1))
+        }
+
+        val started = repo.startRadio(RadioSeed.Artist("MBV", "id"))
+
+        assertThat(started).isFalse()
+        assertThat(repo.radioSeedLabel.value).isNull()
+        verify(exactly = 0) {
+            controller.setMediaItems(any<List<MediaItem>>(), any<Int>(), any<Long>())
+        }
+    }
+
     @Test fun `setQueue disarms the station`() = runTest {
         coEvery { streamingPreference.current() } returns true
         val session = mockk<RadioSession>(relaxed = true)
@@ -165,6 +183,38 @@ class PlayerRepositoryRadioTest {
 
         coVerify { radioGenerator.nextBatch(session) }
         verify { controller.addMediaItems(any<List<MediaItem>>()) }
+    }
+
+    @Test fun `growRadio disarms without appending when Online mode was turned off`() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        val session = mockk<RadioSession>(relaxed = true)
+        coEvery { radioGenerator.start(any()) } returns (session to listOf(track(1)))
+        coEvery { radioGenerator.nextBatch(session) } returns listOf(track(2))
+        repo.startRadio(RadioSeed.Artist("MBV", "id"))
+        coEvery { streamingPreference.current() } returns false
+
+        repo.growRadio()
+
+        assertThat(repo.radioSeedLabel.value).isNull()
+        coVerify(exactly = 0) { radioGenerator.nextBatch(session) }
+        verify(exactly = 0) { controller.addMediaItems(any<List<MediaItem>>()) }
+    }
+
+    @Test fun `growRadio disarms when Online mode turns off during generation`() = runTest {
+        var online = true
+        coEvery { streamingPreference.current() } answers { online }
+        val session = mockk<RadioSession>(relaxed = true)
+        coEvery { radioGenerator.start(any()) } returns (session to listOf(track(1)))
+        coEvery { radioGenerator.nextBatch(session) } answers {
+            online = false
+            listOf(track(2))
+        }
+        repo.startRadio(RadioSeed.Artist("MBV", "id"))
+
+        repo.growRadio()
+
+        assertThat(repo.radioSeedLabel.value).isNull()
+        verify(exactly = 0) { controller.addMediaItems(any<List<MediaItem>>()) }
     }
 
     @Test fun `growRadio is a no-op when no station is active`() = runTest {

--- a/core/media/src/test/kotlin/com/stash/core/media/actions/TrackActionsDelegateQueueActionsTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/actions/TrackActionsDelegateQueueActionsTest.kt
@@ -28,6 +28,7 @@ class TrackActionsDelegateQueueActionsTest {
     private val musicRepository: com.stash.core.data.repository.MusicRepository = mockk(relaxed = true)
     private val blocklistGuard: com.stash.core.data.blocklist.BlocklistGuard = mockk(relaxed = true)
     private val trackDao: com.stash.core.data.db.dao.TrackDao = mockk(relaxed = true)
+    private val streamingPreference: com.stash.core.data.prefs.StreamingPreference = mockk(relaxed = true)
 
     // Real flows, not relaxed stubs: bindToScope collects playerErrors, and a
     // relaxed mock's `collect` (returns Nothing) throws, killing the scope.
@@ -36,18 +37,21 @@ class TrackActionsDelegateQueueActionsTest {
         every { playerErrors } returns MutableSharedFlow()
     }
 
-    private fun delegate() = TrackActionsDelegate(
-        previewPlayer = previewPlayer,
-        searchPreviewMediaSource = mockk(relaxed = true),
-        previewUrlExtractor = mockk(relaxed = true),
-        previewUrlCache = mockk(relaxed = true),
-        trackDao = trackDao,
-        searchDownloadCoordinator = mockk(relaxed = true),
-        playerRepository = playerRepository,
-        streamingPreference = mockk(relaxed = true),
-        musicRepository = musicRepository,
-        blocklistGuard = blocklistGuard,
-    )
+    private fun delegate(online: Boolean = true): TrackActionsDelegate {
+        coEvery { streamingPreference.current() } returns online
+        return TrackActionsDelegate(
+            previewPlayer = previewPlayer,
+            searchPreviewMediaSource = mockk(relaxed = true),
+            previewUrlExtractor = mockk(relaxed = true),
+            previewUrlCache = mockk(relaxed = true),
+            trackDao = trackDao,
+            searchDownloadCoordinator = mockk(relaxed = true),
+            playerRepository = playerRepository,
+            streamingPreference = streamingPreference,
+            musicRepository = musicRepository,
+            blocklistGuard = blocklistGuard,
+        )
+    }
 
     private val item = TrackItem(
         videoId = "abc123", title = "Song", artist = "Artist",
@@ -58,7 +62,7 @@ class TrackActionsDelegateQueueActionsTest {
     fun `addToQueue maps TrackItem and calls repo with streamable Track`() = runTest {
         val d = delegate().apply { bindToScope(backgroundScope) }
         val slot = slot<Track>()
-        coEvery { playerRepository.addToQueue(capture(slot)) } returns Unit
+        coEvery { playerRepository.addToQueue(capture(slot)) } returns true
 
         val messages = mutableListOf<String>()
         backgroundScope.launch { d.userMessages.collect { messages.add(it) } }
@@ -78,8 +82,37 @@ class TrackActionsDelegateQueueActionsTest {
     }
 
     @Test
+    fun `offline addToQueue refuses stream track with an Online mode hint`() = runTest {
+        val d = delegate(online = false).apply { bindToScope(backgroundScope) }
+        val messages = mutableListOf<String>()
+        backgroundScope.launch { d.userMessages.collect { messages.add(it) } }
+        runCurrent()
+
+        d.addToQueue(item)
+        runCurrent()
+
+        assertThat(messages).containsExactly("Turn on Online mode to queue this track.")
+        coVerify(exactly = 0) { playerRepository.addToQueue(any<Track>()) }
+    }
+
+    @Test
+    fun `addToQueue reports failure when repository rejects after the mode precheck`() = runTest {
+        val d = delegate().apply { bindToScope(backgroundScope) }
+        coEvery { playerRepository.addToQueue(any<Track>()) } returns false
+        val messages = mutableListOf<String>()
+        backgroundScope.launch { d.userMessages.collect { messages.add(it) } }
+        runCurrent()
+
+        d.addToQueue(item)
+        runCurrent()
+
+        assertThat(messages).containsExactly("Couldn't add to queue")
+    }
+
+    @Test
     fun `playNext calls addNext and emits message`() = runTest {
         val d = delegate().apply { bindToScope(backgroundScope) }
+        coEvery { playerRepository.addNext(any<Track>()) } returns true
 
         val messages = mutableListOf<String>()
         backgroundScope.launch { d.userMessages.collect { messages.add(it) } }
@@ -90,6 +123,20 @@ class TrackActionsDelegateQueueActionsTest {
 
         assertThat(messages).containsExactly("Playing next")
         coVerify(exactly = 1) { playerRepository.addNext(any<Track>()) }
+    }
+
+    @Test
+    fun `playNext reports failure when repository rejects after the mode precheck`() = runTest {
+        val d = delegate().apply { bindToScope(backgroundScope) }
+        coEvery { playerRepository.addNext(any<Track>()) } returns false
+        val messages = mutableListOf<String>()
+        backgroundScope.launch { d.userMessages.collect { messages.add(it) } }
+        runCurrent()
+
+        d.playNext(item)
+        runCurrent()
+
+        assertThat(messages).containsExactly("Couldn't add to queue")
     }
 
     @Test

--- a/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/listening/ListeningRecorderSkipTest.kt
@@ -84,9 +84,9 @@ class ListeningRecorderSkipTest {
         override suspend fun startRadio(seed: com.stash.core.data.radio.RadioSeed, keepCurrent: Boolean) = false
         override fun stopRadio() = Unit
         override val radioSeedLabel: StateFlow<String?> = MutableStateFlow(null)
-        override suspend fun addNext(track: Track) = Unit
-        override suspend fun addToQueue(track: Track) = Unit
-        override suspend fun addToQueue(tracks: List<Track>) = Unit
+        override suspend fun addNext(track: Track) = false
+        override suspend fun addToQueue(track: Track) = false
+        override suspend fun addToQueue(tracks: List<Track>) = false
         override suspend fun toggleShuffle() = Unit
         override suspend fun cycleRepeatMode() = Unit
         override suspend fun removeFromQueue(index: Int) = Unit

--- a/feature/search/src/main/kotlin/com/stash/feature/search/AlbumDiscoveryViewModel.kt
+++ b/feature/search/src/main/kotlin/com/stash/feature/search/AlbumDiscoveryViewModel.kt
@@ -295,11 +295,14 @@ class AlbumDiscoveryViewModel @Inject constructor(
         viewModelScope.launch {
             val tracks = buildQueueTracks()
             if (tracks.isEmpty()) return@launch
-            // Emit immediately — URL resolution can take ~20-30s for 15
-            // streaming tracks against a degraded Kennyy/Squid. Without this
-            // optimistic toast the user gets zero feedback during the wait.
-            _userMessages.emit("Adding ${tracks.size} tracks to queue...")
-            playerRepository.addToQueue(tracks)
+            val added = playerRepository.addToQueue(tracks)
+            _userMessages.emit(
+                if (added) {
+                    "Added album to queue"
+                } else {
+                    "Couldn't add album to queue"
+                },
+            )
         }
     }
 

--- a/feature/search/src/test/kotlin/com/stash/feature/search/AlbumDiscoveryViewModelTest.kt
+++ b/feature/search/src/test/kotlin/com/stash/feature/search/AlbumDiscoveryViewModelTest.kt
@@ -293,6 +293,7 @@ class AlbumDiscoveryViewModelTest {
             whenever(it.get(any(), any())).thenReturn(detail)
         }
         val player = mock<PlayerRepository>()
+        whenever(player.addToQueue(any<List<Track>>())).thenReturn(true)
 
         val vm = vmWith(cache = cache, playerRepository = player)
         advanceUntilIdle()
@@ -300,7 +301,29 @@ class AlbumDiscoveryViewModelTest {
         vm.userMessages.test {
             vm.addAlbumToQueue()
             advanceUntilIdle()
-            assertEquals("Adding 3 tracks to queue...", awaitItem())
+            assertEquals("Added album to queue", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `addAlbumToQueue reports when the repository rejects the album`() = runTest {
+        val detail = albumDetail(
+            tracks = listOf("v1", "v2", "v3").map(::trackSummary),
+        )
+        val cache = mock<AlbumCache>().also {
+            whenever(it.get(any(), any())).thenReturn(detail)
+        }
+        val player = mock<PlayerRepository>()
+        whenever(player.addToQueue(any<List<Track>>())).thenReturn(false)
+
+        val vm = vmWith(cache = cache, playerRepository = player)
+        advanceUntilIdle()
+
+        vm.userMessages.test {
+            vm.addAlbumToQueue()
+            advanceUntilIdle()
+            assertEquals("Couldn't add album to queue", awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
## Summary

- coalesce repeated Spotify, YouTube, and canonical identities before the batched track insert so playlist memberships never reference IDs invalidated by Room REPLACE
- preserve distinct provider identities, normalize blank IDs, and prevent YouTube backfills from overwriting an established identity
- preserve last-occurrence position/artwork semantics and add Room-backed regressions for Spotify, YouTube Music, offline queueing, identity conflicts, and blank IDs

## Root cause

DiffWorker performed one pre-insert lookup for a whole playlist. Repeated previously unseen identities were therefore staged more than once. TrackDao.insertAll() uses OnConflictStrategy.REPLACE, so a later duplicate deleted the first generated row and left its generated ID stale. Inserting playlist_tracks with that stale ID raised SQLite foreign-key error 787 and rolled the playlist transaction back.

## Test plan

- [x] ./gradlew :core:data:testDebugUnitTest --tests com.stash.core.data.sync.workers.DiffWorkerTest --tests *TrackDaoFindExistingForBatchTest --tests *DefaultSyncEnabledTest --no-daemon
- [x] ./gradlew :app:compileDebugKotlin --no-daemon
- [x] git diff --check

## Notes

Exact repeated occurrences still collapse to one local membership because playlist_tracks is keyed by (playlist_id, track_id); the final occurrence position is retained. Supporting visible duplicate occurrences would require a schema change.

A forced full :core:data:testDebugUnitTest run currently reports five failures in unrelated existing test areas: DiscoveryQueueDaoFairnessTest, TrackDaoStreamableTest, MusicRepositoryDownloadsMixTest, and two StashDiscoveryWorkerStreamOnlyTest cases.