### PR TITLE
Add "View Album" option to TrackOptionsSheet

### DIFF
--- a/core/ui/src/main/kotlin/com/stash/core/ui/components/TrackOptionsSheet.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/components/TrackOptionsSheet.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Album
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.DownloadDone
@@ -68,6 +69,7 @@ fun TrackOptionsSheet(
     onAddToQueue: ((Track) -> Unit)? = null,
     onStartRadio: ((Track) -> Unit)? = null,
     onShare: ((Track) -> Unit)? = null,
+    onViewAlbum: ((Track) -> Unit)? = null,
     onDownload: ((Track) -> Unit)? = null,
     onRemoveDownload: ((Track) -> Unit)? = null,
     onDelete: ((Track) -> Unit)? = null,
@@ -195,6 +197,15 @@ fun TrackOptionsSheet(
                 icon = Icons.Default.Share,
                 label = "Share",
                 onClick = { onShare(track) },
+            )
+        }
+
+        // -- View Album option --
+        if (onViewAlbum != null) {
+            SheetOptionRow(
+                icon = Icons.Default.Album,
+                label = "View Album",
+                onClick = { onViewAlbum(track) },
             )
         }
 

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
@@ -1444,17 +1444,10 @@ private fun TracksTab(
                 onAddToQueue = { onAddToQueue(it); selectedTrack = null },
                 onSaveToPlaylist = { trackToSave = it; selectedTrack = null },
                 onShare = { trackToShare = it; selectedTrack = null },
+                onViewAlbum = { onViewAlbum(it); selectedTrack = null },
                 onDownload = { onDownloadTrack(it.id); selectedTrack = null },
                 onRemoveDownload = { onRemoveDownloadTrack(it.id); selectedTrack = null },
                 onDelete = { trackToDelete = it; selectedTrack = null },
-            )
-            BottomSheetActionRow(
-                icon = Icons.Default.Album,
-                label = "View Album",
-                onClick = {
-                    onViewAlbum(track)
-                    selectedTrack = null
-                },
             )
 
             // Bottom padding for gesture navigation inset


### PR DESCRIPTION
## Summary
- Moves the "View Album" option out of `LibraryScreen`'s manual/inline definition and into `TrackOptionsSheet`, so it's now a standard entry in the shared track options menu instead of a one-off implementation.
- No behavior change from the user's perspective — tapping "View Album" still navigates to the album — this is purely a consolidation so the option is defined once and reused wherever `TrackOptionsSheet` is shown, rather than duplicated per-screen.

## Changes
- `core/ui/components/TrackOptionsSheet.kt`
  - Added a "View Album" menu item/action to the shared options sheet (+11 lines), matching the existing pattern used by the sheet's other actions.
- `feature/library/LibraryScreen.kt`
  - Removed the standalone "View Album" implementation that previously lived directly in `LibraryScreen`, now that it's handled by `TrackOptionsSheet` (9 lines removed, replaced with a 1-line call into the sheet).

## Test plan
- [x] `./gradlew :app:compileDebugKotlin`
- [x] Installed on a device and manually verified "View Album" still works from both Now Playing and Library entry points
- [x] Device / Android version tested: S26u/Android 16