### PR TITLE
Make Save Data actually save data, and stop waiting on dead sources

### DIFF
--- a/core/media/src/main/kotlin/com/stash/core/media/streaming/StreamQualityPolicy.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/streaming/StreamQualityPolicy.kt
@@ -19,8 +19,22 @@ class StreamQualityPolicy @Inject constructor(
     private val connectivity: ConnectivityMonitor,
     private val prefs: StreamingQualityPreferences,
 ) {
+    /**
+     * Save Data returns the lossy floor, not the lowest lossless tier.
+     *
+     * This used to return [LosslessQualityTier.CD], which is still FLAC — roughly
+     * 28 MB for a four-minute track. That saved real bytes only on the amz path
+     * (where CD maps to 256 kbps AAC), and qbdlx is the only working lossless
+     * provider, so the setting effectively did nothing: a user on a metered plan
+     * enabling "Save Data" still pulled full lossless.
+     *
+     * [LosslessQualityTier.DATA_SAVER] asks Qobuz for `format_id = 5` (MP3 320,
+     * ~10 MB), verified live against the API. Tracks with no lossless match fall to
+     * the YouTube path, which is already lossy (~5 MB), so the floor holds across
+     * both routes.
+     */
     suspend fun streamingTier(): LosslessQualityTier {
-        if (prefs.saveDataNow()) return LosslessQualityTier.CD
+        if (prefs.saveDataNow()) return LosslessQualityTier.DATA_SAVER
         return if (connectivity.isCellular()) prefs.cellularTierNow() else prefs.wifiTierNow()
     }
 }

--- a/core/media/src/main/kotlin/com/stash/core/media/streaming/StreamSourceRegistry.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/streaming/StreamSourceRegistry.kt
@@ -140,22 +140,26 @@ class StreamSourceRegistry @Inject constructor(
                 if (allowYtDlp && BuildConfig.QBDLX_CONFIGURED) {
                     add("qbdlx" to qbdlx::resolve)
                 }
-                // amz (Amazon Music) is the SLOWEST lossless source: its stream
-                // resolver decrypts the whole FLAC to a local cache file before
-                // returning a URL (tens of seconds), serialized behind a single
-                // captcha / per-asin lock. Foreground/next-up only, and skipped
-                // on cellular fast-start so it doesn't starve the YouTube
-                // fallback (observed on-device 2026-06-21: 52s to resolve one
-                // next-up).
-                if (allowYtDlp) {
-                    add("amz" to amz::resolve)
-                }
-                // ARCOD is an authenticated, per-user-account fallback. Foreground/
-                // next-up only, and only when the build bundles the private
-                // stream base — an unconfigured build can never get a match.
-                if (allowYtDlp && BuildConfig.ARCOD_CONFIGURED) {
-                    add("arcod" to arcod::resolve)
-                }
+                // PARKED 2026-07-30: amz and arcod are no longer working lossless
+                // providers — qbdlx is the only one. Leaving them in the chain cost
+                // every YouTube-fallback play a wait for two sources that cannot
+                // succeed. Measured on-device that day:
+                //
+                //   57.772  chain [qbdlx,amz,arcod,youtube]
+                //   58.148  qbdlx 403                     (0.4s)
+                //   59.391  amz attempted                 (1.2s)
+                //   02.991  youtube served                (arcod 3.6s)
+                //
+                // ~4.8s of the 5.2s resolve spent on dead sources, on top of the
+                // yt-dlp extraction itself. Removing them is a larger win than the
+                // extraction fix that preceded it.
+                //
+                // arcod was ALREADY parked on the download side
+                // (LosslessSourceRegistry.PARKED_SOURCE_IDS); this brings streaming
+                // in line. Re-enabling either is uncommenting its block — the
+                // resolvers, their force-toggles, and their tests all stay.
+                // add("amz" to amz::resolve)
+                // add("arcod" to arcod::resolve)
                 if (allowYouTube) add("youtube" to { t: TrackEntity -> youtube.resolve(t, allowYtDlp) })
             }
         }

--- a/core/media/src/test/kotlin/com/stash/core/media/streaming/StreamQualityPolicyTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/streaming/StreamQualityPolicyTest.kt
@@ -37,13 +37,33 @@ class StreamQualityPolicyTest {
         assertThat(policy.streamingTier()).isEqualTo(LosslessQualityTier.CD)
     }
 
-    @Test fun `save data forces CD on wifi`() = runTest {
+    /**
+     * Save Data must reach the LOSSY floor, not merely the lowest lossless tier.
+     *
+     * These asserted CD before, which is still FLAC (~28 MB / 4 min). That only
+     * saved bytes on the amz path where CD maps to 256 kbps AAC — and qbdlx is the
+     * only working lossless provider, so the setting saved a user on a metered plan
+     * essentially nothing. Qobuz format_id 5 (MP3 320, ~10 MB) is the real floor,
+     * verified live against the API.
+     */
+    @Test fun `save data drops to the lossy floor on wifi`() = runTest {
         setup(cellular = false, wifi = LosslessQualityTier.MAX, saveData = true)
-        assertThat(policy.streamingTier()).isEqualTo(LosslessQualityTier.CD)
+        assertThat(policy.streamingTier()).isEqualTo(LosslessQualityTier.DATA_SAVER)
     }
 
-    @Test fun `save data forces CD on cellular`() = runTest {
+    @Test fun `save data drops to the lossy floor on cellular`() = runTest {
         setup(cellular = true, cell = LosslessQualityTier.HI_RES, saveData = true)
-        assertThat(policy.streamingTier()).isEqualTo(LosslessQualityTier.CD)
+        assertThat(policy.streamingTier()).isEqualTo(LosslessQualityTier.DATA_SAVER)
+    }
+
+    /** The floor is what actually gets requested from Qobuz: 5 = MP3 320. */
+    @Test fun `the lossy floor requests qobuz format 5`() {
+        assertThat(LosslessQualityTier.DATA_SAVER.qobuzCode).isEqualTo(5)
+    }
+
+    /** Save Data overrides an explicit high tier rather than being averaged with it. */
+    @Test fun `save data overrides the user's chosen tier`() = runTest {
+        setup(cellular = false, wifi = LosslessQualityTier.MAX, saveData = true)
+        assertThat(policy.streamingTier()).isNotEqualTo(LosslessQualityTier.MAX)
     }
 }

--- a/core/media/src/test/kotlin/com/stash/core/media/streaming/StreamSourceRegistryTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/streaming/StreamSourceRegistryTest.kt
@@ -118,18 +118,16 @@ class StreamSourceRegistryTest {
 
         registry().resolve(track, allowYouTube = true)
 
-        // The premise still holds without qbdlx (amz misses → youtube), so only
-        // the qbdlx leg is conditional. See the class KDoc on build-gated sources.
+        // Only the qbdlx leg is build-gated; the chain is qbdlx -> youtube now.
         if (BuildConfig.QBDLX_CONFIGURED) coVerify { qbdlx.resolve(track) }
-        coVerify { amz.resolve(track) }
         coVerify { youtube.resolve(track, allowYtDlp = true) }
-        coVerify(exactly = 0) { kennyy.resolve(any()) } // parked
-        coVerify(exactly = 0) { qobuz.resolve(any()) } // parked
-        // ARCOD is NOT parked — resolve() adds it whenever the build bundles the
-        // private stream base, and this is the one case that walks the WHOLE chain
-        // (nothing short-circuits before arcod), so "never called" only holds for
-        // an unconfigured build.
-        if (!BuildConfig.ARCOD_CONFIGURED) coVerify(exactly = 0) { arcod.resolve(any()) }
+        // All parked as of 2026-07-30 — qbdlx is the only lossless provider, so a
+        // miss goes straight to YouTube rather than waiting on sources that cannot
+        // succeed.
+        coVerify(exactly = 0) { amz.resolve(any()) }
+        coVerify(exactly = 0) { arcod.resolve(any()) }
+        coVerify(exactly = 0) { kennyy.resolve(any()) }
+        coVerify(exactly = 0) { qobuz.resolve(any()) }
     }
 
     /**
@@ -161,36 +159,45 @@ class StreamSourceRegistryTest {
     }
 
     /**
-     * amz sits AFTER qbdlx and BEFORE youtube: when qbdlx misses but amz has a
-     * match, amz serves it and youtube is never consulted. The parked proxies
-     * are skipped.
+     * amz and arcod are PARKED (2026-07-30). They are no longer working lossless
+     * providers, and leaving them in the chain made every YouTube-fallback play
+     * wait on sources that could not succeed — ~4.8s of a 5.2s resolve, measured
+     * on device.
+     *
+     * This asserts they are never consulted, which is the inverse of what this
+     * test checked before. The resolvers, their force-toggles and their own tests
+     * all remain, so re-enabling either is uncommenting one line in the registry.
      */
     @Test
-    fun resolve_amz_consulted_after_qbdlx_before_youtube() = runTest {
+    fun resolve_skips_parked_amz_and_arcod() = runTest {
         coEvery { streamingPreference.isForceAmzOnly() } returns false
         coEvery { streamingPreference.isForceYouTubeFallback() } returns false
         coEvery { qbdlx.resolve(any()) } returns null
+        // amz is stubbed to SUCCEED on purpose: if it were still in the chain it
+        // would serve this resolve, so "youtube served instead" is proof it was
+        // skipped rather than merely absent from the fixture.
         coEvery { amz.resolve(any()) } returns StreamUrl(
             url = "https://amz.squid.wtf/api/stream?asin=B00X",
             expiresAtMs = Long.MAX_VALUE,
             codec = "flac",
             origin = AmzStreamResolver.ORIGIN,
         )
+        coEvery { youtube.resolve(any(), any()) } returns StreamUrl(
+            url = "https://yt/x",
+            expiresAtMs = Long.MAX_VALUE,
+            codec = "aac",
+            origin = YouTubeStreamResolver.ORIGIN,
+        )
         val track = stubTrack()
 
         val result = registry().resolve(track, allowYouTube = true)
 
-        assertThat(result).isNotNull()
-        assertThat(result!!.origin).isEqualTo("amz")
-        // Only the qbdlx leg is build-gated; "amz serves it, youtube never runs"
-        // holds either way. Resolution short-circuits at amz, which precedes arcod
-        // in the chain, so the arcod assertion below is safe unconditionally.
+        assertThat(result!!.origin).isEqualTo(YouTubeStreamResolver.ORIGIN)
         if (BuildConfig.QBDLX_CONFIGURED) coVerify { qbdlx.resolve(track) }
-        coVerify { amz.resolve(track) }
-        coVerify(exactly = 0) { youtube.resolve(any(), any()) }
-        coVerify(exactly = 0) { kennyy.resolve(any()) } // parked
-        coVerify(exactly = 0) { qobuz.resolve(any()) } // parked
-        coVerify(exactly = 0) { arcod.resolve(any()) } // parked
+        coVerify(exactly = 0) { amz.resolve(any()) }
+        coVerify(exactly = 0) { arcod.resolve(any()) }
+        coVerify(exactly = 0) { kennyy.resolve(any()) }
+        coVerify(exactly = 0) { qobuz.resolve(any()) }
     }
 
     /**

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessQualityTier.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessQualityTier.kt
@@ -28,6 +28,23 @@ enum class LosslessQualityTier(
     /** Approximate file size for a 4-minute track at this tier. */
     val sizeHint: String,
 ) {
+    /**
+     * Lossy floor for Save Data. Qobuz `format_id = 5` is MP3 320 — verified live
+     * on 2026-07-30: requesting 5 returns `format_id=5, mime=audio/mpeg`.
+     *
+     * This exists because "Save Data" previously mapped to [CD], which is still
+     * FLAC — about 28 MB for a four-minute track. On the amz path that resolved to
+     * 256 kbps AAC and genuinely saved data, but qbdlx is the only working lossless
+     * provider, so in practice the setting changed nothing on the one path that
+     * matters. A user on a metered plan turning it on saved essentially zero bytes.
+     *
+     * Deliberately NOT offered in the Settings quality radios — those choose
+     * between lossless tiers, and this is the automatic floor Save Data applies on
+     * top of whatever the user picked. It is a lossy member of an enum named for
+     * lossless tiers, which is a wart; the alternative was a parallel type threaded
+     * through five resolvers for one extra case.
+     */
+    DATA_SAVER(qobuzCode = 5, amzTier = "high", displayLabel = "Data Saver (MP3 320)", sizeHint = "~10 MB / 4 min"),
     CD(qobuzCode = 6, amzTier = "high", displayLabel = "CD (16-bit/44.1 kHz)", sizeHint = "~28 MB / 4 min"),
     HI_RES(qobuzCode = 7, amzTier = "hd", displayLabel = "Hi-Res (24-bit/96 kHz)", sizeHint = "~70 MB / 4 min"),
     MAX(qobuzCode = 27, amzTier = "ultrahd", displayLabel = "Max (24-bit/192 kHz)", sizeHint = "~140 MB / 4 min");

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAudioQualityScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAudioQualityScreen.kt
@@ -292,8 +292,12 @@ fun SettingsAudioQualityScreen(
                                 Spacer(modifier = Modifier.height(8.dp))
                                 SettingsToggleRow(
                                     title = "Save Data",
-                                    subtitle = "Request the lowest streaming quality on every network " +
-                                        "to minimize data. Not every source honors this yet.",
+                                    // States the actual trade rather than hedging. The old copy
+                                    // ("Not every source honors this yet") was describing a
+                                    // limitation that no longer exists — and understated a worse
+                                    // one, since Save Data used to still stream lossless.
+                                    subtitle = "Stream at 320 kbps instead of lossless — roughly " +
+                                        "10 MB per track instead of 28 MB. Downloads are unaffected.",
                                     checked = uiState.streamingSaveData,
                                     onCheckedChange = viewModel::onStreamingSaveDataChanged,
                                     titleTrailing = { BetaPill() },


### PR DESCRIPTION
Two streaming-efficiency fixes found while looking at data usage.

## Save Data didn't save data (~28 MB → ~10 MB per track)

`StreamQualityPolicy` mapped Save Data to `LosslessQualityTier.CD` — which is still FLAC. On the amz path `CD` resolves to 256 kbps AAC and genuinely saved bytes, but **qbdlx is the only working lossless provider**, so on the one path that matters the setting changed nothing. Someone on a metered plan enabling "Save Data" still pulled ~28 MB per four-minute track, while the subtitle quietly blamed the sources: *"Not every source honors this yet."* They all honored it — honoring it just meant lossless.

Adds a `DATA_SAVER` tier requesting Qobuz `format_id = 5`. Verified live against the API rather than assumed:

```
requested  5 -> format_id=5  mime=audio/mpeg  16/44.1   (MP3 320, ~10 MB)
requested  6 -> format_id=6  mime=audio/flac            (~28 MB)
requested 27 -> format_id=7  mime=audio/flac 24-bit
```

Tracks with no lossless match already fall to YouTube at ~5 MB, so the floor now holds on both routes instead of one. Downloads unaffected. Settings copy states the trade instead of hedging.

**Known wart:** `DATA_SAVER` is a lossy member of an enum named `LosslessQualityTier`. The alternative was threading a parallel type through five resolvers for one extra case, and the enum already carried a lossy mapping (`CD` → amz `"high"`), so this makes an existing compromise explicit rather than adding one. It's deliberately absent from the Settings quality radios — those pick between lossless tiers; this is the floor Save Data applies on top of that choice.

## amz and arcod parked — ~4.8s of dead weight per fallback play

They stayed in the streaming chain despite no longer being working providers, so every track without a qbdlx match waited on both before YouTube was attempted. Measured on device:

```
57.772  chain [qbdlx,amz,arcod,youtube]
58.148  qbdlx 403                        0.4s
59.391  amz attempted                    1.2s
02.991  youtube served                   arcod 3.6s
```

**~4.8s of a 5.2s resolve** spent on sources that cannot serve — larger than the yt-dlp extraction fix in v0.9.87 (15s → 2.7s), and stacking on top of it. A YouTube-fallback play should now start in ~3s instead of ~8s.

arcod was **already** parked on the download side (`LosslessSourceRegistry.PARKED_SOURCE_IDS`), so this brings streaming in line rather than setting new policy. Both resolvers, their force-toggles and their own tests stay — re-enabling either is uncommenting one line.

**Downloads are untouched:** amz remains an active download source, where a slow attempt costs background time rather than time-to-first-audio.

## Testing

1936 tests green repo-wide.

The ordering test that asserted "amz serves after qbdlx, before youtube" is inverted to assert amz and arcod are never consulted. It still stubs **amz to succeed** — otherwise "youtube served" would pass whether or not amz was in the chain, so the stub is what makes it prove skipping rather than absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
