### PR TITLE
Fix backup import always failing integrity check due to read-only DB connection

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
@@ -108,7 +108,7 @@ class DatabaseBackupManager @Inject constructor(
      */
     internal fun verifyDatabaseIntegrity(file: File) {
         val db = android.database.sqlite.SQLiteDatabase.openDatabase(
-            file.path, null, android.database.sqlite.SQLiteDatabase.OPEN_READONLY,
+            file.path, null, android.database.sqlite.SQLiteDatabase.OPEN_READWRITE,
         )
         db.use {
             val ok = it.rawQuery("PRAGMA integrity_check", null).use { cursor ->


### PR DESCRIPTION
## Summary
- `verifyDatabaseIntegrity` in `DatabaseBackupManager.kt` opened the staged backup file with `SQLiteDatabase.OPEN_READONLY` before running `PRAGMA integrity_check`. Because `tracks_fts` is an FTS4 virtual table, `integrity_check` internally dispatches the FTS module's own check as `INSERT INTO tracks_fts(tracks_fts) VALUES('integrity-check')` — a write-shaped statement even though it doesn't persist anything. On a read-only connection this always throws `attempt to write a readonly database`, so every import failed this gate regardless of whether the backup was actually valid.
- Fix: open the staged file `OPEN_READWRITE` instead. It's a throwaway `.import-tmp` copy that's either moved into place or deleted immediately after — never the live db — so this carries no risk to existing data. Behavior for genuinely corrupt backups is unchanged: a bad file still fails `integrity_check` and gets rejected as before, just for the right reason now.

## Changes
- `core/data/db/DatabaseBackupManager.kt`
  - `verifyDatabaseIntegrity`: `SQLiteDatabase.OPEN_READONLY` → `SQLiteDatabase.OPEN_READWRITE` (1 line)

## Test plan
- [x] `./gradlew :app:compileDebugKotlin`
- [x] Exported a fresh, unedited backup and re-imported it immediately — previously failed 100% of the time with `attempt to write a readonly database`; now succeeds
- [x] Device / Android version tested: S26u/Android 16