### PR TITLE
Last.fm loves honour the first-artist toggle too

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/social/LikeDestinationDispatcher.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/social/LikeDestinationDispatcher.kt
@@ -80,7 +80,7 @@ class LikeDestinationDispatcher @Inject constructor(
                         ?: throw NoLastFmSessionException()
                     lastFmApiClient.setLoved(
                         sessionKey = session.sessionKey,
-                        artist = track.artist,
+                        artist = scrobbleArtist(track.artist),
                         track = track.title,
                         loved = true,
                     ).getOrThrow()
@@ -144,7 +144,7 @@ class LikeDestinationDispatcher @Inject constructor(
                         ?: throw NoLastFmSessionException()
                     lastFmApiClient.setLoved(
                         sessionKey = session.sessionKey,
-                        artist = track.artist,
+                        artist = scrobbleArtist(track.artist),
                         track = track.title,
                         loved = false,
                     ).getOrThrow()
@@ -159,6 +159,26 @@ class LikeDestinationDispatcher @Inject constructor(
             Result.failure(t)
         }
     }
+
+    /**
+     * Applies the same "only first artist" preference the scrobbler uses.
+     *
+     * Loves and scrobbles must agree. Last.fm matches a love against its own catalog
+     * entry, so submitting "Calvin Harris" for the scrobble and "Calvin Harris, Dua
+     * Lipa" for the love lands them on different entries — or the love on nothing at
+     * all. That split is precisely what the toggle exists to prevent, so it has to
+     * govern both writes, not just one.
+     *
+     * Reuses [com.stash.core.data.lastfm.primaryArtist] rather than reimplementing
+     * the split: one definition of "primary artist", one place to fix it when the
+     * "Tyler, The Creator" limitation is eventually addressed.
+     */
+    private suspend fun scrobbleArtist(artist: String): String =
+        if (lastFmSessionPreference.firstArtistOnly.first() == true) {
+            com.stash.core.data.lastfm.primaryArtist(artist)
+        } else {
+            artist
+        }
 
     private fun alreadySaved(track: Track, dest: Destination): Boolean = when (dest) {
         Destination.STASH -> track.stashLikedAt != null

--- a/core/data/src/test/kotlin/com/stash/core/data/social/LikeDestinationDispatcherUnlikeTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/social/LikeDestinationDispatcherUnlikeTest.kt
@@ -6,6 +6,7 @@ import com.stash.core.data.social.stash.StashLikedPlaylistRepository
 import com.stash.core.data.social.ytmusic.YtMusicLibraryApiClient
 import com.stash.core.model.Track
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
@@ -90,4 +91,43 @@ class LikeDestinationDispatcherUnlikeTest {
     @Test fun `empty destination set is a no-op`() = runBlocking {
         assertTrue(dispatcher.unlike(track(), emptySet()).isEmpty())
     }
+    /**
+     * Loves must use the SAME artist string as scrobbles.
+     *
+     * The first-artist toggle (#392) was applied to scrobbles only; loves still sent
+     * the raw `track.artist`. With the toggle on that scrobbles "Calvin Harris" and
+     * loves "Calvin Harris, Dua Lipa" — two different Last.fm catalog entries for one
+     * track, which is exactly the mismatch the toggle exists to prevent.
+     */
+    @Test fun `love uses the primary artist when the toggle is on`() = runBlocking {
+        every { lastFmSession.session } returns kotlinx.coroutines.flow.flowOf(
+            com.stash.core.data.lastfm.LastFmSession(username = "u", sessionKey = "k"),
+        )
+        every { lastFmSession.firstArtistOnly } returns kotlinx.coroutines.flow.flowOf(true)
+        coEvery { lastFm.setLoved(any(), any(), any(), any()) } returns Result.success(Unit)
+
+        dispatcher.like(
+            track(spotifyUri = null, youtubeId = null).copy(artist = "Calvin Harris, Dua Lipa"),
+            setOf(Destination.LAST_FM),
+        )
+
+        coVerify { lastFm.setLoved(any(), "Calvin Harris", any(), true) }
+    }
+
+    /** Toggle off: the full credit is preserved, unchanged behaviour. */
+    @Test fun `love keeps the full artist when the toggle is off`() = runBlocking {
+        every { lastFmSession.session } returns kotlinx.coroutines.flow.flowOf(
+            com.stash.core.data.lastfm.LastFmSession(username = "u", sessionKey = "k"),
+        )
+        every { lastFmSession.firstArtistOnly } returns kotlinx.coroutines.flow.flowOf(false)
+        coEvery { lastFm.setLoved(any(), any(), any(), any()) } returns Result.success(Unit)
+
+        dispatcher.like(
+            track(spotifyUri = null, youtubeId = null).copy(artist = "Calvin Harris, Dua Lipa"),
+            setOf(Destination.LAST_FM),
+        )
+
+        coVerify { lastFm.setLoved(any(), "Calvin Harris, Dua Lipa", any(), true) }
+    }
+
 }


### PR DESCRIPTION
Follow-up to #392, closing a gap I introduced.

#392 added a "scrobble only the primary artist" preference and wired it into scrobbles. Love-mirroring — which I added a few days earlier — kept sending the raw `track.artist`. So with the toggle on:

```
scrobble -> Calvin Harris
love     -> Calvin Harris, Dua Lipa
```

Two different Last.fm catalog entries for one track. Last.fm matches a love against its own entry, so it lands somewhere other than the scrobble, or on nothing — exactly the split the toggle exists to prevent.

My gap, not @chaudhary-lakshay's: the love path landed after their PR was opened.

Both love and un-love now run the artist through the same transform, reusing `primaryArtist` from `:core:data` rather than reimplementing the split — one definition, one place to fix when the documented "Tyler, The Creator" limitation is addressed.

Two tests assert the exact string reaching `setLoved`: toggle on submits the primary artist, toggle off preserves the full credit. A future change that desynchronises the two paths fails here.

1996 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)