### PR TITLE
fix(sync): deduplicate tracks within playlist batches

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
@@ -89,6 +89,22 @@ class DiffWorker @AssistedInject constructor(
         private const val NEVER_MATCH_SENTINEL = "\u0000__stash_never_match__"
     }
 
+    /**
+     * Mutable identity state for one playlist batch. Newly discovered tracks
+     * are registered before the bulk insert so duplicate snapshots reuse the
+     * same pending row instead of staging another UNIQUE-key conflict.
+     */
+    private class BatchTrack(
+        var entity: TrackEntity,
+        val isNew: Boolean,
+        var persistedId: Long? = entity.id.takeUnless { isNew },
+    )
+
+    private data class CanonicalKey(
+        val title: String,
+        val artist: String,
+    )
+
     override suspend fun doWork(): Result {
         val syncId = inputData.getLong(PlaylistFetchWorker.KEY_SYNC_ID, -1L)
         if (syncId == -1L) {
@@ -366,24 +382,72 @@ class DiffWorker @AssistedInject constructor(
         // with a single batched lookup, then matches candidates in memory
         // using the same spotifyUri -> youtubeId -> canonical priority.
         val canonicalOf = allowedSnapshots.associateWith {
-            trackMatcher.canonicalTitle(it.title) to trackMatcher.canonicalArtist(it.artist)
+            CanonicalKey(
+                title = trackMatcher.canonicalTitle(it.title),
+                artist = trackMatcher.canonicalArtist(it.artist),
+            )
         }
-        val spotifyUris = allowedSnapshots.mapNotNull { it.spotifyUri }.distinct()
+        val spotifyUris = allowedSnapshots.mapNotNull { it.spotifyUri?.takeIf(String::isNotBlank) }.distinct()
             .ifEmpty { listOf(NEVER_MATCH_SENTINEL) }
-        val youtubeIds = allowedSnapshots.mapNotNull { it.youtubeId }.distinct()
+        val youtubeIds = allowedSnapshots.mapNotNull { it.youtubeId?.takeIf(String::isNotBlank) }.distinct()
             .ifEmpty { listOf(NEVER_MATCH_SENTINEL) }
         val canonicalKeys = canonicalOf.values.map { (t, a) -> "$t|$a" }.distinct()
 
         val candidates = trackDao.findExistingForBatch(spotifyUris, youtubeIds, canonicalKeys)
-        val bySpotifyUri = candidates.filter { it.spotifyUri != null }.associateBy { it.spotifyUri }
-        val byYoutubeId = candidates.filter { it.youtubeId != null }.associateBy { it.youtubeId }
-        val byCanonical = candidates.associateBy { "${it.canonicalTitle}|${it.canonicalArtist}" }
+        val candidateTracks = candidates.associate { candidate ->
+            candidate.id to BatchTrack(candidate, isNew = false)
+        }
+        val bySpotifyUri = mutableMapOf<String, BatchTrack>()
+        val byYoutubeId = mutableMapOf<String, BatchTrack>()
+        val byCanonical = mutableMapOf<CanonicalKey, BatchTrack>()
 
-        fun matchExisting(snapshot: RemoteTrackSnapshotEntity): TrackEntity? {
-            snapshot.spotifyUri?.let { uri -> bySpotifyUri[uri]?.let { return it } }
-            snapshot.youtubeId?.let { yid -> byYoutubeId[yid]?.let { return it } }
-            val (ct, ca) = canonicalOf.getValue(snapshot)
-            return byCanonical["$ct|$ca"]
+        fun registerBatchTrack(track: BatchTrack) {
+            track.entity.spotifyUri?.takeIf(String::isNotBlank)?.let { bySpotifyUri[it] = track }
+            track.entity.youtubeId?.takeIf(String::isNotBlank)?.let { byYoutubeId[it] = track }
+            byCanonical[
+                CanonicalKey(
+                    title = track.entity.canonicalTitle,
+                    artist = track.entity.canonicalArtist,
+                )
+            ] = track
+        }
+
+        candidateTracks.values.forEach(::registerBatchTrack)
+
+        fun matchBatchTrack(snapshot: RemoteTrackSnapshotEntity): BatchTrack? {
+            snapshot.spotifyUri?.takeIf(String::isNotBlank)?.let { uri ->
+                bySpotifyUri[uri]?.let { return it }
+            }
+            snapshot.youtubeId?.takeIf(String::isNotBlank)?.let { yid ->
+                byYoutubeId[yid]?.let { return it }
+            }
+            return byCanonical[canonicalOf.getValue(snapshot)]
+        }
+
+        suspend fun enrichExistingBatchTrack(
+            batchTrack: BatchTrack,
+            snapshot: RemoteTrackSnapshotEntity,
+        ) {
+            val existingTrack = batchTrack.entity
+            val snapshotYtId = snapshot.youtubeId?.takeIf(String::isNotBlank)
+            if (snapshotYtId != null && existingTrack.youtubeId.isNullOrBlank()) {
+                val youtubeOwner = byYoutubeId[snapshotYtId]
+                if (youtubeOwner == null || youtubeOwner === batchTrack) {
+                    val applied = trackDao.updateYoutubeIdIfUnclaimed(existingTrack.id, snapshotYtId)
+                    if (applied == 1) {
+                        batchTrack.entity = batchTrack.entity.copy(youtubeId = snapshotYtId)
+                        byYoutubeId[snapshotYtId] = batchTrack
+                        val ytUrl = "https://music.youtube.com/watch?v=$snapshotYtId"
+                        downloadQueueDao.fillMissingYoutubeUrlForTrack(existingTrack.id, ytUrl)
+                    }
+                }
+            }
+
+            val snapshotArt = snapshot.albumArtUrl
+            if (!snapshotArt.isNullOrBlank() && snapshotArt != batchTrack.entity.albumArtUrl) {
+                trackDao.updateAlbumArtUrl(existingTrack.id, snapshotArt)
+                batchTrack.entity = batchTrack.entity.copy(albumArtUrl = snapshotArt)
+            }
         }
 
         // Preload every current cross-ref for this playlist ONCE instead of
@@ -391,86 +455,105 @@ class DiffWorker @AssistedInject constructor(
         val existingCrossRefs = playlistDao.getCrossRefsForPlaylist(localPlaylist.id)
             .associateBy { it.trackId }
 
-        val newSnapshots = mutableListOf<RemoteTrackSnapshotEntity>()
-        val newEntities = mutableListOf<TrackEntity>()
-        val existingPairs = mutableListOf<Pair<TrackEntity, RemoteTrackSnapshotEntity>>()
+        val newTracks = mutableListOf<BatchTrack>()
+        val newOccurrences = mutableListOf<Pair<BatchTrack, RemoteTrackSnapshotEntity>>()
+        val existingPairs = mutableListOf<Pair<BatchTrack, RemoteTrackSnapshotEntity>>()
 
         for (snapshot in allowedSnapshots) {
-            val existing = matchExisting(snapshot)
-            if (existing != null) {
-                existingPairs.add(existing to snapshot)
-            } else {
+            val batchTrack = matchBatchTrack(snapshot) ?: run {
                 val (ct, ca) = canonicalOf.getValue(snapshot)
-                newEntities.add(
-                    TrackEntity(
+                BatchTrack(
+                    entity = TrackEntity(
                         title = snapshot.title,
                         artist = snapshot.artist,
                         album = snapshot.album ?: "",
                         durationMs = snapshot.durationMs,
                         source = playlistSnapshot.source,
-                        spotifyUri = snapshot.spotifyUri,
-                        youtubeId = snapshot.youtubeId,
+                        spotifyUri = snapshot.spotifyUri?.takeIf(String::isNotBlank),
+                        youtubeId = snapshot.youtubeId?.takeIf(String::isNotBlank),
                         albumArtUrl = snapshot.albumArtUrl,
                         canonicalTitle = ct,
                         canonicalArtist = ca,
                         isDownloaded = false,
                         isrc = snapshot.isrc,
                         explicit = snapshot.explicit,
-                    )
-                )
-                newSnapshots.add(snapshot)
+                    ),
+                    isNew = true,
+                ).also {
+                    newTracks.add(it)
+                    registerBatchTrack(it)
+                }
+            }
+
+            if (batchTrack.isNew) {
+                val snapshotYtId = snapshot.youtubeId?.takeIf(String::isNotBlank)
+                val youtubeOwner = snapshotYtId?.let(byYoutubeId::get)
+                if (snapshotYtId != null &&
+                    batchTrack.entity.youtubeId.isNullOrBlank() &&
+                    (youtubeOwner == null || youtubeOwner === batchTrack)
+                ) {
+                    batchTrack.entity = batchTrack.entity.copy(youtubeId = snapshotYtId)
+                    byYoutubeId[snapshotYtId] = batchTrack
+                }
+
+                val snapshotArt = snapshot.albumArtUrl
+                if (!snapshotArt.isNullOrBlank() && snapshotArt != batchTrack.entity.albumArtUrl) {
+                    batchTrack.entity = batchTrack.entity.copy(albumArtUrl = snapshotArt)
+                }
+                newOccurrences.add(batchTrack to snapshot)
+            } else {
+                enrichExistingBatchTrack(batchTrack, snapshot)
+                existingPairs.add(batchTrack to snapshot)
             }
         }
 
         // ── Bulk insert new tracks ───────────────────────────────────────
         // Room's insertAll returns generated row ids in the same order as
         // the input list.
-        val newTrackIds = if (newEntities.isNotEmpty()) trackDao.insertAll(newEntities) else emptyList()
+        val newTrackIds = if (newTracks.isNotEmpty()) {
+            trackDao.insertAll(newTracks.map { it.entity })
+        } else {
+            emptyList()
+        }
+        check(newTrackIds.size == newTracks.size) {
+            "Expected ${newTracks.size} generated track ids, got ${newTrackIds.size}"
+        }
+        newTracks.zip(newTrackIds).forEach { (track, trackId) ->
+            track.persistedId = trackId
+        }
 
-        val crossRefsToInsert = mutableListOf<PlaylistTrackCrossRef>()
+        val crossRefsToInsert = linkedMapOf<Long, PlaylistTrackCrossRef>()
         val downloadEntries = mutableListOf<DownloadQueueEntity>()
-        var newTrackCount = 0
 
-        newTrackIds.forEachIndexed { index, trackId ->
-            val snapshot = newSnapshots[index]
+        for ((batchTrack, snapshot) in newOccurrences) {
+            val trackId = checkNotNull(batchTrack.persistedId)
             addCrossRefIfNotSoftDeleted(localPlaylist.id, trackId, snapshot.position, existingCrossRefs, crossRefsToInsert)
-            if (!streamingMode) {
+        }
+
+        if (!streamingMode) {
+            for (batchTrack in newTracks) {
+                val trackId = checkNotNull(batchTrack.persistedId)
                 downloadEntries.add(
                     DownloadQueueEntity(
                         trackId = trackId,
                         syncId = syncId,
-                        searchQuery = "${snapshot.artist} - ${snapshot.title}",
-                        youtubeUrl = snapshot.youtubeId?.let { "https://music.youtube.com/watch?v=$it" },
+                        searchQuery = "${batchTrack.entity.artist} - ${batchTrack.entity.title}",
+                        youtubeUrl = batchTrack.entity.youtubeId?.let {
+                            "https://music.youtube.com/watch?v=$it"
+                        },
                     )
                 )
             }
-            newTrackCount++
         }
+        val newTrackCount = newTracks.size
 
         // ── Existing-track path: membership + enrichment ─────────────────
         // Enrichment writes (youtubeId backfill, art refresh, auto-
         // reconciliation) stay per-row — they're targeted single-column
         // UPDATEs, not the insert flood that caused the slowdown.
-        for ((existingTrack, snapshot) in existingPairs) {
+        for ((batchTrack, snapshot) in existingPairs) {
+            val existingTrack = batchTrack.entity
             addCrossRefIfNotSoftDeleted(localPlaylist.id, existingTrack.id, snapshot.position, existingCrossRefs, crossRefsToInsert)
-
-            val snapshotYtId = snapshot.youtubeId
-            if (!snapshotYtId.isNullOrBlank() && existingTrack.youtubeId.isNullOrBlank()) {
-                // Guarded: a DIFFERENT track can already own this youtube_id
-                // (UNIQUE column) — e.g. one snapshot matching separate rows
-                // by spotifyUri and youtubeId. The unguarded UPDATE threw
-                // SQLiteConstraintException and failed the entire diff.
-                val applied = trackDao.updateYoutubeIdIfUnclaimed(existingTrack.id, snapshotYtId)
-                if (applied == 1) {
-                    val ytUrl = "https://music.youtube.com/watch?v=$snapshotYtId"
-                    downloadQueueDao.fillMissingYoutubeUrlForTrack(existingTrack.id, ytUrl)
-                }
-            }
-
-            val snapshotArt = snapshot.albumArtUrl
-            if (!snapshotArt.isNullOrBlank() && snapshotArt != existingTrack.albumArtUrl) {
-                trackDao.updateAlbumArtUrl(existingTrack.id, snapshotArt)
-            }
 
             if (!existingTrack.isDownloaded && !existingTrack.matchDismissed) {
                 val downloadedMatch = trackDao.findDownloadedByCanonical(
@@ -489,7 +572,7 @@ class DiffWorker @AssistedInject constructor(
 
         // ── Flush batched writes ─────────────────────────────────────────
         if (crossRefsToInsert.isNotEmpty()) {
-            playlistDao.insertAllCrossRefs(crossRefsToInsert)
+            playlistDao.insertAllCrossRefs(crossRefsToInsert.values.toList())
         }
         if (downloadEntries.isNotEmpty()) {
             downloadQueueDao.insertAll(downloadEntries)
@@ -521,20 +604,19 @@ class DiffWorker @AssistedInject constructor(
         trackId: Long,
         position: Int,
         existingByTrackId: Map<Long, PlaylistTrackCrossRef>,
-        out: MutableList<PlaylistTrackCrossRef>,
+        out: MutableMap<Long, PlaylistTrackCrossRef>,
     ) {
-        val prior = existingByTrackId[trackId]
-        if (prior != null && prior.removedAt != null) {
+        val storedPrior = existingByTrackId[trackId]
+        if (storedPrior != null && storedPrior.removedAt != null) {
             Log.d(TAG, "Skipping re-link for soft-deleted track $trackId in playlist $playlistId (user removed it)")
             return
         }
-        out.add(
-            PlaylistTrackCrossRef(
-                playlistId = playlistId,
-                trackId = trackId,
-                position = position,
-                addedAt = prior?.addedAt ?: java.time.Instant.now(),
-            )
+        val batchPrior = out[trackId]
+        out[trackId] = PlaylistTrackCrossRef(
+            playlistId = playlistId,
+            trackId = trackId,
+            position = position,
+            addedAt = batchPrior?.addedAt ?: storedPrior?.addedAt ?: java.time.Instant.now(),
         )
     }
 

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
@@ -21,10 +21,12 @@ import com.stash.core.data.repository.MusicRepository
 import com.stash.core.data.sync.SyncPreferencesManager
 import com.stash.core.data.sync.SyncStateManager
 import com.stash.core.data.sync.TrackMatcher
+import com.stash.core.model.DownloadStatus
 import com.stash.core.model.MusicSource
 import com.stash.core.model.PlaylistType
 import com.stash.core.model.SyncMode
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
@@ -223,6 +225,304 @@ class DiffWorkerTest {
         assertEquals(1, crossRefs.size)
         assertEquals("spotifyUri match must win", bySpotify, crossRefs.single().trackId)
         assertEquals("no new track should be inserted — matched existing", 3, trackDao.getAllForIntegrityScan().size)
+    }
+
+    @Test
+    fun `duplicate new Spotify URI reuses one track and keeps the last playlist position`() = runBlocking {
+        coEvery { streamingPreference.current() } returns true
+        every { syncPreferencesManager.spotifySyncMode } returns flowOf(SyncMode.ACCUMULATE)
+        val playlistId = db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Duplicates", source = MusicSource.SPOTIFY,
+                sourceId = "spotify:playlist:duplicates", type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val snapshot = RemotePlaylistSnapshotEntity(
+            id = 5L, syncId = 1L, source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "spotify:playlist:duplicates",
+            playlistName = "Duplicates", playlistType = PlaylistType.CUSTOM,
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(snapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(5L) } returns listOf(
+            RemoteTrackSnapshotEntity(
+                id = 51L, syncId = 1L, snapshotPlaylistId = 5L,
+                title = "Repeated Song", artist = "Artist",
+                spotifyUri = "spotify:track:repeat", position = 1,
+            ),
+            RemoteTrackSnapshotEntity(
+                id = 52L, syncId = 1L, snapshotPlaylistId = 5L,
+                title = "Provider Renamed Song", artist = "Different Artist",
+                spotifyUri = "spotify:track:repeat", position = 7,
+            ),
+        )
+        val result = buildWorker().doWork()
+
+        assertTrue("duplicate provider identities must not fail the diff", result is androidx.work.ListenableWorker.Result.Success)
+        val tracks = db.trackDao().getAllForIntegrityScan()
+        assertEquals("one provider identity creates one track row", 1, tracks.size)
+        assertEquals("spotify:track:repeat", tracks.single().spotifyUri)
+        val crossRefs = db.playlistDao().getCrossRefsForPlaylist(playlistId)
+        assertEquals("one track has one membership row in the current schema", 1, crossRefs.size)
+        assertEquals("duplicate membership keeps the existing last-occurrence behavior", 7, crossRefs.single().position)
+        assertEquals("only one new track is reported", 1, result.outputData.getInt(DiffWorker.KEY_NEW_TRACKS, -1))
+        coVerify(exactly = 0) { downloadQueueDao.insertAll(any()) }
+    }
+
+    @Test
+    fun `duplicate new YouTube ID queues one offline download`() = runBlocking {
+        every { syncPreferencesManager.youtubeSyncMode } returns flowOf(SyncMode.ACCUMULATE)
+        val playlistId = db.playlistDao().insert(
+            PlaylistEntity(
+                name = "YouTube Duplicates", source = MusicSource.YOUTUBE,
+                sourceId = "youtube:playlist:duplicates", type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val snapshot = RemotePlaylistSnapshotEntity(
+            id = 6L, syncId = 1L, source = MusicSource.YOUTUBE,
+            sourcePlaylistId = "youtube:playlist:duplicates",
+            playlistName = "YouTube Duplicates", playlistType = PlaylistType.CUSTOM,
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(snapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(6L) } returns listOf(
+            RemoteTrackSnapshotEntity(
+                id = 61L, syncId = 1L, snapshotPlaylistId = 6L,
+                title = "Repeated Video", artist = "Artist",
+                youtubeId = "repeat-video", position = 2,
+            ),
+            RemoteTrackSnapshotEntity(
+                id = 62L, syncId = 1L, snapshotPlaylistId = 6L,
+                title = "Provider Renamed Video", artist = "Different Artist",
+                youtubeId = "repeat-video", position = 9,
+            ),
+        )
+
+        val result = buildWorker().doWork()
+
+        assertTrue("duplicate YouTube identities must not fail the diff", result is androidx.work.ListenableWorker.Result.Success)
+        val storedTrack = db.trackDao().getAllForIntegrityScan().single()
+        assertEquals(9, db.playlistDao().getCrossRefsForPlaylist(playlistId).single().position)
+        assertEquals(1, result.outputData.getInt(DiffWorker.KEY_NEW_TRACKS, -1))
+        coVerify(exactly = 1) {
+            downloadQueueDao.insertAll(match { entries ->
+                entries.size == 1 &&
+                    entries.single().trackId == storedTrack.id &&
+                    entries.single().syncId == 1L &&
+                    entries.single().status == DownloadStatus.PENDING &&
+                    entries.single().youtubeUrl == "https://music.youtube.com/watch?v=repeat-video"
+            })
+        }
+    }
+
+    @Test
+    fun `canonical-only duplicates create one offline track and queue entry`() = runBlocking {
+        every { syncPreferencesManager.spotifySyncMode } returns flowOf(SyncMode.ACCUMULATE)
+        val playlistId = db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Canonical Duplicates", source = MusicSource.SPOTIFY,
+                sourceId = "spotify:playlist:canonical-duplicates", type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val snapshot = RemotePlaylistSnapshotEntity(
+            id = 10L, syncId = 1L, source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "spotify:playlist:canonical-duplicates",
+            playlistName = "Canonical Duplicates", playlistType = PlaylistType.CUSTOM,
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(snapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(10L) } returns listOf(
+            RemoteTrackSnapshotEntity(
+                id = 101L, syncId = 1L, snapshotPlaylistId = 10L,
+                title = "Canonical Song", artist = "The Artist", position = 4,
+            ),
+            RemoteTrackSnapshotEntity(
+                id = 102L, syncId = 1L, snapshotPlaylistId = 10L,
+                title = "Canonical Song", artist = "The Artist", position = 6,
+            ),
+        )
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals(1, db.trackDao().getAllForIntegrityScan().size)
+        assertEquals(6, db.playlistDao().getCrossRefsForPlaylist(playlistId).single().position)
+        assertEquals(1, result.outputData.getInt(DiffWorker.KEY_NEW_TRACKS, -1))
+        coVerify(exactly = 1) {
+            downloadQueueDao.insertAll(match { it.size == 1 })
+        }
+    }
+
+    @Test
+    fun `blank provider IDs are stored as missing and do not merge unrelated tracks`() = runBlocking {
+        coEvery { streamingPreference.current() } returns true
+        every { syncPreferencesManager.spotifySyncMode } returns flowOf(SyncMode.ACCUMULATE)
+        db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Blank IDs", source = MusicSource.SPOTIFY,
+                sourceId = "spotify:playlist:blank-ids", type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val snapshot = RemotePlaylistSnapshotEntity(
+            id = 7L, syncId = 1L, source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "spotify:playlist:blank-ids",
+            playlistName = "Blank IDs", playlistType = PlaylistType.CUSTOM,
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(snapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(7L) } returns listOf(
+            RemoteTrackSnapshotEntity(
+                id = 71L, syncId = 1L, snapshotPlaylistId = 7L,
+                title = "First Song", artist = "First Artist",
+                spotifyUri = " ", youtubeId = "", position = 0,
+            ),
+            RemoteTrackSnapshotEntity(
+                id = 72L, syncId = 1L, snapshotPlaylistId = 7L,
+                title = "Second Song", artist = "Second Artist",
+                spotifyUri = "", youtubeId = " ", position = 1,
+            ),
+        )
+
+        val result = buildWorker().doWork()
+        val tracks = db.trackDao().getAllForIntegrityScan()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals("different canonical identities stay distinct", 2, tracks.size)
+        assertTrue(tracks.all { it.spotifyUri == null && it.youtubeId == null })
+    }
+
+    @Test
+    fun `canonical identity keeps title and artist delimiters separate`() = runBlocking {
+        coEvery { streamingPreference.current() } returns true
+        every { syncPreferencesManager.spotifySyncMode } returns flowOf(SyncMode.ACCUMULATE)
+        db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Delimiter IDs", source = MusicSource.SPOTIFY,
+                sourceId = "spotify:playlist:delimiter-ids", type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val snapshot = RemotePlaylistSnapshotEntity(
+            id = 9L, syncId = 1L, source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "spotify:playlist:delimiter-ids",
+            playlistName = "Delimiter IDs", playlistType = PlaylistType.CUSTOM,
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(snapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(9L) } returns listOf(
+            RemoteTrackSnapshotEntity(
+                id = 91L, syncId = 1L, snapshotPlaylistId = 9L,
+                title = "A|B", artist = "C", position = 0,
+            ),
+            RemoteTrackSnapshotEntity(
+                id = 92L, syncId = 1L, snapshotPlaylistId = 9L,
+                title = "A", artist = "B|C", position = 1,
+            ),
+        )
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals(
+            "canonical pairs must not collide through their query-string encoding",
+            2,
+            db.trackDao().getAllForIntegrityScan().size,
+        )
+    }
+
+    @Test
+    fun `canonical query false positive is rejected by the typed in-memory key`() = runBlocking {
+        coEvery { streamingPreference.current() } returns true
+        every { syncPreferencesManager.spotifySyncMode } returns flowOf(SyncMode.ACCUMULATE)
+        val existingTrackId = db.trackDao().insert(
+            TrackEntity(
+                title = "A|B", artist = "C",
+                canonicalTitle = "a|b", canonicalArtist = "c",
+            )
+        )
+        val playlistId = db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Delimiter Candidate", source = MusicSource.SPOTIFY,
+                sourceId = "spotify:playlist:delimiter-candidate", type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val snapshot = RemotePlaylistSnapshotEntity(
+            id = 11L, syncId = 1L, source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "spotify:playlist:delimiter-candidate",
+            playlistName = "Delimiter Candidate", playlistType = PlaylistType.CUSTOM,
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(snapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(11L) } returns listOf(
+            RemoteTrackSnapshotEntity(
+                id = 111L, syncId = 1L, snapshotPlaylistId = 11L,
+                title = "A", artist = "B|C", position = 0,
+            )
+        )
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals(2, db.trackDao().getAllForIntegrityScan().size)
+        val linkedTrackId = db.playlistDao().getCrossRefsForPlaylist(playlistId).single().trackId
+        assertTrue("the delimiter collision must not select the existing row", linkedTrackId != existingTrackId)
+    }
+
+    @Test
+    fun `duplicate existing track keeps first YouTube ID final artwork and original addedAt`() = runBlocking {
+        coEvery { streamingPreference.current() } returns true
+        every { syncPreferencesManager.spotifySyncMode } returns flowOf(SyncMode.ACCUMULATE)
+        val trackId = db.trackDao().insert(
+            TrackEntity(
+                title = "Mutable", artist = "Artist",
+                spotifyUri = "spotify:track:mutable",
+                albumArtUrl = "https://cdn.example/original.jpg",
+                canonicalTitle = "mutable", canonicalArtist = "artist",
+            )
+        )
+        val playlistId = db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Mutable State", source = MusicSource.SPOTIFY,
+                sourceId = "spotify:playlist:mutable", type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val originalAddedAt = Instant.parse("2024-01-01T00:00:00Z")
+        db.playlistDao().insertCrossRef(
+            PlaylistTrackCrossRef(
+                playlistId = playlistId, trackId = trackId, position = 0,
+                addedAt = originalAddedAt,
+            )
+        )
+        val snapshot = RemotePlaylistSnapshotEntity(
+            id = 8L, syncId = 1L, source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "spotify:playlist:mutable",
+            playlistName = "Mutable State", playlistType = PlaylistType.CUSTOM,
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(snapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(8L) } returns listOf(
+            RemoteTrackSnapshotEntity(
+                id = 81L, syncId = 1L, snapshotPlaylistId = 8L,
+                title = "Mutable", artist = "Artist",
+                spotifyUri = "spotify:track:mutable", youtubeId = "first-video",
+                albumArtUrl = "https://cdn.example/alternate.jpg", position = 3,
+            ),
+            RemoteTrackSnapshotEntity(
+                id = 82L, syncId = 1L, snapshotPlaylistId = 8L,
+                title = "Mutable", artist = "Artist",
+                spotifyUri = "spotify:track:mutable", youtubeId = "second-video",
+                albumArtUrl = "https://cdn.example/original.jpg", position = 8,
+            ),
+        )
+
+        val result = buildWorker().doWork()
+        val storedTrack = db.trackDao().getById(trackId)
+        val membership = db.playlistDao().getCrossRef(playlistId, trackId)
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals("first nonblank YouTube ID wins", "first-video", storedTrack?.youtubeId)
+        assertEquals("last nonblank artwork wins", "https://cdn.example/original.jpg", storedTrack?.albumArtUrl)
+        assertEquals(originalAddedAt, membership?.addedAt)
+        assertEquals(8, membership?.position)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- register newly staged tracks in the per-playlist identity maps so duplicate Spotify URIs, YouTube IDs, and canonical identities reuse one pending row
- accumulate memberships and download jobs per persisted track, preserving first `addedAt`, last occurrence position, and mutable YouTube/art enrichment
- normalize blank provider IDs and use typed in-memory canonical keys to avoid UNIQUE/FK failures and delimiter collisions

## Test plan
- [x] `./gradlew :core:data:testDebugUnitTest --tests com.stash.core.data.sync.workers.DiffWorkerTest` (17 tests passed)
- [x] Red/green regression reproduced the original duplicate-provider SQLite FK failure before the fix
- [x] Full `:core:data:testDebugUnitTest` run: 539/544 passed; the 5 failures below reproduce identically on clean `origin/master` and are unrelated to this diff:
  - `DiscoveryQueueDaoFairnessTest.getPendingForRecipe returns up to limit oldest-first`
  - `TrackDaoStreamableTest.getByPlaylist excludes unavailable even when streamable true`
  - `MusicRepositoryDownloadsMixTest.linkTrackToDownloadsMix seeds then adds track when no existing link`
  - two existing `StashDiscoveryWorkerStreamOnlyTest` failures

Follow-up to the SQLite 787 sync failures reported in #343.