### PR TITLE
fix(sync): reject cross-identity merges when canonical match carries a conflicting provider ID

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
@@ -399,20 +399,42 @@ class DiffWorker @AssistedInject constructor(
         }
         val bySpotifyUri = mutableMapOf<String, BatchTrack>()
         val byYoutubeId = mutableMapOf<String, BatchTrack>()
-        val byCanonical = mutableMapOf<CanonicalKey, BatchTrack>()
+        // A canonical key can legitimately map to MULTIPLE rows — e.g. two
+        // distinct YouTube uploads of "the same song" that arrive with
+        // different videoIds. A single-value map here would collapse them
+        // into one row, silently discarding the second identity.
+        val byCanonical = mutableMapOf<CanonicalKey, MutableList<BatchTrack>>()
 
         fun registerBatchTrack(track: BatchTrack) {
             track.entity.spotifyUri?.takeIf(String::isNotBlank)?.let { bySpotifyUri[it] = track }
             track.entity.youtubeId?.takeIf(String::isNotBlank)?.let { byYoutubeId[it] = track }
-            byCanonical[
-                CanonicalKey(
-                    title = track.entity.canonicalTitle,
-                    artist = track.entity.canonicalArtist,
-                )
-            ] = track
+            val canonicalKey = CanonicalKey(
+                title = track.entity.canonicalTitle,
+                artist = track.entity.canonicalArtist,
+            )
+            val canonicalMatches = byCanonical.getOrPut(canonicalKey) { mutableListOf() }
+            if (canonicalMatches.none { it === track }) {
+                canonicalMatches.add(track)
+            }
         }
 
         candidateTracks.values.forEach(::registerBatchTrack)
+
+        // A canonical-title/artist match is only safe to reuse when neither
+        // side's strong identifiers actively disagree. Without this, two
+        // tracks that share a title/artist but carry different spotifyUri
+        // or youtubeId values would incorrectly merge into a single row —
+        // e.g. two different YouTube uploads of the same song.
+        fun strongIdsCompatible(
+            track: BatchTrack,
+            snapshot: RemoteTrackSnapshotEntity,
+        ): Boolean {
+            fun compatible(stored: String?, incoming: String?): Boolean =
+                stored.isNullOrBlank() || incoming.isNullOrBlank() || stored == incoming
+
+            return compatible(track.entity.spotifyUri, snapshot.spotifyUri) &&
+                compatible(track.entity.youtubeId, snapshot.youtubeId)
+        }
 
         fun matchBatchTrack(snapshot: RemoteTrackSnapshotEntity): BatchTrack? {
             snapshot.spotifyUri?.takeIf(String::isNotBlank)?.let { uri ->
@@ -421,7 +443,9 @@ class DiffWorker @AssistedInject constructor(
             snapshot.youtubeId?.takeIf(String::isNotBlank)?.let { yid ->
                 byYoutubeId[yid]?.let { return it }
             }
-            return byCanonical[canonicalOf.getValue(snapshot)]
+            return byCanonical[canonicalOf.getValue(snapshot)]?.firstOrNull {
+                strongIdsCompatible(it, snapshot)
+            }
         }
 
         suspend fun enrichExistingBatchTrack(

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
@@ -316,6 +316,122 @@ class DiffWorkerTest {
     }
 
     @Test
+    fun `distinct YouTube IDs with the same canonical metadata stay separate`() = runBlocking {
+        db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Strong IDs",
+                source = MusicSource.YOUTUBE,
+                sourceId = "youtube:playlist:strong-ids",
+                type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val playlistSnapshot = RemotePlaylistSnapshotEntity(
+            id = 6L,
+            syncId = 1L,
+            source = MusicSource.YOUTUBE,
+            sourcePlaylistId = "youtube:playlist:strong-ids",
+            playlistName = "Strong IDs",
+            playlistType = PlaylistType.CUSTOM,
+        )
+        val snapshots = listOf(
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 6L,
+                title = "Same Song",
+                artist = "Artist",
+                youtubeId = "video-one",
+                position = 0,
+            ),
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 6L,
+                title = "Same Song",
+                artist = "Artist",
+                youtubeId = "video-two",
+                position = 1,
+            ),
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(playlistSnapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(6L) } returns snapshots
+        coEvery { streamingPreference.current() } returns true
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals(2, db.trackDao().getAllForIntegrityScan().size)
+        assertEquals(
+            setOf("video-one", "video-two"),
+            db.trackDao().getAllForIntegrityScan().mapNotNull { it.youtubeId }.toSet(),
+        )
+        val playlist = requireNotNull(db.playlistDao().findBySourceId("youtube:playlist:strong-ids"))
+        assertEquals(2, db.playlistDao().getCrossRefsForPlaylist(playlist.id).size)
+    }
+
+    @Test
+    fun `existing canonical match reserves its first YouTube identity`() = runBlocking {
+        val existingId = db.trackDao().insert(
+            TrackEntity(
+                title = "Same Song",
+                artist = "Artist",
+                canonicalTitle = "same song",
+                canonicalArtist = "artist",
+                source = MusicSource.SPOTIFY,
+                spotifyUri = "spotify:track:existing",
+            )
+        )
+        db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Identity Backfill",
+                source = MusicSource.YOUTUBE,
+                sourceId = "youtube:playlist:identity-backfill",
+                type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+        val playlistSnapshot = RemotePlaylistSnapshotEntity(
+            id = 7L,
+            syncId = 1L,
+            source = MusicSource.YOUTUBE,
+            sourcePlaylistId = "youtube:playlist:identity-backfill",
+            playlistName = "Identity Backfill",
+            playlistType = PlaylistType.CUSTOM,
+        )
+        val snapshots = listOf(
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 7L,
+                title = "Same Song",
+                artist = "Artist",
+                youtubeId = "video-one",
+                position = 0,
+            ),
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = 7L,
+                title = "Same Song",
+                artist = "Artist",
+                youtubeId = "video-two",
+                position = 1,
+            ),
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(playlistSnapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(7L) } returns snapshots
+        coEvery { streamingPreference.current() } returns true
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals("video-one", db.trackDao().getById(existingId)?.youtubeId)
+        assertEquals(
+            setOf("video-one", "video-two"),
+            db.trackDao().getAllForIntegrityScan().mapNotNull { it.youtubeId }.toSet(),
+        )
+        val playlist = requireNotNull(db.playlistDao().findBySourceId("youtube:playlist:identity-backfill"))
+        assertEquals(2, db.playlistDao().getCrossRefsForPlaylist(playlist.id).size)
+    }
+
+    @Test
     fun `canonical-only duplicates create one offline track and queue entry`() = runBlocking {
         every { syncPreferencesManager.spotifySyncMode } returns flowOf(SyncMode.ACCUMULATE)
         val playlistId = db.playlistDao().insert(


### PR DESCRIPTION
## Summary
- Follow-up to #357 — restores the `strongIdsCompatible` guard from #355 that didn't make it into the merged fix, so a canonical-title/artist match is only reused when neither snapshot's spotifyUri/youtubeId actively conflicts with what's already stored on that row.
- Without the guard, two distinct YouTube uploads of the same song (same canonical title/artist, different videoIds) collapse into a single track row instead of staying separate — the second identity's videoId is silently dropped.
- `byCanonical` changes from a single-value map to a list per canonical key, since a canonical key can now legitimately resolve to more than one row.

## Root cause
`DiffWorker`'s bulk identity resolution matches a new/incoming snapshot against in-batch and in-DB candidates in priority order: spotifyUri → youtubeId → canonical identity. The canonical fallback in master takes whatever `BatchTrack` last registered under that (title, artist) key with no compatibility check — so if two snapshots share a canonical key but carry different youtubeIds, the second snapshot's canonical lookup returns the first snapshot's row and merges into it, discarding its own youtubeId.

## Changes
- `core/data/.../sync/workers/DiffWorker.kt`
  - `byCanonical` is now `MutableMap<CanonicalKey, MutableList<BatchTrack>>`
    instead of a single-value map.
  - `registerBatchTrack` appends to the per-key list instead of
    overwriting it.
  - New `strongIdsCompatible(track, snapshot)` — true only when neither
    side's spotifyUri/youtubeId is non-blank AND disagrees with the other.
  - `matchBatchTrack`'s canonical fallback now filters candidates through
    `strongIdsCompatible` via `firstOrNull { ... }` instead of returning
    an unconditional single match.
- `core/data/.../sync/workers/DiffWorkerTest.kt`
  - Added `distinct YouTube IDs with the same canonical metadata stay separate`
  - Added `existing canonical match reserves its first YouTube identity`

## Test plan
- [x] `./gradlew :core:data:testDebugUnitTest --tests com.stash.core.data.sync.workers.DiffWorkerTest` — full suite passes, including the two new regression tests
- [x] `./gradlew :app:compileDebugKotlin`
- [x] Device / Android version tested: S26u/Android 16