### PR TITLE
feat(nowplaying): keep screen on in lyrics sheet

### DIFF
--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/LyricsBottomSheet.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/LyricsBottomSheet.kt
@@ -24,8 +24,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
@@ -59,6 +61,18 @@ fun LyricsBottomSheet(
     onSaveToFile: () -> Unit = {},
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    // Issue #382 — hold the screen on while lyrics are on screen. This
+    // composable only exists while the sheet is open (the call site guards
+    // it with `if (showLyrics)`), so the flag is scoped to exactly that.
+    // Restore the previous value rather than forcing false, so we never
+    // clear a keep-screen-on set by something else.
+    val view = LocalView.current
+    DisposableEffect(view) {
+        val wasKeepingScreenOn = view.keepScreenOn
+        view.keepScreenOn = true
+        onDispose { view.keepScreenOn = wasKeepingScreenOn }
+    }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,


### PR DESCRIPTION
Closes #382.

### Problem

The lyrics sheet is a read-along surface, but the display timeout still fires, so the phone sleeps mid-song and has to be woken repeatedly.

Nothing in the repo currently touches keep-screen-on — `keepScreenOn` / `FLAG_KEEP_SCREEN_ON` had zero matches before this change.

### Change

Six lines in `LyricsBottomSheet.kt`:

```kotlin
val view = LocalView.current
DisposableEffect(view) {
    val wasKeepingScreenOn = view.keepScreenOn
    view.keepScreenOn = true
    onDispose { view.keepScreenOn = wasKeepingScreenOn }
}
```

Two deliberate details:

- **Scope.** `NowPlayingScreen.kt:265` guards the composable with `if (showLyrics)`, so the composable exists exactly while the sheet is open. The flag goes up on open and comes down on dismiss — no separate lifecycle to manage, and nothing is held while the sheet is closed.
- **Restore, don't force false.** `onDispose` puts back the previous value instead of hard-setting `false`, so this can never clear a keep-screen-on flag set by something else on the same view.

No setting was added. The sheet is an explicit foreground action that the user dismisses, and Android's guidance is to hold the flag for as short a time as possible — which this already does. Happy to put it behind a toggle if you'd prefer.

### Scope

`LiveLyricsBar` (the always-visible one-line ticker) is intentionally untouched — keeping the screen on for a persistent bar would be a very different battery tradeoff.

### Verification

- `./gradlew :feature:nowplaying:compileDebugKotlin` — BUILD SUCCESSFUL, no new warnings from this file.
- **Not exercised on a device.** The lifetime argument above is from reading the call site, not from watching the screen stay lit. Worth a quick manual check before merge.