### PR TITLE
fix(sync): chunk the batch identity lookup under SQLite's 999-bind cap

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -10,6 +10,16 @@ import com.stash.core.data.db.entity.TrackEntity
 import kotlinx.coroutines.flow.Flow
 
 /**
+ * Max IN() keys per dimension in one [TrackDao.findExistingForBatchRaw] call.
+ * Android <= 11 caps a statement at 999 bind variables; 800 + two sentinel
+ * pads keeps every chunked query comfortably under it.
+ */
+private const val BATCH_BIND_LIMIT = 800
+
+/** Never-match pad for unused dimensions in a chunked batch query. */
+private const val BATCH_NEVER_MATCH = "\u0000__stash_never_match__"
+
+/**
  * Summary projection for artist browsing.
  *
  * @property artist  Artist name.
@@ -384,6 +394,11 @@ interface TrackDao {
      * SQLite `IN ()` clause is a syntax error. Pass a sentinel value
      * (e.g. a value guaranteed not to appear in real data) instead of an
      * empty list when a caller has no identifiers of that kind.
+     *
+     * Do not call this directly — use [findExistingForBatch], which chunks
+     * the key lists so no single query exceeds SQLite's bind-variable cap
+     * (999 on Android <= 11; a ~500-track playlist blows it and the whole
+     * sync fails with "too many SQL variables" — issue #337).
      */
     @Query(
         """
@@ -393,11 +408,39 @@ interface TrackDao {
            OR (canonical_title || '|' || canonical_artist) IN (:canonicalKeys)
         """
     )
-    suspend fun findExistingForBatch(
+    suspend fun findExistingForBatchRaw(
         spotifyUris: List<String>,
         youtubeIds: List<String>,
         canonicalKeys: List<String>,
     ): List<TrackEntity>
+
+    /**
+     * Bind-safe wrapper for [findExistingForBatchRaw]: when the combined key
+     * count fits one query it passes straight through; otherwise each
+     * dimension is queried in chunks (other dimensions padded with a
+     * never-match sentinel) and the results are unioned by id.
+     */
+    suspend fun findExistingForBatch(
+        spotifyUris: List<String>,
+        youtubeIds: List<String>,
+        canonicalKeys: List<String>,
+    ): List<TrackEntity> {
+        if (spotifyUris.size + youtubeIds.size + canonicalKeys.size <= BATCH_BIND_LIMIT) {
+            return findExistingForBatchRaw(spotifyUris, youtubeIds, canonicalKeys)
+        }
+        val pad = listOf(BATCH_NEVER_MATCH)
+        val byId = LinkedHashMap<Long, TrackEntity>()
+        spotifyUris.chunked(BATCH_BIND_LIMIT).forEach { chunk ->
+            findExistingForBatchRaw(chunk, pad, pad).forEach { byId[it.id] = it }
+        }
+        youtubeIds.chunked(BATCH_BIND_LIMIT).forEach { chunk ->
+            findExistingForBatchRaw(pad, chunk, pad).forEach { byId[it.id] = it }
+        }
+        canonicalKeys.chunked(BATCH_BIND_LIMIT).forEach { chunk ->
+            findExistingForBatchRaw(pad, pad, chunk).forEach { byId[it.id] = it }
+        }
+        return byId.values.toList()
+    }
 
     /** Find a track by primary key. */
     @Query("SELECT * FROM tracks WHERE id = :trackId LIMIT 1")

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackDaoFindExistingForBatchTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/TrackDaoFindExistingForBatchTest.kt
@@ -81,4 +81,56 @@ class TrackDaoFindExistingForBatchTest {
 
         assertTrue(result.isEmpty())
     }
+
+    @Test fun `oversized key sets stay under the SQLite bind limit and lose no matches`() = runTest {
+        // Issue #337: Android <= 11 ships SQLite with a 999 bind-variable cap.
+        // A ~500-track playlist produces >999 IN() variables in one query and
+        // sync dies with "too many SQL variables". Robolectric's SQLite is too
+        // new to enforce the cap, so assert on observed bind counts instead.
+        var maxSelectBinds = 0
+        val watchedDb = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .setQueryCallback(
+                { sqlQuery, bindArgs ->
+                    if (sqlQuery.trimStart().startsWith("SELECT", ignoreCase = true)) {
+                        maxSelectBinds = maxOf(maxSelectBinds, bindArgs.size)
+                    }
+                },
+                Runnable::run,
+            )
+            .build()
+        try {
+            val watchedDao = watchedDb.trackDao()
+            // Rows 0..899 are queried by spotify_uri and youtube_id; rows
+            // 900..999 ONLY by canonical key — they can only be found by a
+            // later chunk, so a dropped or unmerged chunk fails the test.
+            watchedDao.insertAll(
+                (0 until 1000).map { i ->
+                    TrackEntity(
+                        title = "T$i", artist = "A$i",
+                        spotifyUri = "spotify:track:$i", youtubeId = "yt$i",
+                        canonicalTitle = "t$i", canonicalArtist = "a$i",
+                    )
+                }
+            )
+
+            val result = watchedDao.findExistingForBatch(
+                spotifyUris = (0 until 900).map { "spotify:track:$it" },
+                youtubeIds = (0 until 900).map { "yt$it" },
+                canonicalKeys = (900 until 1000).map { "t$it|a$it" },
+            )
+
+            assertEquals(1000, result.size)
+            assertEquals(1000, result.map { it.id }.distinct().size)
+            assertTrue(
+                "a single SELECT bound $maxSelectBinds variables (device limit is 999)",
+                maxSelectBinds <= 999,
+            )
+        } finally {
+            watchedDb.close()
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Second half of the #337 sync failures. The batched identity lookup added in #307 binds one SQL variable per key across three `IN()` lists — about 2× playlist size + 1 — so any ~500-track playlist exceeds the **999 bind-variable cap on Android ≤ 11** (SQLite < 3.32) and the whole sync aborts with `too many SQL variables (code 1 SQLITE_ERROR)`. Devices on Android 12+ (cap 32,766) never hit it, which is why reports split by device: the Redmi Note 8 Pro (Android 11) diagnostics show this error while the OnePlus (Android 16) shows only the FK failure.

## Fix

`TrackDao` only — no conflict with #355/#357:

- the raw `@Query` becomes `findExistingForBatchRaw`
- `findExistingForBatch` is now a default-method wrapper: small key sets pass straight through (one query, same as today); oversized sets are queried per dimension in 800-key chunks (other dimensions padded with the never-match sentinel) and unioned by id

## Test plan

- [x] New regression test observes per-SELECT bind counts via Room's `setQueryCallback` (Robolectric's bundled SQLite is too new to enforce the device cap) — red on master (1900 binds in one SELECT), green with the chunked wrapper; rows findable only via a later chunk prove union completeness
- [x] `:core:data:testDebugUnitTest --tests DiffWorkerTest --tests TrackDaoFindExistingForBatchTest` green on this branch
- [x] Same filters green with this change stacked on #357's DiffWorker dedupe fix (the two compose; both are needed to fully close #337)

🤖 Generated with [Claude Code](https://claude.com/claude-code)