### PR TITLE
Only download what users ask for, and stop the 15s YouTube stall

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt
@@ -100,12 +100,18 @@ interface DownloadQueueDao {
                 -- Replay Mix queued 90 tracks). Mirrors the is_active=1
                 -- guard in PlaylistDao.getSyncEnabledPlaylists.
                 AND p.is_active = 1
-                -- Stash Mixes are stream-only (v0.9.37 seam): their stubs
-                -- live in a sync_enabled playlist (so they stay visible
-                -- offline) but must NEVER be download-eligible. Require a
-                -- sync-enabled, NON-mix parent. A track also in Liked Songs
-                -- /a real playlist still matches via that membership.
-                AND p.type != 'STASH_MIX'
+                -- Mixes are stream-only (v0.9.37 seam): their stubs live in a
+                -- sync_enabled playlist (so they stay visible offline) but must
+                -- NEVER be download-eligible. Require a sync-enabled, NON-mix
+                -- parent. A track also in Liked Songs / a real playlist still
+                -- matches via that membership.
+                --
+                -- DAILY_MIX was missing here until #368: discovered Spotify/YT
+                -- mixes were auto-enabled, so this predicate treated their whole
+                -- contents as download-eligible and the blanket requeue in
+                -- TrackDownloadWorker pulled them — thousands of tracks the user
+                -- never toggled on, refreshed every time the mixes rotated.
+                AND p.type NOT IN ('STASH_MIX', 'DAILY_MIX')
           )
         ORDER BY (CASE WHEN dq.youtube_url IS NULL THEN 0 ELSE 1 END) ASC, dq.created_at ASC
     """)
@@ -144,12 +150,18 @@ interface DownloadQueueDao {
                 -- Replay Mix queued 90 tracks). Mirrors the is_active=1
                 -- guard in PlaylistDao.getSyncEnabledPlaylists.
                 AND p.is_active = 1
-                -- Stash Mixes are stream-only (v0.9.37 seam): their stubs
-                -- live in a sync_enabled playlist (so they stay visible
-                -- offline) but must NEVER be download-eligible. Require a
-                -- sync-enabled, NON-mix parent. A track also in Liked Songs
-                -- /a real playlist still matches via that membership.
-                AND p.type != 'STASH_MIX'
+                -- Mixes are stream-only (v0.9.37 seam): their stubs live in a
+                -- sync_enabled playlist (so they stay visible offline) but must
+                -- NEVER be download-eligible. Require a sync-enabled, NON-mix
+                -- parent. A track also in Liked Songs / a real playlist still
+                -- matches via that membership.
+                --
+                -- DAILY_MIX was missing here until #368: discovered Spotify/YT
+                -- mixes were auto-enabled, so this predicate treated their whole
+                -- contents as download-eligible and the blanket requeue in
+                -- TrackDownloadWorker pulled them — thousands of tracks the user
+                -- never toggled on, refreshed every time the mixes rotated.
+                AND p.type NOT IN ('STASH_MIX', 'DAILY_MIX')
           )
         ORDER BY (CASE WHEN dq.youtube_url IS NULL THEN 0 ELSE 1 END) ASC, dq.created_at ASC
     """)
@@ -418,6 +430,12 @@ interface DownloadQueueDao {
             WHERE p.sync_enabled = 1
               AND p.is_active = 1
               AND pt.removed_at IS NULL
+              -- Mix membership does not count as "wanted" (#368). This query had
+              -- no type filter at all, so an auto-enabled DAILY_MIX — or any
+              -- STASH_MIX, which is created with sync_enabled = true — spared its
+              -- tracks' queue rows and the drain then serviced them. Same rule as
+              -- getUnqueuedTrackIds and deleteOrphanedQueueEntries.
+              AND p.type NOT IN ('STASH_MIX', 'DAILY_MIX')
           )
         """
     )
@@ -496,12 +514,18 @@ interface DownloadQueueDao {
                 -- Replay Mix queued 90 tracks). Mirrors the is_active=1
                 -- guard in PlaylistDao.getSyncEnabledPlaylists.
                 AND p.is_active = 1
-                -- Stash Mixes are stream-only (v0.9.37 seam): their stubs
-                -- live in a sync_enabled playlist (so they stay visible
-                -- offline) but must NEVER be download-eligible. Require a
-                -- sync-enabled, NON-mix parent. A track also in Liked Songs
-                -- /a real playlist still matches via that membership.
-                AND p.type != 'STASH_MIX'
+                -- Mixes are stream-only (v0.9.37 seam): their stubs live in a
+                -- sync_enabled playlist (so they stay visible offline) but must
+                -- NEVER be download-eligible. Require a sync-enabled, NON-mix
+                -- parent. A track also in Liked Songs / a real playlist still
+                -- matches via that membership.
+                --
+                -- DAILY_MIX was missing here until #368: discovered Spotify/YT
+                -- mixes were auto-enabled, so this predicate treated their whole
+                -- contents as download-eligible and the blanket requeue in
+                -- TrackDownloadWorker pulled them — thousands of tracks the user
+                -- never toggled on, refreshed every time the mixes rotated.
+                AND p.type NOT IN ('STASH_MIX', 'DAILY_MIX')
           )
           AND t.id NOT IN (
               SELECT dq.track_id FROM download_queue dq
@@ -545,12 +569,18 @@ interface DownloadQueueDao {
                 -- Replay Mix queued 90 tracks). Mirrors the is_active=1
                 -- guard in PlaylistDao.getSyncEnabledPlaylists.
                 AND p.is_active = 1
-                -- Stash Mixes are stream-only (v0.9.37 seam): their stubs
-                -- live in a sync_enabled playlist (so they stay visible
-                -- offline) but must NEVER be download-eligible. Require a
-                -- sync-enabled, NON-mix parent. A track also in Liked Songs
-                -- /a real playlist still matches via that membership.
-                AND p.type != 'STASH_MIX'
+                -- Mixes are stream-only (v0.9.37 seam): their stubs live in a
+                -- sync_enabled playlist (so they stay visible offline) but must
+                -- NEVER be download-eligible. Require a sync-enabled, NON-mix
+                -- parent. A track also in Liked Songs / a real playlist still
+                -- matches via that membership.
+                --
+                -- DAILY_MIX was missing here until #368: discovered Spotify/YT
+                -- mixes were auto-enabled, so this predicate treated their whole
+                -- contents as download-eligible and the blanket requeue in
+                -- TrackDownloadWorker pulled them — thousands of tracks the user
+                -- never toggled on, refreshed every time the mixes rotated.
+                AND p.type NOT IN ('STASH_MIX', 'DAILY_MIX')
           )
           AND t.id NOT IN (
               SELECT dq.track_id FROM download_queue dq
@@ -594,11 +624,14 @@ interface DownloadQueueDao {
                 -- the invisible-download backlog (Replay Mix's 90 queued
                 -- tracks) the same way it drains mix-only orphans.
                 AND p.is_active = 1
-                -- A sync-enabled STASH_MIX membership does NOT spare a row:
-                -- mix tracks are stream-only, so a mix-only track's queue
-                -- entry is an orphan and gets swept. This drains the legacy
-                -- pre-v0.9.48 backlog of force-queued mix downloads.
-                AND p.type != 'STASH_MIX'
+                -- A sync-enabled mix membership does NOT spare a row: mix tracks
+                -- are stream-only, so a mix-only track's queue entry is an orphan
+                -- and gets swept. This drains the legacy pre-v0.9.48 backlog of
+                -- force-queued mix downloads, and — since DAILY_MIX joined the
+                -- exclusion in #368 — the accumulated backlog of auto-enabled
+                -- Spotify/YT mix downloads. That sweep is why #368 needs no
+                -- migration: the phantom rows drain on the next worker run.
+                AND p.type NOT IN ('STASH_MIX', 'DAILY_MIX')
           )
     """)
     suspend fun deleteOrphanedQueueEntries(): Int

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt
@@ -423,6 +423,12 @@ interface DownloadQueueDao {
         """
         DELETE FROM download_queue
         WHERE status = 'PENDING'
+          -- Sync partition only. A NULL sync_id is a user's explicit "download
+          -- this" tap, which is the strongest statement of intent there is — this
+          -- sweep drains phantom rows a SYNC created, never a request the user
+          -- made. Without this, tapping Download on a track that lives only in a
+          -- mix silently produced nothing.
+          AND sync_id IS NOT NULL
           AND track_id NOT IN (
             SELECT DISTINCT pt.track_id
             FROM playlist_tracks pt
@@ -613,6 +619,10 @@ interface DownloadQueueDao {
     @Query("""
         DELETE FROM download_queue
         WHERE status IN ('PENDING', 'FAILED', 'WAITING_FOR_LOSSLESS')
+          -- Sync partition only — see cancelDownloadsWithNoEnabledPlaylist. A
+          -- manual (sync_id NULL) row is a download the user asked for; sweeping
+          -- it is how search-tab downloads went missing on relaunch.
+          AND sync_id IS NOT NULL
           AND track_id NOT IN (
               SELECT pt.track_id FROM playlist_tracks pt
               INNER JOIN playlists p ON p.id = pt.playlist_id

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
@@ -33,15 +33,24 @@ import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.first
 
 /**
- * A newly-discovered playlist's initial [PlaylistEntity.syncEnabled].
- * Algorithmic mixes (DAILY_MIX) auto-enable in Online mode so they surface
- * immediately with no download. Everything else — and every playlist in
- * Offline mode — stays opt-in: the first Sync Now is a discovery pass that
- * downloads nothing unasked. [online] is the streaming-mode flag (on = stream,
- * don't download).
+ * A newly-discovered playlist's initial [PlaylistEntity.syncEnabled]: always
+ * opt-in. The first Sync Now is a discovery pass that downloads nothing unasked.
+ *
+ * DAILY_MIX used to auto-enable in Online mode "so they surface immediately with
+ * no download". That was redundant and load-bearing only for harm:
+ * [com.stash.core.data.db.dao.PlaylistDao.getAllVisible] already surfaces a
+ * `sync_enabled = 0` playlist whose tracks are streamable when
+ * `includeStreamable = true` (pinned by PlaylistDaoMixVisibilityTest), so mixes
+ * still appear on Home in Online mode without it. The flag's only other effects
+ * were making the mix download-eligible and making the orphan sweep spare its
+ * tracks — and because mixes rotate, every new one pulled a fresh batch of
+ * downloads the user never asked for (#368).
+ *
+ * Parameters are retained to document what was considered and to keep the
+ * decision testable.
  */
-internal fun defaultSyncEnabled(type: PlaylistType, online: Boolean): Boolean =
-    type == PlaylistType.DAILY_MIX && online
+@Suppress("UNUSED_PARAMETER")
+internal fun defaultSyncEnabled(type: PlaylistType, online: Boolean): Boolean = false
 
 /**
  * Whether a playlist's tracks should be enqueued for download during this sync.

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
@@ -50,6 +50,10 @@ internal fun defaultSyncEnabled(type: PlaylistType, online: Boolean): Boolean =
  * surface-only (stream-on-tap), so an auto-enabled mix never pulls bytes even
  * after the user switches to Offline and re-syncs.
  */
+// STASH_MIX is deliberately absent from this exclusion: a locally-generated mix
+// never arrives as a remote playlist snapshot, so it cannot reach this guard, and
+// ShouldEnqueueForDownloadTest pins that on purpose. Stash mixes are kept
+// download-ineligible where they ARE reachable — the DownloadQueueDao predicates.
 internal fun shouldEnqueueForDownload(type: PlaylistType, streamingMode: Boolean): Boolean =
     !streamingMode && type != PlaylistType.DAILY_MIX
 
@@ -562,7 +566,13 @@ class DiffWorker @AssistedInject constructor(
             addCrossRefIfNotSoftDeleted(localPlaylist.id, trackId, snapshot.position, existingCrossRefs, crossRefsToInsert)
         }
 
-        if (!streamingMode) {
+        // Mixes are surface-only: they stream on tap and must never pull bytes.
+        // shouldEnqueueForDownload has encoded that since it was written, and was
+        // unit-tested — but this site tested raw `!streamingMode`, so the guard
+        // was never consulted and every track of every rotating mix was queued in
+        // Offline mode (#368: "it downloads 6000+ from users playlists and
+        // Spotify mixes that I don't need").
+        if (shouldEnqueueForDownload(localPlaylist.type, streamingMode)) {
             for (batchTrack in newTracks) {
                 val trackId = checkNotNull(batchTrack.persistedId)
                 downloadEntries.add(

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoDeferredTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoDeferredTest.kt
@@ -4,6 +4,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import com.stash.core.data.db.StashDatabase
 import com.stash.core.data.db.entity.DownloadQueueEntity
+import com.stash.core.data.db.entity.SyncHistoryEntity
 import com.stash.core.data.db.entity.TrackEntity
 import com.stash.core.model.DownloadStatus
 import kotlinx.coroutines.flow.first
@@ -47,6 +48,11 @@ class DownloadQueueDaoDeferredTest {
         trackDao.insert(track(id = 1L))
         trackDao.insert(track(id = 2L))
         trackDao.insert(track(id = 3L))
+        // These fixtures are SYNC-created rows (sync_id set). The orphan sweeps
+        // only touch that partition — a manual sync_id NULL row is a download the
+        // user explicitly asked for and is spared. These tests are about status
+        // coverage (WAITING_FOR_LOSSLESS joining the sweep), not partitions.
+        db.syncHistoryDao().insert(SyncHistoryEntity(id = 1L))
     }
 
     @After
@@ -84,6 +90,7 @@ class DownloadQueueDaoDeferredTest {
 
     private fun entry(trackId: Long, status: DownloadStatus) = DownloadQueueEntity(
         trackId = trackId,
+        syncId = 1L,
         status = status,
         searchQuery = "test query",
     )

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoMixExclusionTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoMixExclusionTest.kt
@@ -7,6 +7,7 @@ import com.stash.core.data.db.StashDatabase
 import com.stash.core.data.db.entity.DownloadQueueEntity
 import com.stash.core.data.db.entity.PlaylistEntity
 import com.stash.core.data.db.entity.PlaylistTrackCrossRef
+import com.stash.core.data.db.entity.SyncHistoryEntity
 import com.stash.core.data.db.entity.TrackEntity
 import com.stash.core.model.DownloadStatus
 import com.stash.core.model.MusicSource
@@ -48,6 +49,7 @@ class DownloadQueueDaoMixExclusionTest {
     private var customQueued = 0L
     private var dailyMixUnqueued = 0L
     private var customUnqueued = 0L
+    private var dailyMixManual = 0L
 
     @Before fun setUp() = runTest {
         db = Room.inMemoryDatabaseBuilder(
@@ -66,11 +68,17 @@ class DownloadQueueDaoMixExclusionTest {
         val stashMix = newPlaylist("Deep Cuts", "stash_mix_1", PlaylistType.STASH_MIX)
         val custom = newPlaylist("My Playlist", "spotify:playlist:mine", PlaylistType.CUSTOM)
 
-        dailyMixQueued = newTrack("A", dailyMix, queued = true)
-        stashMixQueued = newTrack("B", stashMix, queued = true)
-        customQueued = newTrack("C", custom, queued = true)
+        // Sync-created queue rows carry a sync_id — these are the phantom rows
+        // the sweeps exist to drain.
+        db.syncHistoryDao().insert(SyncHistoryEntity(id = 5L))
+        dailyMixQueued = newTrack("A", dailyMix, queued = true, syncId = 5L)
+        stashMixQueued = newTrack("B", stashMix, queued = true, syncId = 5L)
+        customQueued = newTrack("C", custom, queued = true, syncId = 5L)
         dailyMixUnqueued = newTrack("D", dailyMix, queued = false)
         customUnqueued = newTrack("E", custom, queued = false)
+        // A user's explicit Download tap on a mix-only track: manual partition
+        // (sync_id NULL), no eligible parent playlist.
+        dailyMixManual = newTrack("F", dailyMix, queued = true, syncId = null)
     }
 
     @After fun tearDown() { db.close() }
@@ -97,6 +105,23 @@ class DownloadQueueDaoMixExclusionTest {
         assertThat(dao.getByTrackId(customQueued)).isNotNull()
     }
 
+    /**
+     * The other half of "only download what the user wants": a Download tap is
+     * the strongest signal of intent there is, so neither sweep may evict it.
+     * Manual rows live in the sync_id NULL partition; the sweeps exist to drain
+     * phantom rows that a *sync* created, not a user's explicit request. Without
+     * this, tapping Download on a track that lives only in a mix silently
+     * produced nothing — the same class as the search-tab downloads that vanish
+     * on relaunch.
+     */
+    @Test fun `neither sweep evicts a manually requested download`() = runTest {
+        dao.deleteOrphanedQueueEntries()
+        assertThat(dao.getByTrackId(dailyMixManual)).isNotNull()
+
+        dao.cancelDownloadsWithNoEnabledPlaylist()
+        assertThat(dao.getByTrackId(dailyMixManual)).isNotNull()
+    }
+
     private suspend fun newPlaylist(name: String, sourceId: String, type: PlaylistType): Long =
         playlistDao.insert(
             PlaylistEntity(
@@ -109,7 +134,12 @@ class DownloadQueueDaoMixExclusionTest {
             )
         )
 
-    private suspend fun newTrack(tag: String, playlistId: Long, queued: Boolean): Long {
+    private suspend fun newTrack(
+        tag: String,
+        playlistId: Long,
+        queued: Boolean,
+        syncId: Long? = null,
+    ): Long {
         val trackId = trackDao.insert(
             TrackEntity(
                 title = "Track $tag",
@@ -133,7 +163,7 @@ class DownloadQueueDaoMixExclusionTest {
             dao.insert(
                 DownloadQueueEntity(
                     trackId = trackId,
-                    syncId = null,
+                    syncId = syncId,
                     status = DownloadStatus.PENDING,
                     searchQuery = "Artist $tag - Track $tag",
                 )

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoMixExclusionTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoMixExclusionTest.kt
@@ -1,0 +1,144 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.DownloadQueueEntity
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.PlaylistTrackCrossRef
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.model.DownloadStatus
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.Instant
+
+/**
+ * #368: mix membership must never make a track download-eligible, and must never
+ * spare its queue row from a sweep.
+ *
+ * Three predicates enforce "download-eligible" and they disagreed:
+ * [DownloadQueueDao.getUnqueuedTrackIds] and
+ * [DownloadQueueDao.deleteOrphanedQueueEntries] excluded only STASH_MIX, and
+ * [DownloadQueueDao.cancelDownloadsWithNoEnabledPlaylist] excluded no types at
+ * all. So an auto-enabled DAILY_MIX kept its tracks download-eligible, and the
+ * v0.9.85 sweep spared them because they sat in a sync_enabled playlist.
+ *
+ * One rule, applied at all three sites: a track is download-eligible only via a
+ * membership in an active, sync-enabled, NON-mix playlist.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DownloadQueueDaoMixExclusionTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: DownloadQueueDao
+    private lateinit var trackDao: TrackDao
+    private lateinit var playlistDao: PlaylistDao
+
+    private var dailyMixQueued = 0L
+    private var stashMixQueued = 0L
+    private var customQueued = 0L
+    private var dailyMixUnqueued = 0L
+    private var customUnqueued = 0L
+
+    @Before fun setUp() = runTest {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.downloadQueueDao()
+        trackDao = db.trackDao()
+        playlistDao = db.playlistDao()
+
+        // All three parents are sync_enabled + active. The mixes mimic the state
+        // the old auto-enable produced and that existing installs still carry.
+        val dailyMix = newPlaylist("Daily Mix 1", "spotify:playlist:dm", PlaylistType.DAILY_MIX)
+        val stashMix = newPlaylist("Deep Cuts", "stash_mix_1", PlaylistType.STASH_MIX)
+        val custom = newPlaylist("My Playlist", "spotify:playlist:mine", PlaylistType.CUSTOM)
+
+        dailyMixQueued = newTrack("A", dailyMix, queued = true)
+        stashMixQueued = newTrack("B", stashMix, queued = true)
+        customQueued = newTrack("C", custom, queued = true)
+        dailyMixUnqueued = newTrack("D", dailyMix, queued = false)
+        customUnqueued = newTrack("E", custom, queued = false)
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `daily-mix-only track is not requeue-eligible`() = runTest {
+        val eligible = dao.getUnqueuedTrackIds(listOf(MusicSource.SPOTIFY.name))
+        assertThat(eligible).doesNotContain(dailyMixUnqueued)
+        assertThat(eligible).contains(customUnqueued)
+    }
+
+    @Test fun `orphan sweep evicts mix-only queue rows`() = runTest {
+        dao.deleteOrphanedQueueEntries()
+
+        assertThat(dao.getByTrackId(dailyMixQueued)).isNull()
+        assertThat(dao.getByTrackId(stashMixQueued)).isNull()
+        assertThat(dao.getByTrackId(customQueued)).isNotNull()
+    }
+
+    @Test fun `enabled-playlist sweep evicts mix-only queue rows`() = runTest {
+        dao.cancelDownloadsWithNoEnabledPlaylist()
+
+        assertThat(dao.getByTrackId(dailyMixQueued)).isNull()
+        assertThat(dao.getByTrackId(stashMixQueued)).isNull()
+        assertThat(dao.getByTrackId(customQueued)).isNotNull()
+    }
+
+    private suspend fun newPlaylist(name: String, sourceId: String, type: PlaylistType): Long =
+        playlistDao.insert(
+            PlaylistEntity(
+                name = name,
+                source = MusicSource.SPOTIFY,
+                sourceId = sourceId,
+                type = type,
+                syncEnabled = true,
+                isActive = true,
+            )
+        )
+
+    private suspend fun newTrack(tag: String, playlistId: Long, queued: Boolean): Long {
+        val trackId = trackDao.insert(
+            TrackEntity(
+                title = "Track $tag",
+                artist = "Artist $tag",
+                canonicalTitle = "track ${tag.lowercase()}",
+                canonicalArtist = "artist ${tag.lowercase()}",
+                source = MusicSource.SPOTIFY,
+                isDownloaded = false,
+            )
+        )
+        playlistDao.insertCrossRef(
+            PlaylistTrackCrossRef(
+                playlistId = playlistId,
+                trackId = trackId,
+                position = 0,
+                addedAt = Instant.parse("2026-07-01T00:00:00Z"),
+                removedAt = null,
+            )
+        )
+        if (queued) {
+            dao.insert(
+                DownloadQueueEntity(
+                    trackId = trackId,
+                    syncId = null,
+                    status = DownloadStatus.PENDING,
+                    searchQuery = "Artist $tag - Track $tag",
+                )
+            )
+        }
+        return trackId
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoMixVisibilityTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoMixVisibilityTest.kt
@@ -1,0 +1,98 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.PlaylistTrackCrossRef
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.Instant
+
+/**
+ * Pins the assumption the "mixes are opt-in" change rests on (#368).
+ *
+ * `defaultSyncEnabled` used to auto-enable a discovered DAILY_MIX in Online mode
+ * so it would "surface immediately with no download". Making discovery opt-in is
+ * only safe because [PlaylistDao.getAllVisible] already surfaces a
+ * `sync_enabled = 0` playlist through its streamable escape hatch — the
+ * auto-enable was redundant for surfacing and load-bearing only for the download
+ * harm.
+ *
+ * If this test ever goes red, that change silently HIDES mixes instead of merely
+ * un-downloading them, and it must be revisited rather than patched around.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PlaylistDaoMixVisibilityTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var playlistDao: PlaylistDao
+    private var mixId: Long = 0L
+
+    @Before fun setUp() = runTest {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        playlistDao = db.playlistDao()
+
+        // A discovered algorithmic mix as it will exist after the change: opt-in
+        // (sync_enabled = false), active, holding stream-only tracks.
+        mixId = playlistDao.insert(
+            PlaylistEntity(
+                name = "Daily Mix 1",
+                source = MusicSource.SPOTIFY,
+                sourceId = "spotify:playlist:dm1",
+                type = PlaylistType.DAILY_MIX,
+                syncEnabled = false,
+                isActive = true,
+            )
+        )
+
+        val trackId = db.trackDao().insert(
+            TrackEntity(
+                title = "Borderline",
+                artist = "Tame Impala",
+                canonicalTitle = "borderline",
+                canonicalArtist = "tame impala",
+                isDownloaded = false,
+                isStreamable = true,
+            )
+        )
+        playlistDao.insertCrossRef(
+            PlaylistTrackCrossRef(
+                playlistId = mixId,
+                trackId = trackId,
+                position = 0,
+                addedAt = Instant.parse("2026-07-01T00:00:00Z"),
+                removedAt = null,
+            )
+        )
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `sync-disabled daily mix with streamable tracks is visible online`() = runTest {
+        val visible = playlistDao.getAllVisible(includeStreamable = true).first().map { it.id }
+        assertThat(visible).contains(mixId)
+    }
+
+    /** Offline, with nothing downloaded, hiding it is correct — it can't play. */
+    @Test fun `sync-disabled daily mix with nothing downloaded is hidden offline`() = runTest {
+        val visible = playlistDao.getAllVisible(includeStreamable = false).first().map { it.id }
+        assertThat(visible).doesNotContain(mixId)
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DefaultSyncEnabledTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DefaultSyncEnabledTest.kt
@@ -5,15 +5,23 @@ import com.stash.core.model.PlaylistType
 import org.junit.Test
 
 /**
- * Unit test for [defaultSyncEnabled] — the one-line decision that makes
- * newly-discovered algorithmic mixes surface immediately in Online mode
- * while everything else (and everything in Offline mode) stays opt-in.
+ * Unit test for [defaultSyncEnabled] — the one-line decision that keeps every
+ * newly-discovered playlist opt-in, in both modes.
  */
 class DefaultSyncEnabledTest {
 
+    /**
+     * #368: DAILY_MIX used to auto-enable in Online mode so mixes would surface
+     * immediately with no download. That was redundant — getAllVisible's
+     * streamable escape hatch surfaces a sync_enabled = 0 mix anyway (pinned by
+     * PlaylistDaoMixVisibilityTest) — and the flag's only other effects were
+     * making the mix download-eligible and making the orphan sweep spare its
+     * tracks. Mixes rotate, so each new one pulled a fresh batch of downloads
+     * nobody asked for.
+     */
     @Test
-    fun `daily mix enabled only in online mode`() {
-        assertThat(defaultSyncEnabled(PlaylistType.DAILY_MIX, online = true)).isTrue()
+    fun `daily mix is opt-in in both modes`() {
+        assertThat(defaultSyncEnabled(PlaylistType.DAILY_MIX, online = true)).isFalse()
         assertThat(defaultSyncEnabled(PlaylistType.DAILY_MIX, online = false)).isFalse()
     }
 

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerMixNoDownloadTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerMixNoDownloadTest.kt
@@ -1,0 +1,174 @@
+package com.stash.core.data.sync.workers
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import androidx.work.testing.TestListenableWorkerBuilder
+import androidx.work.workDataOf
+import com.stash.core.data.blocklist.BlocklistGuard
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.dao.DownloadQueueDao
+import com.stash.core.data.db.dao.SyncHistoryDao
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.RemotePlaylistSnapshotEntity
+import com.stash.core.data.db.entity.RemoteTrackSnapshotEntity
+import com.stash.core.data.prefs.StreamingPreference
+import com.stash.core.data.repository.MusicRepository
+import com.stash.core.data.sync.SyncPreferencesManager
+import com.stash.core.data.sync.SyncStateManager
+import com.stash.core.data.sync.TrackMatcher
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import com.stash.core.model.SyncMode
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * #368: an auto-discovered algorithmic mix must never enqueue downloads, even in
+ * Offline mode.
+ *
+ * The guard [shouldEnqueueForDownload] excluded DAILY_MIX from the day it was
+ * written, and was unit-tested in ShouldEnqueueForDownloadTest — but DiffWorker's
+ * enqueue site tested raw `!streamingMode`, so the guard was never consulted and
+ * every track of every rotating Spotify/YT mix was queued. Users reported 6000+
+ * unwanted downloads.
+ *
+ * These tests therefore run the WORKER and observe what reaches the DAO. A
+ * helper-level test cannot catch this class of bug: it passes whether or not
+ * anything calls the helper.
+ *
+ * Fixture mirrors DiffWorkerTest (Robolectric + in-memory Room + mockk DAOs).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DiffWorkerMixNoDownloadTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var db: StashDatabase
+
+    private val remoteSnapshotDao = mockk<com.stash.core.data.db.dao.RemoteSnapshotDao>()
+    private val downloadQueueDao = mockk<DownloadQueueDao>(relaxed = true)
+    private val syncHistoryDao = mockk<SyncHistoryDao>(relaxed = true)
+    private val syncStateManager = mockk<SyncStateManager>(relaxed = true)
+    private val musicRepository = mockk<MusicRepository>(relaxed = true)
+    private val syncPreferencesManager = mockk<SyncPreferencesManager>()
+    private val blocklistGuard = mockk<BlocklistGuard>()
+    private val streamingPreference = mockk<StreamingPreference>()
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(context, StashDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+
+        coEvery { blocklistGuard.isBlocked(any(), any(), any(), any()) } returns false
+        // Offline mode — the mode in which a mix used to pull its whole contents.
+        coEvery { streamingPreference.current() } returns false
+        every { syncPreferencesManager.spotifySyncMode } returns flowOf(SyncMode.ACCUMULATE)
+        every { syncPreferencesManager.youtubeSyncMode } returns flowOf(SyncMode.ACCUMULATE)
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    @Test
+    fun `daily mix enqueues nothing in offline mode`() = runBlocking {
+        // sync_enabled = true is the state defaultSyncEnabled used to produce
+        // automatically for a discovered mix, and the state existing installs
+        // still carry.
+        seedPlaylistAndSnapshot(PlaylistType.DAILY_MIX, "spotify:playlist:dm", "Daily Mix 1")
+
+        buildWorker().doWork()
+
+        coVerify(exactly = 0) { downloadQueueDao.insertAll(any()) }
+    }
+
+    /**
+     * Control: the fix must be "mixes don't download", not "nothing downloads".
+     * Without this, disabling all enqueueing would pass the test above.
+     */
+    @Test
+    fun `custom playlist still enqueues in offline mode`() = runBlocking {
+        seedPlaylistAndSnapshot(PlaylistType.CUSTOM, "spotify:playlist:mine", "My Playlist")
+
+        buildWorker().doWork()
+
+        coVerify(atLeast = 1) { downloadQueueDao.insertAll(any()) }
+    }
+
+    /** Seeds a sync-enabled local playlist plus a remote snapshot of 3 new tracks. */
+    private suspend fun seedPlaylistAndSnapshot(
+        type: PlaylistType,
+        sourceId: String,
+        name: String,
+    ) {
+        db.playlistDao().insert(
+            PlaylistEntity(
+                name = name,
+                source = MusicSource.SPOTIFY,
+                sourceId = sourceId,
+                type = type,
+                syncEnabled = true,
+            )
+        )
+
+        val snapshotId = 7L
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(
+            RemotePlaylistSnapshotEntity(
+                id = snapshotId,
+                syncId = 1L,
+                source = MusicSource.SPOTIFY,
+                sourcePlaylistId = sourceId,
+                playlistName = name,
+                playlistType = type,
+            )
+        )
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(snapshotId) } returns (0 until 3).map { i ->
+            RemoteTrackSnapshotEntity(
+                syncId = 1L,
+                snapshotPlaylistId = snapshotId,
+                title = "Track $i",
+                artist = "Artist $i",
+                spotifyUri = "spotify:track:new$i",
+                position = i,
+            )
+        }
+    }
+
+    private fun buildWorker(): DiffWorker = TestListenableWorkerBuilder<DiffWorker>(context)
+        .setInputData(workDataOf(PlaylistFetchWorker.KEY_SYNC_ID to 1L))
+        .setWorkerFactory(object : WorkerFactory() {
+            override fun createWorker(
+                appContext: Context,
+                workerClassName: String,
+                workerParameters: WorkerParameters,
+            ) = DiffWorker(
+                appContext, workerParameters,
+                database = db,
+                remoteSnapshotDao = remoteSnapshotDao,
+                trackDao = db.trackDao(),
+                playlistDao = db.playlistDao(),
+                downloadQueueDao = downloadQueueDao,
+                syncHistoryDao = syncHistoryDao,
+                trackMatcher = TrackMatcher(),
+                syncStateManager = syncStateManager,
+                musicRepository = musicRepository,
+                syncPreferencesManager = syncPreferencesManager,
+                blocklistGuard = blocklistGuard,
+                streamingPreference = streamingPreference,
+            )
+        })
+        .build()
+}

--- a/core/media/src/main/kotlin/com/stash/core/media/streaming/StreamSourceRegistry.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/streaming/StreamSourceRegistry.kt
@@ -159,6 +159,22 @@ class StreamSourceRegistry @Inject constructor(
                 if (allowYouTube) add("youtube" to { t: TrackEntity -> youtube.resolve(t, allowYtDlp) })
             }
         }
+        // Which sources are actually IN PLAY for this resolve, and why.
+        //
+        // Added after a "works in debug, dead in release" hunt where qbdlx never
+        // appeared in the logs at all and there was no way to tell whether it had
+        // been tried and failed, or silently excluded before it ever ran. The two
+        // gates that can drop a source here are invisible from the outside:
+        // `allowYtDlp` (false for speculative background fill) and the
+        // compile-time BuildConfig flags. Info level so a release build says so.
+        Log.i(
+            TAG,
+            "chain for ${track.id}: [${resolvers.joinToString(",") { it.first }}] " +
+                "allowYouTube=$allowYouTube allowYtDlp=$allowYtDlp " +
+                "qbdlxConfigured=${BuildConfig.QBDLX_CONFIGURED} " +
+                "arcodConfigured=${BuildConfig.ARCOD_CONFIGURED}",
+        )
+
         for ((name, fn) in resolvers) {
             val result = runCatching { fn(track) }
                 .onFailure { e ->

--- a/core/media/src/main/kotlin/com/stash/core/media/streaming/YouTubeStreamResolver.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/streaming/YouTubeStreamResolver.kt
@@ -25,21 +25,26 @@ import kotlinx.coroutines.withTimeoutOrNull
  * YouTube has effectively complete coverage; falling back to it
  * trades lossless fidelity for actually playing the music.
  *
- * **Playback uses yt-dlp; fill uses InnerTube (`allowYtDlp`).** The
- * InnerTube fast lane returns audio URLs in ~200 ms, but on-device
- * verification (2026-06-08) proved those URLs are PO-token-gated to a
- * ~1 MB preview and return HTTP 403 on any full-file request — they
- * cannot stream a whole track. So:
- *  - `allowYtDlp = true` (foreground tap, 1-ahead prefetch, and the
- *    [RefreshingDataSourceFactory] 403-refresh) resolves via yt-dlp
- *    DIRECT ([PreviewUrlExtractor.extractStreamUrlViaYtDlp]) — ~11 s but
- *    yields a full-range-playable URL.
- *  - `allowYtDlp = false` (background queue-fill) still uses the cheap
- *    InnerTube fast lane to seed the deep in-order timeline without
- *    touching the serialized cap-1 yt-dlp slot. Those placeholder URLs
- *    never actually stream audio: prefetch swaps the next-up to a yt-dlp
- *    URL before it plays, and any placeholder skipped-to before the swap
- *    403s and is transparently re-resolved via yt-dlp by the refresh seam.
+ * **Both lanes race ([PreviewUrlExtractor.extractStreamUrl]).** InnerTube
+ * returns audio URLs in ~200-500 ms against yt-dlp's ~3.6-15 s, and the
+ * first success wins.
+ *
+ * History worth keeping: on-device verification (2026-06-08) found the
+ * InnerTube URLs of the day were PO-token-gated to a ~1 MB preview and
+ * 403'd on any full-file request, so playback was pinned to yt-dlp
+ * DIRECT. That pinning outlived its cause. yt-dlp itself now extracts by
+ * pinning `player_client=android_vr` — the same client [InnerTubeClient]
+ * can query directly — so the slow lane was spawning Python to make one
+ * HTTPS request. Playback races again, and
+ * [com.stash.data.download.preview.AudioUrlTailProbe] is what makes that
+ * safe: a URL that can't serve its final byte is rejected before it
+ * reaches ExoPlayer and falls through to yt-dlp.
+ *
+ * `allowYtDlp = false` remains the fast-lane-only contract (InnerTube
+ * alone, never the serialized cap-1 yt-dlp slot) for speculative callers.
+ * No caller passes it today; the background queue-fill that did was
+ * refactored away.
+ *
  * The whole call is bound to [YT_RESOLVE_TIMEOUT_MS]; on timeout we treat
  * the track as unavailable.
  *
@@ -97,11 +102,17 @@ class YouTubeStreamResolver @Inject constructor(
             // placeholders never actually stream audio (prefetch / 403-refresh
             // swap them to a yt-dlp URL before playback).
             runCatching {
-                if (allowYtDlp) {
-                    urlExtractor.extractStreamUrlViaYtDlp(videoId)
-                } else {
-                    urlExtractor.extractStreamUrl(videoId, allowYtDlp = false)
-                }
+                // Race both lanes: InnerTube (ANDROID_VR, ~200-500ms) against
+                // yt-dlp, first success wins. This used to call
+                // extractStreamUrlViaYtDlp directly whenever allowYtDlp was true —
+                // i.e. on every real playback — which put a Python process spawn on
+                // the critical path of every YouTube-fallback tap and left the race
+                // as dead code, since nothing passes allowYtDlp = false any more.
+                //
+                // Racing again is safe now that AudioUrlTailProbe rejects the
+                // PO-token-gated URLs that forced the 2026-06-08 bypass: a gated
+                // URL never reaches ExoPlayer, it just falls through to yt-dlp.
+                urlExtractor.extractStreamUrl(videoId, allowYtDlp = allowYtDlp)
             }
                 .onFailure { t ->
                     // CancellationException MUST propagate — swallowing it would

--- a/core/media/src/test/kotlin/com/stash/core/media/streaming/YouTubeStreamResolverTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/streaming/YouTubeStreamResolverTest.kt
@@ -32,8 +32,8 @@ class YouTubeStreamResolverTest {
         // Mock throws CE synchronously — simulates an in-flight
         // extraction call hitting a suspension point that observes
         // parent cancellation. resolve() defaults allowYtDlp=true, which
-        // now routes through the yt-dlp-direct path.
-        coEvery { extractor.extractStreamUrlViaYtDlp(any()) } throws
+        // routes through the raced extractStreamUrl path.
+        coEvery { extractor.extractStreamUrl(any(), any()) } throws
             CancellationException("outer cancel")
         val resolver = YouTubeStreamResolver(extractor, ytMusic)
         val track = trackWithYoutubeId("abc123")
@@ -92,22 +92,30 @@ class YouTubeStreamResolverTest {
     }
 
     /**
-     * Core of the 2026-06-08 fix: playback resolution (allowYtDlp=true)
-     * must go straight to yt-dlp — the InnerTube/iOS fast lane returns
-     * PO-token-gated URLs that 403 past ~1MB and can't stream a full track.
+     * Playback resolution (allowYtDlp=true) races both lanes rather than going
+     * straight to yt-dlp.
+     *
+     * This test previously pinned the opposite, as "the core of the 2026-06-08
+     * fix": the InnerTube URLs of that day were PO-token-gated, 403'd past ~1MB
+     * and could not stream a full track, so playback was pinned to yt-dlp direct.
+     * That pinning outlived its cause — yt-dlp now extracts by pinning
+     * `player_client=android_vr`, a client InnerTubeClient can query itself, so
+     * the slow lane was spawning Python to make one HTTPS request. Racing is safe
+     * again because AudioUrlTailProbe rejects a URL that can't serve its final
+     * byte, so a gated URL falls through to yt-dlp instead of reaching ExoPlayer.
      */
     @Test
-    fun resolve_allowYtDlpTrue_routesToYtDlpDirect_notInnerTubeRace() = runTest {
+    fun resolve_allowYtDlpTrue_racesBothLanes_notYtDlpDirect() = runTest {
         val extractor: PreviewUrlExtractor = mockk()
         val ytMusic: YTMusicApiClient = mockk()
-        coEvery { extractor.extractStreamUrlViaYtDlp("abc123") } returns "https://ytdlp/abc123"
+        coEvery { extractor.extractStreamUrl("abc123", true) } returns "https://raced/abc123"
         val resolver = YouTubeStreamResolver(extractor, ytMusic)
 
         val result = resolver.resolve(trackWithYoutubeId("abc123"), allowYtDlp = true)
 
-        assertThat(result?.url).isEqualTo("https://ytdlp/abc123")
-        coVerify(exactly = 1) { extractor.extractStreamUrlViaYtDlp("abc123") }
-        coVerify(exactly = 0) { extractor.extractStreamUrl(any(), any()) }
+        assertThat(result?.url).isEqualTo("https://raced/abc123")
+        coVerify(exactly = 1) { extractor.extractStreamUrl("abc123", true) }
+        coVerify(exactly = 0) { extractor.extractStreamUrlViaYtDlp(any()) }
     }
 
     /**

--- a/data/download/src/main/kotlin/com/stash/data/download/preview/AudioUrlTailProbe.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/preview/AudioUrlTailProbe.kt
@@ -1,0 +1,74 @@
+package com.stash.data.download.preview
+
+import android.util.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Proves an audio URL can serve its WHOLE body, not just its opening megabyte.
+ *
+ * InnerTube can hand back PO-token-gated URLs that stream ~1 MB and then 403.
+ * Those look perfect in a 30-second search preview and die mid-track in playback
+ * — the failure that got the InnerTube fast lane removed from the playback path
+ * on 2026-06-08, leaving every YouTube-fallback play to pay for a yt-dlp process
+ * spawn. A HEAD or head-range request cannot tell a gated URL from a good one.
+ * The last byte can.
+ *
+ * **Fails OPEN.** No `contentLength`, a timeout, or a transport error all return
+ * true. A false rejection costs a needless ~3.6 s yt-dlp fallback, while a false
+ * acceptance is still caught downstream by RefreshingDataSourceFactory's 403
+ * re-resolve — so absence of evidence must never veto a URL. Only an explicit
+ * refusal from the CDN rejects.
+ */
+@Singleton
+class AudioUrlTailProbe @Inject constructor(private val client: OkHttpClient) {
+
+    /**
+     * @param contentLength the chosen `adaptiveFormats` entry's `contentLength`.
+     *   Null (or non-positive) means we have nothing to probe against and the URL
+     *   is accepted.
+     */
+    suspend fun servesFullFile(url: String, contentLength: Long?): Boolean {
+        if (contentLength == null || contentLength <= 0L) return true
+
+        val code = withTimeoutOrNull(PROBE_TIMEOUT_MS) {
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val request = Request.Builder()
+                        .url(url)
+                        // The final byte: a gated URL refuses here while serving
+                        // the head of the file happily.
+                        .header("Range", "bytes=${contentLength - 1}-")
+                        .build()
+                    client.newBuilder()
+                        .callTimeout(PROBE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                        .build()
+                        .newCall(request)
+                        .execute()
+                        .use { it.code }
+                }.getOrElse { t ->
+                    if (t is CancellationException) throw t
+                    Log.d(TAG, "tail probe transport failure for ${url.take(60)}: ${t.message}")
+                    null
+                }
+            }
+        }
+
+        if (code == null) return true
+        val ok = code == 206 || code == 200
+        if (!ok) Log.i(TAG, "tail probe rejected a gated URL: code=$code")
+        return ok
+    }
+
+    private companion object {
+        private const val TAG = "AudioUrlTailProbe"
+        private const val PROBE_TIMEOUT_MS = 2_000L
+    }
+}

--- a/data/download/src/main/kotlin/com/stash/data/download/preview/PreviewUrlExtractor.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/preview/PreviewUrlExtractor.kt
@@ -109,6 +109,35 @@ class PreviewUrlExtractor @Inject constructor(
         private const val FORMAT_SELECTOR = "251/250/bestaudio"
 
         /**
+         * Selector for the pinned fast client. Audio-only itags first (251/250
+         * opus, 140 m4a); `best` last.
+         *
+         * That trailing `best` is a deliberate compromise, measured on-device
+         * 2026-07-29: android_vr currently advertises NO audio-only format, so an
+         * audio-only-only selector fails the attempt and the track falls to the
+         * default client at ~13s. With `best` it serves itag 18 — a combined 360p
+         * MP4, AAC ~96k — in ~2.8s. So the choice on this path is 2.8s at 96k AAC
+         * (plus discarded video bytes) versus 13s at 160k opus.
+         *
+         * Fast wins here because this is already the lossy last-resort path — it
+         * only runs when the track has no lossless source at all, and Now Playing
+         * badges it "via YT". A 13-second stall is the worse experience. Flip the
+         * order (drop `/best`) to trade back to quality.
+         */
+        private const val FAST_CLIENT_FORMAT_SELECTOR = "251/250/140/bestaudio/best"
+
+        /**
+         * Client pinned for the fast first attempt. Must be cookie-free (see
+         * [COOKIE_INCOMPATIBLE_CLIENTS]).
+         *
+         * Measured alternatives, same session: `ios` returns no usable URLs at all
+         * (YouTube's SABR-only experiment — yt-dlp #12482), and our own InnerTube
+         * request returns URLs that are PO-token-gated and 403 past the first
+         * megabyte, which [AudioUrlTailProbe] catches and rejects.
+         */
+        internal const val FAST_PLAYER_CLIENT = "android_vr"
+
+        /**
          * Concurrency caps for the two extractors. Shared process-wide.
          *
          * yt-dlp-android throws YoutubeDLException at ~120ms when a second
@@ -163,6 +192,33 @@ class PreviewUrlExtractor @Inject constructor(
             }
             return best
         }
+
+        /**
+         * Clients yt-dlp will not run with a `--cookies` file. Passing both makes
+         * yt-dlp skip the client entirely ("Skipping client X since it does not
+         * support cookies") rather than dropping the cookies, so a pinned
+         * cookie-incompatible client silently becomes a wasted round-trip plus a
+         * fallback. These clients are unauthenticated by design — that is why
+         * they return PO-token-free URLs — so they lose nothing without cookies.
+         */
+        private val COOKIE_INCOMPATIBLE_CLIENTS = setOf("android_vr")
+
+        internal fun supportsCookies(playerClient: String?): Boolean =
+            playerClient == null || playerClient !in COOKIE_INCOMPATIBLE_CLIENTS
+
+        /**
+         * Per-client format selector. The default client set reliably serves
+         * Opus itag 251/250, so ask for it by number and get the best free audio.
+         *
+         * android_vr does NOT (as of 2026-07-29 it answers
+         * "Requested format is not available" for 251/250/bestaudio), so pinning
+         * those itags failed the entire attempt and sent every extraction to the
+         * slow default path. Ask it for the best audio it actually has, falling
+         * back to a combined stream only if it offers no audio-only format.
+         */
+        internal fun formatSelectorFor(playerClient: String?): String =
+            if (playerClient in COOKIE_INCOMPATIBLE_CLIENTS) FAST_CLIENT_FORMAT_SELECTOR
+            else FORMAT_SELECTOR
 
         /**
          * Test-only: exercises [race] directly without Android deps. Reuses
@@ -508,11 +564,11 @@ class PreviewUrlExtractor @Inject constructor(
                 // to the default clients so coverage never regresses (the broad
                 // catalog reach is the whole reason YT fallback exists).
                 val fast = try {
-                    runYtDlp(videoId, playerClient = "android_vr")
+                    runYtDlp(videoId, playerClient = FAST_PLAYER_CLIENT)
                 } catch (ce: CancellationException) {
                     throw ce
                 } catch (e: Exception) {
-                    Log.d(TAG, "yt-dlp android_vr attempt failed for $videoId: ${e.message}")
+                    Log.d(TAG, "yt-dlp $FAST_PLAYER_CLIENT attempt failed for $videoId: ${e.message}")
                     null
                 }
                 fast ?: (runYtDlp(videoId, playerClient = null)
@@ -534,8 +590,13 @@ class PreviewUrlExtractor @Inject constructor(
             val url = "https://www.youtube.com/watch?v=$videoId"
 
             val request = YoutubeDLRequest(url).apply {
-                addOption("-f", FORMAT_SELECTOR)
+                addOption("-f", formatSelectorFor(playerClient))
                 addOption("--print", "urls")
+                // Diagnostic: which format the client actually served. android_vr
+                // stopped offering itag 251/250, so a selector that demands them
+                // fails the whole attempt — this makes the next such drift legible
+                // instead of a bare "Requested format is not available".
+                addOption("--print", "fmt=%(format_id)s acodec=%(acodec)s vcodec=%(vcodec)s")
                 addOption("--no-download")
                 playerClient?.let { addOption("--extractor-args", "youtube:player_client=$it") }
 
@@ -546,8 +607,19 @@ class PreviewUrlExtractor @Inject constructor(
                 }
             }
 
+            // Cookies and android_vr are mutually exclusive: yt-dlp refuses the
+            // client outright rather than dropping the cookies —
+            //   WARNING: [youtube] Skipping client "android_vr" since it does not
+            //   support cookies
+            // — so passing both silently disabled the whole fast path. Measured
+            // on-device 2026-07-29: 3.5s burned being refused, then 11.6s on the
+            // default multi-client path, ~15s per track, for every YouTube
+            // extraction since the two features met. android_vr needs no auth
+            // (that's why it's PO-token-free), so dropping cookies for that
+            // attempt costs nothing; the default-client fallback still sends them
+            // for age-gated / private content.
             val cookie = tokenManager.getYouTubeCookie()
-            if (cookie != null) {
+            if (cookie != null && supportsCookies(playerClient)) {
                 CookieFileWriter.write(cookie, cookieFile)
                 cookieFile.setReadable(false, false)
                 cookieFile.setReadable(true, true)
@@ -567,6 +639,14 @@ class PreviewUrlExtractor @Inject constructor(
             Log.d(TAG, "yt-dlp: exit=${response.exitCode} client=${playerClient ?: "default"} stdoutLen=${stdout.length}")
             if (stderr.isNotBlank()) {
                 Log.d(TAG, "yt-dlp stderr: ${stderr.take(500)}")
+            }
+
+            // The `fmt=` line comes from the diagnostic --print above. Logging it
+            // tells us whether a client served audio-only or fell back to a
+            // combined (video-carrying) stream, which matters for a music app's
+            // data use.
+            stdout.trim().lines().firstOrNull { it.startsWith("fmt=") }?.let {
+                Log.d(TAG, "yt-dlp: $it client=${playerClient ?: "default"}")
             }
 
             val streamUrl = stdout.trim().lines().firstOrNull { it.startsWith("http") }

--- a/data/download/src/main/kotlin/com/stash/data/download/preview/PreviewUrlExtractor.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/preview/PreviewUrlExtractor.kt
@@ -78,6 +78,7 @@ class PreviewUrlExtractor @Inject constructor(
     private val ytDlpManager: YtDlpManager,
     private val tokenManager: TokenManager,
     private val innerTubeClient: InnerTubeClient,
+    private val tailProbe: AudioUrlTailProbe,
 ) {
     /** Test-only injection point for race logic. Not wired in production. */
     internal interface TestHooks {
@@ -140,7 +141,15 @@ class PreviewUrlExtractor @Inject constructor(
          * Only formats with a direct `url` (not signatureCipher) are
          * considered; ciphered formats are skipped.
          */
-        internal fun selectBestAudioUrl(formats: List<JsonObject>): String? {
+        internal fun selectBestAudioUrl(formats: List<JsonObject>): String? =
+            selectBestAudioFormat(formats)?.get("url")?.jsonPrimitive?.content
+
+        /**
+         * Format-returning form of [selectBestAudioUrl]. Playback needs the whole
+         * format object, not just its `url`, so the caller can read
+         * `contentLength` and tail-probe it — see [AudioUrlTailProbe].
+         */
+        internal fun selectBestAudioFormat(formats: List<JsonObject>): JsonObject? {
             val audio = formats.filter { f ->
                 (f["mimeType"]?.jsonPrimitive?.content ?: "").startsWith("audio/") && f["url"] != null
             }
@@ -152,7 +161,7 @@ class PreviewUrlExtractor @Inject constructor(
                 val mime = best["mimeType"]?.jsonPrimitive?.content
                 Log.d(TAG, "InnerTube selected mime=$mime bitrate=${bitrate(best)} opusPreferred=${opusBest != null}")
             }
-            return best?.get("url")?.jsonPrimitive?.content
+            return best
         }
 
         /**
@@ -460,9 +469,20 @@ class PreviewUrlExtractor @Inject constructor(
 
             // Find the best audio format with a direct URL (not signatureCipher).
             // Prefers Opus 251/250 over AAC even at equal/lower bitrate.
-            val streamUrl = selectBestAudioUrl(adaptiveFormats.filterIsInstance<JsonObject>()) ?: run {
+            val bestFormat = selectBestAudioFormat(adaptiveFormats.filterIsInstance<JsonObject>()) ?: run {
                 Log.d(TAG, "InnerTube: no audio formats with direct URL for $videoId " +
                     "(${adaptiveFormats.size} total formats, all may be ciphered)")
+                return@withTimeout null
+            }
+            val streamUrl = bestFormat["url"]?.jsonPrimitive?.content ?: return@withTimeout null
+
+            // A PO-token-gated URL serves ~1MB then 403s. Handing one back is what
+            // killed playback on 2026-06-08 and cost us the fast lane; the probe is
+            // what makes this path safe for whole tracks rather than previews only.
+            // Rejection just defers to yt-dlp, exactly as a cipher miss does.
+            val contentLength = bestFormat["contentLength"]?.jsonPrimitive?.content?.toLongOrNull()
+            if (!tailProbe.servesFullFile(streamUrl, contentLength)) {
+                Log.i(TAG, "InnerTube: URL failed the tail probe for $videoId — deferring to yt-dlp")
                 return@withTimeout null
             }
 

--- a/data/download/src/test/kotlin/com/stash/data/download/preview/AudioUrlTailProbeTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/preview/AudioUrlTailProbeTest.kt
@@ -1,0 +1,70 @@
+package com.stash.data.download.preview
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The probe exists because "does this URL play" is not answerable from the head of
+ * the file. A PO-token-gated InnerTube URL serves its first ~1 MB and then 403s:
+ * it looks perfect in a search preview and dies mid-track in playback, which is
+ * what got the InnerTube fast lane pulled off the playback path. Only the last
+ * byte distinguishes the two.
+ *
+ * It fails OPEN on purpose. A false rejection costs a needless ~3.6 s yt-dlp
+ * fallback; a false acceptance is still caught downstream by
+ * RefreshingDataSourceFactory's 403 re-resolve. So absence of evidence (no
+ * contentLength, a timeout, a dead socket) must never veto a URL.
+ *
+ * Uses `runBlocking`, NOT `runTest`: the probe does real socket I/O on
+ * Dispatchers.IO while its budget is a `withTimeoutOrNull`. Under `runTest`'s
+ * virtual clock that timeout fires instantly, the probe fails open, and every
+ * assertion that depends on the real response code silently passes for the
+ * wrong reason.
+ */
+class AudioUrlTailProbeTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var probe: AudioUrlTailProbe
+
+    @Before fun setUp() {
+        server = MockWebServer().also { it.start() }
+        probe = AudioUrlTailProbe(OkHttpClient())
+    }
+
+    @After fun tearDown() { server.shutdown() }
+
+    @Test fun `206 on the tail byte passes`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(206).setBody("x"))
+        assertThat(probe.servesFullFile(server.url("/a").toString(), contentLength = 5_000_000L))
+            .isTrue()
+    }
+
+    @Test fun `403 on the tail byte fails`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(403))
+        assertThat(probe.servesFullFile(server.url("/a").toString(), contentLength = 5_000_000L))
+            .isFalse()
+    }
+
+    @Test fun `missing contentLength passes without making a request`() = runBlocking {
+        assertThat(probe.servesFullFile(server.url("/a").toString(), contentLength = null)).isTrue()
+        assertThat(server.requestCount).isEqualTo(0)
+    }
+
+    @Test fun `the probe requests only the final byte`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(206).setBody("x"))
+        probe.servesFullFile(server.url("/a").toString(), contentLength = 1000L)
+        assertThat(server.takeRequest().getHeader("Range")).isEqualTo("bytes=999-")
+    }
+
+    @Test fun `transport failure passes rather than vetoing`() = runBlocking {
+        val url = server.url("/a").toString()
+        server.shutdown()
+        assertThat(probe.servesFullFile(url, contentLength = 1000L)).isTrue()
+    }
+}

--- a/data/download/src/test/kotlin/com/stash/data/download/preview/CookieIncompatibleClientTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/preview/CookieIncompatibleClientTest.kt
@@ -1,0 +1,33 @@
+package com.stash.data.download.preview
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * yt-dlp responds to `--cookies` + a cookie-incompatible client by skipping the
+ * client, not by dropping the cookies:
+ *
+ *     WARNING: [youtube] Skipping client "android_vr" since it does not support cookies
+ *
+ * So sending both silently disabled the android_vr fast path. Measured on-device
+ * 2026-07-29: 3.5s burned being refused, then 11.6s on the default multi-client
+ * path — ~15s for every YouTube extraction, for as long as the two features have
+ * coexisted. The failure is invisible without reading yt-dlp's stderr, which is
+ * why it lasted, and why the rule gets a test of its own.
+ */
+class CookieIncompatibleClientTest {
+
+    @Test fun `android_vr never gets a cookie file`() {
+        assertThat(PreviewUrlExtractor.supportsCookies("android_vr")).isFalse()
+    }
+
+    /** The default client set is where cookies earn their keep (age-gated, private). */
+    @Test fun `default client still gets cookies`() {
+        assertThat(PreviewUrlExtractor.supportsCookies(null)).isTrue()
+    }
+
+    @Test fun `other pinned clients are unaffected`() {
+        assertThat(PreviewUrlExtractor.supportsCookies("web")).isTrue()
+        assertThat(PreviewUrlExtractor.supportsCookies("ios")).isTrue()
+    }
+}

--- a/data/download/src/test/kotlin/com/stash/data/download/preview/PreviewUrlExtractorTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/preview/PreviewUrlExtractorTest.kt
@@ -149,6 +149,9 @@ class PreviewUrlExtractorTest {
             ytDlpManager = mockk(relaxed = true),
             tokenManager = mockk(relaxed = true),
             innerTubeClient = mockk(relaxed = true),
+            // Never consulted: these tests drive the TestHooks SPI, which
+            // bypasses extractViaInnerTube where the probe lives.
+            tailProbe = mockk(relaxed = true),
         )
         val hooks = object : PreviewUrlExtractor.TestHooks {
             override suspend fun innerTubeExtract(id: String): String? {
@@ -179,6 +182,9 @@ class PreviewUrlExtractorTest {
             ytDlpManager = mockk(relaxed = true),
             tokenManager = mockk(relaxed = true),
             innerTubeClient = mockk(relaxed = true),
+            // Never consulted: these tests drive the TestHooks SPI, which
+            // bypasses extractViaInnerTube where the probe lives.
+            tailProbe = mockk(relaxed = true),
         )
         val hooks = object : PreviewUrlExtractor.TestHooks {
             override suspend fun innerTubeExtract(id: String): String? = gate.await()
@@ -208,6 +214,9 @@ class PreviewUrlExtractorTest {
             ytDlpManager = mockk(relaxed = true),
             tokenManager = mockk(relaxed = true),
             innerTubeClient = mockk(relaxed = true),
+            // Never consulted: these tests drive the TestHooks SPI, which
+            // bypasses extractViaInnerTube where the probe lives.
+            tailProbe = mockk(relaxed = true),
         )
         val hooks = object : PreviewUrlExtractor.TestHooks {
             override suspend fun innerTubeExtract(id: String): String? = null
@@ -249,6 +258,9 @@ class PreviewUrlExtractorTest {
             ytDlpManager = mockk(relaxed = true),
             tokenManager = mockk(relaxed = true),
             innerTubeClient = mockk(relaxed = true),
+            // Never consulted: these tests drive the TestHooks SPI, which
+            // bypasses extractViaInnerTube where the probe lives.
+            tailProbe = mockk(relaxed = true),
         )
         val invocations = AtomicInteger(0)
         val hooks = object : PreviewUrlExtractor.TestHooks {
@@ -274,6 +286,9 @@ class PreviewUrlExtractorTest {
             ytDlpManager = mockk(relaxed = true),
             tokenManager = mockk(relaxed = true),
             innerTubeClient = mockk(relaxed = true),
+            // Never consulted: these tests drive the TestHooks SPI, which
+            // bypasses extractViaInnerTube where the probe lives.
+            tailProbe = mockk(relaxed = true),
         )
         val ytdlpCalled = AtomicBoolean(false)
         val hooks = object : PreviewUrlExtractor.TestHooks {
@@ -299,6 +314,9 @@ class PreviewUrlExtractorTest {
             ytDlpManager = mockk(relaxed = true),
             tokenManager = mockk(relaxed = true),
             innerTubeClient = mockk(relaxed = true),
+            // Never consulted: these tests drive the TestHooks SPI, which
+            // bypasses extractViaInnerTube where the probe lives.
+            tailProbe = mockk(relaxed = true),
         )
         val ytdlpCalled = AtomicBoolean(false)
         val hooks = object : PreviewUrlExtractor.TestHooks {
@@ -322,6 +340,9 @@ class PreviewUrlExtractorTest {
             ytDlpManager = mockk(relaxed = true),
             tokenManager = mockk(relaxed = true),
             innerTubeClient = mockk(relaxed = true),
+            // Never consulted: these tests drive the TestHooks SPI, which
+            // bypasses extractViaInnerTube where the probe lives.
+            tailProbe = mockk(relaxed = true),
         )
         val hooks = object : PreviewUrlExtractor.TestHooks {
             override suspend fun innerTubeExtract(id: String): String? = null
@@ -343,6 +364,9 @@ class PreviewUrlExtractorTest {
             ytDlpManager = mockk(relaxed = true),
             tokenManager = mockk(relaxed = true),
             innerTubeClient = mockk(relaxed = true),
+            // Never consulted: these tests drive the TestHooks SPI, which
+            // bypasses extractViaInnerTube where the probe lives.
+            tailProbe = mockk(relaxed = true),
         )
         val innerTubeCalled = AtomicBoolean(false)
         val hooks = object : PreviewUrlExtractor.TestHooks {
@@ -370,6 +394,9 @@ class PreviewUrlExtractorTest {
             ytDlpManager = mockk(relaxed = true),
             tokenManager = mockk(relaxed = true),
             innerTubeClient = mockk(relaxed = true),
+            // Never consulted: these tests drive the TestHooks SPI, which
+            // bypasses extractViaInnerTube where the probe lives.
+            tailProbe = mockk(relaxed = true),
         )
         val ytMax = AtomicInteger(0); val ytCur = AtomicInteger(0)
         val hooks = object : PreviewUrlExtractor.TestHooks {
@@ -392,6 +419,9 @@ class PreviewUrlExtractorTest {
             ytDlpManager = mockk(relaxed = true),
             tokenManager = mockk(relaxed = true),
             innerTubeClient = mockk(relaxed = true),
+            // Never consulted: these tests drive the TestHooks SPI, which
+            // bypasses extractViaInnerTube where the probe lives.
+            tailProbe = mockk(relaxed = true),
         )
         val invocations = AtomicInteger(0)
         val hooks = object : PreviewUrlExtractor.TestHooks {

--- a/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/InnerTubeClient.kt
+++ b/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/InnerTubeClient.kt
@@ -50,7 +50,18 @@ enum class InnerTubeVariant(
     /** Whether unauthenticated requests should append the YT-Music API key. */
     val sendsApiKey: Boolean = false,
 ) {
-    /** Oculus Quest 3 VR browser. Historically returns unciphered URLs. */
+    /**
+     * Oculus Quest 3 VR browser. Returns direct, unciphered audio URLs with no PO
+     * token — this is the client yt-dlp pins as `player_client=android_vr`, and
+     * every URL Stash currently streams through the YouTube fallback comes from
+     * it (via a ~3.6 s Python process instead of this ~200 ms request).
+     *
+     * Must be queried on the `www.youtube.com` host, keyless, with the numeric
+     * client-name header (`28`). It was dropped from [AUDIO_VARIANT_ORDER] once
+     * as "no longer unciphered" while still pointing at the YT-Music host with a
+     * blank client-name id — the identical misconfiguration that made IOS look
+     * broken until it was moved to www/keyless/numeric.
+     */
     ANDROID_VR(
         clientName = "ANDROID_VR",
         clientVersion = "1.60.19",
@@ -64,6 +75,9 @@ enum class InnerTubeVariant(
             "osVersion" to "12L",
             "androidSdkVersion" to 32,
         ),
+        apiBase = "https://www.youtube.com/youtubei/v1",
+        clientNameId = "28",
+        sendsApiKey = false,
     ),
 
     /**
@@ -149,13 +163,25 @@ class InnerTubeClient @Inject constructor(
         private const val API_KEY = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30"
 
         /**
-         * Ordered attempt list for audio URL extraction. Only the IOS client
-         * reliably returns direct (unciphered) URLs on the fast lane, so it is
-         * the sole entry; ANDROID_VR / WEB_REMIX no longer serve the unciphered
-         * shape and only added latency. `internal` so variant tests can assert
-         * the order without widening to the public API.
+         * Ordered attempt list for audio URL extraction.
+         *
+         * ANDROID_VR first: it is the client yt-dlp pins to get a direct itag-251
+         * URL with no PO token, no m3u8 manifest and no QuickJS signature solve.
+         * It was removed from this list once as "no longer unciphered", but it had
+         * never been given the www-host / numeric-client-id / keyless transport
+         * that the same change applied to IOS — so it was judged on a
+         * misconfiguration rather than on merit.
+         *
+         * IOS second: the proven fast lane, kept as the backstop.
+         *
+         * WEB_REMIX is deliberately absent: it wraps URLs in `signatureCipher`,
+         * which forces the yt-dlp path anyway, so trying it only adds latency.
+         *
+         * `internal` so variant tests can assert the order without widening to
+         * the public API.
          */
         internal val AUDIO_VARIANT_ORDER = listOf(
+            InnerTubeVariant.ANDROID_VR,
             InnerTubeVariant.IOS,
         )
     }

--- a/data/ytmusic/src/test/kotlin/com/stash/data/ytmusic/InnerTubeVariantTest.kt
+++ b/data/ytmusic/src/test/kotlin/com/stash/data/ytmusic/InnerTubeVariantTest.kt
@@ -28,7 +28,24 @@ class InnerTubeVariantTest {
         assertTrue(web.sendsApiKey)
     }
 
-    @Test fun audio_variant_order_is_ios_only() {
-        assertEquals(listOf(InnerTubeVariant.IOS), InnerTubeClient.AUDIO_VARIANT_ORDER)
+    /**
+     * ANDROID_VR is the client yt-dlp pins (`player_client=android_vr`) to get a
+     * direct itag-251 URL with no PO token, no m3u8 manifest and no signature
+     * solve — the URLs this app streams today are android_vr URLs, minted the
+     * slow way through a Python process. It must be tried on the www host as
+     * client 28, the same transport shape that made IOS work.
+     */
+    @Test fun android_vr_uses_www_host_as_client_28_keyless() {
+        val vr = InnerTubeVariant.ANDROID_VR
+        assertEquals("https://www.youtube.com/youtubei/v1", vr.apiBase)
+        assertEquals("28", vr.clientNameId)
+        assertFalse(vr.sendsApiKey)
+    }
+
+    @Test fun audio_variant_order_tries_android_vr_then_ios() {
+        assertEquals(
+            listOf(InnerTubeVariant.ANDROID_VR, InnerTubeVariant.IOS),
+            InnerTubeClient.AUDIO_VARIANT_ORDER,
+        )
     }
 }

--- a/docs/superpowers/plans/2026-07-29-streaming-fast-lane-and-download-consent.md
+++ b/docs/superpowers/plans/2026-07-29-streaming-fast-lane-and-download-consent.md
@@ -1,0 +1,839 @@
+# Streaming Fast Lane + Download Consent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop algorithmic mixes from downloading without consent, and stop every YouTube-fallback playback from paying the slow yt-dlp lane.
+
+**Architecture:** Part A is pure predicate work — wire one guard that already exists and unify three SQL predicates around a single definition of "download-eligible". Part B re-opens the existing InnerTube/yt-dlp race for playback, fixing the ANDROID_VR client's transport config and adding a tail-range probe so a PO-token-gated URL can never reach ExoPlayer.
+
+**Tech Stack:** Kotlin, Room, Hilt, WorkManager, OkHttp, Robolectric + in-memory Room for DAO tests, MockWebServer for HTTP tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-streaming-fast-lane-and-download-consent-design.md`
+
+**Branch:** `fix/stream-fast-lane-and-mix-downloads` (already created; spec committed at 98484f18)
+
+**Do Part A first.** It is pure logic with no network dependency, it fixes the user-facing data-loss-adjacent bug (#368), and it cannot be destabilised by Part B's on-device findings.
+
+---
+
+## File Structure
+
+**Part A — download consent**
+
+| File | Responsibility | Change |
+|---|---|---|
+| `core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt` | Sync diff + enqueue decision | Modify `:43-44` (`defaultSyncEnabled`), `:565` (enqueue gate) |
+| `core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt` | Queue predicates | Modify `:553`, `:601`, `:412-424` |
+| `core/data/src/test/kotlin/com/stash/core/data/sync/workers/DefaultSyncEnabledTest.kt` | Existing test, asserts current auto-enable | Update expectations |
+| `core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerMixNoDownloadTest.kt` | Enqueue-gate regression | Create |
+| `core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoMixExclusionTest.kt` | All three predicates vs mix parents | Create |
+| `core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoMixVisibilityTest.kt` | Pins the load-bearing visibility assumption | Create |
+
+**Part B — streaming fast lane**
+
+| File | Responsibility | Change |
+|---|---|---|
+| `data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/InnerTubeClient.kt` | Client variants + player lookup | Modify `ANDROID_VR` config (`:54-67`), `AUDIO_VARIANT_ORDER` (`:151-160`) |
+| `data/download/src/main/kotlin/com/stash/data/download/preview/AudioUrlTailProbe.kt` | Proves a URL serves its whole body | Create |
+| `data/download/src/main/kotlin/com/stash/data/download/preview/PreviewUrlExtractor.kt` | Extraction + race | Modify `selectBestAudioUrl` (`:143`), `extractViaInnerTube` (`:428`) |
+| `core/media/src/main/kotlin/com/stash/core/media/streaming/YouTubeStreamResolver.kt` | Playback resolve | Modify `:100-104` |
+| `data/download/src/test/kotlin/com/stash/data/download/preview/AudioUrlTailProbeTest.kt` | Probe behaviour over MockWebServer | Create |
+
+---
+
+## Definition of "download-eligible"
+
+Both parts of Part A converge on one rule. Write it once, apply it three times:
+
+> A track is download-eligible when it is a member (`removed_at IS NULL`) of a
+> playlist with `is_active = 1 AND sync_enabled = 1` whose `type` is neither
+> `STASH_MIX` nor `DAILY_MIX`.
+
+Three SQL sites enforce it today, inconsistently: `getUnqueuedTrackIds` and
+`deleteOrphanedQueueEntries` exclude only `STASH_MIX`;
+`cancelDownloadsWithNoEnabledPlaylist` excludes no types at all.
+
+---
+
+# Part A — Download consent
+
+### Task A1: Wire the enqueue guard that already exists
+
+`shouldEnqueueForDownload` (`DiffWorker.kt:53-54`) excludes `DAILY_MIX`, is already unit-tested, and is called by nothing but its test. The real enqueue site tests raw `!streamingMode`.
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt:565`
+- Test: `core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerMixNoDownloadTest.kt` (create)
+
+- [ ] **Step 1: Write the failing test — at the WORKER level, not the helper**
+
+**This distinction is the whole point of the task.** A test that calls
+`shouldEnqueueForDownload` directly passes today and would keep passing if the
+wiring were reverted — the helper was always correct; nothing called it. The
+test must fail when the enqueue site tests raw `!streamingMode`, so it has to
+run the worker and observe what reaches the DAO.
+
+`DiffWorkerTest.kt` already has the exact harness: Robolectric + real in-memory
+Room, `downloadQueueDao = mockk<DownloadQueueDao>(relaxed = true)` (`:60`),
+`streamingPreference` stubbed to Offline by default (`:74`), and a `buildWorker()`
+helper (`:806-830`). Model the new file on it and reuse that construction
+verbatim.
+
+```kotlin
+package com.stash.core.data.sync.workers
+
+// Fixture setup (db, mockk DAOs, buildWorker) copied from DiffWorkerTest.kt —
+// see :52-90 and :806-830. Only the scenario below differs.
+
+/**
+ * #368: an auto-discovered algorithmic mix must never enqueue downloads, even in
+ * Offline mode. The guard `shouldEnqueueForDownload` excluded DAILY_MIX from the
+ * day it was written and was unit-tested — but DiffWorker's enqueue site tested
+ * raw `!streamingMode`, so every track of every rotating Spotify/YT mix was
+ * queued. This asserts the WIRING, which a helper-level test cannot.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DiffWorkerMixNoDownloadTest {
+
+    @Test fun `daily mix enqueues nothing in offline mode`() = runBlocking {
+        // Offline mode: the mode in which a mix used to pull its whole contents.
+        coEvery { streamingPreference.current() } returns false
+
+        // A DAILY_MIX that is already sync_enabled — the state defaultSyncEnabled
+        // used to produce automatically, and the state existing installs carry.
+        seedPlaylist(type = PlaylistType.DAILY_MIX, syncEnabled = true)
+        seedRemoteSnapshotWithNewTracks(count = 3)
+
+        buildWorker().doWork()
+
+        coVerify(exactly = 0) { downloadQueueDao.insertAll(any()) }
+    }
+
+    @Test fun `custom playlist still enqueues in offline mode`() = runBlocking {
+        coEvery { streamingPreference.current() } returns false
+        seedPlaylist(type = PlaylistType.CUSTOM, syncEnabled = true)
+        seedRemoteSnapshotWithNewTracks(count = 3)
+
+        buildWorker().doWork()
+
+        coVerify(atLeast = 1) { downloadQueueDao.insertAll(any()) }
+    }
+}
+```
+
+The second test is not padding: it is what stops the fix from being "disable all
+downloads", which would pass the first test and break the product.
+
+Separately, `shouldEnqueueForDownload(STASH_MIX, false)` currently returns
+**true** and `ShouldEnqueueForDownloadTest:25` asserts that. Step 3 excludes both
+mix types, so update that existing assertion in the same commit.
+
+- [ ] **Step 2: Run it and confirm the mix case fails**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.DiffWorkerMixNoDownloadTest"
+```
+
+Expected: FAIL on `daily mix enqueues nothing in offline mode` — `insertAll` was
+called once. The `custom playlist` test must already PASS. If the mix test passes
+before the fix, the fixture isn't producing new tracks — fix the fixture before
+touching production code, or the task proves nothing.
+
+- [ ] **Step 3: Exclude both mix types in the helper, and wire it at the enqueue site**
+
+In `DiffWorker.kt:53-54`, replace the body:
+
+```kotlin
+internal fun shouldEnqueueForDownload(type: PlaylistType, streamingMode: Boolean): Boolean =
+    !streamingMode && type != PlaylistType.DAILY_MIX && type != PlaylistType.STASH_MIX
+```
+
+In `DiffWorker.kt:565`, replace `if (!streamingMode) {` with:
+
+```kotlin
+        // Mixes are surface-only: they stream on tap and must never pull bytes.
+        // This guard existed (and was unit-tested) since it was written but was
+        // never wired here — the site tested raw `!streamingMode`, so every
+        // track of every rotating mix was queued in Offline mode (#368).
+        if (shouldEnqueueForDownload(localPlaylist.type, streamingMode)) {
+```
+
+Update `ShouldEnqueueForDownloadTest.kt:25` to expect `isFalse()` for `STASH_MIX`, with a comment naming #368.
+
+- [ ] **Step 4: Run both test classes**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.DiffWorkerMixNoDownloadTest" --tests "com.stash.core.data.sync.workers.ShouldEnqueueForDownloadTest"
+```
+
+Expected: PASS, both classes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerMixNoDownloadTest.kt core/data/src/test/kotlin/com/stash/core/data/sync/workers/ShouldEnqueueForDownloadTest.kt
+git commit -m "fix(sync): wire the mix download guard DiffWorker never called (#368)"
+```
+
+---
+
+### Task A2: Stop auto-enabling discovered mixes
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt:36-44`
+- Test: `core/data/src/test/kotlin/com/stash/core/data/sync/workers/DefaultSyncEnabledTest.kt` (update)
+
+- [ ] **Step 1: Update the existing test to the new contract**
+
+Replace the DAILY_MIX/online expectation with:
+
+```kotlin
+    /**
+     * Auto-enabling a discovered mix is what made it download-eligible and what
+     * made the sweep spare it. Surfacing does NOT depend on it: getAllVisible's
+     * streamable escape hatch already shows a sync_enabled = 0 mix in Online
+     * mode, so opt-in costs nothing (see PlaylistDaoMixVisibilityTest).
+     */
+    @Test fun `discovered playlists are opt-in in both modes`() {
+        assertThat(defaultSyncEnabled(PlaylistType.DAILY_MIX, online = true)).isFalse()
+        assertThat(defaultSyncEnabled(PlaylistType.DAILY_MIX, online = false)).isFalse()
+        assertThat(defaultSyncEnabled(PlaylistType.CUSTOM, online = true)).isFalse()
+    }
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.DefaultSyncEnabledTest"
+```
+
+Expected: FAIL — the DAILY_MIX/online case currently returns true.
+
+- [ ] **Step 3: Make it always opt-in**
+
+In `DiffWorker.kt:35-44`, replace the KDoc and body:
+
+```kotlin
+/**
+ * A newly-discovered playlist's initial [PlaylistEntity.syncEnabled]: always
+ * opt-in. The first Sync Now is a discovery pass that downloads nothing unasked.
+ *
+ * DAILY_MIX used to auto-enable in Online mode "so mixes surface immediately
+ * with no download". That was redundant and load-bearing only for harm:
+ * [com.stash.core.data.db.dao.PlaylistDao.getAllVisible] already surfaces a
+ * `sync_enabled = 0` playlist whose tracks are streamable when
+ * `includeStreamable = true`, so mixes still appear on Home in Online mode.
+ * The flag's only other effects were making the mix download-eligible and
+ * making the orphan sweep spare its tracks (#368).
+ *
+ * Parameters are retained to document what was considered and to keep the
+ * decision testable.
+ */
+@Suppress("UNUSED_PARAMETER")
+internal fun defaultSyncEnabled(type: PlaylistType, online: Boolean): Boolean = false
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.sync.workers.DefaultSyncEnabledTest"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt core/data/src/test/kotlin/com/stash/core/data/sync/workers/DefaultSyncEnabledTest.kt
+git commit -m "fix(sync): discovered mixes are opt-in, not auto-enabled (#368)"
+```
+
+---
+
+### Task A3: Pin the visibility assumption A2 rests on
+
+If this test is ever red, A2 silently hides mixes instead of merely un-downloading them. Write it even though it should pass today — it is the guard rail on the design's central claim.
+
+**Files:**
+- Test: `core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoMixVisibilityTest.kt` (create)
+
+- [ ] **Step 1: Write the test**
+
+Use the setup pattern from `DownloadQueueDaoPartitionTest.kt:25-52`. Seed one `DAILY_MIX` playlist with `syncEnabled = false`, one track with `isDownloaded = false, isStreamable = true`, and a cross-ref with `removedAt = null`.
+
+```kotlin
+    @Test fun `sync-disabled daily mix with streamable tracks is visible online`() = runTest {
+        assertThat(playlistDao.getAllVisible(includeStreamable = true).first().map { it.id })
+            .contains(mixId)
+    }
+
+    @Test fun `sync-disabled daily mix with nothing downloaded is hidden offline`() = runTest {
+        assertThat(playlistDao.getAllVisible(includeStreamable = false).first().map { it.id })
+            .doesNotContain(mixId)
+    }
+```
+
+- [ ] **Step 2: Run it — expect PASS immediately (it documents existing behaviour)**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.PlaylistDaoMixVisibilityTest"
+```
+
+Expected: PASS. If it FAILS, **stop and reassess A2** — the design's premise is wrong.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoMixVisibilityTest.kt
+git commit -m "test(db): pin that a sync-disabled mix still surfaces online"
+```
+
+---
+
+### Task A4: Unify the three queue predicates
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt:553`, `:601`, `:412-424`
+- Test: `core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoMixExclusionTest.kt` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Seed three tracks, each with a PENDING queue row: one whose only parent is a `DAILY_MIX` (`syncEnabled = true`, mimicking an already-auto-enabled mix), one whose only parent is a `STASH_MIX` (`syncEnabled = true`), one in a `CUSTOM` playlist (`syncEnabled = true`). Then:
+
+```kotlin
+    @Test fun `daily-mix-only track is not requeue-eligible`() = runTest {
+        assertThat(dao.getUnqueuedTrackIds(listOf("SPOTIFY"))).doesNotContain(dailyMixTrackId)
+    }
+
+    @Test fun `orphan sweep evicts a daily-mix-only queue row`() = runTest {
+        dao.deleteOrphanedQueueEntries()
+        assertThat(dao.getByTrackId(dailyMixTrackId)).isNull()
+        assertThat(dao.getByTrackId(customTrackId)).isNotNull()
+    }
+
+    @Test fun `enabled-playlist sweep evicts a mix-only queue row`() = runTest {
+        dao.cancelDownloadsWithNoEnabledPlaylist()
+        assertThat(dao.getByTrackId(dailyMixTrackId)).isNull()
+        assertThat(dao.getByTrackId(stashMixTrackId)).isNull()
+        assertThat(dao.getByTrackId(customTrackId)).isNotNull()
+    }
+```
+
+For `getUnqueuedTrackIds` the seeded track must have **no** queue row (that query excludes tracks with PENDING/IN_PROGRESS/FAILED rows) — seed a fourth, queue-row-free `DAILY_MIX`-only track for that assertion.
+
+- [ ] **Step 2: Run it and confirm failures**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.DownloadQueueDaoMixExclusionTest"
+```
+
+Expected: FAIL on all three — `DAILY_MIX` is excluded nowhere, and `cancelDownloadsWithNoEnabledPlaylist` has no type filter at all.
+
+- [ ] **Step 3: Apply the same exclusion to all three queries**
+
+`DownloadQueueDao.kt:553` and `:601` — replace `AND p.type != 'STASH_MIX'` with:
+
+```sql
+                -- Mixes (generated STASH_MIX and algorithmic DAILY_MIX) are
+                -- stream-only: a mix-only membership never makes a track
+                -- download-eligible and never spares its queue row. DAILY_MIX
+                -- was missing here, so auto-enabled Spotify/YT mixes queued
+                -- their whole contents in Offline mode (#368).
+                AND p.type NOT IN ('STASH_MIX', 'DAILY_MIX')
+```
+
+`:412-424` (`cancelDownloadsWithNoEnabledPlaylist`) — add the same clause to its spared subquery, after `AND pt.removed_at IS NULL`.
+
+- [ ] **Step 4: Run the new test plus the whole DAO suite for regressions**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.stash.core.data.db.dao.*"
+```
+
+Expected: PASS. Existing sweep/partition tests must stay green — if one flips, read it: it may be asserting the old mix-spares-row behaviour and need updating with a comment.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoMixExclusionTest.kt
+git commit -m "fix(db): mix membership never makes a track download-eligible (#368)"
+```
+
+---
+
+### Task A5: Verify Part A whole-module, then on device
+
+- [ ] **Step 1: Full module suite**
+
+```bash
+./gradlew :core:data:testDebugUnitTest
+```
+
+Expected: PASS (baseline is 578 tests green per `infra_ci_now_green_baseline`). A red test here is this change.
+
+- [ ] **Step 2: Install and observe the sweep**
+
+```bash
+./gradlew :app:installDebug
+```
+
+Then trigger a sync and confirm from logcat that mix tracks are neither queued nor requeued:
+
+```powershell
+adb logcat -c
+# trigger Sync Now in the app
+adb logcat -d | Select-String "QueueTrace|Re-queuing|sync disabled, skipping"
+```
+
+Expected: no `Re-queuing` line naming mix tracks. `QueueTrace` counts should reflect real playlists only.
+
+- [ ] **Step 3: Commit any fixes, then stop for review before Part B**
+
+---
+
+# Part B — Streaming fast lane
+
+### Task B1: Measure the baseline first
+
+Do not skip this. The "~3.6 s" figure is a 2026-06-26 measurement; the reported symptom is "super slow", which suggests Chaquopy cold-start or the per-call `--remote-components ejs:github` fetch dominates. The number decides whether B is sufficient on its own.
+
+**Files:** none (measurement only)
+
+- [ ] **Step 1: Capture timings on device**
+
+```powershell
+adb logcat -c
+# in the app: play a track that has no lossless match (forces the YT fallback)
+Start-Sleep -Seconds 30
+adb logcat -d | Select-String "yt-dlp: invoking|yt-dlp: exit|StreamSourceRegistry: (youtube served|chain for)"
+```
+
+- [ ] **Step 2: Record the delta**
+
+Subtract the `yt-dlp: invoking` timestamp from `yt-dlp: exit`. Repeat on three different tracks, including one cold (right after force-stop) to separate cold-start cost. Write the numbers into the plan file under this task before proceeding.
+
+---
+
+### Task B2: Fix the ANDROID_VR transport config and restore it to the order
+
+**Context that changes the decision:** ANDROID_VR was in `AUDIO_VARIANT_ORDER` originally (195cd603) and removed in 5475aa05 with the comment "ANDROID_VR / WEB_REMIX no longer serve the unciphered shape". But that same commit is what *fixed* IOS by moving it to the `www.youtube.com` host with a numeric client-name header and no API key — and ANDROID_VR was never given that treatment. It still defaults to `apiBase = music.youtube.com` and `clientNameId = ""` (`InnerTubeClient.kt:54-67`). yt-dlp's `player_client=android_vr` — which posts to `www.youtube.com` as client 28 — works in this app today and is the source of every URL we currently stream. So ANDROID_VR was very likely judged on a misconfiguration, not on merit.
+
+**Files:**
+- Modify: `data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/InnerTubeClient.kt:54-67`, `:151-160`
+- Test: `data/ytmusic/src/test/kotlin/com/stash/data/ytmusic/InnerTubeVariantTest.kt` (update)
+
+- [ ] **Step 1: Update the variant-order test**
+
+```kotlin
+    /**
+     * ANDROID_VR first: it is the client yt-dlp pins (`player_client=android_vr`)
+     * to get a direct itag-251 URL with no PO token and no signature solve, and
+     * it must be tried on the www host as client 28 — the same transport fix
+     * that made IOS work in 5475aa05. IOS stays as the second attempt.
+     */
+    @Test fun `audio variant order tries ANDROID_VR before IOS`() {
+        assertThat(InnerTubeClient.AUDIO_VARIANT_ORDER)
+            .containsExactly(InnerTubeVariant.ANDROID_VR, InnerTubeVariant.IOS)
+            .inOrder()
+    }
+
+    @Test fun `ANDROID_VR posts to the www host as client 28 without an api key`() {
+        assertThat(InnerTubeVariant.ANDROID_VR.apiBase).isEqualTo("https://www.youtube.com/youtubei/v1")
+        assertThat(InnerTubeVariant.ANDROID_VR.clientNameId).isEqualTo("28")
+        assertThat(InnerTubeVariant.ANDROID_VR.sendsApiKey).isFalse()
+    }
+```
+
+- [ ] **Step 2: Run and confirm both fail**
+
+```bash
+./gradlew :data:ytmusic:testDebugUnitTest --tests "com.stash.data.ytmusic.InnerTubeVariantTest"
+```
+
+Expected: FAIL — order is `[IOS]`, and ANDROID_VR carries the defaults.
+
+- [ ] **Step 3: Fix the config and the order**
+
+In the `ANDROID_VR` declaration (`:54-67`) add, alongside the existing fields:
+
+```kotlin
+        apiBase = "https://www.youtube.com/youtubei/v1",
+        clientNameId = "28",
+        sendsApiKey = false,
+```
+
+Replace `AUDIO_VARIANT_ORDER` (`:151-160`) — and its KDoc, which currently states the stale conclusion:
+
+```kotlin
+        /**
+         * Ordered attempt list for audio URL extraction.
+         *
+         * ANDROID_VR first: it is the client yt-dlp pins to get a direct
+         * itag-251 URL with no PO token, no m3u8 manifest and no QuickJS
+         * signature solve — the URLs this app streams today are android_vr
+         * URLs, minted the slow way through a Python process. It was dropped
+         * from this list in 5475aa05 as "no longer unciphered", but it had
+         * never been moved to the www host with a numeric client-name header,
+         * which is exactly the transport fix that same commit applied to IOS.
+         *
+         * IOS second: proven fast lane, kept as the backstop.
+         *
+         * `internal` so variant tests can assert the order.
+         */
+        internal val AUDIO_VARIANT_ORDER = listOf(
+            InnerTubeVariant.ANDROID_VR,
+            InnerTubeVariant.IOS,
+        )
+```
+
+- [ ] **Step 4: Run the module suite**
+
+```bash
+./gradlew :data:ytmusic:testDebugUnitTest
+```
+
+Expected: PASS. (Per `infra_preexisting_matcher_test_failures` this module once had 22 known-red tests; the baseline has since flipped green — a red test here is this change.)
+
+- [ ] **Step 5: Prove it on device before building anything on top**
+
+```bash
+./gradlew :app:installDebug
+```
+
+```powershell
+adb logcat -c
+# in the app: search for a track and tap it to trigger a preview extract
+Start-Sleep -Seconds 15
+adb logcat -d | Select-String "playerForAudio|InnerTube: SUCCESS|InnerTube: no audio formats"
+```
+
+Expected: `playerForAudio videoId=… won with variant=ANDROID_VR`.
+
+**If ANDROID_VR loses here, stop.** The rest of Part B has no value without it: revert this task, record the finding in the spec, and leave playback on yt-dlp.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/InnerTubeClient.kt data/ytmusic/src/test/kotlin/com/stash/data/ytmusic/InnerTubeVariantTest.kt
+git commit -m "fix(yt): ANDROID_VR on the www host as client 28, restored to the audio order"
+```
+
+---
+
+### Task B3: Build the tail-range probe
+
+A PO-token-gated URL serves its first ~1 MB and then 403s, so "does it play" is not answerable by fetching the head. Probe the last byte.
+
+**Files:**
+- Create: `data/download/src/main/kotlin/com/stash/data/download/preview/AudioUrlTailProbe.kt`
+- Test: `data/download/src/test/kotlin/com/stash/data/download/preview/AudioUrlTailProbeTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+`data/download` already has `mockwebserver` on `testImplementation` (`build.gradle.kts:169`).
+
+```kotlin
+package com.stash.data.download.preview
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class AudioUrlTailProbeTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var probe: AudioUrlTailProbe
+
+    @Before fun setUp() {
+        server = MockWebServer().also { it.start() }
+        probe = AudioUrlTailProbe(OkHttpClient())
+    }
+
+    @After fun tearDown() = server.shutdown()
+
+    @Test fun `206 on the tail byte passes`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(206).setBody("x"))
+        assertThat(probe.servesFullFile(server.url("/a").toString(), contentLength = 5_000_000L)).isTrue()
+    }
+
+    @Test fun `403 on the tail byte fails`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(403))
+        assertThat(probe.servesFullFile(server.url("/a").toString(), contentLength = 5_000_000L)).isFalse()
+    }
+
+    /** Absence of contentLength is not evidence of gating — don't reject. */
+    @Test fun `missing contentLength passes without a request`() = runTest {
+        assertThat(probe.servesFullFile(server.url("/a").toString(), contentLength = null)).isTrue()
+        assertThat(server.requestCount).isEqualTo(0)
+    }
+
+    @Test fun `the probe requests only the final byte`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(206).setBody("x"))
+        probe.servesFullFile(server.url("/a").toString(), contentLength = 1000L)
+        assertThat(server.takeRequest().getHeader("Range")).isEqualTo("bytes=999-")
+    }
+
+    /** A network failure must not veto a URL we have no evidence against. */
+    @Test fun `transport failure passes`() = runTest {
+        server.shutdown()
+        assertThat(probe.servesFullFile(server.url("/a").toString(), contentLength = 1000L)).isTrue()
+    }
+}
+```
+
+- [ ] **Step 2: Run and confirm it fails to compile (class does not exist)**
+
+```bash
+./gradlew :data:download:testDebugUnitTest --tests "com.stash.data.download.preview.AudioUrlTailProbeTest"
+```
+
+Expected: FAIL — unresolved reference `AudioUrlTailProbe`.
+
+- [ ] **Step 3: Implement the probe**
+
+```kotlin
+package com.stash.data.download.preview
+
+import android.util.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Proves an audio URL can serve its WHOLE body, not just its opening megabyte.
+ *
+ * InnerTube can hand back PO-token-gated URLs that stream ~1 MB and then 403.
+ * Those played fine in a preview and died mid-track in playback — the failure
+ * that got the InnerTube fast lane removed from the playback path on
+ * 2026-06-08. A HEAD or head-range request cannot tell the two apart; the last
+ * byte can.
+ *
+ * Fails OPEN: no `contentLength`, a timeout, or a transport error all return
+ * true. We only reject on an explicit refusal from the CDN, because a false
+ * rejection costs a needless 3.6 s yt-dlp fallback while a false acceptance is
+ * caught downstream by RefreshingDataSourceFactory's 403 re-resolve.
+ */
+@Singleton
+class AudioUrlTailProbe @Inject constructor(private val client: OkHttpClient) {
+
+    suspend fun servesFullFile(url: String, contentLength: Long?): Boolean {
+        if (contentLength == null || contentLength <= 0L) return true
+        val result = withTimeoutOrNull(PROBE_TIMEOUT_MS) {
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val request = Request.Builder()
+                        .url(url)
+                        .header("Range", "bytes=${contentLength - 1}-")
+                        .build()
+                    client.newBuilder()
+                        .callTimeout(PROBE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                        .build()
+                        .newCall(request)
+                        .execute()
+                        .use { it.code }
+                }.getOrElse { t ->
+                    if (t is CancellationException) throw t
+                    Log.d(TAG, "tail probe transport failure for ${url.take(60)}: ${t.message}")
+                    null
+                }
+            }
+        }
+        if (result == null) return true
+        val ok = result == 206 || result == 200
+        if (!ok) Log.i(TAG, "tail probe rejected a gated URL: code=$result")
+        return ok
+    }
+
+    private companion object {
+        private const val TAG = "AudioUrlTailProbe"
+        private const val PROBE_TIMEOUT_MS = 2_000L
+    }
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+./gradlew :data:download:testDebugUnitTest --tests "com.stash.data.download.preview.AudioUrlTailProbeTest"
+```
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add data/download/src/main/kotlin/com/stash/data/download/preview/AudioUrlTailProbe.kt data/download/src/test/kotlin/com/stash/data/download/preview/AudioUrlTailProbeTest.kt
+git commit -m "feat(preview): tail-range probe proving an audio URL serves its whole body"
+```
+
+---
+
+### Task B4: Gate InnerTube results behind the probe
+
+`selectBestAudioUrl` returns only a `String`, so the chosen format's `contentLength` is lost. Split the selection from the URL extraction.
+
+**Files:**
+- Modify: `data/download/src/main/kotlin/com/stash/data/download/preview/PreviewUrlExtractor.kt:143-156`, `:428-472`, constructor `:76-81`
+
+- [ ] **Step 1: Add `selectBestAudioFormat`, keeping `selectBestAudioUrl` as a delegating wrapper**
+
+Existing tests call `selectBestAudioUrl`; do not break them.
+
+```kotlin
+        /** Format-returning form of [selectBestAudioUrl] — keeps `contentLength`
+         *  reachable so the caller can tail-probe the URL. */
+        internal fun selectBestAudioFormat(formats: List<JsonObject>): JsonObject? {
+            val audio = formats.filter { f ->
+                (f["mimeType"]?.jsonPrimitive?.content ?: "").startsWith("audio/") && f["url"] != null
+            }
+            fun bitrate(f: JsonObject) = f["bitrate"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L
+            fun isOpus(f: JsonObject) = (f["mimeType"]?.jsonPrimitive?.content ?: "").contains("opus")
+            val opusBest = audio.filter(::isOpus).maxByOrNull(::bitrate)
+            val best = opusBest ?: audio.maxByOrNull(::bitrate)
+            if (best != null) {
+                val mime = best["mimeType"]?.jsonPrimitive?.content
+                Log.d(TAG, "InnerTube selected mime=$mime bitrate=${bitrate(best)} opusPreferred=${opusBest != null}")
+            }
+            return best
+        }
+
+        internal fun selectBestAudioUrl(formats: List<JsonObject>): String? =
+            selectBestAudioFormat(formats)?.get("url")?.jsonPrimitive?.content
+```
+
+- [ ] **Step 2: Inject the probe and apply it in `extractViaInnerTube`**
+
+Add `private val tailProbe: AudioUrlTailProbe,` to the constructor (`:76-81`). Replace the `selectBestAudioUrl` block at `:463-467` with:
+
+```kotlin
+            val bestFormat = selectBestAudioFormat(adaptiveFormats.filterIsInstance<JsonObject>()) ?: run {
+                Log.d(TAG, "InnerTube: no audio formats with direct URL for $videoId " +
+                    "(${adaptiveFormats.size} total formats, all may be ciphered)")
+                return@withTimeout null
+            }
+            val streamUrl = bestFormat["url"]?.jsonPrimitive?.content ?: return@withTimeout null
+            val contentLength = bestFormat["contentLength"]?.jsonPrimitive?.content?.toLongOrNull()
+
+            // A PO-token-gated URL serves ~1 MB then 403s. Returning one here is
+            // what killed playback on 2026-06-08; the probe is what makes the
+            // fast lane safe to use for full tracks rather than previews only.
+            if (!tailProbe.servesFullFile(streamUrl, contentLength)) {
+                Log.i(TAG, "InnerTube: URL failed the tail probe for $videoId — deferring to yt-dlp")
+                return@withTimeout null
+            }
+```
+
+- [ ] **Step 3: Run the module suite**
+
+```bash
+./gradlew :data:download:testDebugUnitTest
+```
+
+Expected: PASS. Hilt supplies `OkHttpClient` in this module already (see `AmzApiClient`); if the injection fails to resolve, add the probe to the same Hilt module that provides the client rather than creating a new one.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add data/download/src/main/kotlin/com/stash/data/download/preview/PreviewUrlExtractor.kt
+git commit -m "fix(preview): tail-probe InnerTube URLs before returning them"
+```
+
+---
+
+### Task B5: Point playback at the race
+
+**Files:**
+- Modify: `core/media/src/main/kotlin/com/stash/core/media/streaming/YouTubeStreamResolver.kt:90-115`, class KDoc `:28-44`
+
+- [ ] **Step 1: Replace the yt-dlp-direct call with the race**
+
+At `:99-105`, replace the `if (allowYtDlp)` branch:
+
+```kotlin
+            runCatching {
+                // Both lanes: InnerTube (ANDROID_VR, ~200-500ms) raced against
+                // yt-dlp, first success wins. Playback used to call
+                // extractStreamUrlViaYtDlp directly, which made the race dead
+                // code and put a Python process spawn on every tap. Safe to
+                // race again because AudioUrlTailProbe now rejects the
+                // PO-token-gated URLs that forced the 2026-06-08 bypass.
+                urlExtractor.extractStreamUrl(videoId, allowYtDlp = allowYtDlp)
+            }
+```
+
+Update the class KDoc at `:28-44` to describe the current behaviour: both paths race; `allowYtDlp = false` is InnerTube-only for the fast-lane contract.
+
+- [ ] **Step 2: Run the module suite**
+
+```bash
+./gradlew :core:media:testDebugUnitTest
+```
+
+Expected: PASS (345 tests). Per `infra_core_media_test_flaky_hang` this suite has hung historically — if it hangs, that regression was fixed by using `UnconfinedTestDispatcher` in `LoudnessGainProcessorTest`; a fresh hang is worth a jstack rather than a retry.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/media/src/main/kotlin/com/stash/core/media/streaming/YouTubeStreamResolver.kt
+git commit -m "perf(stream): race InnerTube against yt-dlp on the playback path"
+```
+
+---
+
+### Task B6: Verify end to end on device
+
+- [ ] **Step 1: Install**
+
+```bash
+./gradlew :app:installDebug
+```
+
+- [ ] **Step 2: Confirm the fast lane wins and the track plays to completion**
+
+```powershell
+adb logcat -c
+# play a YT-fallback track; let it run past the 1MB mark (60+ seconds)
+Start-Sleep -Seconds 75
+adb logcat -d | Select-String "chain for|youtube served|won with variant|tail probe|yt-dlp: invoking"
+```
+
+Expected: `won with variant=ANDROID_VR`, `youtube served`, **no** `yt-dlp: invoking`, and no 403/re-resolve after the first minute. Playing past 1 MB is the point — a gated URL survives a short listen.
+
+- [ ] **Step 3: Re-measure and compare against B1's numbers**
+
+Record the before/after in the spec document.
+
+- [ ] **Step 4: Confirm no lossless regression**
+
+Play a track that qbdlx can serve and confirm `qbdlx served` still appears — this change must not alter source priority, only the YT fallback's cost.
+
+- [ ] **Step 5: Whole-repo test run before proposing a release**
+
+```bash
+./gradlew testDebugUnitTest --continue
+```
+
+Expected: green across all 15 modules (1892 baseline).
+
+- [ ] **Step 6: Commit and stop for review**
+
+---
+
+## Follow-ups (not in this plan)
+
+- yt-dlp cold-start and the per-call `--remote-components ejs:github` fetch, if B1's numbers show they dominate.
+- #264 (slow offline loads) and #334 (streamed tracks skipping) — re-check after B ships; both are plausibly downstream but unproven.
+- `deleteOrphanedQueueEntries` and `cancelDownloadsWithNoEnabledPlaylist` are near-duplicate sweeps. Consolidating them would remove a class of "fixed one, missed the other" bug, but it is refactoring beyond this fix.
+- `YtLibraryBackfillWorker` stays dormant. Nothing enqueues it; re-arming it is a separate decision.

--- a/docs/superpowers/specs/2026-07-29-streaming-fast-lane-and-download-consent-design.md
+++ b/docs/superpowers/specs/2026-07-29-streaming-fast-lane-and-download-consent-design.md
@@ -1,0 +1,219 @@
+# Streaming fast lane + download consent — design
+
+Date: 2026-07-29
+Status: approved, ready for implementation planning
+
+Two independent defects, grouped because both are "the guard exists but nothing
+calls it" and both are diagnosed from the same reading of the streaming/download
+pipeline.
+
+---
+
+## Problem 1 — every playback pays the slow yt-dlp lane
+
+### Evidence
+
+`PreviewUrlExtractor.extractStreamUrl` (`data/download/.../preview/PreviewUrlExtractor.kt:237`)
+races two extractors and returns the first win:
+
+- InnerTube player API, ~200 ms–2 s, cap 8 concurrent (`:428`)
+- yt-dlp + QuickJS, ~3.6–15 s, cap 1–2 concurrent (`:477`)
+
+`YouTubeStreamResolver.resolve` (`core/media/.../streaming/YouTubeStreamResolver.kt:100-104`)
+calls `extractStreamUrlViaYtDlp` (`PreviewUrlExtractor.kt:390`) — **yt-dlp only,
+race skipped** — whenever `allowYtDlp = true`. The race is reachable only via
+`allowYtDlp = false`, and no live call site passes that: every remaining
+occurrence of `allowYtDlp = false` in the repo is a comment. The fast lane is
+dead code **for playback** only — the race is still live for search previews
+(`SearchPreviewMediaSource.kt:54`, `PreviewPrefetcher.kt:71`), the track-actions
+preview (`TrackActionsDelegate.kt:241`) and failed-match auditioning
+(`FailedMatchesViewModel.kt:342,587`). Those callers are unaffected by this
+change and are useful corroboration that the race works in production.
+
+The bypass was justified (documented 2026-06-08): InnerTube URLs were
+PO-token-gated to ~1 MB and returned 403 on full-file requests, so they could
+not stream a whole track.
+
+**That justification is stale.** On 2026-06-26 `extractViaYtDlp` learned to pin
+`player_client=android_vr` (`PreviewUrlExtractor.kt:490-497`), which returns "a
+working itag-251 URL directly — no PO token, no m3u8 manifest, no QuickJS
+signature/n-challenge solve". Meanwhile
+`InnerTubeClient.AUDIO_VARIANT_ORDER` is still `[IOS]` alone
+(`data/ytmusic/.../InnerTubeClient.kt:158-160`), even though the KDoc at
+`PreviewUrlExtractor.kt:432-435` claims ANDROID_VR is attempted.
+
+Net: the app spawns a Python interpreter to perform the single HTTPS call
+`InnerTubeClient` already knows how to make.
+
+### Key risk reframe
+
+The URLs the app streams today **are** `android_vr` URLs, minted through yt-dlp.
+This design does not bet on an unproven URL class; it mints the same URL with a
+direct request. The residual risk is only whether `InnerTubeClient` impersonates
+`android_vr` correctly (client version, headers) — mechanical, and provable in
+one on-device run. On failure the race simply loses and behaviour is identical
+to today.
+
+### Design
+
+1. **Add `ANDROID_VR` to `AUDIO_VARIANT_ORDER`**, ordered first, keeping `IOS`
+   as the second attempt. `playerForAudio` (`InnerTubeClient.kt:405`) already
+   walks the list and accepts the first variant whose response satisfies
+   `hasDirectAudioUrl` (`:429`), so no control-flow change is needed.
+
+2. **Validate before use — tail-range probe.** `adaptiveFormats` entries carry
+   `contentLength`. After `selectBestAudioUrl` picks a URL, issue one
+   `Range: bytes=(contentLength-1)-` request and require 206. A PO-gated URL
+   serves its first ~1 MB and then 403s, so a tail probe is the only cheap check
+   that distinguishes "playable" from "playable for 15 seconds". ~100 ms against
+   ~3.5 s saved. Probe failure → return null → the race falls through to yt-dlp,
+   exactly as today.
+
+   This is deliberate insurance, not ceremony: the unguarded version of this
+   change is what shipped the June regression, and its failure mode (audio dies
+   mid-track) is worse than a slow start.
+
+3. **Point playback at the race.** `YouTubeStreamResolver.resolve` calls
+   `extractStreamUrl(videoId, allowYtDlp = true)` instead of
+   `extractStreamUrlViaYtDlp(videoId)`. The `allowYtDlp = false` branch stays for
+   the fast-only contract (`NoFastStreamException`).
+
+4. **Measure, before and after.** `runYtDlp` already logs
+   `yt-dlp: invoking …` and `exit=…` (`PreviewUrlExtractor.kt:539-547`). Capture
+   real numbers on device. If the current cost is far above the 3.6 s measured on
+   2026-06-26, the dominant term is Chaquopy cold-start or the per-call
+   `--remote-components ejs:github` fetch, and cold-start work is a worthwhile
+   follow-up rather than something this change subsumes.
+
+### Existing safety nets preserved
+
+`RefreshingDataSourceFactory` re-resolves through the registry on a mid-stream
+403, and `StreamUrlCache` never caches a provisional lossy fallback
+(`PlayerRepositoryImpl.kt:1324-1328`). Both continue to apply unchanged.
+
+---
+
+## Problem 2 — algorithmic mixes download without consent
+
+### Evidence
+
+The pipeline's intended contract is stated in `DiffWorker.kt:46-54`: mixes are
+surface-only, "so an auto-enabled mix never pulls bytes even after the user
+switches to Offline and re-syncs". Three defects break it.
+
+1. **Auto-enable.** `defaultSyncEnabled` (`DiffWorker.kt:43-44`) returns `true`
+   for `DAILY_MIX` in Online mode, applied at `findOrCreatePlaylist`
+   (`:313`). Discovered mixes become sync-enabled without being asked.
+
+2. **The enqueue guard is dead code.** `shouldEnqueueForDownload(type,
+   streamingMode)` (`DiffWorker.kt:53-54`) excludes `DAILY_MIX`, is unit-tested
+   in `ShouldEnqueueForDownloadTest`, and **is called by nothing but that test**.
+   The real enqueue site (`DiffWorker.kt:565`) tests raw `!streamingMode` and
+   queues every new track.
+
+3. **The requeue predicate misses `DAILY_MIX`.** `getUnqueuedTrackIds`
+   (`DownloadQueueDao.kt:535-560`), which drives the blanket requeue at
+   `TrackDownloadWorker.kt:196-208`, requires a sync-enabled active parent and
+   excludes `p.type != 'STASH_MIX'` (`:553`) — but not `DAILY_MIX`.
+
+The v0.9.85 sweep cannot rescue any of it: `cancelDownloadsWithNoEnabledPlaylist`
+(`:412-424`) spares any track in a playlist with `sync_enabled = 1`, which these
+mixes are. And because mixes rotate, each new one pulls a fresh batch — the
+"random downloads" users describe.
+
+`DownloadQueueDao.kt:540-547` records the same failure mode occurring before (a
+Replay Mix queueing 90 tracks) and being patched narrowly with an `is_active`
+guard rather than at the type level. This design fixes it at the type level.
+
+### Why removing the auto-enable costs nothing
+
+`getAllVisible` (`PlaylistDao.kt:279-294`) renders a playlist when
+`is_active = 1 AND (sync_enabled = 1 OR has a downloaded track OR
+(includeStreamable AND has a streamable track))`.
+
+In Online mode `includeStreamable = true`, so a discovered mix with
+`sync_enabled = 0` **still surfaces** — its tracks are streamable. The
+auto-enable's stated purpose (surface immediately, download nothing) is already
+delivered by the streamable escape hatch, making the auto-enable redundant for
+surfacing and load-bearing only for the harm. In Offline mode the mix correctly
+disappears: a mix with nothing downloaded is not playable there.
+
+Therefore `discoverAutoMixes` stays **ON**. Discovery is a working feature whose
+surfacing survives this change; flipping its default would remove a feature to
+fix a bug that isn't the feature's fault, and would confound the signal on
+whether #335/#344 are resolved.
+
+### Design
+
+One definition of "wanted", used by all three sites:
+
+> A track is download-eligible when it is a member (`removed_at IS NULL`) of a
+> playlist with `is_active = 1 AND sync_enabled = 1` whose `type` is not an
+> algorithmic or generated mix (`STASH_MIX`, `DAILY_MIX`).
+
+Changes:
+
+1. `defaultSyncEnabled` → always `false`. New discoveries are opt-in in both
+   modes.
+2. `DiffWorker.kt:565` → gate on
+   `shouldEnqueueForDownload(localPlaylist.type, streamingMode)` instead of
+   `!streamingMode`. The helper and its test already exist; this is the wiring.
+3. `getUnqueuedTrackIds` → `p.type NOT IN ('STASH_MIX', 'DAILY_MIX')`.
+4. `cancelDownloadsWithNoEnabledPlaylist` → apply the same type exclusion to its
+   "spared" subquery. Without this, a track whose only sync-enabled parent is a
+   mix keeps a PENDING row the drain will happily service. This also closes the
+   `StashMixRefreshWorker.kt:691` path, where generated mixes are created with
+   `syncEnabled = true` hardcoded.
+
+### No migration required
+
+Existing auto-enabled mixes keep `sync_enabled = 1`; that only affects
+visibility, which is harmless. Because changes 2–4 exclude mixes **by type**,
+no new rows are created regardless of the stale flag, and the corrected sweep
+evicts the accumulated phantom rows on the next `TrackDownloadWorker` run.
+
+**Nothing deletes a downloaded file.** The cleanup evicts queue rows only. Users
+who deliberately enabled a mix keep their downloaded audio.
+
+---
+
+## Testing
+
+Red-green required on every behavioural fix: assert the test fails against
+current `master` before the fix, passes after.
+
+- `DiffWorker`-level test: a `DAILY_MIX` playlist in Offline mode produces zero
+  `download_queue` rows; a `CUSTOM` playlist still produces rows. Fails today.
+- DAO tests (in-memory Room): `getUnqueuedTrackIds` and
+  `cancelDownloadsWithNoEnabledPlaylist` for a track whose only enabled parent is
+  a `DAILY_MIX`, a `STASH_MIX`, and a real playlist.
+- `PlaylistDao.getAllVisible` test pinning the claim this design rests on: a
+  `sync_enabled = 0` `DAILY_MIX` with streamable tracks is visible when
+  `includeStreamable = true`, hidden when `false`.
+- Tail-range probe: unit test over a fake HTTP layer (206 → accept, 403 →
+  reject, missing `contentLength` → accept, since absence is not evidence of
+  gating).
+- On-device: streaming resolve latency before/after from the existing
+  `yt-dlp: invoking` / `exit=` log timestamps, plus confirmation that a
+  `qbdlx`-miss track still plays through the YT fallback.
+
+## Out of scope
+
+- `YtLibraryBackfillWorker.kt:329-336` deletes a downloaded file and re-queues it
+  when the YT source is non-canonical. Nothing currently schedules it (no
+  `enqueueUniqueWork` call exists) — it is dormant. It stays dormant and behind
+  explicit user action; re-arming it is a separate decision.
+- yt-dlp cold-start / `--remote-components` work, pending the measurement in
+  Problem 1 step 4.
+- #264 (slow offline loads) and #334 (streamed tracks skipping) are plausibly
+  downstream of the slow lane but unproven; re-check after this ships rather
+  than assuming.
+
+## Issues addressed
+
+- **#368** — unwanted downloads of user playlists and Spotify mixes. Direct fix.
+- **#335 / #344** — unwanted playlists surfacing. Same root (auto-enable);
+  surfacing behaviour is deliberately unchanged, so these are re-evaluated after
+  the download harm stops.
+- **#210** — "Process ID already present" was already fixed by the `null`
+  processId at `PreviewUrlExtractor.kt:540-543`; no further work here.

--- a/docs/superpowers/specs/2026-07-29-streaming-fast-lane-and-download-consent-design.md
+++ b/docs/superpowers/specs/2026-07-29-streaming-fast-lane-and-download-consent-design.md
@@ -85,6 +85,45 @@ to today.
    `--remote-components ejs:github` fetch, and cold-start work is a worthwhile
    follow-up rather than something this change subsumes.
 
+### Measured on device 2026-07-29 — the premise was wrong, usefully
+
+Everything above assumed the win was "call InnerTube's ANDROID_VR instead of
+spawning Python for the same URL". Measurement said otherwise. Recorded here
+because the wrong hypothesis is what led to the instrument that found the real
+cause.
+
+| path | outcome | time |
+|---|---|---|
+| InnerTube, any variant (our own request) | returns a URL, but PO-token-gated: 403 past the head. `AudioUrlTailProbe` rejects it | ~800 ms, wasted |
+| yt-dlp `ios` | no usable URLs — YouTube's SABR-only experiment (yt-dlp #12482) | ~2.8 s, wasted |
+| yt-dlp `android_vr` | **works**, after two fixes below | **~2.7 s** |
+| yt-dlp default client | works, itag 251 opus audio-only | ~12-13 s |
+
+**The actual cause of the slowness had nothing to do with InnerTube.** The June
+`android_vr` fast path was dead, from one unread line of yt-dlp stderr:
+`Skipping client "android_vr" since it does not support cookies`. yt-dlp answers
+`--cookies` + a cookie-incompatible client by discarding the *client*. Every
+extraction paid ~3.5 s being refused, then ~11.6 s on the default path — ~15 s.
+
+Fixing that revealed a second layer: `android_vr` no longer advertises itag
+251/250, so the June selector failed the attempt outright. With audio-only itags
+preferred and `best` as last resort it succeeds in ~2.7 s (three consecutive
+tracks: 2.74, 2.71, 2.75), serving itag 18 — combined 360p, ~96k AAC — versus
+160k opus from the slow path. Playback verified healthy 85 s in
+(`position=84760, error=null`), proving the URL is not range-gated.
+
+**Conclusions for the record:**
+
+- The 2026-06-08 finding still holds. InnerTube URLs remain PO-token-gated, and
+  the probe caught it live (`tail probe rejected a gated URL: code=403`, plus a
+  `0-byte body` 403 from googlevideo with `c=IOS`). So the probe was not
+  belt-and-braces — it is the only reason racing InnerTube is safe at all.
+- The race itself is retained: it costs ~800 ms when InnerTube loses and would
+  pay off immediately if the gating ever lifts, which the probe now detects
+  automatically instead of requiring another on-device investigation.
+- Unrelated but surfaced: `qbdlx api call failed status=403 USER_BLOCKED` — a
+  pool token is blocked, not merely expired.
+
 ### Existing safety nets preserved
 
 `RefreshingDataSourceFactory` re-resolves through the registry on a mid-stream


### PR DESCRIPTION
Two defects that share a shape: the guard existed, was unit-tested, and nothing called it.

## Downloads — users get only the tracks they asked for (#368)

Reporters saw thousands of downloads they never toggled on ("it downloads 6000+ from users playlists and Spotify mixes that I don't need"). Four separate things had to be wrong at once:

- `shouldEnqueueForDownload` excluded `DAILY_MIX` from the day it was written, and was called by nothing but its own test. `DiffWorker`'s real enqueue site tested raw `!streamingMode`.
- `defaultSyncEnabled` auto-enabled every discovered mix in Online mode, which is what made it download-eligible.
- Four SQL predicates decided "download-eligible" and disagreed: two excluded `STASH_MIX` only, one excluded no types at all.
- Because those mixes were `sync_enabled = 1`, the v0.9.85 sweep spared them by design. Mixes rotate, so every new one pulled a fresh batch.

Fixed by wiring the existing guard, making discovery opt-in, and unifying all four predicates on one rule: eligibility comes only from membership in an active, sync-enabled, **non-mix** playlist.

Removing the auto-enable costs nothing: `getAllVisible`'s streamable escape hatch already surfaces a `sync_enabled = 0` mix in Online mode, which is pinned by a new test so a future change can't silently start hiding mixes instead.

**And the mirror bug**, which is the same goal from the other side: a Download tap on a track living only in a mix produced a row with no eligible parent, and a sweep ate it before it finished — the same class as search-tab downloads vanishing on relaunch. Both sweeps are now scoped to the sync partition, so phantom rows a *sync* invented still drain while a row a *person* asked for never does.

No migration needed: eligibility is decided by type, so no new rows are created regardless of stale flags, and the corrected sweeps drain the accumulated backlog on the next worker run. **Queue rows only — no downloaded file is ever touched.**

## Streaming — 15s to 2.7s on the YouTube fallback

The `android_vr` fast path added in June has been dead almost since it landed, from one line of yt-dlp stderr nobody was reading:

```
WARNING: [youtube] Skipping client "android_vr" since it does not support cookies
```

yt-dlp answers `--cookies` + a cookie-incompatible client by discarding the **client**, not the cookies. Every extraction burned ~3.5s being refused, then ~11.6s on the default multi-client path. Fixing that exposed a second layer: `android_vr` no longer advertises itag 251/250, so the June-era selector failed the attempt outright.

Measured on-device, three consecutive tracks after the fix: **2.74s, 2.71s, 2.75s**, no fallback, playback verified healthy 85s in (`position=84760, error=null`) so the URL is not range-gated.

The cost is documented at the constant: `android_vr` currently serves itag 18 (combined 360p, ~96k AAC) versus 160k opus from the slow path. On a lossy last-resort path that only runs when nothing lossless has the track, and which Now Playing badges "via YT", 2.7s beats 13s. Dropping `/best` trades back.

Playback also now races InnerTube against yt-dlp again instead of calling yt-dlp direct — the race had become dead code since nothing passes `allowYtDlp = false` any more. That is only safe because of the new `AudioUrlTailProbe`, which rejects any URL that can't serve its final byte.

**The 2026-06-08 finding still holds and the probe proved it live:** InnerTube URLs remain PO-token-gated (`tail probe rejected a gated URL: code=403`). The probe is not belt-and-braces — it is the only reason racing is safe, and it now detects automatically if the gating ever lifts. Also measured and rejected: the `ios` client returns no usable URLs at all (YouTube's SABR-only experiment, yt-dlp #12482).

## Testing

**1932 tests green across all 15 modules.** Every fix was verified red-first for the right reason, not just "test fails":

- The download guard test runs the **worker** and asserts `insertAll` is never called. A helper-level test passes today and would keep passing if the wiring were reverted — which is exactly how this bug survived being unit-tested.
- A CUSTOM-playlist control test passed throughout, so the fix is "mixes don't download" and not "nothing downloads".
- The probe's 403 test initially passed **for the wrong reason**: under `runTest`'s virtual clock the timeout fired instantly and the probe failed open. Switched to a real clock so it's a genuine assertion.

Two existing tests were changed rather than flipped, with the reasoning recorded: one pinned "yt-dlp direct, not the race" as the core of the 2026-06-08 fix, and `DownloadQueueDaoDeferredTest`'s fixtures were manual-partition only because its `entry()` helper never set `syncId`.

One change was **reverted** during self-review: excluding `STASH_MIX` from `shouldEnqueueForDownload`. The existing test pins the opposite on purpose, and that path is unreachable — stash mixes are held ineligible in the DAO predicates instead.

## Not verified

The download half is test-verified but not yet observed against a live sync on a real library. The streaming half is fully device-verified.

Design and plan: `docs/superpowers/specs/2026-07-29-...-design.md` (including the measurements that disproved its own premise) and `docs/superpowers/plans/2026-07-29-...md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
