### PR TITLE
fix(sync): followed "Made For You" playlists were dropped by the spotify-owner filter

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorker.kt
@@ -65,6 +65,28 @@ internal fun shouldDeactivateMissingSpotifyPlaylists(
     inventoryComplete: Boolean,
 ): Boolean = syncMode == SyncMode.REFRESH && inventoryComplete
 
+private val DAILY_MIX_NAME = Regex("""Daily Mix \d+""")
+
+/**
+ * Whether a `libraryV3` row should be snapshotted as a user playlist.
+ *
+ * libraryV3 lists what the user actually SAVED, so ownership says nothing
+ * about whether they want it synced: a followed "Made For You" playlist —
+ * a friend's Discover Weekly or Release Radar — is owned by "spotify" but
+ * never appears in the user's OWN home feed, so the old
+ * `owner != "spotify"` filter dropped it here and no other pass picked it
+ * up (issue #354).
+ *
+ * Skip only what the home-feed mix pass already snapshotted this run
+ * ([homeFeedMixIds]), plus "Daily Mix N" by name so the home feed stays
+ * the single source of those even when the sp_dc call behind it fails.
+ */
+internal fun keepAsLibraryPlaylist(
+    id: String,
+    name: String,
+    homeFeedMixIds: Set<String>,
+): Boolean = id !in homeFeedMixIds && !DAILY_MIX_NAME.matches(name)
+
 /**
  * First worker in the sync chain. Authenticates with configured music services,
  * fetches playlist and track metadata, and writes everything to the remote
@@ -276,6 +298,9 @@ class PlaylistFetchWorker @AssistedInject constructor(
         Log.d(TAG, "fetchSpotifyPlaylists: starting for syncId=$syncId")
         var dailyMixCount = 0
         var likedSongCount = 0
+        // Ids covered by the home-feed mix pass below; the library walk
+        // excludes exactly these instead of everything spotify owns (#354).
+        val homeFeedMixIds = mutableSetOf<String>()
 
         // Fetch Daily Mixes (sp_dc dependent -- may return empty if GraphQL fails).
         try {
@@ -286,6 +311,7 @@ class PlaylistFetchWorker @AssistedInject constructor(
                     Log.d(TAG, "fetchSpotifyPlaylists: found ${dailyMixes.size} daily mixes")
 
                     for (mix in dailyMixes) {
+                        homeFeedMixIds += mix.id
                         try {
                             val mixNumber = Regex("""\d+""").find(mix.name)?.value?.toIntOrNull()
                             val playlistSnapshotId = remoteSnapshotDao.insertPlaylistSnapshot(
@@ -514,12 +540,11 @@ class PlaylistFetchWorker @AssistedInject constructor(
                 "fetchSpotifyPlaylists: paged ${userPlaylists.size} playlists across " +
                     "$pagesFetched page(s), $foldersWalked folder(s) descended",
             )
-            // Filter out daily mixes (already handled above) and any Spotify-owned playlists.
+            // Drop only what the home-feed mix pass already covered (#354).
             // distinctBy: defensive — a playlist must not snapshot twice even if
             // Spotify ever lists it both at the root and inside a folder.
             val customPlaylists = userPlaylists.distinctBy { it.id }.filter { playlist ->
-                !playlist.owner.id.equals("spotify", ignoreCase = true) &&
-                    !playlist.name.matches(Regex("""Daily Mix \d+"""))
+                keepAsLibraryPlaylist(playlist.id, playlist.name, homeFeedMixIds)
             }
             Log.d(TAG, "fetchSpotifyPlaylists: found ${customPlaylists.size} user playlists (filtered from ${userPlaylists.size})")
 

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/LibraryPlaylistKeepTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/LibraryPlaylistKeepTest.kt
@@ -1,0 +1,49 @@
+package com.stash.core.data.sync.workers
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Contract tests for [keepAsLibraryPlaylist], the keep-check applied to the
+ * `libraryV3` walk.
+ *
+ * Issue #354: the old check was `owner != "spotify"`, which dropped a
+ * FOLLOWED "Made For You" playlist (a friend's Discover Weekly / Release
+ * Radar). Those are spotify-owned but absent from the user's own home feed,
+ * so nothing else in the sync picked them up. The keep-check is now about
+ * what the home-feed pass already covered, not about who owns the row.
+ */
+class LibraryPlaylistKeepTest {
+
+    private val homeFeedMixIds = setOf("hf_discover_weekly", "hf_release_radar")
+
+    @Test fun `a followed friends Discover Weekly is kept`() {
+        assertThat(keepAsLibraryPlaylist("friend_dw", "Discover Weekly", homeFeedMixIds))
+            .isTrue()
+    }
+
+    @Test fun `a followed friends Release Radar is kept`() {
+        assertThat(keepAsLibraryPlaylist("friend_rr", "Release Radar", homeFeedMixIds))
+            .isTrue()
+    }
+
+    @Test fun `an ordinary user playlist is kept`() {
+        assertThat(keepAsLibraryPlaylist("road_trip", "My Road Trip", homeFeedMixIds))
+            .isTrue()
+    }
+
+    @Test fun `the users own mix already snapshotted from the home feed is skipped`() {
+        assertThat(keepAsLibraryPlaylist("hf_discover_weekly", "Discover Weekly", homeFeedMixIds))
+            .isFalse()
+    }
+
+    @Test fun `Daily Mix N is skipped by name even without a home feed hit`() {
+        assertThat(keepAsLibraryPlaylist("dm3", "Daily Mix 3", emptySet()))
+            .isFalse()
+    }
+
+    @Test fun `a name merely containing Daily Mix is kept`() {
+        assertThat(keepAsLibraryPlaylist("clone", "My Daily Mix 3 Clone", emptySet()))
+            .isTrue()
+    }
+}


### PR DESCRIPTION
Fixes #354

## The bug

`PlaylistFetchWorker.fetchSpotifyPlaylists` walks the Spotify `libraryV3` listing — everything the user actually saved or followed — and then discarded every row owned by `spotify`:

```kotlin
val customPlaylists = userPlaylists.distinctBy { it.id }.filter { playlist ->
    !playlist.owner.id.equals("spotify", ignoreCase = true) &&
        !playlist.name.matches(Regex("""Daily Mix \d+"""))
}
```

A friend's Discover Weekly or Release Radar **is** owned by `spotify`. Following it puts it in the library, `libraryV3` returns it, and this filter drops it right there.

The comment justified that with "daily mixes (already handled above)" — but the pass above reads the **home feed**, which only ever contains the user's *own* mixes, never a friend's. So a followed "Made For You" playlist fell through both passes and never appeared under "Your playlists".

This is also why the advice on the issue ("add the playlist to your Spotify library for it to sync") doesn't help: the library path is exactly where these die.

## The fix

Stop filtering on ownership; filter on what the home-feed pass actually covered. The mix pass now records the ids it snapshots in `homeFeedMixIds`, and the library walk keeps any row outside that set.

```kotlin
internal fun keepAsLibraryPlaylist(
    id: String,
    name: String,
    homeFeedMixIds: Set<String>,
): Boolean = id !in homeFeedMixIds && !DAILY_MIX_NAME.matches(name)
```

- A followed friend's Discover Weekly / Release Radar syncs as a normal `CUSTOM` playlist under "Your playlists" — what the issue asks for.
- The user's own home-feed mixes still can't double-snapshot: same playlist, same id, already in the set.
- The `Daily Mix N` name guard stays, so the home feed remains the single source of those even on a sync where the sp_dc call behind it fails.

Extracted as a top-level `internal fun` next to `shouldDeactivateMissingSpotifyPlaylists`, following the existing pure-helper pattern in this file (and `isSpotifyMix` in `SpotifyApiClient`), so the decision is JVM-testable without the worker's DI graph.

## Tests

New `LibraryPlaylistKeepTest` (6 cases): friend's Discover Weekly kept, friend's Release Radar kept, ordinary user playlist kept, own home-feed mix skipped, `Daily Mix 3` skipped without a home-feed hit, `My Daily Mix 3 Clone` kept (the regex is `matches`, not `contains`).

`:core:data:testDebugUnitTest` passes for the new file and the neighbouring `SpotifyPlaylistDeactivationGateTest`.

## Note on `deactivateMissingSpotifyCustomPlaylists`

`currentIds` now includes these spotify-owned rows. That's correct and intended — they're genuinely present in the library, so REFRESH mode should not deactivate them.

## Not covered

Dynamic playlists like Daylist, which the reporter explicitly set aside since they can't be followed from another account. This PR only changes which library rows survive the filter; it doesn't add any new fetch path.
