### PR TITLE
fix(sync): stop manual re-sync from cancelling in-flight sync + show live fetch/diff progress

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/sync/SyncPhase.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/SyncPhase.kt
@@ -25,14 +25,44 @@ sealed interface SyncPhase {
         override val progress: Float = 0.05f
     }
 
-    /** Retrieving playlist metadata from the remote source. */
-    data object FetchingPlaylists : SyncPhase {
-        override val progress: Float = 0.20f
+    /**
+     * Retrieving playlist metadata from the remote source.
+     *
+     * @property playlistsFetched Running count of playlists/mixes fetched so
+     *   far this phase. No total denominator: the true playlist count for
+     *   Spotify (folder-walked) and YouTube isn't known until the fetch
+     *   itself finishes, so this is a live counter for display ("Fetched 42
+     *   playlists…") rather than a fraction — a fabricated total would be
+     *   worse than none. [progress] still nudges forward (capped) as the
+     *   count grows so a long fetch visibly moves instead of sitting dead
+     *   at the phase's starting value.
+     */
+    data class FetchingPlaylists(
+        val playlistsFetched: Int = 0,
+    ) : SyncPhase {
+        override val progress: Float
+            get() = (0.05f + minOf(playlistsFetched, 150) * 0.001f).coerceAtMost(0.20f)
     }
 
-    /** Comparing remote snapshots against local data to find differences. */
-    data object Diffing : SyncPhase {
-        override val progress: Float = 0.25f
+    /**
+     * Comparing remote snapshots against local data to find differences.
+     *
+     * @property playlistsDiffed Playlists reconciled so far this phase.
+     * @property totalPlaylists  Total playlists to reconcile — known
+     *   upfront here (unlike fetch), since the snapshot rows already exist
+     *   in the DB by the time this phase starts.
+     */
+    data class Diffing(
+        val playlistsDiffed: Int = 0,
+        val totalPlaylists: Int = 0,
+    ) : SyncPhase {
+        override val progress: Float
+            get() {
+                val base = 0.20f
+                val span = 0.05f
+                val fraction = if (totalPlaylists > 0) playlistsDiffed.toFloat() / totalPlaylists else 0f
+                return base + span * fraction
+            }
     }
 
     /**

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/SyncScheduler.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/SyncScheduler.kt
@@ -6,6 +6,7 @@ import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.stash.core.data.sync.workers.DiffWorker
 import com.stash.core.data.sync.workers.PlaylistFetchWorker
@@ -86,6 +87,21 @@ class SyncScheduler @Inject constructor(
      * or running sync chain.
      */
     fun triggerManualSync() {
+        // Guard against re-triggering a sync that's already running. Without
+        // this, a second tap (e.g. an impatient user during a long fetch on
+        // a large library) called enqueueChain -> REPLACE, which cancels the
+        // in-flight PlaylistFetchWorker outright — every partially-completed
+        // playlist/mix fetch throws JobCancellationException and the whole
+        // chain restarts from zero. A user who taps repeatedly because sync
+        // LOOKS stalled was actually the one preventing it from ever
+        // finishing. isSyncChainActive() checks WorkManager's live state
+        // directly rather than trusting caller-side flags, so this holds
+        // even if the UI's own isSyncing guard is bypassed or stale.
+        if (isSyncChainActive()) {
+            Log.i(TAG, "Manual sync requested, but a sync is already running — ignoring")
+            return
+        }
+
         Log.i(TAG, "Manual sync triggered by user")
         // Immediately signal the UI that sync is starting so the button
         // shows progress feedback even before WorkManager picks up the work.
@@ -96,6 +112,18 @@ class SyncScheduler @Inject constructor(
             .build()
         enqueueChain(initialDelayMs = 0, constraints = constraints)
     }
+
+    /**
+     * True when [UNIQUE_WORK_NAME] has any work in a non-terminal state
+     * (ENQUEUED or RUNNING). Synchronous — WorkManager's `get...Sync()`
+     * variants block the calling thread, so this must only be called from
+     * a background-safe context (it already is here: ViewModel actions run
+     * off the main thread via viewModelScope, and this itself does no I/O
+     * beyond querying WorkManager's own DB).
+     */
+    private fun isSyncChainActive(): Boolean =
+        workManager.getWorkInfosForUniqueWork(UNIQUE_WORK_NAME).get()
+            .any { it.state == WorkInfo.State.ENQUEUED || it.state == WorkInfo.State.RUNNING }
 
     /**
      * Cancels any pending or running sync chain.

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/SyncStateManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/SyncStateManager.kt
@@ -61,14 +61,23 @@ class SyncStateManager @Inject constructor() {
         _phase.value = SyncPhase.Authenticating
     }
 
-    /** Transition to [SyncPhase.FetchingPlaylists]. */
-    fun onFetchingPlaylists() {
-        _phase.value = SyncPhase.FetchingPlaylists
+    /**
+     * Transition to (or update the live counter within) [SyncPhase.FetchingPlaylists].
+     * Safe to call repeatedly with an increasing [playlistsFetched] as the
+     * fetch worker processes each playlist/mix, so the UI shows a running
+     * count instead of an apparently-frozen bar during a long fetch.
+     */
+    fun onFetchingPlaylists(playlistsFetched: Int = 0) {
+        _phase.value = SyncPhase.FetchingPlaylists(playlistsFetched)
     }
 
-    /** Transition to [SyncPhase.Diffing]. */
-    fun onDiffing() {
-        _phase.value = SyncPhase.Diffing
+    /**
+     * Transition to (or update progress within) [SyncPhase.Diffing]. Unlike
+     * fetch, the diff worker knows its total playlist count upfront, so this
+     * reports a real fraction, not just a live count.
+     */
+    fun onDiffing(playlistsDiffed: Int = 0, totalPlaylists: Int = 0) {
+        _phase.value = SyncPhase.Diffing(playlistsDiffed, totalPlaylists)
     }
 
     /**

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
@@ -131,7 +131,9 @@ class DiffWorker @AssistedInject constructor(
             val streamingMode = streamingPreference.current()
 
             val playlistSnapshots = remoteSnapshotDao.getPlaylistSnapshotsBySyncId(syncId)
+            syncStateManager.onDiffing(playlistsDiffed = 0, totalPlaylists = playlistSnapshots.size)
             var newTrackCount = 0
+            var playlistsDiffed = 0
 
             for (playlistSnapshot in playlistSnapshots) {
                 // Pick the mode for this specific playlist's source so a
@@ -185,6 +187,8 @@ class DiffWorker @AssistedInject constructor(
                     )
                 }
                 newTrackCount += playlistNewTracks
+                playlistsDiffed++
+                syncStateManager.onDiffing(playlistsDiffed, playlistSnapshots.size)
             }
 
             // Soft-hide YouTube playlists that rotated off the home feed

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorker.kt
@@ -51,6 +51,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.time.Instant
@@ -107,6 +108,21 @@ class PlaylistFetchWorker @AssistedInject constructor(
         // sync_history FAILED row and the SyncStateManager onError call
         // can't drift out of sync.
         private const val AUTH_EXPIRED_REASON = "Credentials expired — re-authenticate to resume sync"
+    }
+
+    /**
+     * Running count of playlists/mixes whose tracks have been fetched
+     * (Spotify daily mixes + liked songs + user playlists, YouTube home
+     * mixes + liked songs + user playlists) — fed to
+     * [SyncStateManager.onFetchingPlaylists] so a long fetch on a big
+     * library shows a live "Fetched N playlists…" counter instead of the
+     * bar sitting frozen. Thread-safe: several of these fetches run
+     * concurrently via [fetchYouTubePlaylists]'s Semaphore-bounded async.
+     */
+    private val fetchedPlaylistCounter = AtomicInteger(0)
+
+    private fun reportPlaylistFetched() {
+        syncStateManager.onFetchingPlaylists(fetchedPlaylistCounter.incrementAndGet())
     }
 
     /**
@@ -344,6 +360,7 @@ class PlaylistFetchWorker @AssistedInject constructor(
                             Log.e(TAG, "fetchSpotifyPlaylists: failed to fetch tracks for mix '${mix.name}'", e)
                             // Continue with next mix rather than aborting
                         }
+                        reportPlaylistFetched()
                     }
                 }
                 is SyncResult.Empty -> {
@@ -440,6 +457,7 @@ class PlaylistFetchWorker @AssistedInject constructor(
             Log.e(TAG, "fetchSpotifyPlaylists: liked songs fetch failed (sp_dc issue), continuing", e)
             diagnostics.add(SyncStepResult("SPOTIFY", "getLikedSongs", StepStatus.ERROR, errorMessage = e.message))
         }
+        reportPlaylistFetched()
 
         // Fetch user-created/saved playlists from the Spotify library.
         var userPlaylistCount = 0
@@ -594,6 +612,7 @@ class PlaylistFetchWorker @AssistedInject constructor(
                     inventoryComplete = false
                     Log.w(TAG, "fetchSpotifyPlaylists: snapshot failed for '${playlist.name}'", e)
                 }
+                reportPlaylistFetched()
             }
 
             if (shouldDeactivateMissingSpotifyPlaylists(syncPreferencesManager.spotifySyncMode.first(), inventoryComplete)) {
@@ -765,6 +784,7 @@ class PlaylistFetchWorker @AssistedInject constructor(
         } catch (e: Exception) {
             Log.e(TAG, "fetchAndSnapshotMix: exception for '${mix.title}'", e)
         }
+        reportPlaylistFetched()
     }
 
     /**
@@ -866,6 +886,7 @@ class PlaylistFetchWorker @AssistedInject constructor(
             Log.e(TAG, "fetchAndSnapshotLikedSongs: exception", e)
             diagnostics.add(SyncStepResult("YOUTUBE", "getLikedSongs", StepStatus.ERROR, errorMessage = e.message))
         }
+        reportPlaylistFetched()
     }
 
     /**
@@ -925,6 +946,7 @@ class PlaylistFetchWorker @AssistedInject constructor(
         } catch (e: Exception) {
             Log.e(TAG, "fetchAndSnapshotUserPlaylist: exception for '${playlist.title}'", e)
         }
+        reportPlaylistFetched()
     }
 }
 

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncViewModel.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncViewModel.kt
@@ -285,8 +285,14 @@ class SyncViewModel @Inject constructor(
 
     // -- Public actions -------------------------------------------------------
 
-    /** Trigger an immediate sync, replacing any pending schedule. */
+    /** Trigger an immediate sync, replacing any pending schedule. No-ops
+     *  while a sync is already in progress — see [SyncScheduler.triggerManualSync]
+     *  for why re-triggering mid-sync is actively harmful, not just redundant. */
     fun onSyncNow() {
+        if (_uiState.value.isSyncing) {
+            android.util.Log.i("SyncViewModel", "onSyncNow ignored — sync already in progress")
+            return
+        }
         syncScheduler.triggerManualSync()
     }
 

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/components/SyncActionProgress.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/components/SyncActionProgress.kt
@@ -105,8 +105,26 @@ fun SyncActionProgress(
 /** Human-readable label for the current sync phase. */
 internal fun phaseLabel(phase: SyncPhase): String = when (phase) {
     is SyncPhase.Authenticating -> "Authenticating..."
-    is SyncPhase.FetchingPlaylists -> "Fetching playlists..."
-    is SyncPhase.Diffing -> "Comparing changes..."
+    is SyncPhase.FetchingPlaylists -> {
+        // No fixed total is known during fetch (Spotify's folder-walked
+        // playlist count and YouTube's aren't known until the fetch itself
+        // finishes) — so this is a live running count, not a fraction.
+        // Still gives the user visible proof of forward progress on a
+        // long fetch instead of a static "Fetching playlists..." that
+        // looked frozen for 40+ minutes on large libraries.
+        if (phase.playlistsFetched > 0) {
+            "Fetched ${phase.playlistsFetched} playlist${if (phase.playlistsFetched != 1) "s" else ""}..."
+        } else {
+            "Fetching playlists..."
+        }
+    }
+    is SyncPhase.Diffing -> {
+        if (phase.totalPlaylists > 0) {
+            "Comparing changes (${phase.playlistsDiffed}/${phase.totalPlaylists})..."
+        } else {
+            "Comparing changes..."
+        }
+    }
     is SyncPhase.Downloading -> "Downloading ${phase.downloaded}/${phase.total}..."
     is SyncPhase.Finalizing -> "Finalizing..."
     is SyncPhase.Completed -> "Complete"


### PR DESCRIPTION
## Summary
- Fixes a bug where tapping "Sync Now" while a sync was already running would cancel the in-flight `PlaylistFetchWorker` chain outright (`ExistingWorkPolicy.REPLACE`) and restart from zero — every partially-completed playlist/mix fetch threw `JobCancellationException`, producing repeated failed syncs on large libraries (log evidence: 6 manual re-triggers in ~10 minutes, all ending in `WorkerStoppedException`).
- Root cause was compounded by poor progress visibility: `FetchingPlaylists` and `Diffing` were flat progress markers (20%/25%) with no live counter, so on a large library (4k+ tracks) the bar could sit visually frozen for 40+ minutes before any download began — driving users to repeatedly tap Sync Now, believing it had stalled. This is the same root cause reported in a user-filed enhancement request proposing separate remote-sync vs. local-verification progress.
- This PR fixes the re-trigger bug and adds live progress counters for both phases. It does not yet split fetch/diff into a standalone "Library Verification" action outside the sync chain — that's scoped as a follow-up.

## Changes
- `core/data/.../sync/SyncScheduler.kt`
  - `triggerManualSync()` now checks `isSyncChainActive()` (queries `WorkManager.getWorkInfosForUniqueWork` for any ENQUEUED/RUNNING state) and no-ops if a sync is already running, instead of unconditionally enqueuing with `REPLACE`.
- `feature/sync/.../SyncViewModel.kt`
  - `onSyncNow()` also short-circuits when `uiState.isSyncing` is true, so the redundant call never reaches the scheduler.
- `core/data/.../sync/SyncPhase.kt`
  - `FetchingPlaylists` is now a data class carrying `playlistsFetched: Int` (live count; no fixed total is knowable upfront for either source).
  - `Diffing` is now a data class carrying `playlistsDiffed`/`totalPlaylists: Int` (real fraction — the diff worker knows its total upfront).
- `core/data/.../sync/SyncStateManager.kt`
  - `onFetchingPlaylists()`/`onDiffing()` now take progress params and can be called repeatedly to update the live phase state.
- `core/data/.../sync/workers/PlaylistFetchWorker.kt`
  - Added a thread-safe `AtomicInteger` counter, incremented after every playlist/mix/liked-songs fetch (Spotify daily mixes, liked songs, user playlists; YouTube home mixes, liked songs, user playlists), reporting through `syncStateManager.onFetchingPlaylists(count)`.
- `core/data/.../sync/workers/DiffWorker.kt`
  - Reports `syncStateManager.onDiffing(diffed, total)` before the loop starts and after each playlist is reconciled.
- `feature/sync/.../components/SyncActionProgress.kt`
  - `phaseLabel()` now renders the live counts: "Fetched N playlists..." during fetch, "Comparing changes (N/total)..." during diff, instead of static unchanging text.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin`
- [x] Installed on a device and manually verified the change
- [x] Device / Android version tested: S26u/Android 16