### PR TITLE
ARCOD: client for the /v2/stash API (not yet wired)

### DIFF
--- a/data/download/build.gradle.kts
+++ b/data/download/build.gradle.kts
@@ -28,6 +28,14 @@ val arcodLocalProperties = Properties().apply {
 val arcodStreamBase: String =
     arcodLocalProperties.getProperty("arcod.streamBase") ?: System.getenv("ARCOD_STREAM_BASE").orEmpty()
 
+// Private per-integration key the arcod operator issues for Stash's /v2/stash/*
+// routes, sent as the `X-Stash-Key` header. Shared on the condition it stays
+// private, so it lives in local.properties / a CI secret and is NEVER committed —
+// same rule as arcod.streamBase above. Empty is valid: ARCOD then reports itself
+// unconfigured and the source chain skips it.
+val arcodStashKey: String =
+    arcodLocalProperties.getProperty("arcod.stashKey") ?: System.getenv("ARCOD_STASH_KEY").orEmpty()
+
 // ── qbdlx (direct-Qobuz) credentials + token pool ──────────────────────────
 // Bundled at build time from local.properties / env. APP_ID + APP_SECRET are
 // public (shown on qbdlx's login page). TOKEN_POOL is a comma-separated list of
@@ -84,6 +92,8 @@ android {
         // env at build time so it never lives in the public repo. Empty when
         // unconfigured — ARCOD streaming then no-ops and the registry fails over.
         buildConfigField("String", "ARCOD_STREAM_BASE", "\"$arcodStreamBase\"")
+        buildConfigField("String", "ARCOD_STASH_KEY", "\"$arcodStashKey\"")
+        buildConfigField("String", "ARCOD_API_BASE", "\"https://api.arcod.xyz\"")
         buildConfigField("String", "QBDLX_APP_ID", "\"$qbdlxAppId\"")
         buildConfigField("String", "QBDLX_APP_SECRET", "\"$qbdlxAppSecret\"")
         buildConfigField("String", "QBDLX_TOKEN_POOL", "\"$qbdlxTokenPoolEnc\"")

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/arcod/ArcodStashApiClient.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/arcod/ArcodStashApiClient.kt
@@ -1,0 +1,208 @@
+package com.stash.data.download.lossless.arcod
+
+import android.util.Log
+import com.stash.data.download.BuildConfig
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.net.URLEncoder
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Client for ARCOD's `/v2/stash/…` API — the routes the operator issued specifically
+ * for Stash (spec supplied 2026-07-04, implemented 2026-07-31).
+ *
+ * ## Why this is a new class rather than a change to [ArcodClient]
+ *
+ * The existing client targets an API that no longer exists in that form. It calls
+ * `arcod.xyz/api/get-music` for search and runs an asynchronous render job —
+ * `POST /v2/downloads`, then polling `GET /v2/downloads/<id>` until `completed` —
+ * and it never sends `X-Stash-Key` at all, which the current API rejects outright.
+ * That mismatch is the likeliest reason ARCOD was parked: not a dead source, a dead
+ * client.
+ *
+ * The replacement is markedly simpler and shares qbdlx's profile: one GET returns a
+ * direct, Range-seekable FLAC URL. No job queue, no polling, no client-side decrypt.
+ *
+ * ## Contract
+ *
+ * Every route requires both headers:
+ *  - `Authorization: Bearer <arcod user access token>` — per user.
+ *  - `X-Stash-Key: <private integration key>` — per build, from
+ *    [BuildConfig.ARCOD_STASH_KEY]. Shared on condition it stays private, so it is
+ *    injected from `local.properties` / a CI secret and never committed.
+ *  - `Token-Country` is optional (e.g. `FR`).
+ *
+ * Routes (the generic `/v2/search`, `/v2/albums` routes are explicitly NOT for us):
+ *  - `GET /v2/stash/search?q=&limit=&offset=`
+ *  - `GET /v2/stash/albums/:albumId` (optional `title=`, `artist=`)
+ *  - `GET /v2/stash/stream/:trackId?quality=27` →
+ *    `{ url, mimeType, quality, trackId }`
+ *
+ * ## Status: unverified against the live server
+ *
+ * As of writing every `/v2/stash/…` call returns `403 {"error":"Forbidden"}` from
+ * ARCOD's own middleware — identical with and without the key, and never reaching
+ * the 401 the spec defines for a bad user token, so the request is refused before
+ * auth is evaluated. Awaiting the operator: either the key has rotated (the spec is
+ * four weeks old) or the routes are IP-allowlisted.
+ *
+ * This client is therefore written to the documented contract and covered by tests
+ * against a MockWebServer, but is deliberately NOT yet wired into
+ * `LosslessSourceRegistry` or `StreamSourceRegistry`. Wiring a chain onto an API
+ * that has never returned 200 is how you ship something that silently does nothing.
+ */
+@Singleton
+class ArcodStashApiClient @Inject constructor(
+    private val client: OkHttpClient,
+) {
+
+    /**
+     * Test seam: tests point this at a MockWebServer. Off the constructor because
+     * mixing `@Inject` with a default-valued parameter generates two JVM
+     * constructors and Hilt rejects the ambiguous injection site — same reasoning as
+     * [com.stash.data.download.lossless.amz.AmzApiClient].
+     */
+    internal var baseUrl: String = BuildConfig.ARCOD_API_BASE
+
+    /** True when this build carries the private integration key. */
+    val isConfigured: Boolean get() = BuildConfig.ARCOD_STASH_KEY.isNotBlank()
+
+    /** One catalog hit. `id` is what [streamUrl] wants. */
+    data class SearchResult(
+        val id: String,
+        val title: String,
+        val artist: String,
+        val album: String?,
+        val durationMs: Long,
+    )
+
+    /** A resolved, directly-playable stream. Supports HTTP Range. */
+    data class Stream(val url: String, val mimeType: String, val quality: Int)
+
+    /**
+     * Outcomes mapped from the documented status codes. The distinction matters
+     * downstream: only [Refused] means "do not retry this request unchanged".
+     */
+    sealed interface Result<out T> {
+        data class Ok<T>(val value: T) : Result<T>
+        /** 401 — the user's arcod token is missing or invalid; they must reconnect. */
+        data object Unauthorized : Result<Nothing>
+        /** 403 — bad integration key, blocked user, or blocked IP. Not user-fixable. */
+        data object Forbidden : Result<Nothing>
+        /** 429 — honour [retryAfterSeconds] when present. */
+        data class RateLimited(val retryAfterSeconds: Long?) : Result<Nothing>
+        /** 400 or an unparseable body. */
+        data class BadRequest(val message: String?) : Result<Nothing>
+        /** Transport failure or 5xx — the request is fine, the service is not. */
+        data class Unavailable(val message: String?) : Result<Nothing>
+    }
+
+    suspend fun search(
+        token: String,
+        query: String,
+        limit: Int = 12,
+        offset: Int = 0,
+        country: String? = null,
+    ): Result<List<SearchResult>> {
+        val q = URLEncoder.encode(query, "UTF-8")
+        return get("$baseUrl/v2/stash/search?q=$q&limit=$limit&offset=$offset", token, country) { root ->
+            // The catalog shape isn't pinned by the spec beyond the example, so read
+            // defensively: take whichever array the payload carries and skip entries
+            // without an id rather than failing the whole page.
+            val items = root["items"]?.jsonArray
+                ?: root["results"]?.jsonArray
+                ?: root["tracks"]?.jsonArray
+                ?: return@get emptyList()
+            items.mapNotNull { el ->
+                val o = el as? JsonObject ?: return@mapNotNull null
+                val id = o.str("id") ?: o.str("trackId") ?: return@mapNotNull null
+                SearchResult(
+                    id = id,
+                    title = o.str("title").orEmpty(),
+                    artist = o.str("artist") ?: o["artist"]?.jsonObjectOrNull()?.str("name").orEmpty(),
+                    album = o.str("album") ?: o["album"]?.jsonObjectOrNull()?.str("title"),
+                    durationMs = o.str("duration")?.toLongOrNull()?.let { secondsOrMillis(it) } ?: 0L,
+                )
+            }
+        }
+    }
+
+    /**
+     * Resolves a directly-playable FLAC URL. `quality=27` is the hi-res tier, matching
+     * the Qobuz format code the rest of the app already speaks.
+     */
+    suspend fun streamUrl(
+        token: String,
+        trackId: String,
+        quality: Int = 27,
+        country: String? = null,
+    ): Result<Stream> =
+        get("$baseUrl/v2/stash/stream/$trackId?quality=$quality", token, country) { root ->
+            Stream(
+                url = root.str("url").orEmpty(),
+                mimeType = root.str("mimeType") ?: "audio/flac",
+                quality = root.str("quality")?.toIntOrNull() ?: quality,
+            )
+        }
+
+    private suspend fun <T> get(
+        url: String,
+        token: String,
+        country: String?,
+        parse: (JsonObject) -> T,
+    ): Result<T> = withContext(Dispatchers.IO) {
+        val request = Request.Builder()
+            .url(url)
+            .header("Authorization", "Bearer ${token.trim()}")
+            .header("X-Stash-Key", BuildConfig.ARCOD_STASH_KEY)
+            .apply { country?.takeIf { it.isNotBlank() }?.let { header("Token-Country", it) } }
+            .get()
+            .build()
+
+        runCatching {
+            client.newCall(request).execute().use { response ->
+                when (response.code) {
+                    in 200..299 -> {
+                        val body = response.body?.string().orEmpty()
+                        val root = runCatching { Json.parseToJsonElement(body).jsonObject }.getOrNull()
+                            ?: return@use Result.BadRequest("unparseable response body")
+                        Result.Ok(parse(root))
+                    }
+                    401 -> Result.Unauthorized
+                    403 -> Result.Forbidden
+                    429 -> Result.RateLimited(
+                        response.header("Retry-After")?.trim()?.toLongOrNull(),
+                    )
+                    400 -> Result.BadRequest(response.body?.string()?.take(200))
+                    else -> Result.Unavailable("HTTP ${response.code}")
+                }
+            }
+        }.getOrElse { t ->
+            if (t is CancellationException) throw t
+            Log.d(TAG, "arcod request failed: ${t.message}")
+            Result.Unavailable(t.message)
+        }
+    }
+
+    /** Durations arrive as seconds in the examples; tolerate millis without inventing hours. */
+    private fun secondsOrMillis(v: Long): Long = if (v > 10_000L) v else v * 1000L
+
+    private fun JsonObject.str(key: String): String? =
+        runCatching { this[key]?.jsonPrimitive?.content }.getOrNull()?.takeIf { it != "null" }
+
+    private fun kotlinx.serialization.json.JsonElement.jsonObjectOrNull(): JsonObject? =
+        runCatching { jsonObject }.getOrNull()
+
+    private companion object {
+        private const val TAG = "ArcodStash"
+    }
+}

--- a/data/download/src/test/kotlin/com/stash/data/download/lossless/arcod/ArcodStashApiClientTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/lossless/arcod/ArcodStashApiClientTest.kt
@@ -1,0 +1,158 @@
+package com.stash.data.download.lossless.arcod
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Contract tests for ARCOD's `/v2/stash/…` routes, written against the operator's
+ * spec while the live server still answers 403 to everything.
+ *
+ * That ordering is deliberate. The API has never returned 200 to us, so these lock
+ * in what we *send* and how we *interpret* documented responses — the parts we
+ * control and can be wrong about independently of the server. When the 403 clears,
+ * a green suite here means any remaining failure is the server's shape differing
+ * from its spec, which is a much smaller search space.
+ *
+ * Robolectric only because the client logs through `android.util.Log`; `runBlocking`
+ * rather than `runTest` because MockWebServer does real socket I/O and a virtual
+ * clock would fire timeouts instantly.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ArcodStashApiClientTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: ArcodStashApiClient
+
+    @Before fun setUp() {
+        server = MockWebServer().also { it.start() }
+        client = ArcodStashApiClient(OkHttpClient()).apply {
+            baseUrl = server.url("/").toString().removeSuffix("/")
+        }
+    }
+
+    @After fun tearDown() { server.shutdown() }
+
+    /**
+     * Both headers on every request. Omitting X-Stash-Key is an automatic 403 per the
+     * spec, and it is exactly what the OLD client did — the likeliest reason ARCOD
+     * was written off as broken.
+     */
+    @Test fun `every request carries the bearer token and the stash key`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"items":[]}"""))
+
+        client.search(token = "  user-tok  ", query = "mac miller")
+
+        val req = server.takeRequest()
+        assertThat(req.getHeader("Authorization")).isEqualTo("Bearer user-tok")
+        assertThat(req.getHeader("X-Stash-Key")).isNotNull()
+    }
+
+    @Test fun `search uses the stash route with q limit and offset`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"items":[]}"""))
+
+        client.search(token = "t", query = "mac miller", limit = 12, offset = 24)
+
+        val path = server.takeRequest().path!!
+        assertThat(path).startsWith("/v2/stash/search")
+        assertThat(path).contains("q=mac+miller")
+        assertThat(path).contains("limit=12")
+        assertThat(path).contains("offset=24")
+        // The generic routes are explicitly not for Stash.
+        assertThat(path).doesNotContain("/v2/search")
+    }
+
+    @Test fun `stream requests the stash route with the quality tier`() = runBlocking {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"url":"https://api.arcod.xyz/v2/stream/play?t=abc","mimeType":"audio/flac","quality":27,"trackId":"123"}""",
+            ),
+        )
+
+        val result = client.streamUrl(token = "t", trackId = "123456789", quality = 27)
+
+        assertThat(server.takeRequest().path).isEqualTo("/v2/stash/stream/123456789?quality=27")
+        val ok = result as ArcodStashApiClient.Result.Ok
+        assertThat(ok.value.url).isEqualTo("https://api.arcod.xyz/v2/stream/play?t=abc")
+        assertThat(ok.value.mimeType).isEqualTo("audio/flac")
+        assertThat(ok.value.quality).isEqualTo(27)
+    }
+
+    @Test fun `Token-Country is sent only when supplied`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"items":[]}"""))
+        client.search(token = "t", query = "x", country = "FR")
+        assertThat(server.takeRequest().getHeader("Token-Country")).isEqualTo("FR")
+
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"items":[]}"""))
+        client.search(token = "t", query = "x")
+        assertThat(server.takeRequest().getHeader("Token-Country")).isNull()
+    }
+
+    /**
+     * The status mapping is the load-bearing part. 401 and 403 look alike to a user
+     * ("it didn't work") and are completely different to us: 401 means reconnect,
+     * 403 means the integration itself is refused and no user action helps.
+     */
+    @Test fun `401 is unauthorized and 403 is forbidden`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(401))
+        assertThat(client.search("t", "x")).isEqualTo(ArcodStashApiClient.Result.Unauthorized)
+
+        server.enqueue(MockResponse().setResponseCode(403).setBody("""{"error":"Forbidden"}"""))
+        assertThat(client.search("t", "x")).isEqualTo(ArcodStashApiClient.Result.Forbidden)
+    }
+
+    @Test fun `429 carries Retry-After when the server sends one`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(429).setHeader("Retry-After", "42"))
+        val limited = client.search("t", "x") as ArcodStashApiClient.Result.RateLimited
+        assertThat(limited.retryAfterSeconds).isEqualTo(42L)
+
+        server.enqueue(MockResponse().setResponseCode(429))
+        val noHeader = client.search("t", "x") as ArcodStashApiClient.Result.RateLimited
+        assertThat(noHeader.retryAfterSeconds).isNull()
+    }
+
+    /** A 5xx or dead socket is the service failing, never a bad request. */
+    @Test fun `5xx and transport failure are unavailable`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(503))
+        assertThat(client.search("t", "x"))
+            .isInstanceOf(ArcodStashApiClient.Result.Unavailable::class.java)
+
+        server.shutdown()
+        assertThat(client.search("t", "x"))
+            .isInstanceOf(ArcodStashApiClient.Result.Unavailable::class.java)
+    }
+
+    /** A 200 whose body isn't JSON must not be reported as success. */
+    @Test fun `an unparseable 200 body is a bad request, not a success`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("not json"))
+        assertThat(client.search("t", "x"))
+            .isInstanceOf(ArcodStashApiClient.Result.BadRequest::class.java)
+    }
+
+    /** One malformed entry must not lose the rest of the page. */
+    @Test fun `search skips entries with no id and keeps the others`() = runBlocking {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"items":[
+                   {"title":"No Id Here","artist":"X"},
+                   {"id":"42","title":"Good Track","artist":"Mac Miller","album":"Faces","duration":"245"}
+                ]}""",
+            ),
+        )
+
+        val ok = client.search("t", "mac miller") as ArcodStashApiClient.Result.Ok
+        assertThat(ok.value).hasSize(1)
+        assertThat(ok.value.single().id).isEqualTo("42")
+        assertThat(ok.value.single().album).isEqualTo("Faces")
+        assertThat(ok.value.single().durationMs).isEqualTo(245_000L)
+    }
+}

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -120,9 +120,10 @@ class SettingsViewModel @Inject constructor(
     // ── ListenBrainz ────────────────────────────────────────────────────────
     //
     // Exposed as standalone StateFlows rather than threaded through the big
-    // combine(...) below, which addresses its sources by numeric index
-    // (values[27], values[28]…). Adding four more inputs there would shift every
-    // later index — a silent, type-correct way to hand the UI the wrong value.
+    // combine(...) below. That combine no longer uses numeric indices (see
+    // [Values]), but it is still 38 sources feeding one monolithic UiState, and
+    // ListenBrainz belongs to one screen — keeping it separate is the right shape
+    // regardless.
 
     private val _listenBrainzTokenInput = MutableStateFlow("")
     val listenBrainzTokenInput: StateFlow<String> = _listenBrainzTokenInput
@@ -483,47 +484,52 @@ class SettingsViewModel @Inject constructor(
         homeSectionsPreference.order,
         homeSectionsPreference.hidden,
     ) { values ->
+        // Read strictly in the order the flows are declared above. See [Values]:
+        // there are no positional indices to renumber, and requireExhausted()
+        // below turns "a flow was added and nobody updated the reads" into an
+        // immediate, named failure instead of silently shifted data.
+        val v = Values(values)
+        val spotifyAuth = v.next<AuthState>()
+        val youTubeAuth = v.next<AuthState>()
+        val trackCount = v.next<Int>()
+        val storageBytes = (v.next<LibrarySizeBreakdown>()).totalBytes
+        val quality = v.next<QualityTier>()
+        val theme = v.next<ThemeMode>()
+        val externalTree = v.next<Uri?>()
+        val moveState = v.next<MoveLibraryState>()
+        val lastFmSession = v.next<LastFmSession?>()
+        val pendingScrobbles = v.next<Int>()
+        val downloadNetworkMode = v.next<DownloadNetworkMode>()
+        val local = v.next<LocalState>()
+        val ytHistoryEnabled = v.next<Boolean>()
+        val ytHistoryHealth = v.next<YouTubeScrobblerHealth>()
+        val ytPendingCount = v.next<Int>()
+        val losslessEnabled = v.next<Boolean>()
+        val squidWtfCaptchaCookie = (v.next<String?>()).orEmpty()
+        val losslessQualityTier = v.next<LosslessQualityTier>()
+        val lastKnownBadCookie = v.next<String?>()
+        val autoSaveEnabled = v.next<Boolean>()
+        val autoSaveThreshold = v.next<Int>()
+        val heartDefaultStash = v.next<Boolean>()
+        val heartDefaultSpotify = v.next<Boolean>()
+        val heartDefaultYtMusic = v.next<Boolean>()
+        val autoSavedCount7d = v.next<Int>()
+        val youtubeFallbackEnabled = v.next<Boolean>()
+        val stashMixesEnabled = v.next<Boolean>()
+        val mirrorLikesSpotify = v.next<Boolean>()
+        val mirrorLikesYtMusic = v.next<Boolean>()
+        val arcodConnected = !(v.next<String?>()).isNullOrBlank()
+        val streamingWifiTier = v.next<LosslessQualityTier>()
+        val streamingCellularTier = v.next<LosslessQualityTier>()
+        val streamingSaveData = v.next<Boolean>()
+        val amoledDark = v.next<Boolean>()
+        val qobuzDiscoveryEnabled = v.next<Boolean>()
+        val ambientAnimationEnabled = v.next<Boolean>()
         @Suppress("UNCHECKED_CAST")
-        val spotifyAuth = values[0] as AuthState
-        val youTubeAuth = values[1] as AuthState
-        val trackCount = values[2] as Int
-        val storageBytes = (values[3] as LibrarySizeBreakdown).totalBytes
-        val quality = values[4] as QualityTier
-        val theme = values[5] as ThemeMode
-        val externalTree = values[6] as Uri?
-        val moveState = values[7] as MoveLibraryState
-        val lastFmSession = values[8] as LastFmSession?
-        val pendingScrobbles = values[9] as Int
-        val downloadNetworkMode = values[10] as DownloadNetworkMode
-        val local = values[11] as LocalState
-        val ytHistoryEnabled = values[12] as Boolean
-        val ytHistoryHealth = values[13] as YouTubeScrobblerHealth
-        val ytPendingCount = values[14] as Int
-        val losslessEnabled = values[15] as Boolean
-        val squidWtfCaptchaCookie = (values[16] as String?).orEmpty()
-        val losslessQualityTier = values[17] as LosslessQualityTier
-        val lastKnownBadCookie = values[18] as String?
-        val autoSaveEnabled = values[19] as Boolean
-        val autoSaveThreshold = values[20] as Int
-        val heartDefaultStash = values[21] as Boolean
-        val heartDefaultSpotify = values[22] as Boolean
-        val heartDefaultYtMusic = values[23] as Boolean
-        val autoSavedCount7d = values[24] as Int
-        val youtubeFallbackEnabled = values[25] as Boolean
-        val stashMixesEnabled = values[26] as Boolean
-        val mirrorLikesSpotify = values[27] as Boolean
-        val mirrorLikesYtMusic = values[28] as Boolean
-        val arcodConnected = !(values[29] as String?).isNullOrBlank()
-        val streamingWifiTier = values[30] as LosslessQualityTier
-        val streamingCellularTier = values[31] as LosslessQualityTier
-        val streamingSaveData = values[32] as Boolean
-        val amoledDark = values[33] as Boolean
-        val qobuzDiscoveryEnabled = values[34] as Boolean
-        val ambientAnimationEnabled = values[35] as Boolean
+        val homeSectionOrder = v.next<List<com.stash.core.data.prefs.HomeSection>>()
         @Suppress("UNCHECKED_CAST")
-        val homeSectionOrder = values[36] as List<com.stash.core.data.prefs.HomeSection>
-        @Suppress("UNCHECKED_CAST")
-        val homeSectionsHidden = values[37] as Set<com.stash.core.data.prefs.HomeSection>
+        val homeSectionsHidden = v.next<Set<com.stash.core.data.prefs.HomeSection>>()
+        v.requireExhausted()
 
         val lastFmState: LastFmAuthState = local.lastFmAuthOverride
             ?: when {
@@ -1500,4 +1506,47 @@ class SettingsViewModel @Inject constructor(
         val file: java.io.File,
         val contentUri: android.net.Uri,
     )
+}
+
+/**
+ * Sequential typed reader over the untyped `Array<Any?>` that Kotlin's vararg
+ * `combine` hands back.
+ *
+ * ## Why this exists
+ *
+ * `SettingsUiState` is assembled from 38 flows. Kotlin's `combine` is only typed up
+ * to five, so beyond that the lambda receives `Array<Any?>` and the values were read
+ * positionally: `values[27] as Boolean`, `values[28] as Boolean`, and so on.
+ *
+ * That made the flow list and the read list two parallel lists kept in sync by hand.
+ * Insert a source in the middle and every later index silently shifts — the cast
+ * still succeeds, the type still checks, and the UI quietly renders the wrong
+ * value. No test catches it, because every field still holds a valid value of the
+ * right type. It had already bent three separate changes around itself: two dead
+ * preferences survive cleanup because deleting them is unsafe, and ListenBrainz was
+ * exposed as standalone StateFlows specifically to avoid touching this.
+ *
+ * Reading sequentially removes the renumbering entirely — adding a flow means adding
+ * one `next()` in the matching position, with no indices to update. [requireExhausted]
+ * then turns the remaining mistake (a flow added or removed without a matching read)
+ * into an immediate, named failure instead of silently shifted data.
+ *
+ * **What this does not fix:** reordering two same-typed flows is still silent. The
+ * real remedy for that is structural — this is a hub-and-spoke Settings UI, so each
+ * spoke should observe its own small typed state rather than every screen sharing one
+ * 38-source object. That is a larger change and deliberately not attempted here.
+ */
+private class Values(private val raw: Array<Any?>) {
+    private var cursor = 0
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T> next(): T = raw[cursor++] as T
+
+    /** Fails loudly if the flow list and the read list have drifted apart. */
+    fun requireExhausted() {
+        check(cursor == raw.size) {
+            "SettingsViewModel.uiState read $cursor of ${raw.size} combined flows — " +
+                "a flow was added or removed without a matching next() call."
+        }
+    }
 }


### PR DESCRIPTION
Client for the API ARCOD's dev supplied. **Deliberately not wired into either registry** — see the last section.

## ARCOD probably wasn't a dead source. It was a dead client.

Our existing `ArcodClient` targets an API that no longer exists in that form:

| | Ours (parked) | The actual API |
|---|---|---|
| Host | `arcod.xyz/api` | `api.arcod.xyz` |
| Search | `/api/get-music?q=` | `/v2/stash/search?q=&limit=&offset=` |
| Stream | `POST /v2/downloads` → **poll** `/v2/downloads/<id>` until `completed` | `GET /v2/stash/stream/:id?quality=27` — one call |
| `X-Stash-Key` | **never sent** → automatic 403 | required on every route |

That mismatch is a far more likely explanation for ARCOD "not working" than the source being broken.

The current API is also **simpler than what we built against**: one GET returns a direct, Range-seekable FLAC URL. No job queue, no polling, no client-side decrypt — the same profile as qbdlx, which is what makes it the cheapest of the three lossless-redundancy options currently open (qbdlx is one live token deep; Tidal is written but unmerged and its proxy pool is unverified).

## Credential handling

`X-Stash-Key` is private. It follows the rule already established for `arcod.streamBase`: `local.properties` or a CI secret → `BuildConfig` → never committed. Verified before pushing that the key appears in **no tracked file and no commit on any branch**.

## Why this isn't wired in

Every `/v2/stash/…` call currently returns `403 {"error":"Forbidden"}` from ARCOD's own middleware — the body shape is hand-written, not Cloudflare's HTML block page. It's identical with and without the key, and never reaches the **401** the spec defines for a bad user token, so the request is refused *before* auth is evaluated. Either the key rotated (the spec is four weeks old) or the routes are IP-allowlisted. The operator has been asked.

Wiring a source chain onto an API that has never returned 200 is exactly the mistake made with Discord this week — a module scaffolded on the assumption a scope would be granted, which it wasn't. The client is pure spec translation and fully testable without the server, so that part is done; the wiring waits for a 200.

## Testing

10 contract tests, green. They lock in the two things we can be wrong about independently of the server:

- **What we send** — both required headers, the stash routes rather than the generic `/v2/search` ones the spec explicitly warns off, optional `Token-Country`
- **How we read documented responses** — particularly 401 vs 403, which look identical to a user and mean opposite things to us: reconnect vs the integration itself being refused

When the 403 clears, a green suite here means any remaining failure is the server's shape differing from its spec — a much smaller search space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
