### PR TITLE
feat(lastfm): add first-artist-only scrobble toggle

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmScrobbler.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmScrobbler.kt
@@ -86,10 +86,11 @@ class LastFmScrobbler @Inject constructor(
     suspend fun notifyNowPlaying(artist: String, track: String, album: String? = null) {
         val session = runCatching { sessionPreference.session.firstOrNull() }.getOrNull()
             ?: return
+        val submitArtist = scrobbleArtist(artist)
         runCatching {
             apiClient.updateNowPlaying(
                 sessionKey = session.sessionKey,
-                artist = artist,
+                artist = submitArtist,
                 track = track,
                 album = album,
             )
@@ -128,7 +129,7 @@ class LastFmScrobbler @Inject constructor(
     private suspend fun submit(session: LastFmSession, event: ListeningEventEntity, track: TrackEntity) {
         val result = apiClient.scrobble(
             sessionKey = session.sessionKey,
-            artist = track.artist,
+            artist = scrobbleArtist(track.artist),
             track = track.title,
             album = track.album.takeIf { it.isNotBlank() },
             timestampEpochSeconds = event.startedAt / 1000,
@@ -141,7 +142,29 @@ class LastFmScrobbler @Inject constructor(
         }
     }
 
+    /**
+     * Applies the "only first artist" preference, if the user enabled it.
+     */
+    private suspend fun scrobbleArtist(artist: String): String =
+        if (sessionPreference.firstArtistOnly.firstOrNull() == true) primaryArtist(artist) else artist
+
     companion object {
         private const val TAG = "LastFmScrobbler"
     }
 }
+
+/**
+ * Best-effort primary artist for scrobbling. Every parser in the app joins
+ * multiple artists with `", "` (PlaylistFetchWorker, ResponseParserHelpers,
+ * SearchResponseParser), so the join delimiter is the split delimiter.
+ *
+ * Deliberately NOT a regex on "&" / "feat." / "x" — that shreds real band
+ * names like "Simon & Garfunkel".
+ *
+ * Known limitation: a single artist whose own name contains ", " is
+ * truncated ("Tyler, The Creator" -> "Tyler"). Fixing that properly needs a
+ * structured artist list on TrackEntity and a DB migration. This is why the
+ * setting is opt-in and off by default.
+ */
+internal fun primaryArtist(artist: String): String =
+    artist.substringBefore(", ").trim().ifBlank { artist }

--- a/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmSessionPreference.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmSessionPreference.kt
@@ -39,6 +39,7 @@ class LastFmSessionPreference @Inject constructor(
     private val usernameKey = stringPreferencesKey("username")
     private val sessionKeyKey = stringPreferencesKey("session_key")
     private val bannerDismissedKey = booleanPreferencesKey("home_banner_dismissed")
+    private val firstArtistOnlyKey = booleanPreferencesKey("scrobble_first_artist_only")
 
     val session: Flow<LastFmSession?> = context.lastFmDataStore.data.map { prefs ->
         val u = prefs[usernameKey]
@@ -77,5 +78,18 @@ class LastFmSessionPreference @Inject constructor(
 
     suspend fun setBannerDismissed(dismissed: Boolean) {
         context.lastFmDataStore.edit { it[bannerDismissedKey] = dismissed }
+    }
+
+    /**
+     * When true, only the primary (first) artist is submitted to Last.fm.
+     * Off by default. Deliberately NOT cleared by [clear] — a user who
+     * disconnects and reconnects keeps their choice.
+     */
+    val firstArtistOnly: Flow<Boolean> = context.lastFmDataStore.data.map { prefs ->
+        prefs[firstArtistOnlyKey] ?: false
+    }
+
+    suspend fun setFirstArtistOnly(enabled: Boolean) {
+        context.lastFmDataStore.edit { it[firstArtistOnlyKey] = enabled }
     }
 }

--- a/core/data/src/test/kotlin/com/stash/core/data/lastfm/PrimaryArtistTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/lastfm/PrimaryArtistTest.kt
@@ -1,0 +1,36 @@
+package com.stash.core.data.lastfm
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PrimaryArtistTest {
+    @Test
+    fun `returns the artist unchanged when there is only one`() {
+        assertEquals("Radiohead", primaryArtist("Radiohead"))
+    }
+
+    @Test
+    fun `takes the first artist from a comma-joined list`() {
+        assertEquals("Calvin Harris", primaryArtist("Calvin Harris, Dua Lipa"))
+    }
+
+    @Test
+    fun `keeps ampersand band names intact`() {
+        assertEquals("Simon & Garfunkel", primaryArtist("Simon & Garfunkel"))
+    }
+
+    @Test
+    fun `keeps feat suffixes intact because only comma splits`() {
+        assertEquals("Drake feat. Rihanna", primaryArtist("Drake feat. Rihanna"))
+    }
+
+    @Test
+    fun `falls back to the original when the first segment is blank`() {
+        assertEquals(", Someone", primaryArtist(", Someone"))
+    }
+
+    @Test
+    fun `returns blank input unchanged`() {
+        assertEquals("", primaryArtist(""))
+    }
+}

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAccountsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAccountsScreen.kt
@@ -167,6 +167,7 @@ fun SettingsAccountsScreen(
         // Last.fm renders via its own composable (web-auth / cookie / OAuth UX
         // differs enough from AccountConnectionCard). The deep-link
         // bringIntoViewRequester from the monolith is dropped here.
+        val scrobbleFirstArtistOnly by viewModel.scrobbleFirstArtistOnly.collectAsStateWithLifecycle()
         val lastFmUriHandler = androidx.compose.ui.platform.LocalUriHandler.current
         GlassCard {
             com.stash.feature.settings.components.LastFmSection(
@@ -179,6 +180,8 @@ fun SettingsAccountsScreen(
                 onDismissError = viewModel::onDismissLastFmError,
                 onSyncScrobblesNow = viewModel::onSyncScrobblesNow,
                 isScrobbleDraining = uiState.isScrobbleDraining,
+                firstArtistOnly = scrobbleFirstArtistOnly,
+                onFirstArtistOnlyChange = viewModel::onScrobbleFirstArtistOnlyChanged,
             )
             uiState.scrobbleDrainResult?.let { result ->
                 Spacer(modifier = Modifier.height(8.dp))

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -182,6 +182,22 @@ class SettingsViewModel @Inject constructor(
             initialValue = false,
         )
 
+    /**
+     * Issue #112 — submit only the primary artist to Last.fm. Exposed as its
+     * own flow rather than folded into the main `combine`, which is index-based
+     * (`values[N]`) and would need every downstream index shifted.
+     */
+    val scrobbleFirstArtistOnly: StateFlow<Boolean> =
+        lastFmSessionPreference.firstArtistOnly.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = false,
+        )
+
+    fun onScrobbleFirstArtistOnlyChanged(enabled: Boolean) {
+        viewModelScope.launch { lastFmSessionPreference.setFirstArtistOnly(enabled) }
+    }
+
     fun onListenBrainzTokenChange(value: String) {
         _listenBrainzTokenInput.value = value
         // Clear a previous failure as soon as the user edits — leaving the error up

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LastFmSection.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LastFmSection.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -36,6 +38,8 @@ fun LastFmSection(
     onDismissError: () -> Unit,
     onSyncScrobblesNow: () -> Unit,
     isScrobbleDraining: Boolean,
+    firstArtistOnly: Boolean = false,
+    onFirstArtistOnlyChange: (Boolean) -> Unit = {},
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         when (state) {
@@ -117,6 +121,31 @@ fun LastFmSection(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Only scrobble the first artist",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                        Text(
+                            text = "Submits \"Artist A\" instead of \"Artist A, Artist B\" so collabs " +
+                                "don't split your Last.fm stats. Artist names that contain a comma " +
+                                "may be shortened.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Switch(
+                        checked = firstArtistOnly,
+                        onCheckedChange = onFirstArtistOnlyChange,
+                    )
+                }
                 Spacer(modifier = Modifier.height(12.dp))
                 // "Sync scrobbles now" — manual drain. Useful right after
                 // the Last.fm connect handshake when cold-start import +


### PR DESCRIPTION
Closes #112.

### Problem

Collabs scrobble as `Artist A, Artist B`. Last.fm treats that whole string as a distinct artist from either member, so collabs fragment the user's stats instead of crediting the primary artist.

### Change

New opt-in toggle under Settings → Accounts → Last.fm (visible only when connected), off by default. When on, `LastFmScrobbler` submits only the primary artist — for both `track.scrobble` and `track.updateNowPlaying`.

```kotlin
internal fun primaryArtist(artist: String): String =
    artist.substringBefore(", ").trim().ifBlank { artist }
```

### Why split on `", "` and nothing else

Every parser in the app joins multiple artists with exactly `", "`:

- `PlaylistFetchWorker.kt:410,518,672` — `track.artists.joinToString(", ") { it.name }`
- `ytmusic/AlbumResponseParser.kt:126`
- `ytmusic/ResponseParserHelpers.kt:110`
- `ytmusic/SearchResponseParser.kt:140`

So the join delimiter is the split delimiter. I deliberately did **not** write a regex over `&` / `feat.` / `ft.` / `x` / `vs.` — that shreds real band names (`Simon & Garfunkel`, `Earth, Wind & Fire`, `Florence + the Machine`). A covered case in the tests.

### Known limitation — please read before merging

A single artist whose own name contains `", "` gets truncated: **`Tyler, The Creator` → `Tyler`**. Same for `Crosby, Stills & Nash`.

There is no way to distinguish that from a two-artist join at this layer, because by the time the string reaches the scrobbler the structure is already gone. A correct fix means carrying a structured `List<String>` of artists on `TrackEntity` — a schema change, a migration, and touching every parser. That felt well out of scope for this issue, so instead:

- the setting is **opt-in and off by default**
- the limitation is stated in the toggle's own subtitle, so a user opting in sees it
- it's documented in KDoc on `primaryArtist`

If you'd rather have the structured-artist version, say so and I'll close this — it's a much bigger change but it would be exactly right rather than approximately right.

### Deliberately out of scope

**ListenBrainz is untouched.** It has its own submission path (`ListenBrainzApiClient.kt:141` sends `listen.artist` as `artist_name`), so enabling this leaves ListenBrainz scrobbles unchanged. That's an inconsistency, but the issue asked for Last.fm and I didn't want to make a product decision for a second service unasked. Happy to extend it if you want one shared "submission artist formatting" preference.

**No backfill.** Already-submitted scrobbles are left alone.

### Notes on the implementation

- The preference lives in the existing `lastfm_session` DataStore alongside the session. It is deliberately **not** cleared by `clear()`, so disconnecting and reconnecting preserves the user's choice.
- `SettingsViewModel` exposes it as its own `StateFlow` rather than folding it into the main `combine`, which is index-based (`values[8]`, `values[9]`…) and would have required shifting every downstream index.
- The toggle row is hand-rolled rather than reusing `SettingsToggleRow`, because this section renders inside a `GlassCard` that already applies 16.dp padding and `SettingsToggleRow` adds its own 15.dp — they'd double up and misalign against the surrounding text.

### Verification

- `./gradlew :feature:settings:compileDebugKotlin :core:data:testDebugUnitTest --tests "*PrimaryArtistTest"` — BUILD SUCCESSFUL
- `PrimaryArtistTest` — 6 tests, 0 failures (single artist, comma-joined pair, `&` band name, `feat.` suffix, leading-comma fallback, blank input)
- **Not exercised on a device.** The toggle has not been tapped in a running app and no real scrobble has been submitted with it on. Worth a manual pass before merge.