### PR TITLE
fix(library): Albums tab force-closes on a duplicate album grid key

### DIFF
--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryViewModel.kt
@@ -50,6 +50,30 @@ private fun Track.matchesQuery(query: String): Boolean =
         album.lowercase().contains(query)
 
 /**
+ * Collapses album rows that describe the SAME album but arrived as separate
+ * DAO groups. `getAllAlbums` groups by `(album, album_artist)`, so an album
+ * whose tracks disagree on the `album_artist` tag (common in tag-inconsistent
+ * FLAC rips) yields two rows that resolve to the same displayed name+artist.
+ * The Albums grid keys each card on `"name|artist"`, and two identical keys
+ * crash `LazyVerticalGrid` — the Albums tab force-close in issue #244.
+ *
+ * Merging by case-insensitive (name, artist) guarantees the grid key is
+ * unique again and shows one card per album with the combined track count.
+ */
+internal fun mergeDuplicateAlbums(albums: List<AlbumInfo>): List<AlbumInfo> =
+    albums
+        .groupBy { it.name.lowercase() to it.artist.lowercase() }
+        .map { (_, group) ->
+            group.reduce { acc, next ->
+                acc.copy(
+                    trackCount = acc.trackCount + next.trackCount,
+                    artPath = acc.artPath ?: next.artPath,
+                    artUrl = acc.artUrl ?: next.artUrl,
+                )
+            }
+        }
+
+/**
  * ViewModel for the Library screen.
  *
  * Collects tracks, playlists, artists, albums, and auth state from
@@ -154,7 +178,9 @@ class LibraryViewModel @Inject constructor(
 
         // -- Map DAO projections to UI models --
         val artists = allArtists.map { ArtistInfo(it.artist, it.trackCount, it.totalDurationMs, it.artUrl) }
-        val albums = allAlbums.map { AlbumInfo(it.album, it.artist, it.trackCount, it.artPath, it.artUrl) }
+        val albums = mergeDuplicateAlbums(
+            allAlbums.map { AlbumInfo(it.album, it.artist, it.trackCount, it.artPath, it.artUrl) }
+        )
 
         // -- Apply source filter --
         val sourceFiltered = when (controls.sourceFilter) {

--- a/feature/library/src/test/kotlin/com/stash/feature/library/MergeDuplicateAlbumsTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/MergeDuplicateAlbumsTest.kt
@@ -1,0 +1,55 @@
+package com.stash.feature.library
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Regression tests for [mergeDuplicateAlbums] — the collapse that keeps the
+ * Albums grid from crashing on a duplicate `LazyVerticalGrid` key (issue #244).
+ *
+ * The DAO groups albums by `(album, album_artist)`, so one album with
+ * inconsistent `album_artist` tags across its tracks arrives as two rows that
+ * render to the same `"name|artist"` grid key.
+ */
+class MergeDuplicateAlbumsTest {
+
+    @Test fun `two rows for the same album+artist collapse into one`() {
+        val input = listOf(
+            AlbumInfo(name = "Songs in the Key of Life", artist = "Stevie Wonder", trackCount = 9, artPath = null, artUrl = "http://art"),
+            AlbumInfo(name = "Songs in the Key of Life", artist = "Stevie Wonder", trackCount = 12, artPath = "/local/cover.jpg", artUrl = null),
+        )
+
+        val merged = mergeDuplicateAlbums(input)
+
+        assertThat(merged).hasSize(1)
+        assertThat(merged.single().trackCount).isEqualTo(21)
+        // first non-null art of each kind survives the merge
+        assertThat(merged.single().artUrl).isEqualTo("http://art")
+        assertThat(merged.single().artPath).isEqualTo("/local/cover.jpg")
+    }
+
+    @Test fun `resulting grid keys are unique (the crash guard)`() {
+        val input = listOf(
+            AlbumInfo("Greatest Hits", "ABBA", 2),
+            AlbumInfo("greatest hits", "abba", 3), // same album, different tag casing
+            AlbumInfo("Greatest Hits", "Queen", 4), // genuinely different artist
+        )
+
+        val keys = mergeDuplicateAlbums(input).map { "${it.name}|${it.artist}" }
+
+        assertThat(keys).containsNoDuplicates()
+    }
+
+    @Test fun `distinct albums are left untouched`() {
+        val input = listOf(
+            AlbumInfo("Rumours", "Fleetwood Mac", 11),
+            AlbumInfo("Innervisions", "Stevie Wonder", 9),
+        )
+
+        assertThat(mergeDuplicateAlbums(input)).containsExactlyElementsIn(input)
+    }
+
+    @Test fun `empty input yields empty output`() {
+        assertThat(mergeDuplicateAlbums(emptyList())).isEmpty()
+    }
+}


### PR DESCRIPTION
Fixes #244

## The crash

Opening **Library → Albums** force-closes the app instantly.

`TrackDao.getAllAlbums` groups albums by `(album, album_artist)`:

```sql
GROUP BY t.album, t.album_artist
```

An album whose tracks disagree on the `album_artist` tag — some tag it, some leave it blank — comes back as **two separate rows**. Both resolve to the *same* displayed name and artist (the query falls back to the most common track artist when `album_artist` is empty). This is routine in tag-inconsistent FLAC rips, which is exactly the library in the reporter's screenshot.

The Albums grid keys each card on `"name|artist"`:

```kotlin
items(displayList, key = { "${it.name}|${it.artist}" }) { album -> ... }
```

Two rows → two identical keys → `LazyVerticalGrid` throws `IllegalArgumentException: Key "…" was already used` the moment the tab composes. Hence the immediate force-close.

## The fix

Collapse album rows sharing a case-insensitive `(name, artist)` into one, right after the DAO → UI mapping in `LibraryViewModel`:

```kotlin
internal fun mergeDuplicateAlbums(albums: List<AlbumInfo>): List<AlbumInfo> =
    albums
        .groupBy { it.name.lowercase() to it.artist.lowercase() }
        .map { (_, group) ->
            group.reduce { acc, next ->
                acc.copy(
                    trackCount = acc.trackCount + next.trackCount,
                    artPath = acc.artPath ?: next.artPath,
                    artUrl = acc.artUrl ?: next.artUrl,
                )
            }
        }
```

- Grid keys are unique again → no more crash.
- The duplicate album cards the user would otherwise see are gone too, with the track count summed across the merged rows.
- Fixing it here (rather than widening the Compose key) keeps the DAO's `(album, album_artist)` grouping intact for every other consumer, and treats the real problem: two rows that are one album to the user.

The **Artists** tab groups by `artist` alone, so its `key = { it.name }` was already unique — unaffected.

## Tests

New `MergeDuplicateAlbumsTest` (4 cases): two rows for one album collapse with summed count + first-non-null art; resulting `"name|artist"` keys contain no duplicates (the crash guard, incl. a casing-only duplicate); genuinely distinct albums pass through untouched; empty input → empty output.

`:feature:library:testDebugUnitTest` green (`tests=4, failures=0`).
