### PR TITLE
Evict stale StreamUrlCache entries when a track's youtube_id changes

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/social/CrossPlatformLikeResolver.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/social/CrossPlatformLikeResolver.kt
@@ -3,7 +3,7 @@ package com.stash.core.data.social
 import android.util.Log
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.sync.TrackMatcher
-import com.stash.core.media.streaming.StreamUrlCache
+import com.stash.core.data.sync.TrackIdentityEvents
 import com.stash.core.model.Track
 import com.stash.data.spotify.SpotifyApiClient
 import com.stash.data.spotify.SpotifyTrackCandidate
@@ -43,7 +43,7 @@ class CrossPlatformLikeResolver @Inject constructor(
     private val ytMusicApiClient: YTMusicApiClient,
     private val matcher: TrackMatcher,
     private val trackDao: TrackDao,
-    private val streamUrlCache: StreamUrlCache,
+    private val trackIdentityEvents: TrackIdentityEvents,
 ) {
     /** The track's Spotify URI, resolving + persisting it if missing. Null when no safe match. */
     suspend fun ensureSpotifyUri(track: Track): String? {
@@ -92,7 +92,7 @@ class CrossPlatformLikeResolver @Inject constructor(
         // The track's youtubeId identity just changed — drop any StreamUrl
         // cached for this track id so the next play resolves fresh instead
         // of reusing a URL that was (or wasn't) resolved against this id.
-        streamUrlCache.invalidate(track.id)
+        trackIdentityEvents.emitIdentityChanged(track.id)
         Log.i(TAG, "ensureYoutubeId: matched ${track.id} → $videoId")
         return videoId
     }

--- a/core/data/src/main/kotlin/com/stash/core/data/social/CrossPlatformLikeResolver.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/social/CrossPlatformLikeResolver.kt
@@ -3,6 +3,7 @@ package com.stash.core.data.social
 import android.util.Log
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.sync.TrackMatcher
+import com.stash.core.media.streaming.StreamUrlCache
 import com.stash.core.model.Track
 import com.stash.data.spotify.SpotifyApiClient
 import com.stash.data.spotify.SpotifyTrackCandidate
@@ -42,6 +43,7 @@ class CrossPlatformLikeResolver @Inject constructor(
     private val ytMusicApiClient: YTMusicApiClient,
     private val matcher: TrackMatcher,
     private val trackDao: TrackDao,
+    private val streamUrlCache: StreamUrlCache,
 ) {
     /** The track's Spotify URI, resolving + persisting it if missing. Null when no safe match. */
     suspend fun ensureSpotifyUri(track: Track): String? {
@@ -87,6 +89,10 @@ class CrossPlatformLikeResolver @Inject constructor(
 
         runCatching { trackDao.updateYoutubeId(track.id, videoId) }
             .onFailure { Log.d(TAG, "ensureYoutubeId: persist skipped for ${track.id}: ${it.message}") }
+        // The track's youtubeId identity just changed — drop any StreamUrl
+        // cached for this track id so the next play resolves fresh instead
+        // of reusing a URL that was (or wasn't) resolved against this id.
+        streamUrlCache.invalidate(track.id)
         Log.i(TAG, "ensureYoutubeId: matched ${track.id} → $videoId")
         return videoId
     }

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/TrackIdentityEvents.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/TrackIdentityEvents.kt
@@ -1,0 +1,34 @@
+package com.stash.core.data.sync
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Emits a track id every time that track's `youtube_id` is REPLACED (not
+ * first-set) — i.e. an existing platform identity is swapped for a
+ * different one. Resync approval, wrong-match swap, and OMV→ATV
+ * canonicalization all go through [emitIdentityChanged].
+ *
+ * Exists so `:core:media` (PlayerRepositoryImpl) can evict any
+ * [com.stash.core.media.streaming.StreamUrlCache] entry keyed on the
+ * OLD identity without `:core:data` call sites needing a direct
+ * dependency on `:core:media` (which would be circular — StreamUrlCache
+ * lives in `:core:media`, which already depends on `:core:data`).
+ * Mirrors `MusicRepository.trackDeletions`, same reasoning.
+ */
+@Singleton
+class TrackIdentityEvents @Inject constructor() {
+    private val _changes = MutableSharedFlow<Long>(
+        extraBufferCapacity = 8,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    val changes: SharedFlow<Long> = _changes.asSharedFlow()
+
+    fun emitIdentityChanged(trackId: Long) {
+        _changes.tryEmit(trackId)
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/social/CrossPlatformLikeResolverTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/social/CrossPlatformLikeResolverTest.kt
@@ -2,6 +2,7 @@ package com.stash.core.data.social
 
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.sync.TrackMatcher
+import com.stash.core.data.sync.TrackIdentityEvents
 import com.stash.core.model.Track
 import com.stash.data.spotify.SpotifyApiClient
 import com.stash.data.spotify.SpotifyTrackCandidate
@@ -24,7 +25,8 @@ class CrossPlatformLikeResolverTest {
     private val spotify = mockk<SpotifyApiClient>()
     private val yt = mockk<YTMusicApiClient>()
     private val dao = mockk<TrackDao>(relaxed = true)
-    private fun resolver() = CrossPlatformLikeResolver(spotify, yt, TrackMatcher(), dao)
+    private val trackIdentityEvents = mockk<TrackIdentityEvents>(relaxed = true)
+    private fun resolver() = CrossPlatformLikeResolver(spotify, yt, TrackMatcher(), dao, trackIdentityEvents)
 
     private fun track(sp: String? = null, ytId: String? = null) = Track(
         id = 5L,

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -94,6 +94,7 @@ class PlayerRepositoryImpl @Inject constructor(
     private val trackDao: TrackDao,
     private val playbackResumer: PlaybackResumer,
     private val radioGenerator: com.stash.core.data.radio.RadioStationGenerator,
+    private val trackIdentityEvents: com.stash.core.data.sync.TrackIdentityEvents,
 ) : PlayerRepository {
 
     /**
@@ -173,6 +174,16 @@ class PlayerRepositoryImpl @Inject constructor(
         scope.launch {
             musicRepository.trackDeletions.collect { trackId ->
                 evictTrackFromQueue(trackId)
+            }
+        }
+
+        // A track's youtubeId was swapped (resync approval, wrong-match
+        // swap, OMV→ATV canonicalization) — any StreamUrl cached under
+        // this id was resolved against the OLD identity and must not be
+        // served for the new one.
+        scope.launch {
+            trackIdentityEvents.changes.collect { trackId ->
+                streamUrlCache.invalidate(trackId)
             }
         }
 

--- a/core/media/src/main/kotlin/com/stash/core/media/actions/TrackActionsDelegate.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/actions/TrackActionsDelegate.kt
@@ -16,6 +16,7 @@ import com.stash.data.download.search.SearchDownloadStatus
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -95,6 +96,12 @@ class TrackActionsDelegate @Inject constructor(
      * trigger a spurious yt-dlp retry.
      */
     private var lastPreviewVideoId: String? = null
+    private var previewRequestId: Long? = null
+    private var lastPreviewAttemptId: Long? = null
+    private var lastPreviewRetried = false
+    private var previewLoadJob: Job? = null
+    private var previewRetryJob: Job? = null
+    private var previewGeneration = 0L
 
     /**
      * Wall-clock timestamp of the most recent [PreviewPlayer.playUrl] call.
@@ -116,7 +123,7 @@ class TrackActionsDelegate @Inject constructor(
         boundScope = scope
         scope.launch {
             previewPlayer.playerErrors.collect { event ->
-                onPreviewError(event.videoId, event.error)
+                onPreviewError(event.videoId, event.attemptId, event.error)
             }
         }
     }
@@ -142,9 +149,9 @@ class TrackActionsDelegate @Inject constructor(
      * for ExoPlayer-level IO failures that fire after [play] returns.
      *
      * ### Bookkeeping
-     * [lastPreviewVideoId] / [lastPreviewStartedAt] are recorded BEFORE calling
-     * [play] so a synchronous [onPlayerError] (possible for malformed URLs)
-     * still observes the correct "most recent preview" state.
+     * Preview ownership is recorded through [PreviewPlayer]'s attempt callback
+     * before ExoPlayer receives the media source, so immediate failures are
+     * attributed to the exact request that started them.
      *
      * @param track Full [TrackItem] so that [SearchPreviewMediaSource] can
      *              perform artist+title matching for lossless-source selection.
@@ -152,14 +159,31 @@ class TrackActionsDelegate @Inject constructor(
     fun previewTrack(track: TrackItem) {
         val videoId = track.videoId
 
-        scope().launch {
+        if ((previewState.value as? PreviewState.Playing)?.videoId == videoId) return
+        if (_previewLoadingId.value == videoId) return
+
+        val generation = ++previewGeneration
+        previewLoadJob?.cancel()
+        previewRetryJob?.cancel()
+        previewRetryJob = null
+        lastPreviewVideoId = videoId
+        lastPreviewAttemptId = null
+        lastPreviewRetried = false
+        // A new user selection deliberately preempts the singleton player.
+        previewPlayer.stop()
+        val requestId = previewPlayer.claimRequest()
+        previewRequestId = requestId
+
+        previewLoadJob = scope().launch {
             // Streaming mode: skip preview entirely. Route to full-track playback
             // via PlayerRepository.playFromStream. Same routing as
             // SearchViewModel.onResultTap, so every surface that calls
             // delegate.previewTrack (SearchScreen, ArtistProfileScreen,
             // AlbumDiscoveryScreen, etc.) behaves identically when streaming
             // is enabled instead of falling back to the 30s preview clip.
-            if (streamingPreference.current()) {
+            val streamingEnabled = streamingPreference.current()
+            if (!isActivePreviewRequest(generation, videoId)) return@launch
+            if (streamingEnabled) {
                 // Drive the row-level spinner while the stream resolves. The
                 // resolve can take seconds (worst for amz, which fetch+decrypts
                 // a whole FLAC), so without this the row sits silent and looks
@@ -170,6 +194,7 @@ class TrackActionsDelegate @Inject constructor(
                 _previewLoadingId.value = videoId
                 try {
                     val result = playerRepository.playFromStream(track)
+                    if (!isActivePreviewRequest(generation, videoId)) return@launch
                     when (result) {
                         is com.stash.core.media.StreamRoutingResult.Item -> Unit
                         com.stash.core.media.StreamRoutingResult.Deduped -> Unit
@@ -183,7 +208,9 @@ class TrackActionsDelegate @Inject constructor(
                             _userMessages.emit("You're offline — can't stream this track.")
                     }
                 } finally {
-                    _previewLoadingId.value = null
+                    if (isActivePreviewRequest(generation, videoId)) {
+                        _previewLoadingId.value = null
+                    }
                 }
                 return@launch
             }
@@ -198,7 +225,6 @@ class TrackActionsDelegate @Inject constructor(
             if ((previewState.value as? PreviewState.Playing)?.videoId == videoId) return@launch
             if (_previewLoadingId.value == videoId) return@launch
 
-            previewPlayer.stop()
             val t0 = System.currentTimeMillis()
             _previewLoadingId.value = videoId
             try {
@@ -209,16 +235,26 @@ class TrackActionsDelegate @Inject constructor(
                 // and constructs the source, but does NOT begin network I/O yet —
                 // that happens inside ExoPlayer once prepare() is called by play().
                 val mediaSource = searchPreviewMediaSource.create(track)
+                if (!isActivePreviewRequest(generation, videoId)) return@launch
 
-                // Set bookkeeping BEFORE play() so a synchronous onPlayerError
-                // (which can fire for a malformed upstream URL before prepare()
-                // completes) still sees the correct "most recent preview" state
-                // and triggers the onPreviewError retry path correctly.
-                lastPreviewVideoId = videoId
-                lastPreviewStartedAt = SystemClock.elapsedRealtime()
-
-                previewPlayer.play(videoId, mediaSource)
-                _previewLoadingId.value = null
+                val attemptId = previewPlayer.playIfClaimed(
+                    requestId,
+                    videoId,
+                    mediaSource,
+                ) { attemptId ->
+                    if (isActivePreviewRequest(generation, videoId)) {
+                        lastPreviewVideoId = videoId
+                        lastPreviewAttemptId = attemptId
+                        lastPreviewStartedAt = SystemClock.elapsedRealtime()
+                    }
+                }
+                if (attemptId == null) {
+                    abandonPreviewRequest(generation, videoId)
+                    return@launch
+                }
+                if (isActivePreviewRequest(generation, videoId)) {
+                    _previewLoadingId.value = null
+                }
 
                 android.util.Log.d(
                     "LATDIAG",
@@ -226,6 +262,7 @@ class TrackActionsDelegate @Inject constructor(
                 )
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
+                if (!isActivePreviewRequest(generation, videoId)) return@launch
 
                 // Happy-path failure: fall back to the URL-only extractor so the
                 // user still gets a preview even when the Qobuz proxy is unavailable.
@@ -241,32 +278,74 @@ class TrackActionsDelegate @Inject constructor(
                         ?: previewUrlExtractor.extractStreamUrl(videoId).also {
                             previewUrlCache[videoId] = it
                         }
-                    lastPreviewVideoId = videoId
-                    lastPreviewStartedAt = SystemClock.elapsedRealtime()
-                    previewPlayer.playUrl(videoId, url)
-                    _previewLoadingId.value = null
+                    if (!isActivePreviewRequest(generation, videoId)) return@runCatching
+                    val attemptId = previewPlayer.playUrlIfClaimed(
+                        requestId,
+                        videoId,
+                        url,
+                    ) { attemptId ->
+                        if (isActivePreviewRequest(generation, videoId)) {
+                            lastPreviewVideoId = videoId
+                            lastPreviewAttemptId = attemptId
+                            lastPreviewStartedAt = SystemClock.elapsedRealtime()
+                        }
+                    }
+                    if (attemptId == null) {
+                        abandonPreviewRequest(generation, videoId)
+                        return@runCatching
+                    }
+                    if (isActivePreviewRequest(generation, videoId)) {
+                        _previewLoadingId.value = null
+                    }
                     android.util.Log.d(
                         "LATDIAG",
                         "preview-url-fallback-play videoId=$videoId cache=$cacheHit totalDt=${System.currentTimeMillis() - t0}ms",
                     )
                 }.onFailure { retryError ->
                     if (retryError is CancellationException) throw retryError
+                    if (!isActivePreviewRequest(generation, videoId)) return@onFailure
                     Log.e(TAG, "URL-fallback preview also failed for videoId=$videoId", retryError)
                     android.util.Log.d(
                         "LATDIAG",
                         "preview-fail videoId=$videoId totalDt=${System.currentTimeMillis() - t0}ms err=${retryError.javaClass.simpleName}",
                     )
                     _previewLoadingId.value = null
+                    previewPlayer.cancelRequest(previewRequestId)
+                    previewRequestId = null
+                    lastPreviewVideoId = null
                     _userMessages.emit("Couldn't load preview.")
-                    previewPlayer.stop()
+                    previewPlayer.stopIfCurrent(lastPreviewAttemptId)
                 }
             }
         }
     }
 
+    private fun isActivePreviewRequest(generation: Long, videoId: String): Boolean =
+        previewGeneration == generation && lastPreviewVideoId == videoId
+
+    private fun abandonPreviewRequest(generation: Long, videoId: String) {
+        if (!isActivePreviewRequest(generation, videoId)) return
+        previewRequestId = null
+        lastPreviewVideoId = null
+        lastPreviewAttemptId = null
+        if (_previewLoadingId.value == videoId) _previewLoadingId.value = null
+    }
+
     /** Stops the current audio preview, if any, and clears the loading flag. */
     fun stopPreview() {
-        previewPlayer.stop()
+        val ownedRequestId = previewRequestId
+        val ownedAttemptId = lastPreviewAttemptId
+        ++previewGeneration
+        previewLoadJob?.cancel()
+        previewRetryJob?.cancel()
+        previewLoadJob = null
+        previewRetryJob = null
+        previewPlayer.cancelRequest(ownedRequestId)
+        previewRequestId = null
+        lastPreviewVideoId = null
+        lastPreviewAttemptId = null
+        lastPreviewRetried = false
+        previewPlayer.stopIfCurrent(ownedAttemptId)
         _previewLoadingId.value = null
     }
 
@@ -277,31 +356,77 @@ class TrackActionsDelegate @Inject constructor(
      *
      * Retries via yt-dlp IFF all three hold:
      *  - [error] is an IO-class [PlaybackException] code (2000..2999).
-     *  - [videoId] matches [lastPreviewVideoId] (ignores stale late errors).
+     *  - [videoId] and [attemptId] match the exact active player request.
      *  - It fired within [RETRY_WINDOW_MS] of [lastPreviewStartedAt] — playback
      *    never went ready before failing.
      *
      * On retry failure we surface a snackbar so the user knows preview isn't
      * going to recover on its own.
      */
-    fun onPreviewError(videoId: String, error: PlaybackException) {
+    fun onPreviewError(videoId: String, attemptId: Long, error: PlaybackException) {
         if (!isIoError(error)) return
         if (videoId != lastPreviewVideoId) return
+        if (attemptId != lastPreviewAttemptId) return
+        val requestId = previewRequestId ?: return
+        if (!previewPlayer.isRequestCurrent(requestId)) {
+            abandonPreviewRequest(previewGeneration, videoId)
+            return
+        }
         val elapsed = SystemClock.elapsedRealtime() - lastPreviewStartedAt
         if (elapsed > RETRY_WINDOW_MS) return
 
-        scope().launch {
+        if (lastPreviewRetried) {
+            val ownedAttemptId = lastPreviewAttemptId
+            previewPlayer.cancelRequest(requestId)
+            previewRequestId = null
+            lastPreviewVideoId = null
+            lastPreviewAttemptId = null
+            previewPlayer.stopIfCurrent(ownedAttemptId)
+            _previewLoadingId.value = null
+            _userMessages.tryEmit("Couldn't load preview.")
+            return
+        }
+
+        lastPreviewRetried = true
+        lastPreviewAttemptId = null
+        val generation = previewGeneration
+        previewRetryJob?.cancel()
+
+        previewRetryJob = scope().launch {
             _previewLoadingId.value = videoId
             try {
                 val retryUrl = previewUrlExtractor.extractViaYtDlpForRetry(videoId)
+                if (!isActivePreviewRequest(generation, videoId) || !lastPreviewRetried) {
+                    return@launch
+                }
                 previewUrlCache[videoId] = retryUrl
-                previewPlayer.playUrl(videoId, retryUrl)
-                _previewLoadingId.value = null
+                val retryAttemptId = previewPlayer.playUrlIfClaimed(
+                    requestId,
+                    videoId,
+                    retryUrl,
+                ) { retryAttemptId ->
+                    if (isActivePreviewRequest(generation, videoId) && lastPreviewRetried) {
+                        lastPreviewVideoId = videoId
+                        lastPreviewAttemptId = retryAttemptId
+                        lastPreviewStartedAt = SystemClock.elapsedRealtime()
+                    }
+                }
+                if (retryAttemptId == null) {
+                    abandonPreviewRequest(generation, videoId)
+                    return@launch
+                }
+                if (isActivePreviewRequest(generation, videoId)) {
+                    _previewLoadingId.value = null
+                }
                 Log.d(TAG, "yt-dlp retry SUCCESS for $videoId after InnerTube error $error")
             } catch (t: Throwable) {
                 if (t is CancellationException) throw t
+                if (!isActivePreviewRequest(generation, videoId)) return@launch
                 Log.e(TAG, "yt-dlp retry FAILED for $videoId", t)
                 _previewLoadingId.value = null
+                previewPlayer.cancelRequest(requestId)
+                previewRequestId = null
+                lastPreviewVideoId = null
                 _userMessages.emit("Couldn't load preview.")
             }
         }
@@ -556,7 +681,7 @@ class TrackActionsDelegate @Inject constructor(
      * structured concurrency; no need to stop the error collector manually.
      */
     fun onOwnerCleared() {
-        previewPlayer.stop()
+        stopPreview()
     }
 
     /**

--- a/core/media/src/main/kotlin/com/stash/core/media/preview/PreviewPlayer.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/preview/PreviewPlayer.kt
@@ -47,11 +47,15 @@ sealed interface PreviewState {
  * Error event surfaced by [PreviewPlayer] when ExoPlayer's [Player.Listener]
  * reports an [onPlayerError]. Emitted on [PreviewPlayer.playerErrors].
  *
- * Search and Artist Profile ViewModels collect this flow so they can
- * transparently retry a failed preview via the yt-dlp fallback path
- * (see `SearchViewModel.onPreviewError` for the retry policy).
+ * [attemptId] identifies the exact [playUrl] request that failed. Consumers
+ * that retry must compare it with the token returned by [PreviewPlayer.playUrl]
+ * so a buffered error from an older URL cannot stop a newer attempt.
  */
-data class PreviewErrorEvent(val videoId: String, val error: PlaybackException)
+data class PreviewErrorEvent(
+    val videoId: String,
+    val attemptId: Long,
+    val error: PlaybackException,
+)
 
 // ---------------------------------------------------------------------------
 // Player
@@ -113,6 +117,7 @@ class PreviewPlayer @Inject constructor(
      * All internal helpers check [requirePlayer] or guard against null.
      */
     private var exoPlayer: ExoPlayer? = null
+    private var attemptErrorListener: Player.Listener? = null
 
     /**
      * The [videoId] passed to the most recent [playUrl] call.
@@ -121,6 +126,10 @@ class PreviewPlayer @Inject constructor(
      * have been replaced by a subsequent [playUrl] call.
      */
     private var currentVideoId: String = ""
+    private var requestSequence = 0L
+    private var currentRequestId = 0L
+    private var attemptSequence = 0L
+    private var currentAttemptId = 0L
 
     // ------------------------------------------------------------------
     // Listener
@@ -171,18 +180,6 @@ class PreviewPlayer @Inject constructor(
             }
         }
 
-        override fun onPlayerError(error: PlaybackException) {
-            // Any playback error resets state so the UI does not remain stuck in Playing.
-            _previewState.value = PreviewState.Idle
-            // Surface the error to any VM subscribed to [playerErrors] so it
-            // can decide whether to retry (e.g. InnerTube URL rejected → yt-dlp).
-            val id = currentVideoId
-            if (id.isNotEmpty()) {
-                // Non-blocking; fits in the 4-slot buffer even if the VM's
-                // collector hasn't drained the previous event yet.
-                _playerErrors.tryEmit(PreviewErrorEvent(id, error))
-            }
-        }
     }
 
     // ------------------------------------------------------------------
@@ -230,8 +227,69 @@ class PreviewPlayer @Inject constructor(
      *
      * @param videoId   Logical identifier of the track being previewed.
      * @param streamUrl Direct audio stream URL that ExoPlayer can open.
+     * @param onAttemptStarted Called with the attempt token before ExoPlayer
+     *                         receives or prepares the media item.
+     * @return An opaque token identifying this exact playback attempt.
      */
-    fun playUrl(videoId: String, streamUrl: String) {
+    @Synchronized
+    fun playUrl(
+        videoId: String,
+        streamUrl: String,
+        onAttemptStarted: (Long) -> Unit = {},
+    ): Long = checkNotNull(
+        playUrlIfClaimed(
+            requestId = claimRequest(),
+            videoId = videoId,
+            streamUrl = streamUrl,
+            onAttemptStarted = onAttemptStarted,
+        ),
+    )
+
+    /**
+     * Claims global ownership before a caller begins asynchronous URL/source
+     * resolution. A later claim from another screen supersedes this token.
+     */
+    @Synchronized
+    fun claimRequest(): Long {
+        requestSequence += 1L
+        currentRequestId = requestSequence
+        return currentRequestId
+    }
+
+    /** Invalidates [requestId] only if no newer screen has claimed playback. */
+    @Synchronized
+    fun cancelRequest(requestId: Long?) {
+        if (requestId != null && requestId == currentRequestId) {
+            currentRequestId = 0L
+        }
+    }
+
+    /** Returns whether [requestId] is still the latest global preview claim. */
+    @Synchronized
+    fun isRequestCurrent(requestId: Long?): Boolean =
+        requestId != null && requestId == currentRequestId
+
+    /**
+     * Starts URL playback only while [requestId] remains the latest global
+     * request. Returns `null` when another screen won ownership while the
+     * caller was suspended.
+     */
+    @Synchronized
+    fun playUrlIfClaimed(
+        requestId: Long,
+        videoId: String,
+        streamUrl: String,
+        onAttemptStarted: (Long) -> Unit = {},
+    ): Long? {
+        if (requestId != currentRequestId) return null
+        return playUrlInternal(videoId, streamUrl, onAttemptStarted)
+    }
+
+    private fun playUrlInternal(
+        videoId: String,
+        streamUrl: String,
+        onAttemptStarted: (Long) -> Unit,
+    ): Long {
         // Capture BEFORE any work so the bookend measures the full
         // tap→audible latency (spec §4.1 target: p50 <500ms / p95 <3s).
         val t0 = SystemClock.elapsedRealtime()
@@ -240,10 +298,13 @@ class PreviewPlayer @Inject constructor(
         // Stop any previous playback and clear the queue before loading the
         // new item.  This ensures the listener does not fire stale STATE_ENDED
         // events for the previous track after we replace it.
+        clearAttemptErrorListener(player)
         player.stop()
         player.clearMediaItems()
 
-        currentVideoId = videoId
+        val attemptId = beginAttempt(videoId)
+        installAttemptErrorListener(player, videoId, attemptId)
+        onAttemptStarted(attemptId)
 
         player.setMediaItem(MediaItem.fromUri(streamUrl))
         player.prepare()
@@ -265,6 +326,7 @@ class PreviewPlayer @Inject constructor(
                 }
             }
         })
+        return attemptId
     }
 
     /**
@@ -288,23 +350,89 @@ class PreviewPlayer @Inject constructor(
      * @param mediaSource Pre-built [MediaSource] from [SearchPreviewMediaSource.create].
      */
     @OptIn(UnstableApi::class)
-    fun play(videoId: String, mediaSource: MediaSource) {
+    @Synchronized
+    fun play(
+        videoId: String,
+        mediaSource: MediaSource,
+        onAttemptStarted: (Long) -> Unit = {},
+    ): Long = checkNotNull(
+        playIfClaimed(
+            requestId = claimRequest(),
+            videoId = videoId,
+            mediaSource = mediaSource,
+            onAttemptStarted = onAttemptStarted,
+        ),
+    )
+
+    /** MediaSource counterpart to [playUrlIfClaimed]. */
+    @OptIn(UnstableApi::class)
+    @Synchronized
+    fun playIfClaimed(
+        requestId: Long,
+        videoId: String,
+        mediaSource: MediaSource,
+        onAttemptStarted: (Long) -> Unit = {},
+    ): Long? {
+        if (requestId != currentRequestId) return null
+        return playInternal(videoId, mediaSource, onAttemptStarted)
+    }
+
+    @OptIn(UnstableApi::class)
+    private fun playInternal(
+        videoId: String,
+        mediaSource: MediaSource,
+        onAttemptStarted: (Long) -> Unit,
+    ): Long {
         val player = requirePlayer()
         // Idempotency: skip if already playing this exact videoId.
-        if (currentVideoId == videoId && player.isPlaying) return
+        if (currentVideoId == videoId && player.isPlaying) {
+            onAttemptStarted(currentAttemptId)
+            return currentAttemptId
+        }
 
         // Stop previous playback and clear queue so stale STATE_ENDED events
         // from the prior track cannot fire after we replace the source.
+        clearAttemptErrorListener(player)
         player.stop()
         player.clearMediaItems()
 
-        currentVideoId = videoId
+        val attemptId = beginAttempt(videoId)
+        installAttemptErrorListener(player, videoId, attemptId)
+        onAttemptStarted(attemptId)
 
         player.setMediaSource(mediaSource)
         player.prepare()
         player.playWhenReady = true
 
         PerfLog.d { "PreviewPlayer.play($videoId) via MediaSource" }
+        return attemptId
+    }
+
+    private fun beginAttempt(videoId: String): Long {
+        attemptSequence += 1L
+        currentAttemptId = attemptSequence
+        currentVideoId = videoId
+        return currentAttemptId
+    }
+
+    private fun installAttemptErrorListener(
+        player: ExoPlayer,
+        videoId: String,
+        attemptId: Long,
+    ) {
+        val listener = object : Player.Listener {
+            override fun onPlayerError(error: PlaybackException) {
+                _previewState.value = PreviewState.Idle
+                _playerErrors.tryEmit(PreviewErrorEvent(videoId, attemptId, error))
+            }
+        }
+        attemptErrorListener = listener
+        player.addListener(listener)
+    }
+
+    private fun clearAttemptErrorListener(player: ExoPlayer) {
+        attemptErrorListener?.let(player::removeListener)
+        attemptErrorListener = null
     }
 
     /**
@@ -315,13 +443,30 @@ class PreviewPlayer @Inject constructor(
      *
      * Safe to call when no playback is active.
      */
+    @Synchronized
     fun stop() {
-        exoPlayer?.stop()
-        exoPlayer?.clearMediaItems()
+        exoPlayer?.let { player ->
+            clearAttemptErrorListener(player)
+            player.stop()
+            player.clearMediaItems()
+        }
         // Clear so a late onPlayerError (fired after stop tears down the
         // source) can't be attributed to the stopped videoId.
         currentVideoId = ""
+        currentRequestId = 0L
+        currentAttemptId = 0L
         _previewState.value = PreviewState.Idle
+    }
+
+    /**
+     * Stops playback only when [attemptId] still owns the current source.
+     *
+     * ViewModels call this from teardown/failure paths so a stale screen cannot
+     * stop a newer screen's preview after the singleton player was preempted.
+     */
+    @Synchronized
+    fun stopIfCurrent(attemptId: Long?) {
+        if (attemptId != null && attemptId == currentAttemptId) stop()
     }
 
     /**
@@ -333,10 +478,15 @@ class PreviewPlayer @Inject constructor(
      * Should be called from the DI component's teardown (e.g. [Application.onTerminate]
      * or a [ViewModel.onCleared] that owns this singleton's scope).
      */
+    @Synchronized
     fun release() {
+        exoPlayer?.let(::clearAttemptErrorListener)
         exoPlayer?.removeListener(playerListener)
         exoPlayer?.release()
         exoPlayer = null
+        currentVideoId = ""
+        currentRequestId = 0L
+        currentAttemptId = 0L
         _previewState.value = PreviewState.Idle
     }
 }

--- a/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryFullTimelineTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryFullTimelineTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.prefs.StreamingPreference
 import com.stash.core.data.repository.MusicRepository
+import com.stash.core.data.sync.TrackIdentityEvents
 import com.stash.core.media.service.StashPlaybackService.Companion.EXTRA_TRACK_ID
 import com.stash.core.media.streaming.ConnectivityMonitor
 import com.stash.core.media.streaming.StreamSourceRegistry
@@ -44,6 +45,9 @@ class PlayerRepositoryFullTimelineTest {
     private val connectivity: ConnectivityMonitor = mockk(relaxed = true)
     private val trackDao: TrackDao = mockk(relaxed = true)
     private val controller: MediaController = mockk(relaxed = true)
+    private val trackIdentityEvents: TrackIdentityEvents = mockk {
+        every { changes } returns MutableSharedFlow()
+    }
 
     private lateinit var repo: PlayerRepositoryImpl
 
@@ -60,6 +64,7 @@ class PlayerRepositoryFullTimelineTest {
             trackDao = trackDao,
             playbackResumer = PlaybackResumer(playbackStateStore, trackDao),
             radioGenerator = mockk(relaxed = true),
+            trackIdentityEvents = trackIdentityEvents,
         )
         repo.controllerDeferred = controller
     }

--- a/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryRadioTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryRadioTest.kt
@@ -10,6 +10,7 @@ import com.stash.core.data.radio.RadioSeed
 import com.stash.core.data.radio.RadioSession
 import com.stash.core.data.radio.RadioStationGenerator
 import com.stash.core.data.repository.MusicRepository
+import com.stash.core.data.sync.TrackIdentityEvents
 import com.stash.core.media.streaming.ConnectivityMonitor
 import com.stash.core.media.streaming.StreamSourceRegistry
 import com.stash.core.media.streaming.StreamUrlCache
@@ -42,6 +43,9 @@ class PlayerRepositoryRadioTest {
     private val trackDao: TrackDao = mockk(relaxed = true)
     private val controller: MediaController = mockk(relaxed = true)
     private val radioGenerator: RadioStationGenerator = mockk()
+    private val trackIdentityEvents: TrackIdentityEvents = mockk {
+        every { changes } returns MutableSharedFlow()
+    }
 
     private lateinit var repo: PlayerRepositoryImpl
 
@@ -58,6 +62,7 @@ class PlayerRepositoryRadioTest {
             trackDao = trackDao,
             playbackResumer = PlaybackResumer(playbackStateStore, trackDao),
             radioGenerator = radioGenerator,
+            trackIdentityEvents = trackIdentityEvents,
         )
         repo.controllerDeferred = controller
     }
@@ -98,6 +103,7 @@ class PlayerRepositoryRadioTest {
             trackDao = trackDao,
             playbackResumer = PlaybackResumer(playbackStateStore, trackDao),
             radioGenerator = radioGenerator,
+            trackIdentityEvents = trackIdentityEvents,
         )
 
         val started = coldRepo.startRadio(RadioSeed.Song("t", "a"))

--- a/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryStreamingTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryStreamingTest.kt
@@ -7,6 +7,7 @@ import com.stash.core.common.constants.StashConstants
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.db.entity.TrackEntity
 import com.stash.core.data.prefs.StreamingPreference
+import com.stash.core.data.sync.TrackIdentityEvents
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.streaming.ConnectivityMonitor
 import com.stash.core.media.streaming.StreamSourceRegistry
@@ -53,6 +54,9 @@ class PlayerRepositoryStreamingTest {
     private val streamUrlCache: StreamUrlCache = mockk(relaxUnitFun = true)
     private val connectivity: ConnectivityMonitor = mockk()
     private val trackDao: TrackDao = mockk()
+    private val trackIdentityEvents: TrackIdentityEvents = mockk {
+        every { changes } returns MutableSharedFlow()
+    }
 
     private lateinit var repo: PlayerRepositoryImpl
 
@@ -70,6 +74,7 @@ class PlayerRepositoryStreamingTest {
             trackDao = trackDao,
             playbackResumer = PlaybackResumer(playbackStateStore, trackDao),
             radioGenerator = mockk(relaxed = true),
+            trackIdentityEvents = trackIdentityEvents,
         )
         // Tests that don't care about disk existence get a "file is there"
         // default; the not-downloaded tests can override per-test.
@@ -99,6 +104,7 @@ class PlayerRepositoryStreamingTest {
             trackDao = trackDao,
             playbackResumer = PlaybackResumer(playbackStateStore, trackDao),
             radioGenerator = mockk(relaxed = true),
+            trackIdentityEvents = trackIdentityEvents,
         )
 
         val empty = File.createTempFile("stash-empty", ".flac").apply { deleteOnExit() }

--- a/core/media/src/test/kotlin/com/stash/core/media/actions/TrackActionsDelegatePreviewAttemptTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/actions/TrackActionsDelegatePreviewAttemptTest.kt
@@ -1,0 +1,218 @@
+package com.stash.core.media.actions
+
+import androidx.media3.common.PlaybackException
+import androidx.media3.exoplayer.source.MediaSource
+import com.stash.core.media.PlayerRepository
+import com.stash.core.media.preview.PreviewPlayer
+import com.stash.core.media.preview.PreviewState
+import com.stash.core.media.preview.SearchPreviewMediaSource
+import com.stash.core.model.TrackItem
+import com.stash.data.download.preview.PreviewUrlExtractor
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** Ensures the singleton preview error flow cannot cross screen/attempt owners. */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TrackActionsDelegatePreviewAttemptTest {
+
+    private var requestSequence = 0L
+    private var currentRequestId = 0L
+    private var attemptSequence = 40L
+    private val previewPlayer: PreviewPlayer = mockk(relaxed = true) {
+        every { previewState } returns MutableStateFlow(PreviewState.Idle)
+        every { playerErrors } returns MutableSharedFlow()
+        every { claimRequest() } answers {
+            currentRequestId = ++requestSequence
+            currentRequestId
+        }
+        every { isRequestCurrent(any()) } answers {
+            firstArg<Long?>() == currentRequestId
+        }
+        every { cancelRequest(any()) } answers {
+            if (firstArg<Long?>() == currentRequestId) currentRequestId = 0L
+            Unit
+        }
+        every { playIfClaimed(any(), any(), any(), any()) } answers {
+            if (firstArg<Long>() != currentRequestId) {
+                null
+            } else {
+                val attemptId = ++attemptSequence
+                arg<(Long) -> Unit>(3).invoke(attemptId)
+                attemptId
+            }
+        }
+        every { playUrlIfClaimed(any(), any(), any(), any()) } answers {
+            if (firstArg<Long>() != currentRequestId) {
+                null
+            } else {
+                val attemptId = ++attemptSequence
+                arg<(Long) -> Unit>(3).invoke(attemptId)
+                attemptId
+            }
+        }
+    }
+    private val mediaSourceFactory: SearchPreviewMediaSource = mockk()
+    private val extractor: PreviewUrlExtractor = mockk(relaxed = true)
+    private val streamingPreference: com.stash.core.data.prefs.StreamingPreference = mockk()
+
+    private fun delegate() = TrackActionsDelegate(
+        previewPlayer = previewPlayer,
+        searchPreviewMediaSource = mediaSourceFactory,
+        previewUrlExtractor = extractor,
+        previewUrlCache = mockk(relaxed = true),
+        trackDao = mockk(relaxed = true),
+        searchDownloadCoordinator = mockk(relaxed = true),
+        playerRepository = mockk<PlayerRepository>(relaxed = true),
+        streamingPreference = streamingPreference,
+        musicRepository = mockk(relaxed = true),
+        blocklistGuard = mockk(relaxed = true),
+    )
+
+    private fun ioError() = PlaybackException(
+        "preview URL rejected",
+        IOException("HTTP 403"),
+        PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS,
+    )
+
+    @Test
+    fun `only the exact owned playback attempt may trigger yt-dlp retry`() = runTest {
+        val track = mockk<TrackItem> { every { videoId } returns "same-video" }
+        val mediaSource = mockk<MediaSource>()
+        coEvery { streamingPreference.current() } returns false
+        coEvery { mediaSourceFactory.create(track) } returns mediaSource
+        coEvery { extractor.extractViaYtDlpForRetry("same-video") } returns "https://retry"
+        val delegate = delegate()
+        delegate.bindToScope(backgroundScope)
+
+        delegate.previewTrack(track)
+        runCurrent()
+        verify(exactly = 1) {
+            previewPlayer.playIfClaimed(any(), "same-video", mediaSource, any())
+        }
+
+        delegate.onPreviewError("same-video", attemptId = 99L, error = ioError())
+        runCurrent()
+        coVerify(exactly = 0) { extractor.extractViaYtDlpForRetry(any()) }
+
+        delegate.onPreviewError("same-video", attemptId = 41L, error = ioError())
+        runCurrent()
+        coVerify(exactly = 1) { extractor.extractViaYtDlpForRetry("same-video") }
+    }
+
+    @Test
+    fun `a superseded suspended source load cannot revive stale playback`() = runTest {
+        val first = mockk<TrackItem> { every { videoId } returns "first" }
+        val second = mockk<TrackItem> { every { videoId } returns "second" }
+        val firstSource = mockk<MediaSource>()
+        val secondSource = mockk<MediaSource>()
+        val firstGate = CompletableDeferred<Unit>()
+        coEvery { streamingPreference.current() } returns false
+        coEvery { mediaSourceFactory.create(first) } coAnswers {
+            withContext(NonCancellable) { firstGate.await() }
+            firstSource
+        }
+        coEvery { mediaSourceFactory.create(second) } returns secondSource
+        val delegate = delegate()
+        delegate.bindToScope(backgroundScope)
+
+        delegate.previewTrack(first)
+        runCurrent()
+        delegate.previewTrack(second)
+        runCurrent()
+        firstGate.complete(Unit)
+        runCurrent()
+
+        verify(exactly = 0) {
+            previewPlayer.playIfClaimed(any(), "first", firstSource, any())
+        }
+        verify(exactly = 1) {
+            previewPlayer.playIfClaimed(any(), "second", secondSource, any())
+        }
+    }
+
+    @Test
+    fun `a newer owner claim rejects another owners suspended source load`() = runTest {
+        val first = mockk<TrackItem> { every { videoId } returns "first" }
+        val second = mockk<TrackItem> { every { videoId } returns "second" }
+        val firstSource = mockk<MediaSource>()
+        val secondSource = mockk<MediaSource>()
+        val firstGate = CompletableDeferred<Unit>()
+        coEvery { streamingPreference.current() } returns false
+        coEvery { mediaSourceFactory.create(first) } coAnswers {
+            firstGate.await()
+            firstSource
+        }
+        coEvery { mediaSourceFactory.create(second) } returns secondSource
+        val firstOwner = delegate()
+        val secondOwner = delegate()
+        firstOwner.bindToScope(backgroundScope)
+        secondOwner.bindToScope(backgroundScope)
+
+        firstOwner.previewTrack(first)
+        runCurrent()
+        secondOwner.previewTrack(second)
+        runCurrent()
+        firstGate.complete(Unit)
+        runCurrent()
+
+        verify(exactly = 1) {
+            previewPlayer.playIfClaimed(1L, "first", firstSource, any())
+        }
+        verify(exactly = 1) {
+            previewPlayer.playIfClaimed(2L, "second", secondSource, any())
+        }
+        assertNull(firstOwner.previewLoadingId.value)
+    }
+
+    @Test
+    fun `a newer owner claim rejects another owners suspended retry`() = runTest {
+        val first = mockk<TrackItem> { every { videoId } returns "first" }
+        val second = mockk<TrackItem> { every { videoId } returns "second" }
+        val firstSource = mockk<MediaSource>()
+        val secondSource = mockk<MediaSource>()
+        val retryGate = CompletableDeferred<Unit>()
+        coEvery { streamingPreference.current() } returns false
+        coEvery { mediaSourceFactory.create(first) } returns firstSource
+        coEvery { mediaSourceFactory.create(second) } returns secondSource
+        coEvery { extractor.extractViaYtDlpForRetry("first") } coAnswers {
+            withContext(NonCancellable) { retryGate.await() }
+            "https://stale-retry"
+        }
+        val firstOwner = delegate()
+        val secondOwner = delegate()
+        firstOwner.bindToScope(backgroundScope)
+        secondOwner.bindToScope(backgroundScope)
+
+        firstOwner.previewTrack(first)
+        runCurrent()
+        firstOwner.onPreviewError("first", attemptId = 41L, error = ioError())
+        runCurrent()
+        secondOwner.previewTrack(second)
+        runCurrent()
+        retryGate.complete(Unit)
+        runCurrent()
+
+        coVerify(exactly = 1) { extractor.extractViaYtDlpForRetry("first") }
+        verify(exactly = 1) {
+            previewPlayer.playUrlIfClaimed(1L, "first", "https://stale-retry", any())
+        }
+        verify(exactly = 1) {
+            previewPlayer.playIfClaimed(2L, "second", secondSource, any())
+        }
+        assertNull(firstOwner.previewLoadingId.value)
+    }
+}

--- a/core/media/src/test/kotlin/com/stash/core/media/preview/PreviewPlayerRequestLeaseTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/preview/PreviewPlayerRequestLeaseTest.kt
@@ -1,0 +1,65 @@
+package com.stash.core.media.preview
+
+import android.content.Context
+import androidx.media3.exoplayer.source.MediaSource
+import com.stash.core.media.equalizer.EqController
+import com.stash.core.media.equalizer.LoudnessController
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PreviewPlayerRequestLeaseTest {
+
+    private fun player() = PreviewPlayer(
+        context = mockk<Context>(relaxed = true),
+        eqController = mockk<EqController>(relaxed = true),
+        loudnessController = mockk<LoudnessController>(relaxed = true),
+    )
+
+    @Test
+    fun `a stale request cannot initialize URL playback`() {
+        val player = player()
+        val staleRequest = player.claimRequest()
+        player.claimRequest()
+
+        val attemptId = player.playUrlIfClaimed(
+            requestId = staleRequest,
+            videoId = "stale",
+            streamUrl = "https://audio.example/stale",
+        )
+
+        assertNull(attemptId)
+        assertTrue(player.previewState.value is PreviewState.Idle)
+    }
+
+    @Test
+    fun `a stale request cannot initialize MediaSource playback`() {
+        val player = player()
+        val staleRequest = player.claimRequest()
+        player.claimRequest()
+
+        val attemptId = player.playIfClaimed(
+            requestId = staleRequest,
+            videoId = "stale",
+            mediaSource = mockk<MediaSource>(),
+        )
+
+        assertNull(attemptId)
+        assertTrue(player.previewState.value is PreviewState.Idle)
+    }
+
+    @Test
+    fun `cancelling a stale request preserves the latest claim`() {
+        val player = player()
+        val staleRequest = player.claimRequest()
+        val latestRequest = player.claimRequest()
+
+        player.cancelRequest(staleRequest)
+        assertTrue(player.isRequestCurrent(latestRequest))
+
+        player.cancelRequest(latestRequest)
+        assertFalse(player.isRequestCurrent(latestRequest))
+    }
+}

--- a/data/download/src/main/kotlin/com/stash/data/download/files/SwapCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/SwapCoordinator.kt
@@ -147,7 +147,6 @@ class SwapCoordinator @Inject constructor(
                     Log.w(TAG, "swap: discarded too-small download for trackId=$trackId: ${committed.filePath}")
                     reFlagAfterFailure(trackId)
                 } else {
-                    } else {
                     trackDao.updateYoutubeId(trackId, newVideoId)
                     trackDao.markAsDownloaded(trackId, committed.filePath, committed.sizeBytes)
                     // The cached StreamUrl was resolved against the OLD

--- a/data/download/src/main/kotlin/com/stash/data/download/files/SwapCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/SwapCoordinator.kt
@@ -2,6 +2,7 @@ package com.stash.data.download.files
 
 import android.util.Log
 import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.media.streaming.StreamUrlCache
 import com.stash.data.download.DownloadExecutor
 import com.stash.data.download.DownloadResult
 import com.stash.data.download.prefs.QualityPreferencesManager
@@ -59,6 +60,7 @@ class SwapCoordinator @Inject constructor(
     private val trackDao: TrackDao,
     private val blocklistGuard: com.stash.core.data.blocklist.BlocklistGuard,
     private val localFileOps: com.stash.core.data.files.LocalFileOps,
+    private val streamUrlCache: StreamUrlCache,
 ) {
     companion object {
         private const val TAG = "SwapCoordinator"
@@ -145,8 +147,14 @@ class SwapCoordinator @Inject constructor(
                     Log.w(TAG, "swap: discarded too-small download for trackId=$trackId: ${committed.filePath}")
                     reFlagAfterFailure(trackId)
                 } else {
+                    } else {
                     trackDao.updateYoutubeId(trackId, newVideoId)
                     trackDao.markAsDownloaded(trackId, committed.filePath, committed.sizeBytes)
+                    // The cached StreamUrl was resolved against the OLD
+                    // youtubeId — without evicting it, buildMediaItemForTrack
+                    // keeps serving the stale (possibly-expired, definitely
+                    // wrong-song) URL after a swap.
+                    streamUrlCache.invalidate(trackId)
 
                     // Only now is it safe to remove the old file — and only if it
                     // isn't the very path we just wrote (same artist/title can

--- a/data/download/src/main/kotlin/com/stash/data/download/files/SwapCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/SwapCoordinator.kt
@@ -2,7 +2,7 @@ package com.stash.data.download.files
 
 import android.util.Log
 import com.stash.core.data.db.dao.TrackDao
-import com.stash.core.media.streaming.StreamUrlCache
+import com.stash.core.data.sync.TrackIdentityEvents
 import com.stash.data.download.DownloadExecutor
 import com.stash.data.download.DownloadResult
 import com.stash.data.download.prefs.QualityPreferencesManager
@@ -60,7 +60,7 @@ class SwapCoordinator @Inject constructor(
     private val trackDao: TrackDao,
     private val blocklistGuard: com.stash.core.data.blocklist.BlocklistGuard,
     private val localFileOps: com.stash.core.data.files.LocalFileOps,
-    private val streamUrlCache: StreamUrlCache,
+    private val trackIdentityEvents: TrackIdentityEvents,
 ) {
     companion object {
         private const val TAG = "SwapCoordinator"
@@ -154,7 +154,7 @@ class SwapCoordinator @Inject constructor(
                     // youtubeId — without evicting it, buildMediaItemForTrack
                     // keeps serving the stale (possibly-expired, definitely
                     // wrong-song) URL after a swap.
-                    streamUrlCache.invalidate(trackId)
+                    trackIdentityEvents.emitIdentityChanged(trackId)
 
                     // Only now is it safe to remove the old file — and only if it
                     // isn't the very path we just wrote (same artist/title can

--- a/data/download/src/main/kotlin/com/stash/data/download/matching/YtLibraryCanonicalizer.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/matching/YtLibraryCanonicalizer.kt
@@ -3,6 +3,7 @@ package com.stash.data.download.matching
 import android.util.Log
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.sync.TrackMatcher
+import com.stash.core.media.streaming.StreamUrlCache
 import com.stash.core.model.Track
 import com.stash.data.ytmusic.model.MusicVideoType
 import javax.inject.Inject
@@ -37,6 +38,7 @@ class YtLibraryCanonicalizer @Inject constructor(
     private val matchScorer: MatchScorer,
     private val trackDao: TrackDao,
     private val trackMatcher: TrackMatcher,
+    private val streamUrlCache: StreamUrlCache,
 ) {
     companion object {
         private const val TAG = "YtLibCanonicalizer"
@@ -109,6 +111,13 @@ class YtLibraryCanonicalizer @Inject constructor(
         // on the new (correct) videoId and try again without re-running
         // canonicalization — strictly better than the pre-persist state.
         trackDao.updateYoutubeId(track.id, best.videoId)
+        // Evict any StreamUrl cached under the OLD (OMV) videoId — otherwise
+        // the "next resolveUrl short-circuits on the new videoId" promise
+        // above is broken: PlayerRepositoryImpl.buildMediaItemForTrack checks
+        // StreamUrlCache BEFORE calling the resolver, so a stale cache hit
+        // would keep serving the old OMV audio/URL despite the DB now
+        // pointing at the ATV videoId.
+        streamUrlCache.invalidate(track.id)
 
         // Also refresh the display/dedup metadata so the UI stops showing
         // the OMV's title ("Smooth Criminal (Official Video)") and its

--- a/data/download/src/main/kotlin/com/stash/data/download/matching/YtLibraryCanonicalizer.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/matching/YtLibraryCanonicalizer.kt
@@ -3,7 +3,7 @@ package com.stash.data.download.matching
 import android.util.Log
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.sync.TrackMatcher
-import com.stash.core.media.streaming.StreamUrlCache
+import com.stash.core.data.sync.TrackIdentityEvents
 import com.stash.core.model.Track
 import com.stash.data.ytmusic.model.MusicVideoType
 import javax.inject.Inject
@@ -38,7 +38,7 @@ class YtLibraryCanonicalizer @Inject constructor(
     private val matchScorer: MatchScorer,
     private val trackDao: TrackDao,
     private val trackMatcher: TrackMatcher,
-    private val streamUrlCache: StreamUrlCache,
+    private val trackIdentityEvents: TrackIdentityEvents,
 ) {
     companion object {
         private const val TAG = "YtLibCanonicalizer"
@@ -117,7 +117,7 @@ class YtLibraryCanonicalizer @Inject constructor(
         // StreamUrlCache BEFORE calling the resolver, so a stale cache hit
         // would keep serving the old OMV audio/URL despite the DB now
         // pointing at the ATV videoId.
-        streamUrlCache.invalidate(track.id)
+        trackIdentityEvents.emitIdentityChanged(track.id)
 
         // Also refresh the display/dedup metadata so the UI stops showing
         // the OMV's title ("Smooth Criminal (Official Video)") and its

--- a/data/download/src/test/kotlin/com/stash/data/download/files/SwapCoordinatorTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/files/SwapCoordinatorTest.kt
@@ -2,6 +2,7 @@ package com.stash.data.download.files
 
 import com.stash.core.data.blocklist.BlocklistGuard
 import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.sync.TrackIdentityEvents
 import com.stash.core.model.QualityTier
 import com.stash.data.download.DownloadExecutor
 import com.stash.data.download.DownloadResult
@@ -34,6 +35,7 @@ class SwapCoordinatorTest {
     private val qualityPrefs = mockk<QualityPreferencesManager>()
     private val trackDao = mockk<TrackDao>(relaxed = true)
     private val blocklistGuard = mockk<BlocklistGuard>(relaxed = true)
+    private val trackIdentityEvents = mockk<TrackIdentityEvents>(relaxed = true)
 
     private lateinit var coordinator: SwapCoordinator
 
@@ -48,6 +50,7 @@ class SwapCoordinatorTest {
             trackDao = trackDao,
             blocklistGuard = blocklistGuard,
             localFileOps = mockk(relaxed = true) { every { acceptDownloadOrDelete(any()) } returns true },
+            trackIdentityEvents = trackIdentityEvents,
         )
     }
 

--- a/data/download/src/test/kotlin/com/stash/data/download/matching/YtLibraryCanonicalizerTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/matching/YtLibraryCanonicalizerTest.kt
@@ -2,6 +2,7 @@ package com.stash.data.download.matching
 
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.sync.TrackMatcher
+import com.stash.core.data.sync.TrackIdentityEvents
 import com.stash.core.model.MusicSource
 import com.stash.core.model.Track
 import com.stash.data.download.ytdlp.YtDlpSearchResult
@@ -83,6 +84,7 @@ class YtLibraryCanonicalizerTest {
             matchScorer = MatchScorer(TrackMatcher()),
             trackDao = trackDao,
             trackMatcher = TrackMatcher(),
+            trackIdentityEvents = mock(),
         )
 
         // Track as imported from the user's Archive Mix — MV duration,
@@ -141,6 +143,7 @@ class YtLibraryCanonicalizerTest {
             matchScorer = MatchScorer(TrackMatcher()),
             trackDao = trackDao,
             trackMatcher = TrackMatcher(),
+            trackIdentityEvents = mock(),
         )
         val track = Track(
             title = "Studio Song",
@@ -173,6 +176,7 @@ class YtLibraryCanonicalizerTest {
             matchScorer = MatchScorer(TrackMatcher()),
             trackDao = trackDao,
             trackMatcher = TrackMatcher(),
+            trackIdentityEvents = mock(),
         )
         val track = Track(
             title = "Obscure Song",

--- a/feature/sync/build.gradle.kts
+++ b/feature/sync/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
     implementation(libs.compose.material.icons.extended)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
+    // FailedMatchesViewModel classifies PreviewPlayer's asynchronous
+    // PlaybackException events before its one-shot yt-dlp retry.
+    implementation(libs.media3.exoplayer)
     // For the "Fix wrong-version downloads" trigger (enqueues
     // YtLibraryBackfillWorker via WorkManager).
     implementation(libs.work.runtime.ktx)

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
@@ -9,7 +9,7 @@ import com.stash.core.data.db.dao.UnmatchedTrackView
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.preview.PreviewPlayer
 import com.stash.core.media.preview.PreviewState
-import com.stash.core.media.streaming.StreamUrlCache
+import com.stash.core.data.sync.TrackIdentityEvents
 import com.stash.core.model.DownloadStatus
 import com.stash.data.download.DownloadExecutor
 import com.stash.data.download.DownloadResult
@@ -128,7 +128,7 @@ class FailedMatchesViewModel @Inject constructor(
     private val swapCoordinator: SwapCoordinator,
     private val blocklistGuard: com.stash.core.data.blocklist.BlocklistGuard,
     private val localFileOps: com.stash.core.data.files.LocalFileOps,
-    private val streamUrlCache: StreamUrlCache,
+    private val trackIdentityEvents: TrackIdentityEvents,
 ) : ViewModel() {
 
     companion object {
@@ -398,7 +398,7 @@ class FailedMatchesViewModel @Inject constructor(
                 )
                 // Drop any StreamUrl cached under the OLD youtubeId — otherwise
                 // playback keeps serving the pre-approval (wrong/stale) URL.
-                streamUrlCache.invalidate(trackId)
+                trackIdentityEvents.emitIdentityChanged(trackId)
 
                 // Remove from resync candidates map
                 _resyncCandidates.update { it - trackId }

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
@@ -9,6 +9,7 @@ import com.stash.core.data.db.dao.UnmatchedTrackView
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.preview.PreviewPlayer
 import com.stash.core.media.preview.PreviewState
+import com.stash.core.media.streaming.StreamUrlCache
 import com.stash.core.model.DownloadStatus
 import com.stash.data.download.DownloadExecutor
 import com.stash.data.download.DownloadResult
@@ -127,6 +128,7 @@ class FailedMatchesViewModel @Inject constructor(
     private val swapCoordinator: SwapCoordinator,
     private val blocklistGuard: com.stash.core.data.blocklist.BlocklistGuard,
     private val localFileOps: com.stash.core.data.files.LocalFileOps,
+    private val streamUrlCache: StreamUrlCache,
 ) : ViewModel() {
 
     companion object {
@@ -394,6 +396,9 @@ class FailedMatchesViewModel @Inject constructor(
                     id = queueEntryId,
                     status = DownloadStatus.COMPLETED,
                 )
+                // Drop any StreamUrl cached under the OLD youtubeId — otherwise
+                // playback keeps serving the pre-approval (wrong/stale) URL.
+                streamUrlCache.invalidate(trackId)
 
                 // Remove from resync candidates map
                 _resyncCandidates.update { it - trackId }

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
@@ -1,6 +1,7 @@
 package com.stash.feature.sync
 
 import android.util.Log
+import androidx.media3.common.PlaybackException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.stash.core.data.db.dao.DownloadQueueDao
@@ -18,6 +19,7 @@ import com.stash.data.download.files.SwapCoordinator
 import com.stash.data.download.matching.HybridSearchExecutor
 import com.stash.data.download.prefs.QualityPreferencesManager
 import com.stash.data.download.prefs.toYtDlpArgs
+import com.stash.data.download.preview.NoFastStreamException
 import com.stash.data.download.preview.PreviewUrlExtractor
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
@@ -140,8 +142,12 @@ class FailedMatchesViewModel @Inject constructor(
         /** How many resync candidates to pre-extract preview URLs for. */
         private const val PRE_EXTRACT_LIMIT = 10
 
-        /** Max concurrent yt-dlp preview extractions (each is CPU-heavy). */
+        /** Max concurrent speculative InnerTube-only preview extractions. */
         private const val PRE_EXTRACT_CONCURRENCY = 2
+
+        private const val PREVIEW_FAILURE_MESSAGE =
+            "Couldn't load that preview. Try again, or approve to hear the full track."
+
     }
 
     /** Observable preview playback state for the UI to highlight the active row. */
@@ -173,6 +179,29 @@ class FailedMatchesViewModel @Inject constructor(
 
     /** Active pre-extraction jobs — cancelled when a new resync starts. */
     private var preExtractJobs = mutableListOf<Job>()
+
+    /** User-initiated extraction and one-shot fallback jobs. */
+    private var previewLoadJob: Job? = null
+    private var previewRetryJob: Job? = null
+
+    /**
+     * Ownership token for asynchronous preview work. A new tap or explicit stop
+     * advances the generation so late extractor/player events cannot revive an
+     * older candidate.
+     */
+    private var previewRequestGeneration = 0L
+    private var activePreviewRequestId: Long? = null
+    private var activePreviewVideoId: String? = null
+    private var activePreviewAttemptId: Long? = null
+    private var activePreviewRetried = false
+
+    init {
+        viewModelScope.launch {
+            previewPlayer.playerErrors.collect { event ->
+                onPreviewPlayerError(event.videoId, event.attemptId, event.error)
+            }
+        }
+    }
 
     // -- Combined UI state --------------------------------------------------
 
@@ -236,18 +265,36 @@ class FailedMatchesViewModel @Inject constructor(
             _resyncProgress.value = ""
 
             // Single search pass over BOTH unmatched and user-flagged tracks.
-            // Each row becomes a (trackId, searchQuery, rejectedVideoId?)
-            // triple so the same semaphored search loop handles both kinds.
-            val unmatched = uiState.value.tracks.map {
+            // Keep whether an excluded result may be surfaced as a last resort:
+            // unmatched rows can still preview their rejected candidate, while a
+            // flagged row must never be offered its current wrong video again.
+            // A track can transiently appear in both repository flows; flagged
+            // ownership wins so an unmatched fallback cannot reintroduce the
+            // very video the user marked as wrong.
+            val flaggedRowsSnapshot = uiState.value.flaggedTracks
+            val flaggedTrackIds = flaggedRowsSnapshot.mapTo(mutableSetOf()) { it.trackId }
+            val unmatched = uiState.value.tracks
+                .filterNot { it.trackId in flaggedTrackIds }
+                .map {
                 // Auto-requeued tracks (TrackDownloadWorker) get a blank
                 // download_queue.search_query. Fall back to "artist - title"
                 // — which we already have on the row — so resync can actually
                 // search instead of firing a blank query that finds nothing.
                 val query = it.searchQuery.ifBlank { "${it.artist} - ${it.title}" }
-                Triple(it.trackId, query, it.rejectedVideoId)
+                ResyncSearch(
+                    trackId = it.trackId,
+                    query = query,
+                    excludeVideoId = it.rejectedVideoId,
+                    allowExcludedFallback = true,
+                )
             }
-            val flagged = uiState.value.flaggedTracks.map {
-                Triple(it.trackId, it.searchQuery, it.currentYoutubeId)
+            val flagged = flaggedRowsSnapshot.map {
+                ResyncSearch(
+                    trackId = it.trackId,
+                    query = it.searchQuery,
+                    excludeVideoId = it.currentYoutubeId,
+                    allowExcludedFallback = false,
+                )
             }
             val jobs = unmatched + flagged
 
@@ -255,15 +302,17 @@ class FailedMatchesViewModel @Inject constructor(
             val total = jobs.size
             val completed = AtomicInteger(0)
 
-            jobs.map { (trackId, query, excludeVideoId) ->
+            jobs.map { request ->
                 launch {
                     semaphore.acquire()
                     try {
-                        val results = searchExecutor.search(query, maxResults = 5)
+                        val results = searchExecutor.search(request.query, maxResults = 5)
                         // For flagged tracks, skip the currently-associated
                         // (wrong) video — surfacing it as the candidate would
                         // just swap the track with itself.
-                        var best = results.firstOrNull { excludeVideoId == null || it.id != excludeVideoId }
+                        var best = results.firstOrNull {
+                            request.excludeVideoId == null || it.id != request.excludeVideoId
+                        }
 
                         // #19/#143: search() is InnerTube-first and only falls
                         // back to yt-dlp when YT Music returns *zero* results.
@@ -273,19 +322,21 @@ class FailedMatchesViewModel @Inject constructor(
                         // surfaces tracks that exist on YouTube but not YouTube
                         // Music (and genuine alternatives to a wrong match).
                         if (best == null) {
-                            val direct = searchExecutor.searchYtDlpDirect(query, maxResults = 5)
-                            best = direct.firstOrNull { excludeVideoId == null || it.id != excludeVideoId }
+                            val direct = searchExecutor.searchYtDlpDirect(request.query, maxResults = 5)
+                            best = direct.firstOrNull {
+                                request.excludeVideoId == null || it.id != request.excludeVideoId
+                            }
                         }
 
                         // Last resort: surface the top result even if it's the
                         // excluded one, so an unmatched track still gets *a*
                         // candidate to preview rather than nothing.
-                        if (best == null) {
+                        if (best == null && request.allowExcludedFallback) {
                             best = results.firstOrNull()
                         }
                         if (best != null) {
                             _resyncCandidates.update { current ->
-                                current + (trackId to ResyncCandidate(
+                                current + (request.trackId to ResyncCandidate(
                                     videoId = best.id,
                                     title = best.title,
                                     artist = best.uploader,
@@ -295,7 +346,7 @@ class FailedMatchesViewModel @Inject constructor(
                             }
                         }
                     } catch (e: Exception) {
-                        Log.w(TAG, "Resync search failed for '$query': ${e.message}")
+                        Log.w(TAG, "Resync search failed for '${request.query}': ${e.message}")
                     } finally {
                         semaphore.release()
                         val done = completed.incrementAndGet()
@@ -328,9 +379,10 @@ class FailedMatchesViewModel @Inject constructor(
     /**
      * Pre-extracts stream URLs for resync candidates in the background.
      *
-     * Runs up to [PRE_EXTRACT_LIMIT] extractions concurrently (limited by
-     * [PRE_EXTRACT_CONCURRENCY] semaphore). Extracted URLs are cached in
-     * [previewUrlCache] and served instantly when the user taps preview.
+     * Speculative work is InnerTube-only so it can never occupy the serialized
+     * yt-dlp lane needed by a foreground tap. Runs up to [PRE_EXTRACT_LIMIT]
+     * extractions concurrently (limited by [PRE_EXTRACT_CONCURRENCY]).
+     * Extracted URLs are cached and served instantly on a later tap.
      */
     private fun preExtractStreamUrls(candidates: Map<Long, ResyncCandidate>) {
         cancelPreExtraction()
@@ -341,13 +393,18 @@ class FailedMatchesViewModel @Inject constructor(
             val job = viewModelScope.launch {
                 semaphore.acquire()
                 try {
-                    val url = previewUrlExtractor.extractStreamUrl(candidate.videoId)
+                    val url = previewUrlExtractor.extractStreamUrl(
+                        candidate.videoId,
+                        allowYtDlp = false,
+                    )
                     previewUrlCache[candidate.videoId] = url
                     Log.d(TAG, "Pre-extracted preview URL for ${candidate.videoId}")
                 } catch (e: CancellationException) {
-                    // Expected: a user tap cancels this prefetch to take the
-                    // extractor permit. Not a failure — don't log it as one.
+                    // Expected when a new resync/tap drops the caller-side
+                    // prefetch. Extractor-owned single-flight work may finish.
                     throw e
+                } catch (e: NoFastStreamException) {
+                    Log.d(TAG, "No fast preview stream for ${candidate.videoId}")
                 } catch (e: Exception) {
                     Log.w(TAG, "Pre-extract failed for ${candidate.videoId}: ${e.message}")
                 } finally {
@@ -477,15 +534,18 @@ class FailedMatchesViewModel @Inject constructor(
 
     /**
      * Approves a replacement candidate for a user-flagged (wrong-match)
-     * track. Deletes the old audio file, kicks a fresh yt-dlp download of
-     * the new video in the background, then swaps youtubeId + file_path +
-     * file_size + clears the flag so the track disappears from the Failed
-     * Matches screen. File IO failures on the old-file delete are swallowed
-     * — a stray leftover file is strictly better than a lost swap, and the
-     * orphan cleanup pass will eventually catch it.
+     * track. [SwapCoordinator] downloads and validates the replacement before
+     * atomically changing identity/file state, then removes the old file.
      */
     fun approveSwap(row: FlaggedTrackRow, candidate: ResyncCandidate) {
         viewModelScope.launch {
+            // Defense in depth: candidates normally pass the resync exclusion
+            // above, but stale UI state or an external caller must not self-swap.
+            if (candidate.videoId == row.currentYoutubeId) {
+                _userMessages.tryEmit("Choose a different replacement for this track.")
+                return@launch
+            }
+
             // Guard: another track already owns this videoId — swapping would
             // violate the UNIQUE(youtube_id) constraint and blow up silently.
             val existing = trackDao.findByYoutubeId(candidate.videoId)
@@ -571,45 +631,186 @@ class FailedMatchesViewModel @Inject constructor(
      * @param videoId The YouTube video ID of the rejected candidate.
      */
     fun previewRejectedMatch(videoId: String) {
+        if (
+            activePreviewVideoId == videoId &&
+            previewPlayer.isRequestCurrent(activePreviewRequestId) &&
+            (_previewLoading.value == videoId ||
+                activePreviewAttemptId != null ||
+                (previewState.value as? PreviewState.Playing)?.videoId == videoId)
+        ) {
+            return
+        }
+
+        previewLoadJob?.cancel()
+        previewRetryJob?.cancel()
         previewPlayer.stop()
-        viewModelScope.launch {
-            _previewLoading.value = videoId
+        val requestId = previewPlayer.claimRequest()
+
+        val generation = ++previewRequestGeneration
+        activePreviewRequestId = requestId
+        activePreviewVideoId = videoId
+        activePreviewAttemptId = null
+        activePreviewRetried = false
+        _previewLoading.value = videoId
+
+        previewLoadJob = viewModelScope.launch {
             try {
                 // Check cache first — if pre-extraction finished, this is instant
-                val cached = previewUrlCache[videoId]
-                val url = if (cached != null) {
-                    cached
-                } else {
-                    // #372: a cache miss has to extract NOW, and the extractor's
-                    // yt-dlp/InnerTube semaphores are shared process-wide with the
-                    // background pre-extraction kicked off after every resync (up
-                    // to PRE_EXTRACT_LIMIT jobs). Without this the user's tap
-                    // queues behind that batch and the button just sits there for
-                    // many seconds — reported as "preview not working, kinda
-                    // static". A live tap outranks speculative prefetch, so drop
-                    // the background work and take the permit.
+                val url = previewUrlCache[videoId] ?: run {
+                    // Stop caller-side cache warming. Speculative extraction is
+                    // fast-only, while this foreground request may use yt-dlp.
                     cancelPreExtraction()
-                    previewUrlExtractor.extractStreamUrl(videoId).also {
+                    previewUrlExtractor.extractStreamUrl(
+                        videoId,
+                        allowYtDlp = true,
+                    ).also {
                         previewUrlCache[videoId] = it
                     }
                 }
-                previewPlayer.playUrl(videoId, url)
+                if (!isActivePreview(generation, videoId)) return@launch
+                val attemptId = previewPlayer.playUrlIfClaimed(requestId, videoId, url) { attemptId ->
+                    if (isActivePreview(generation, videoId)) {
+                        activePreviewAttemptId = attemptId
+                    }
+                }
+                if (attemptId == null) {
+                    abandonActivePreview(generation, videoId)
+                }
             } catch (e: CancellationException) {
                 throw e // never report our own cancellation as a preview failure
             } catch (e: Exception) {
-                // #372: this used to only Log.e, so every failure looked exactly
-                // like a dead button. Tell the user the preview failed.
-                Log.e(TAG, "Preview failed for videoId=$videoId", e)
-                _userMessages.tryEmit("Couldn't load that preview. Try again, or approve to hear the full track.")
+                failActivePreview(
+                    generation = generation,
+                    videoId = videoId,
+                    logMessage = "Preview failed for videoId=$videoId",
+                    error = e,
+                )
+            } finally {
+                clearPreviewLoading(generation, videoId)
             }
-            _previewLoading.value = null
         }
     }
 
     /**
-     * Drops the speculative post-resync prefetch. Safe to call any time: the
-     * cache keeps whatever already finished, and anything cancelled is simply
-     * re-extracted on demand.
+     * Handles source failures emitted after [PreviewPlayer.playUrl] returns.
+     * Only the active preview may retry, and each user request gets one direct
+     * yt-dlp fallback so a rejected retry URL cannot loop forever.
+     */
+    private fun onPreviewPlayerError(
+        videoId: String,
+        attemptId: Long,
+        error: PlaybackException,
+    ) {
+        if (videoId != activePreviewVideoId || attemptId != activePreviewAttemptId) return
+
+        val generation = previewRequestGeneration
+        val requestId = activePreviewRequestId ?: return
+        if (!previewPlayer.isRequestCurrent(requestId)) {
+            abandonActivePreview(generation, videoId)
+            return
+        }
+        if (!isIoError(error)) {
+            failActivePreview(
+                generation = generation,
+                videoId = videoId,
+                logMessage = "Preview playback failed for videoId=$videoId",
+                error = error,
+            )
+            return
+        }
+
+        if (activePreviewRetried) {
+            failActivePreview(
+                generation = generation,
+                videoId = videoId,
+                logMessage = "yt-dlp retry playback failed for videoId=$videoId",
+                error = error,
+            )
+            return
+        }
+
+        // Consume the retry before launching so duplicate error events cannot
+        // start parallel yt-dlp work.
+        activePreviewRetried = true
+        activePreviewAttemptId = null
+        _previewLoading.value = videoId
+        previewRetryJob = viewModelScope.launch {
+            try {
+                val retryUrl = previewUrlExtractor.extractViaYtDlpForRetry(videoId)
+                if (!isActivePreview(generation, videoId)) return@launch
+                previewUrlCache[videoId] = retryUrl
+                val retryAttemptId = previewPlayer.playUrlIfClaimed(
+                    requestId,
+                    videoId,
+                    retryUrl,
+                ) { attemptId ->
+                    if (isActivePreview(generation, videoId)) {
+                        activePreviewAttemptId = attemptId
+                    }
+                }
+                if (retryAttemptId == null) {
+                    abandonActivePreview(generation, videoId)
+                    return@launch
+                }
+                Log.d(TAG, "yt-dlp preview retry succeeded for videoId=$videoId")
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                failActivePreview(
+                    generation = generation,
+                    videoId = videoId,
+                    logMessage = "yt-dlp preview retry failed for videoId=$videoId",
+                    error = e,
+                )
+            } finally {
+                clearPreviewLoading(generation, videoId)
+            }
+        }
+    }
+
+    private fun isActivePreview(generation: Long, videoId: String): Boolean =
+        previewRequestGeneration == generation && activePreviewVideoId == videoId
+
+    private fun clearPreviewLoading(generation: Long, videoId: String) {
+        if (isActivePreview(generation, videoId) && _previewLoading.value == videoId) {
+            _previewLoading.value = null
+        }
+    }
+
+    private fun abandonActivePreview(generation: Long, videoId: String) {
+        if (!isActivePreview(generation, videoId)) return
+        activePreviewRequestId = null
+        activePreviewVideoId = null
+        activePreviewAttemptId = null
+        if (_previewLoading.value == videoId) _previewLoading.value = null
+    }
+
+    private fun failActivePreview(
+        generation: Long,
+        videoId: String,
+        logMessage: String,
+        error: Throwable,
+    ) {
+        if (!isActivePreview(generation, videoId)) return
+        Log.e(TAG, logMessage, error)
+        val ownedRequestId = activePreviewRequestId
+        val ownedAttemptId = activePreviewAttemptId
+        previewPlayer.cancelRequest(ownedRequestId)
+        activePreviewRequestId = null
+        activePreviewVideoId = null
+        activePreviewAttemptId = null
+        if (_previewLoading.value == videoId) _previewLoading.value = null
+        previewPlayer.stopIfCurrent(ownedAttemptId)
+        _userMessages.tryEmit(PREVIEW_FAILURE_MESSAGE)
+    }
+
+    private fun isIoError(error: PlaybackException): Boolean =
+        error.errorCode in 2000..2999
+
+    /**
+     * Drops caller-side speculative prefetch jobs. Extractor-owned single-flight
+     * work intentionally survives caller cancellation, but because speculative
+     * work is InnerTube-only it cannot retain the foreground yt-dlp permit.
      */
     private fun cancelPreExtraction() {
         preExtractJobs.forEach { it.cancel() }
@@ -618,7 +819,19 @@ class FailedMatchesViewModel @Inject constructor(
 
     /** Stops the current audio preview, if any. */
     fun stopPreview() {
-        previewPlayer.stop()
+        val ownedRequestId = activePreviewRequestId
+        val ownedAttemptId = activePreviewAttemptId
+        ++previewRequestGeneration
+        previewLoadJob?.cancel()
+        previewRetryJob?.cancel()
+        previewLoadJob = null
+        previewRetryJob = null
+        previewPlayer.cancelRequest(ownedRequestId)
+        activePreviewRequestId = null
+        activePreviewVideoId = null
+        activePreviewAttemptId = null
+        activePreviewRetried = false
+        previewPlayer.stopIfCurrent(ownedAttemptId)
         _previewLoading.value = null
     }
 
@@ -626,9 +839,16 @@ class FailedMatchesViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        previewPlayer.stop()
+        stopPreview()
         resyncJob?.cancel()
-        preExtractJobs.forEach { it.cancel() }
+        cancelPreExtraction()
         previewUrlCache.clear()
     }
+
+    private data class ResyncSearch(
+        val trackId: Long,
+        val query: String,
+        val excludeVideoId: String?,
+        val allowExcludedFallback: Boolean,
+    )
 }

--- a/feature/sync/src/test/kotlin/com/stash/feature/sync/FailedMatchesReplacementPreviewRegressionTest.kt
+++ b/feature/sync/src/test/kotlin/com/stash/feature/sync/FailedMatchesReplacementPreviewRegressionTest.kt
@@ -1,0 +1,619 @@
+package com.stash.feature.sync
+
+import androidx.media3.common.PlaybackException
+import com.stash.core.data.db.dao.UnmatchedTrackView
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.repository.MusicRepository
+import com.stash.core.data.sync.TrackIdentityEvents
+import com.stash.core.media.preview.PreviewErrorEvent
+import com.stash.core.media.preview.PreviewPlayer
+import com.stash.core.media.preview.PreviewState
+import com.stash.data.download.DownloadExecutor
+import com.stash.data.download.files.FileOrganizer
+import com.stash.data.download.files.SwapCoordinator
+import com.stash.data.download.matching.HybridSearchExecutor
+import com.stash.data.download.prefs.QualityPreferencesManager
+import com.stash.data.download.preview.NoFastStreamException
+import com.stash.data.download.preview.PreviewUrlExtractor
+import com.stash.data.download.ytdlp.YtDlpSearchResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Regression coverage for imported issue #5 ("Can't play replacement song").
+ *
+ * These tests deliberately exercise only public [FailedMatchesViewModel]
+ * behavior. In particular, they pin the distinction between speculative
+ * fast-only prefetch and a user-initiated full extraction, and drive
+ * asynchronous ExoPlayer failures through [PreviewPlayer.playerErrors].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FailedMatchesReplacementPreviewRegressionTest {
+
+    private val musicRepository: MusicRepository = mockk(relaxed = true)
+    private val previewPlayer: PreviewPlayer = mockk(relaxed = true)
+    private val previewUrlExtractor: PreviewUrlExtractor = mockk(relaxed = true)
+    private val searchExecutor: HybridSearchExecutor = mockk(relaxed = true)
+    private val downloadExecutor: DownloadExecutor = mockk(relaxed = true)
+    private val fileOrganizer: FileOrganizer = mockk(relaxed = true)
+    private val qualityPrefs: QualityPreferencesManager = mockk(relaxed = true)
+    private val trackDao = mockk<com.stash.core.data.db.dao.TrackDao>(relaxed = true)
+    private val downloadQueueDao = mockk<com.stash.core.data.db.dao.DownloadQueueDao>(relaxed = true)
+    private val swapCoordinator: SwapCoordinator = mockk(relaxed = true)
+    private val blocklistGuard = mockk<com.stash.core.data.blocklist.BlocklistGuard>(relaxed = true)
+    private val localFileOps = mockk<com.stash.core.data.files.LocalFileOps>(relaxed = true)
+    private val trackIdentityEvents = mockk<TrackIdentityEvents>(relaxed = true)
+
+    private lateinit var playerErrors: MutableSharedFlow<PreviewErrorEvent>
+    private lateinit var previewState: MutableStateFlow<PreviewState>
+    private var requestSequence = 0L
+    private var currentRequestId = 0L
+    private var nextAttemptId = 0L
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        playerErrors = MutableSharedFlow(extraBufferCapacity = 4)
+        previewState = MutableStateFlow(PreviewState.Idle)
+        requestSequence = 0L
+        currentRequestId = 0L
+        nextAttemptId = 0L
+        every { previewPlayer.playerErrors } returns playerErrors
+        every { previewPlayer.previewState } returns previewState
+        every { previewPlayer.claimRequest() } answers {
+            currentRequestId = ++requestSequence
+            currentRequestId
+        }
+        every { previewPlayer.isRequestCurrent(any()) } answers {
+            firstArg<Long?>() == currentRequestId
+        }
+        every { previewPlayer.cancelRequest(any()) } answers {
+            if (firstArg<Long?>() == currentRequestId) currentRequestId = 0L
+            Unit
+        }
+        every { previewPlayer.playUrlIfClaimed(any(), any(), any(), any()) } answers {
+            if (firstArg<Long>() != currentRequestId) {
+                null
+            } else {
+                val attemptId = ++nextAttemptId
+                arg<(Long) -> Unit>(3).invoke(attemptId)
+                attemptId
+            }
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun unmatched() = UnmatchedTrackView(
+        id = 1L,
+        trackId = 1L,
+        title = "Title",
+        artist = "Artist",
+        albumArtUrl = null,
+        createdAt = 0L,
+        rejectedVideoId = null,
+        searchQuery = "Artist - Title",
+    )
+
+    private fun makeVm(
+        tracks: List<UnmatchedTrackView> = emptyList(),
+        flagged: List<TrackEntity> = emptyList(),
+    ): FailedMatchesViewModel {
+        every { musicRepository.getUnmatchedTracks() } returns flowOf(tracks)
+        every { musicRepository.getFlaggedTracks() } returns flowOf(flagged)
+        return FailedMatchesViewModel(
+            musicRepository = musicRepository,
+            previewPlayer = previewPlayer,
+            previewUrlExtractor = previewUrlExtractor,
+            searchExecutor = searchExecutor,
+            downloadExecutor = downloadExecutor,
+            fileOrganizer = fileOrganizer,
+            qualityPrefs = qualityPrefs,
+            trackDao = trackDao,
+            downloadQueueDao = downloadQueueDao,
+            swapCoordinator = swapCoordinator,
+            blocklistGuard = blocklistGuard,
+            localFileOps = localFileOps,
+            trackIdentityEvents = trackIdentityEvents,
+        )
+    }
+
+    private fun ioPlaybackError() = PlaybackException(
+        "preview URL rejected",
+        IOException("HTTP 403"),
+        PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS,
+    )
+
+    private fun decodingPlaybackError() = PlaybackException(
+        "decoder rejected stream",
+        IllegalStateException("unsupported stream"),
+        PlaybackException.ERROR_CODE_DECODING_FAILED,
+    )
+
+    @Test
+    fun `failed fast-only prefetch is followed by full foreground extraction and playback`() = runTest {
+        coEvery { searchExecutor.search(any(), any()) } returns listOf(
+            YtDlpSearchResult(id = "replacement", title = "Replacement"),
+        )
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("replacement", allowYtDlp = false)
+        } throws NoFastStreamException("replacement")
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("replacement", allowYtDlp = true)
+        } returns "https://audio.example/foreground"
+
+        val vm = makeVm(tracks = listOf(unmatched()))
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect {} }
+
+        vm.resync()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            previewUrlExtractor.extractStreamUrl("replacement", allowYtDlp = false)
+        }
+
+        vm.previewRejectedMatch("replacement")
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            previewUrlExtractor.extractStreamUrl("replacement", allowYtDlp = true)
+        }
+        verify(exactly = 1) {
+            previewPlayer.playUrlIfClaimed(
+                any(),
+                "replacement",
+                "https://audio.example/foreground",
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `an error emitted during play preparation still owns and retries the attempt`() = runTest {
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("replacement", allowYtDlp = true)
+        } returns "https://audio.example/initial"
+        coEvery {
+            previewUrlExtractor.extractViaYtDlpForRetry("replacement")
+        } returns "https://audio.example/retry"
+        every {
+            previewPlayer.playUrlIfClaimed(
+                any(),
+                "replacement",
+                "https://audio.example/initial",
+                any(),
+            )
+        } answers {
+            val attemptId = ++nextAttemptId
+            arg<(Long) -> Unit>(3).invoke(attemptId)
+            playerErrors.tryEmit(PreviewErrorEvent("replacement", attemptId, ioPlaybackError()))
+            attemptId
+        }
+        val vm = makeVm()
+
+        vm.previewRejectedMatch("replacement")
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            previewUrlExtractor.extractViaYtDlpForRetry("replacement")
+        }
+        verify(exactly = 1) {
+            previewPlayer.playUrlIfClaimed(any(), "replacement", "https://audio.example/retry", any())
+        }
+    }
+
+    @Test
+    fun `a second tap while the owned attempt is buffering does not restart playback`() = runTest {
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("replacement", allowYtDlp = true)
+        } returns "https://audio.example/initial"
+        val vm = makeVm()
+
+        vm.previewRejectedMatch("replacement")
+        advanceUntilIdle()
+        vm.previewRejectedMatch("replacement")
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            previewUrlExtractor.extractStreamUrl("replacement", allowYtDlp = true)
+        }
+        verify(exactly = 1) {
+            previewPlayer.playUrlIfClaimed(any(), "replacement", "https://audio.example/initial", any())
+        }
+        verify(exactly = 1) { previewPlayer.stop() }
+    }
+
+    @Test
+    fun `the same candidate can restart after another screen preempts its lease`() = runTest {
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("replacement", allowYtDlp = true)
+        } returns "https://audio.example/initial"
+        val vm = makeVm()
+
+        vm.previewRejectedMatch("replacement")
+        advanceUntilIdle()
+        previewPlayer.claimRequest() // Simulate another screen taking the singleton player.
+        vm.previewRejectedMatch("replacement")
+        advanceUntilIdle()
+
+        verify(exactly = 1) {
+            previewPlayer.playUrlIfClaimed(
+                1L,
+                "replacement",
+                "https://audio.example/initial",
+                any(),
+            )
+        }
+        verify(exactly = 1) {
+            previewPlayer.playUrlIfClaimed(
+                3L,
+                "replacement",
+                "https://audio.example/initial",
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `an IO player failure retries through yt-dlp at most once`() = runTest {
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("replacement", allowYtDlp = true)
+        } returns "https://audio.example/initial"
+        coEvery {
+            previewUrlExtractor.extractViaYtDlpForRetry("replacement")
+        } returns "https://audio.example/retry"
+        val vm = makeVm()
+
+        vm.previewRejectedMatch("replacement")
+        advanceUntilIdle()
+        playerErrors.emit(PreviewErrorEvent("replacement", 1L, ioPlaybackError()))
+        advanceUntilIdle()
+        // A buffered duplicate from the failed initial URL must not be
+        // attributed to the healthy retry attempt.
+        playerErrors.emit(PreviewErrorEvent("replacement", 1L, ioPlaybackError()))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            previewUrlExtractor.extractViaYtDlpForRetry("replacement")
+        }
+        verify(exactly = 1) {
+            previewPlayer.playUrlIfClaimed(any(), "replacement", "https://audio.example/retry", any())
+        }
+        verify(exactly = 1) { previewPlayer.stop() }
+    }
+
+    @Test
+    fun `a stale player error from the previous candidate is ignored`() = runTest {
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("first", allowYtDlp = true)
+        } returns "https://audio.example/first"
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("second", allowYtDlp = true)
+        } returns "https://audio.example/second"
+        val vm = makeVm()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect {} }
+
+        vm.previewRejectedMatch("first")
+        advanceUntilIdle()
+        vm.previewRejectedMatch("second")
+        advanceUntilIdle()
+        playerErrors.emit(PreviewErrorEvent("first", 1L, ioPlaybackError()))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) {
+            previewUrlExtractor.extractViaYtDlpForRetry("first")
+        }
+    }
+
+    @Test
+    fun `a superseded cancellation-resistant foreground extraction cannot revive playback`() = runTest {
+        val firstGate = CompletableDeferred<Unit>()
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("first", allowYtDlp = true)
+        } coAnswers {
+            withContext(NonCancellable) { firstGate.await() }
+            "https://audio.example/first"
+        }
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("second", allowYtDlp = true)
+        } returns "https://audio.example/second"
+        val vm = makeVm()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect {} }
+
+        vm.previewRejectedMatch("first")
+        runCurrent()
+        vm.previewRejectedMatch("second")
+        runCurrent()
+        firstGate.complete(Unit)
+        runCurrent()
+
+        verify(exactly = 0) {
+            previewPlayer.playUrlIfClaimed(any(), "first", "https://audio.example/first", any())
+        }
+        verify(exactly = 1) {
+            previewPlayer.playUrlIfClaimed(any(), "second", "https://audio.example/second", any())
+        }
+        assertNull(vm.uiState.value.previewLoading)
+    }
+
+    @Test
+    fun `a superseded cancellation-resistant retry cannot revive playback`() = runTest {
+        val retryGate = CompletableDeferred<Unit>()
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("first", allowYtDlp = true)
+        } returns "https://audio.example/first"
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("second", allowYtDlp = true)
+        } returns "https://audio.example/second"
+        coEvery { previewUrlExtractor.extractViaYtDlpForRetry("first") } coAnswers {
+            withContext(NonCancellable) { retryGate.await() }
+            "https://audio.example/stale-retry"
+        }
+        val vm = makeVm()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect {} }
+
+        vm.previewRejectedMatch("first")
+        runCurrent()
+        playerErrors.emit(PreviewErrorEvent("first", 1L, ioPlaybackError()))
+        runCurrent()
+        vm.previewRejectedMatch("second")
+        runCurrent()
+        retryGate.complete(Unit)
+        runCurrent()
+
+        verify(exactly = 0) {
+            previewPlayer.playUrlIfClaimed(
+                any(),
+                "first",
+                "https://audio.example/stale-retry",
+                any(),
+            )
+        }
+        verify(exactly = 1) {
+            previewPlayer.playUrlIfClaimed(any(), "second", "https://audio.example/second", any())
+        }
+        assertNull(vm.uiState.value.previewLoading)
+    }
+
+    @Test
+    fun `a newer screen claim rejects another screens suspended extraction`() = runTest {
+        val firstGate = CompletableDeferred<Unit>()
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("first", allowYtDlp = true)
+        } coAnswers {
+            firstGate.await()
+            "https://audio.example/first"
+        }
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("second", allowYtDlp = true)
+        } returns "https://audio.example/second"
+        val firstOwner = makeVm()
+        val secondOwner = makeVm()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            firstOwner.uiState.collect {}
+        }
+
+        firstOwner.previewRejectedMatch("first")
+        runCurrent()
+        secondOwner.previewRejectedMatch("second")
+        runCurrent()
+        firstGate.complete(Unit)
+        runCurrent()
+
+        verify(exactly = 1) {
+            previewPlayer.playUrlIfClaimed(1L, "first", "https://audio.example/first", any())
+        }
+        verify(exactly = 1) {
+            previewPlayer.playUrlIfClaimed(2L, "second", "https://audio.example/second", any())
+        }
+        assertNull(firstOwner.uiState.value.previewLoading)
+    }
+
+    @Test
+    fun `a failed yt-dlp retry gives visible preview feedback`() = runTest {
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("replacement", allowYtDlp = true)
+        } returns "https://audio.example/initial"
+        coEvery {
+            previewUrlExtractor.extractViaYtDlpForRetry("replacement")
+        } throws IllegalStateException("yt-dlp failed")
+        val vm = makeVm()
+        val messages = mutableListOf<String>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            vm.userMessages.collect(messages::add)
+        }
+
+        vm.previewRejectedMatch("replacement")
+        advanceUntilIdle()
+        playerErrors.emit(PreviewErrorEvent("replacement", 1L, ioPlaybackError()))
+        advanceUntilIdle()
+
+        assertTrue(
+            "a failed player-error retry must tell the user, got $messages",
+            messages.any { it.contains("preview", ignoreCase = true) },
+        )
+        coVerify(exactly = 1) {
+            previewUrlExtractor.extractViaYtDlpForRetry("replacement")
+        }
+    }
+
+    @Test
+    fun `an IO failure from the retry attempt is terminal and visible`() = runTest {
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("replacement", allowYtDlp = true)
+        } returns "https://audio.example/initial"
+        coEvery {
+            previewUrlExtractor.extractViaYtDlpForRetry("replacement")
+        } returns "https://audio.example/retry"
+        val vm = makeVm()
+        val messages = mutableListOf<String>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            vm.userMessages.collect(messages::add)
+        }
+
+        vm.previewRejectedMatch("replacement")
+        advanceUntilIdle()
+        playerErrors.emit(PreviewErrorEvent("replacement", 1L, ioPlaybackError()))
+        advanceUntilIdle()
+        playerErrors.emit(PreviewErrorEvent("replacement", 2L, ioPlaybackError()))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            previewUrlExtractor.extractViaYtDlpForRetry("replacement")
+        }
+        assertTrue(messages.any { it.contains("preview", ignoreCase = true) })
+        verify(exactly = 1) { previewPlayer.stop() }
+        verify(exactly = 1) { previewPlayer.stopIfCurrent(2L) }
+    }
+
+    @Test
+    fun `an active non-IO playback failure is terminal and visible`() = runTest {
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("replacement", allowYtDlp = true)
+        } returns "https://audio.example/initial"
+        val vm = makeVm()
+        val messages = mutableListOf<String>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            vm.userMessages.collect(messages::add)
+        }
+
+        vm.previewRejectedMatch("replacement")
+        advanceUntilIdle()
+        playerErrors.emit(PreviewErrorEvent("replacement", 1L, decodingPlaybackError()))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) {
+            previewUrlExtractor.extractViaYtDlpForRetry(any())
+        }
+        assertTrue(messages.any { it.contains("preview", ignoreCase = true) })
+        verify(exactly = 1) { previewPlayer.stopIfCurrent(1L) }
+    }
+
+    @Test
+    fun `stopping a stale screen only releases its owned playback attempt`() = runTest {
+        coEvery {
+            previewUrlExtractor.extractStreamUrl("replacement", allowYtDlp = true)
+        } returns "https://audio.example/initial"
+        val vm = makeVm()
+
+        vm.previewRejectedMatch("replacement")
+        advanceUntilIdle()
+        vm.stopPreview()
+
+        verify(exactly = 1) { previewPlayer.stop() }
+        verify(exactly = 1) { previewPlayer.stopIfCurrent(1L) }
+    }
+
+    @Test
+    fun `flagged resync never returns the currently linked youtube id`() = runTest {
+        val flagged = TrackEntity(
+            id = 7L,
+            title = "Wrong Match",
+            artist = "Artist",
+            youtubeId = "current-video",
+            matchFlagged = true,
+            isDownloaded = true,
+            filePath = "/music/wrong.opus",
+        )
+        coEvery { searchExecutor.search(any(), any()) } returns listOf(
+            YtDlpSearchResult(id = "current-video", title = "Wrong Match"),
+        )
+        coEvery { searchExecutor.searchYtDlpDirect(any(), any()) } returns listOf(
+            YtDlpSearchResult(id = "current-video", title = "Wrong Match"),
+        )
+        val vm = makeVm(flagged = listOf(flagged))
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect {} }
+
+        vm.resync()
+        advanceUntilIdle()
+
+        assertNull(
+            "the current rejected youtubeId must never be surfaced as its own replacement",
+            vm.uiState.value.resyncCandidates[flagged.id],
+        )
+    }
+
+    @Test
+    fun `flagged row wins when the same track also appears as unmatched`() = runTest {
+        val flagged = TrackEntity(
+            id = 1L,
+            title = "Wrong Match",
+            artist = "Artist",
+            youtubeId = "current-video",
+            matchFlagged = true,
+            isDownloaded = true,
+            filePath = "/music/wrong.opus",
+        )
+        coEvery { searchExecutor.search(any(), any()) } returns listOf(
+            YtDlpSearchResult(id = "current-video", title = "Wrong Match"),
+        )
+        coEvery { searchExecutor.searchYtDlpDirect(any(), any()) } returns listOf(
+            YtDlpSearchResult(id = "current-video", title = "Wrong Match"),
+        )
+        val vm = makeVm(tracks = listOf(unmatched()), flagged = listOf(flagged))
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect {} }
+
+        vm.resync()
+        advanceUntilIdle()
+
+        assertNull(vm.uiState.value.resyncCandidates[flagged.id])
+        coVerify(exactly = 1) { searchExecutor.search(any(), any()) }
+    }
+
+    @Test
+    fun `approval boundary rejects a self swap`() = runTest {
+        val vm = makeVm()
+        val row = FlaggedTrackRow(
+            trackId = 7L,
+            title = "Wrong Match",
+            artist = "Artist",
+            albumArtUrl = null,
+            currentYoutubeId = "current-video",
+            currentFilePath = "/music/wrong.opus",
+            searchQuery = "Artist - Wrong Match",
+        )
+        val candidate = ResyncCandidate(
+            videoId = "current-video",
+            title = "Wrong Match",
+            artist = "Artist",
+            thumbnailUrl = null,
+            durationSeconds = 180.0,
+        )
+
+        vm.approveSwap(row, candidate)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { trackDao.findByYoutubeId(any()) }
+        coVerify(exactly = 0) { musicRepository.setMatchFlagged(any(), any()) }
+        verify(exactly = 0) {
+            swapCoordinator.swap(any(), any(), any(), any(), any())
+        }
+    }
+}

--- a/feature/sync/src/test/kotlin/com/stash/feature/sync/FailedMatchesResyncFeedbackTest.kt
+++ b/feature/sync/src/test/kotlin/com/stash/feature/sync/FailedMatchesResyncFeedbackTest.kt
@@ -2,6 +2,7 @@ package com.stash.feature.sync
 
 import com.stash.core.data.db.dao.UnmatchedTrackView
 import com.stash.core.data.repository.MusicRepository
+import com.stash.core.data.sync.TrackIdentityEvents
 import com.stash.core.media.preview.PreviewPlayer
 import com.stash.data.download.DownloadExecutor
 import com.stash.data.download.files.FileOrganizer
@@ -47,6 +48,7 @@ class FailedMatchesResyncFeedbackTest {
     private val downloadQueueDao = mockk<com.stash.core.data.db.dao.DownloadQueueDao>(relaxed = true)
     private val swapCoordinator: SwapCoordinator = mockk(relaxed = true)
     private val blocklistGuard = mockk<com.stash.core.data.blocklist.BlocklistGuard>(relaxed = true)
+    private val trackIdentityEvents = mockk<TrackIdentityEvents>(relaxed = true)
 
     @Before fun setUp() {
         Dispatchers.setMain(UnconfinedTestDispatcher())
@@ -72,6 +74,7 @@ class FailedMatchesResyncFeedbackTest {
             downloadExecutor, fileOrganizer, qualityPrefs, trackDao,
             downloadQueueDao, swapCoordinator, blocklistGuard,
             mockk(relaxed = true) { every { acceptDownloadOrDelete(any()) } returns true },
+            trackIdentityEvents,
         )
     }
 

--- a/feature/sync/src/test/kotlin/com/stash/feature/sync/FailedMatchesResyncFeedbackTest.kt
+++ b/feature/sync/src/test/kotlin/com/stash/feature/sync/FailedMatchesResyncFeedbackTest.kt
@@ -2,8 +2,10 @@ package com.stash.feature.sync
 
 import com.stash.core.data.db.dao.UnmatchedTrackView
 import com.stash.core.data.repository.MusicRepository
+import com.stash.core.media.preview.PreviewErrorEvent
 import com.stash.core.data.sync.TrackIdentityEvents
 import com.stash.core.media.preview.PreviewPlayer
+import com.stash.core.media.preview.PreviewState
 import com.stash.data.download.DownloadExecutor
 import com.stash.data.download.files.FileOrganizer
 import com.stash.data.download.files.SwapCoordinator
@@ -16,6 +18,8 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -52,6 +56,8 @@ class FailedMatchesResyncFeedbackTest {
 
     @Before fun setUp() {
         Dispatchers.setMain(UnconfinedTestDispatcher())
+        every { previewPlayer.playerErrors } returns MutableSharedFlow<PreviewErrorEvent>()
+        every { previewPlayer.previewState } returns MutableStateFlow(PreviewState.Idle)
     }
 
     @After fun tearDown() {


### PR DESCRIPTION
## Summary
- After a wrong-match swap (`SwapCoordinator`), a resync approval (`FailedMatchesViewModel.approveMatch`), OMV→ATV canonicalization (`YtLibraryCanonicalizer`), or a cross-platform like backfill (`CrossPlatformLikeResolver`), `tracks.youtube_id` was updated in the DB but the in-memory `StreamUrlCache` entry for that `trackId` was never evicted. `PlayerRepositoryImpl.buildMediaItemForTrack` keys its cache lookup purely on `trackId`, so any track that had been resolved/played *before* one of these identity swaps kept serving the stale `StreamUrl` from the OLD `youtubeId` afterward — either a 403 once the signed URL expired (looks like "won't play") or, worse, silently playing the wrong song.
- This explains three user-facing symptoms that looked unrelated: a resynced replacement track not playing, a Failed Matches swap not playing (or playing the old wrong song), and — for any track previously touched by these flows — a subsequent search/queue play serving stale audio.
- Fix: added `TrackIdentityEvents`, a small `:core:data` singleton event bus (same shape/reasoning as `MusicRepository.trackDeletions`) that emits a `trackId` whenever one of the four call sites changes a track's `youtube_id`. `PlayerRepositoryImpl` (which already owns `StreamUrlCache`) subscribes to it in `init {}` alongside the existing `trackDeletions` collector and calls `streamUrlCache.invalidate(trackId)`. This keeps the dependency direction one-way (`:core:media` → `:core:data`) — `StreamUrlCache` lives in `:core:media`, which itself depends on `:core:data`, so the four call sites can't reference it directly without a circular module dependency.
- Make Failed Matches replacement previews prioritize foreground playback and retry player I/O failures once through yt-dlp
- Add attempt IDs and global request leases so stale work or screen teardown cannot preempt a newer preview
- Prevent flagged resync and approval from selecting the currently rejected YouTube video

## Changes
- `core/data/src/main/kotlin/com/stash/core/data/sync/TrackIdentityEvents.kt` (new)
  - `SharedFlow<Long>` bus + `emitIdentityChanged(trackId)`
- `data/download/src/main/kotlin/com/stash/data/download/files/SwapCoordinator.kt`
  - Inject `TrackIdentityEvents`; emit after `updateYoutubeId` + `markAsDownloaded` on a successful swap
- `feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt`
  - Inject `TrackIdentityEvents`; emit in `approveMatch` after `updateYoutubeId`
- `core/data/src/main/kotlin/com/stash/core/data/social/CrossPlatformLikeResolver.kt`
  - Inject `TrackIdentityEvents`; emit in `ensureYoutubeId` after persisting a newly-resolved id
- `data/download/src/main/kotlin/com/stash/data/download/matching/YtLibraryCanonicalizer.kt`
  - Inject `TrackIdentityEvents`; emit in `canonicalize` after the OMV→ATV `updateYoutubeId` swap
- `core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt`
  - Inject `TrackIdentityEvents`; new `init {}` collector calls `streamUrlCache.invalidate(trackId)` on each emission
- Test updates: `CrossPlatformLikeResolverTest`, `SwapCoordinatorTest`, `YtLibraryCanonicalizerTest`, `FailedMatchesResyncFeedbackTest`, `PlayerRepositoryFullTimelineTest`, `PlayerRepositoryRadioTest`, `PlayerRepositoryStreamingTest` — updated constructors for the new dependency

## Test plan
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew test` (all affected modules)
- [x] Device / Android version tested: S26u/Android 16

Closes https://github.com/ParaliyzedEvo/Stash/issues/5, https://github.com/rawnaldclark/Stash/issues/372