### PR TITLE
Remove the positional indices from the Settings uiState combine

### DIFF
--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -120,9 +120,10 @@ class SettingsViewModel @Inject constructor(
     // ── ListenBrainz ────────────────────────────────────────────────────────
     //
     // Exposed as standalone StateFlows rather than threaded through the big
-    // combine(...) below, which addresses its sources by numeric index
-    // (values[27], values[28]…). Adding four more inputs there would shift every
-    // later index — a silent, type-correct way to hand the UI the wrong value.
+    // combine(...) below. That combine no longer uses numeric indices (see
+    // [Values]), but it is still 38 sources feeding one monolithic UiState, and
+    // ListenBrainz belongs to one screen — keeping it separate is the right shape
+    // regardless.
 
     private val _listenBrainzTokenInput = MutableStateFlow("")
     val listenBrainzTokenInput: StateFlow<String> = _listenBrainzTokenInput
@@ -483,47 +484,52 @@ class SettingsViewModel @Inject constructor(
         homeSectionsPreference.order,
         homeSectionsPreference.hidden,
     ) { values ->
+        // Read strictly in the order the flows are declared above. See [Values]:
+        // there are no positional indices to renumber, and requireExhausted()
+        // below turns "a flow was added and nobody updated the reads" into an
+        // immediate, named failure instead of silently shifted data.
+        val v = Values(values)
+        val spotifyAuth = v.next<AuthState>()
+        val youTubeAuth = v.next<AuthState>()
+        val trackCount = v.next<Int>()
+        val storageBytes = (v.next<LibrarySizeBreakdown>()).totalBytes
+        val quality = v.next<QualityTier>()
+        val theme = v.next<ThemeMode>()
+        val externalTree = v.next<Uri?>()
+        val moveState = v.next<MoveLibraryState>()
+        val lastFmSession = v.next<LastFmSession?>()
+        val pendingScrobbles = v.next<Int>()
+        val downloadNetworkMode = v.next<DownloadNetworkMode>()
+        val local = v.next<LocalState>()
+        val ytHistoryEnabled = v.next<Boolean>()
+        val ytHistoryHealth = v.next<YouTubeScrobblerHealth>()
+        val ytPendingCount = v.next<Int>()
+        val losslessEnabled = v.next<Boolean>()
+        val squidWtfCaptchaCookie = (v.next<String?>()).orEmpty()
+        val losslessQualityTier = v.next<LosslessQualityTier>()
+        val lastKnownBadCookie = v.next<String?>()
+        val autoSaveEnabled = v.next<Boolean>()
+        val autoSaveThreshold = v.next<Int>()
+        val heartDefaultStash = v.next<Boolean>()
+        val heartDefaultSpotify = v.next<Boolean>()
+        val heartDefaultYtMusic = v.next<Boolean>()
+        val autoSavedCount7d = v.next<Int>()
+        val youtubeFallbackEnabled = v.next<Boolean>()
+        val stashMixesEnabled = v.next<Boolean>()
+        val mirrorLikesSpotify = v.next<Boolean>()
+        val mirrorLikesYtMusic = v.next<Boolean>()
+        val arcodConnected = !(v.next<String?>()).isNullOrBlank()
+        val streamingWifiTier = v.next<LosslessQualityTier>()
+        val streamingCellularTier = v.next<LosslessQualityTier>()
+        val streamingSaveData = v.next<Boolean>()
+        val amoledDark = v.next<Boolean>()
+        val qobuzDiscoveryEnabled = v.next<Boolean>()
+        val ambientAnimationEnabled = v.next<Boolean>()
         @Suppress("UNCHECKED_CAST")
-        val spotifyAuth = values[0] as AuthState
-        val youTubeAuth = values[1] as AuthState
-        val trackCount = values[2] as Int
-        val storageBytes = (values[3] as LibrarySizeBreakdown).totalBytes
-        val quality = values[4] as QualityTier
-        val theme = values[5] as ThemeMode
-        val externalTree = values[6] as Uri?
-        val moveState = values[7] as MoveLibraryState
-        val lastFmSession = values[8] as LastFmSession?
-        val pendingScrobbles = values[9] as Int
-        val downloadNetworkMode = values[10] as DownloadNetworkMode
-        val local = values[11] as LocalState
-        val ytHistoryEnabled = values[12] as Boolean
-        val ytHistoryHealth = values[13] as YouTubeScrobblerHealth
-        val ytPendingCount = values[14] as Int
-        val losslessEnabled = values[15] as Boolean
-        val squidWtfCaptchaCookie = (values[16] as String?).orEmpty()
-        val losslessQualityTier = values[17] as LosslessQualityTier
-        val lastKnownBadCookie = values[18] as String?
-        val autoSaveEnabled = values[19] as Boolean
-        val autoSaveThreshold = values[20] as Int
-        val heartDefaultStash = values[21] as Boolean
-        val heartDefaultSpotify = values[22] as Boolean
-        val heartDefaultYtMusic = values[23] as Boolean
-        val autoSavedCount7d = values[24] as Int
-        val youtubeFallbackEnabled = values[25] as Boolean
-        val stashMixesEnabled = values[26] as Boolean
-        val mirrorLikesSpotify = values[27] as Boolean
-        val mirrorLikesYtMusic = values[28] as Boolean
-        val arcodConnected = !(values[29] as String?).isNullOrBlank()
-        val streamingWifiTier = values[30] as LosslessQualityTier
-        val streamingCellularTier = values[31] as LosslessQualityTier
-        val streamingSaveData = values[32] as Boolean
-        val amoledDark = values[33] as Boolean
-        val qobuzDiscoveryEnabled = values[34] as Boolean
-        val ambientAnimationEnabled = values[35] as Boolean
+        val homeSectionOrder = v.next<List<com.stash.core.data.prefs.HomeSection>>()
         @Suppress("UNCHECKED_CAST")
-        val homeSectionOrder = values[36] as List<com.stash.core.data.prefs.HomeSection>
-        @Suppress("UNCHECKED_CAST")
-        val homeSectionsHidden = values[37] as Set<com.stash.core.data.prefs.HomeSection>
+        val homeSectionsHidden = v.next<Set<com.stash.core.data.prefs.HomeSection>>()
+        v.requireExhausted()
 
         val lastFmState: LastFmAuthState = local.lastFmAuthOverride
             ?: when {
@@ -1500,4 +1506,47 @@ class SettingsViewModel @Inject constructor(
         val file: java.io.File,
         val contentUri: android.net.Uri,
     )
+}
+
+/**
+ * Sequential typed reader over the untyped `Array<Any?>` that Kotlin's vararg
+ * `combine` hands back.
+ *
+ * ## Why this exists
+ *
+ * `SettingsUiState` is assembled from 38 flows. Kotlin's `combine` is only typed up
+ * to five, so beyond that the lambda receives `Array<Any?>` and the values were read
+ * positionally: `values[27] as Boolean`, `values[28] as Boolean`, and so on.
+ *
+ * That made the flow list and the read list two parallel lists kept in sync by hand.
+ * Insert a source in the middle and every later index silently shifts — the cast
+ * still succeeds, the type still checks, and the UI quietly renders the wrong
+ * value. No test catches it, because every field still holds a valid value of the
+ * right type. It had already bent three separate changes around itself: two dead
+ * preferences survive cleanup because deleting them is unsafe, and ListenBrainz was
+ * exposed as standalone StateFlows specifically to avoid touching this.
+ *
+ * Reading sequentially removes the renumbering entirely — adding a flow means adding
+ * one `next()` in the matching position, with no indices to update. [requireExhausted]
+ * then turns the remaining mistake (a flow added or removed without a matching read)
+ * into an immediate, named failure instead of silently shifted data.
+ *
+ * **What this does not fix:** reordering two same-typed flows is still silent. The
+ * real remedy for that is structural — this is a hub-and-spoke Settings UI, so each
+ * spoke should observe its own small typed state rather than every screen sharing one
+ * 38-source object. That is a larger change and deliberately not attempted here.
+ */
+private class Values(private val raw: Array<Any?>) {
+    private var cursor = 0
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T> next(): T = raw[cursor++] as T
+
+    /** Fails loudly if the flow list and the read list have drifted apart. */
+    fun requireExhausted() {
+        check(cursor == raw.size) {
+            "SettingsViewModel.uiState read $cursor of ${raw.size} combined flows — " +
+                "a flow was added or removed without a matching next() call."
+        }
+    }
 }


### PR DESCRIPTION
The structural finding from review pass 3. **Not a bug fix — removing a structure that manufactures bugs.**

## The problem

`SettingsUiState` is built from **38 flows**. Kotlin's `combine` is typed only up to five, so beyond that the lambda gets `Array<Any?>` and every value was read positionally:

```kotlin
val mirrorLikesSpotify = values[27] as Boolean
val mirrorLikesYtMusic  = values[28] as Boolean
```

The flow list and the read list were two parallel lists kept in sync **by hand**. Insert a source in the middle and every later index shifts — the cast still succeeds, the type still checks, and the UI quietly renders the wrong value. **No test catches it**, because every field still holds a valid value of the right type.

## Why it was worth doing

This isn't theoretical. It had already bent three separate changes around itself:

- `heartDefault*` survives as a dead preference because deleting it is unsafe
- `streamQuality` likewise
- ListenBrainz was exposed as standalone `StateFlow`s last week *specifically* to avoid touching this

A structure that makes cleanup unsafe accumulates cruft by construction. Two of pass 3's findings existed *because of* this.

## The change

All 38 positional reads become sequential `v.next<T>()` calls in declaration order. Adding a flow now means adding one call in the matching position — nothing to renumber. `requireExhausted()` turns the remaining mistake (a flow added or removed without a matching read) into an immediate, named failure instead of silently shifted data.

## What this does *not* fix

Reordering two same-typed flows is still silent. I'd rather say that than overclaim.

The real remedy is structural: this is a **hub-and-spoke** Settings UI, so each spoke should observe its own small typed state rather than every screen sharing one 38-source object — which would also stop every screen recomposing on unrelated changes. That's a much larger change, documented on the `Values` class rather than half-attempted here.

## Verification

Mechanical, order-preserving transformation. 1996 tests green.

**Not yet confirmed visually on device** — the phone was in use when I got here. Given this touches every value on every Settings screen, it's worth a look at Audio & Quality and Accounts before merging. I'd rather flag that than imply a check I didn't run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
