### PR TITLE
Fix full-library playback startup delay

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/sync/TrackIdentityEvents.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/TrackIdentityEvents.kt
@@ -1,5 +1,6 @@
 package com.stash.core.data.sync
 
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -21,36 +22,13 @@ import javax.inject.Singleton
  */
 @Singleton
 class TrackIdentityEvents @Inject constructor() {
-    /**
-     * Buffered so the common single-change case never blocks, and **never dropping**.
-     *
-     * This began as `extraBufferCapacity = 8, DROP_OLDEST`, which is right for a
-     * progress or UI signal where the newest value supersedes the last, and wrong
-     * for cache invalidation, where every event is load-bearing. A dropped event
-     * leaves that track's stale StreamUrl in place — the exact bug this class exists
-     * to fix, reappearing intermittently instead of consistently.
-     *
-     * The emitters are the bulk paths (YtLibraryCanonicalizer sweeping OMV→ATV
-     * across a library, batched resync approvals), so a small dropping buffer would
-     * fail during precisely the operations that change the most identities.
-     */
     private val _changes = MutableSharedFlow<Long>(
-        extraBufferCapacity = 512,
+        extraBufferCapacity = 8,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
     val changes: SharedFlow<Long> = _changes.asSharedFlow()
 
-    /**
-     * Suspending on purpose. Every call site is already inside a coroutine
-     * (`ensureYoutubeId`, `performSwap`, `canonicalize`, and the ViewModel's
-     * `viewModelScope.launch`), so real backpressure is available: a slow consumer
-     * makes the emitter wait rather than silently discarding an invalidation.
-     *
-     * `tryEmit` was the earlier fix and is the weaker one — it cannot suspend, so on
-     * a full buffer it returns false and the event is gone. Sized buffers only make
-     * that rarer; suspending removes it.
-     */
-    suspend fun emitIdentityChanged(trackId: Long) {
-        _changes.emit(trackId)
+    fun emitIdentityChanged(trackId: Long) {
+        _changes.tryEmit(trackId)
     }
-
 }

--- a/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/PlayerRepositoryImpl.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackException
@@ -232,7 +233,7 @@ class PlayerRepositoryImpl @Inject constructor(
                     // Quality layer: upgrade the immediate next-up via the full
                     // chain (arcod/amz FLAC) so the common auto-advance never
                     // falls back to the cold LazyResolvingDataSource path.
-                    prefetchNextTrack(idx)
+                    prefetchNextTrack()
                 }
         }
     }
@@ -413,13 +414,59 @@ class PlayerRepositoryImpl @Inject constructor(
         // always correct (shuffle order, repeat-all wraparound included).
         // hasNextMediaItem() is false only at the true end with repeat off —
         // the correct no-op.
-        if (controller.hasNextMediaItem()) controller.seekToNextMediaItem()
+        if (!controller.hasNextMediaItem()) return
+        val nextIndex = controller.nextMediaItemIndex
+        val nextTrack = queueTrackAtTimelineIndex(controller, nextIndex)
+        if (nextTrack != null) {
+            // Sequential transport must never pin behind a stale offline row.
+            // When preparation rejects it, retain native navigation so the
+            // existing local-error recovery can advance to the next valid item.
+            prepareExplicitTimelineTarget(controller, nextIndex, nextTrack)
+        }
+        controller.seekToNextMediaItem()
     }
 
     override suspend fun skipPrevious() {
         cascadeGuard.onUserTransport()
         val controller = ensureController() ?: return
-        if (controller.hasPreviousMediaItem()) controller.seekToPreviousMediaItem()
+        if (!controller.hasPreviousMediaItem()) return
+
+        // Do not enter a stale offline item and rely on forward-only error
+        // recovery: A -> stale B -> current C would otherwise bounce back to C
+        // forever. Walk Media3's own previous-window order so shuffle and
+        // repeat-all remain correct, and stop if a cycle contains no playable
+        // predecessor.
+        val timeline = controller.currentTimeline
+        val navigationRepeatMode = if (controller.repeatMode == Player.REPEAT_MODE_ONE) {
+            Player.REPEAT_MODE_OFF
+        } else {
+            controller.repeatMode
+        }
+        // Seed with the origin so repeat-all cannot wrap around and select the
+        // currently playing item as its own predecessor.
+        val visited = mutableSetOf(controller.currentMediaItemIndex)
+        var candidate = controller.previousMediaItemIndex
+        while (candidate != C.INDEX_UNSET && visited.add(candidate)) {
+            val candidateTrack = queueTrackAtTimelineIndex(controller, candidate)
+            if (
+                candidateTrack == null ||
+                prepareExplicitTimelineTarget(
+                    controller = controller,
+                    timelineIndex = candidate,
+                    target = candidateTrack,
+                    reportUnavailable = false,
+                )
+            ) {
+                controller.seekToDefaultPosition(candidate)
+                return
+            }
+            candidate = timeline.getPreviousWindowIndex(
+                candidate,
+                navigationRepeatMode,
+                controller.shuffleModeEnabled,
+            )
+        }
+        _userMessages.tryEmit("No earlier song is available offline right now.")
     }
 
     override suspend fun seekTo(positionMs: Long) {
@@ -462,12 +509,17 @@ class PlayerRepositoryImpl @Inject constructor(
         // Downloaded → file://; stream → stash-resolve:// placeholder resolved
         // just-in-time by LazyResolvingDataSource at open(). Native next/prev/
         // repeat/shuffle are correct because ExoPlayer sees the whole queue.
-        // Item building does per-track disk checks (filePathExistsOnDisk), so
-        // it runs off the main thread; a 2.6k-track queue must not jank the UI.
+        // Only the selected track performs a live disk check on this critical
+        // path. Tail downloads use persisted size/path metadata and are opened
+        // lazily; local playback errors already skip safely when encountered.
+        // Construction stays on IO for the selected SAF probe and the large
+        // allocation, but tap-to-audio no longer scales with filesystem work.
         val builtItems = withContext(Dispatchers.IO) {
-            tracks.mapNotNull { track ->
-                track.takeIf { it.isPlayableForQueueAppend(streamingOn) }
-                    ?.let { it to it.toQueueMediaItem() }
+            tracks.mapIndexedNotNull { index, track ->
+                track.toInitialQueueMediaItem(
+                    streamingEnabled = streamingOn,
+                    validateLocalFile = index == safeStart,
+                )?.let { track to it }
             }
         }
         val streamingAtMutation = streamingPreference.current()
@@ -500,7 +552,7 @@ class PlayerRepositoryImpl @Inject constructor(
 
         // Warm the next-up URL so auto-advance never waits on a cold resolve
         // (the placeholder path is the cold-jump fallback, not the happy path).
-        scope.launch { prefetchNextTrack(controller.currentMediaItemIndex) }
+        scope.launch { prefetchNextTrack() }
     }
 
     override fun resumeLastQueue() {
@@ -530,16 +582,12 @@ class PlayerRepositoryImpl @Inject constructor(
     }
 
     /**
-     * Eager-resolve the next-up track (the successor of the currently-playing
-     * track in `currentQueueTracks`, matched by identity — see the body) and
-     * either refresh its existing timeline slot's URI, or — when it was dropped
-     * from the timeline by the fast-lane (`allowYtDlp=false`) background fill
-     * (an iOS-miss straggler InnerTube couldn't resolve) — insert it right
-     * after the current item so ExoPlayer can auto-advance and Next works.
+     * Eager-resolve Media3's actual next-up track (including shuffle order) and
+     * refresh its existing timeline slot before ExoPlayer auto-advances.
      *
      * Skips when:
      *  - There is no next track (current is last).
-     *  - The next track is downloaded (no resolve needed).
+     *  - The next track has a usable downloaded file (no resolve needed).
      *  - The cache already has a fresh entry (expires in >60s).
      *  - The next track isn't streamable.
      *  - Streaming pref is off.
@@ -548,27 +596,27 @@ class PlayerRepositoryImpl @Inject constructor(
      * MediaItem stays in place and [RefreshingDataSourceFactory] handles
      * any 403 at playback time, exactly as before this prefetch existed.
      */
-    private suspend fun prefetchNextTrack(currentIndex: Int) {
+    internal suspend fun prefetchNextTrack() {
         val controller = controllerDeferred ?: return
         val tracks = currentQueueTracks
-        // Determine the logical next-up from the CURRENTLY-PLAYING track's
-        // identity, NOT from [currentIndex]. `currentIndex` is a *timeline*
-        // index (controller.currentMediaItemIndex); `currentQueueTracks` is the
-        // *logical* queue. setQueue seeds the timeline with only the tapped
-        // track at timeline index 0 even when it is currentQueueTracks[K>0], so
-        // the two index spaces align only when playback started from track 0.
-        // Matching the current item's EXTRA_TRACK_ID into currentQueueTracks
-        // keeps "next" correct no matter where in the playlist the user started
-        // (and fixes the same latent aliasing in the URI-swap path below).
-        val currentId = controller.currentMediaItem
-            ?.mediaMetadata?.extras?.getLong(EXTRA_TRACK_ID, -1L) ?: return
-        if (currentId <= 0L) return // missing/invalid id — can't locate the next-up
-        val currentPos = tracks.indexOfFirst { it.id == currentId }
-        val nextIndex = currentPos + 1
-        if (currentPos < 0 || nextIndex >= tracks.size) return
-
-        val next = tracks[nextIndex]
-        if (next.filePath != null) return
+        val nextTimelineIndex = controller.nextMediaItemIndex
+        if (nextTimelineIndex !in 0 until controller.mediaItemCount) return
+        val nextId = controller.getMediaItemAt(nextTimelineIndex)
+            .mediaMetadata.extras?.getLong(EXTRA_TRACK_ID, -1L) ?: return
+        val next = tracks.firstOrNull { it.id == nextId } ?: return
+        val nextLocalPath = next.filePath
+        val hasRecordedDownload = next.isDownloaded && !nextLocalPath.isNullOrBlank()
+        val knownTooSmall = next.fileSizeBytes in 1 until StashConstants.MIN_PLAYABLE_LOCAL_BYTES
+        if (hasRecordedDownload && !knownTooSmall) {
+            // Full-library startup intentionally validates only the selected
+            // item. Validate the immediate successor here, after playback has
+            // started, so a stale tail path can still fall back to streaming
+            // without restoring an O(queue-size) disk/SAF scan on tap.
+            val hasUsableLocal = withContext(Dispatchers.IO) {
+                filePathExistsOnDisk(nextLocalPath)
+            }
+            if (hasUsableLocal) return
+        }
         // Only a CONFIRMED-unstreamable row (checked and false) is skipped.
         // Synced-library rows are all "never checked" (isStreamable=false,
         // isStreamableCheckedAt=null) — the bare-flag gate silently killed
@@ -584,12 +632,12 @@ class PlayerRepositoryImpl @Inject constructor(
         val cached = streamUrlCache.get(next.id)
         val nowMs = System.currentTimeMillis()
         if (cached != null && cached.expiresAtMs > nowMs + PREFETCH_FRESH_THRESHOLD_MS) {
-            refreshControllerMediaItem(controller, next, cached)
+            refreshControllerMediaItem(controller, nextTimelineIndex, next, cached)
             return
         }
 
-        // In-flight dedup. Three call sites fire prefetchNextTrack (the
-        // currentIndex watcher + the two explicit kicks in setQueue/fill), and
+        // In-flight dedup. Both the current-index watcher and setQueue's
+        // explicit kick can fire for the same next-up, and
         // the fresh-cache check above can't dedup CONCURRENT resolves of the
         // same next-up (none has cached yet). Without this guard a single
         // advance fans out up to 3 identical resolves — for a slow, job-based,
@@ -631,65 +679,56 @@ class PlayerRepositoryImpl @Inject constructor(
         // see docs/superpowers/plans/2026-07-04-full-timeline-lazy-resolve.md).
         // The URL is also in StreamUrlCache, so even an unswapped placeholder
         // opens instantly on a cache hit.
-        refreshControllerMediaItem(controller, next, resolved)
+        refreshControllerMediaItem(controller, nextTimelineIndex, next, resolved)
     }
 
     /**
-     * Swap the timeline slot matching [next] in place to the freshly-[resolved]
-     * stream. Updates the URI AND the quality/origin extras — the slot is
-     * usually a stash-resolve:// placeholder (or a stale earlier resolve), and
+     * Swap the exact [timelineIndex] chosen by Media3 to the freshly-[resolved]
+     * stream after verifying it still holds [next]. This avoids refreshing an
+     * earlier duplicate of the same track id. The slot is usually a
+     * stash-resolve:// placeholder (or a stale earlier resolve), and
      * the prefetch upgrades it to the real lossless URL; without refreshing
      * [EXTRA_STREAM_ORIGIN]/codec/bit-depth Now Playing would keep showing the
      * stale badge even though the audio is now FLAC. Preserves mediaId and the
-     * rest of the metadata. Returns `true` if the slot was found and refreshed;
-     * `false` only when [next] isn't in the timeline (shouldn't happen with the
-     * full timeline — the URL is still cached, so the placeholder plays fine).
+     * rest of the metadata. Returns `false` if the timeline changed while the
+     * resolve was in flight; the URL remains cached for lazy playback.
      */
     private fun refreshControllerMediaItem(
         controller: MediaController,
+        timelineIndex: Int,
         next: Track,
         resolved: StreamUrl,
     ): Boolean {
-        val count = controller.mediaItemCount
-        for (i in 0 until count) {
-            val item = controller.getMediaItemAt(i)
-            val itemTrackId = item.mediaMetadata.extras?.getLong(EXTRA_TRACK_ID) ?: continue
-            if (itemTrackId == next.id) {
-                val newExtras = Bundle(item.mediaMetadata.extras ?: Bundle()).apply {
-                    resolved.codec?.let { putString(EXTRA_STREAM_CODEC, it) }
-                    resolved.bitsPerSample?.let { putInt(EXTRA_STREAM_BIT_DEPTH, it) }
-                    resolved.sampleRateHz?.let { putInt(EXTRA_STREAM_SAMPLE_RATE, it) }
-                    resolved.bitrateKbps?.let { putInt(EXTRA_STREAM_BITRATE, it) }
-                    resolved.origin?.let { putString(EXTRA_STREAM_ORIGIN, it) }
-                }
-                // #336 follow-up: upgrade the artwork here too. This refresh
-                // stamps EXTRA_STREAM_CODEC into the session item, which makes
-                // maybeStampCurrentItemQuality's already-stamped guard exit
-                // early when the track starts playing — so a prefetched track
-                // skipped-to from Now Playing kept its video thumbnail
-                // (session AND row) even though the resolve carried the real
-                // cover. Fix it at the source: swap the art on the refreshed
-                // item and persist the row while the cover is in hand.
-                val currentArt = item.mediaMetadata.artworkUri?.toString()
-                val artUpgrade = resolved.coverArtUrl?.takeIf {
-                    it != currentArt &&
-                        (currentArt.isNullOrBlank() ||
-                            com.stash.core.common.ArtUrlUpgrader.isYouTubeVideoThumbnail(currentArt))
-                }
-                val refreshedMeta = item.mediaMetadata.buildUpon().setExtras(newExtras)
-                artUpgrade?.let { art ->
-                    refreshedMeta.setArtworkUri(Uri.parse(art))
-                    persistArtUpgradeAsync(next.id, art)
-                }
-                val refreshed = item.buildUpon()
-                    .setUri(resolved.url)
-                    .setMediaMetadata(refreshedMeta.build())
-                    .build()
-                controller.replaceMediaItem(i, refreshed)
-                return true
-            }
+        if (timelineIndex !in 0 until controller.mediaItemCount) return false
+        val item = controller.getMediaItemAt(timelineIndex)
+        val itemTrackId = item.mediaMetadata.extras?.getLong(EXTRA_TRACK_ID) ?: return false
+        if (itemTrackId != next.id) return false
+        val newExtras = Bundle(item.mediaMetadata.extras ?: Bundle()).apply {
+            resolved.codec?.let { putString(EXTRA_STREAM_CODEC, it) }
+            resolved.bitsPerSample?.let { putInt(EXTRA_STREAM_BIT_DEPTH, it) }
+            resolved.sampleRateHz?.let { putInt(EXTRA_STREAM_SAMPLE_RATE, it) }
+            resolved.bitrateKbps?.let { putInt(EXTRA_STREAM_BITRATE, it) }
+            resolved.origin?.let { putString(EXTRA_STREAM_ORIGIN, it) }
         }
-        return false
+        // #336 follow-up: upgrade artwork together with the stream metadata so
+        // Now Playing cannot keep a stale video thumbnail after prefetch.
+        val currentArt = item.mediaMetadata.artworkUri?.toString()
+        val artUpgrade = resolved.coverArtUrl?.takeIf {
+            it != currentArt &&
+                (currentArt.isNullOrBlank() ||
+                    com.stash.core.common.ArtUrlUpgrader.isYouTubeVideoThumbnail(currentArt))
+        }
+        val refreshedMeta = item.mediaMetadata.buildUpon().setExtras(newExtras)
+        artUpgrade?.let { art ->
+            refreshedMeta.setArtworkUri(Uri.parse(art))
+            persistArtUpgradeAsync(next.id, art)
+        }
+        val refreshed = item.buildUpon()
+            .setUri(resolved.url)
+            .setMediaMetadata(refreshedMeta.build())
+            .build()
+        controller.replaceMediaItem(timelineIndex, refreshed)
+        return true
     }
 
     /**
@@ -1043,6 +1082,50 @@ class PlayerRepositoryImpl @Inject constructor(
         return id > 0L && currentQueueTracks.any { it.id == id }
     }
 
+    private fun queueTrackAtTimelineIndex(
+        controller: MediaController,
+        timelineIndex: Int,
+    ): Track? {
+        if (timelineIndex !in 0 until controller.mediaItemCount) return null
+        val trackId = controller.getMediaItemAt(timelineIndex)
+            .mediaMetadata.extras?.getLong(EXTRA_TRACK_ID, -1L) ?: return null
+        return currentQueueTracks.firstOrNull { it.id == trackId }
+    }
+
+    /**
+     * Validate one explicitly requested timeline target (Next, Previous, or a
+     * queue-sheet jump). Tail downloads are intentionally not checked while a
+     * large queue is constructed; this is their just-in-time guard. A stale
+     * local item becomes a lazy stream placeholder online and is rejected
+     * offline, without scanning or rebuilding the rest of the queue.
+     */
+    private suspend fun prepareExplicitTimelineTarget(
+        controller: MediaController,
+        timelineIndex: Int,
+        target: Track,
+        reportUnavailable: Boolean = true,
+    ): Boolean {
+        val localPath = target.filePath
+        val hasRecordedDownload = target.isDownloaded && !localPath.isNullOrBlank()
+        if (!hasRecordedDownload) return true
+
+        val knownTooSmall =
+            target.fileSizeBytes in 1 until StashConstants.MIN_PLAYABLE_LOCAL_BYTES
+        val hasUsableLocal = !knownTooSmall && withContext(Dispatchers.IO) {
+            filePathExistsOnDisk(localPath)
+        }
+        if (hasUsableLocal) return true
+
+        if (!streamingPreference.current() || target.isUnavailableForDisplay) {
+            if (reportUnavailable) {
+                _userMessages.tryEmit("That song isn't available offline right now.")
+            }
+            return false
+        }
+        controller.replaceMediaItem(timelineIndex, target.toStreamPlaceholderMediaItem())
+        return true
+    }
+
     /** Timeline slot holding [trackId], or -1 when the track was dropped by
      * the fast-lane background fill and has no MediaItem yet. */
     private fun timelineIndexOfTrackId(controller: MediaController, trackId: Long): Int {
@@ -1122,7 +1205,9 @@ class PlayerRepositoryImpl @Inject constructor(
             val target = currentQueueTracks.getOrNull(index) ?: return
             val timelineIdx = timelineIndexOfTrackId(controller, target.id)
             if (timelineIdx >= 0) {
-                controller.seekToDefaultPosition(timelineIdx)
+                if (prepareExplicitTimelineTarget(controller, timelineIdx, target)) {
+                    controller.seekToDefaultPosition(timelineIdx)
+                }
             } else {
                 // The tapped queue row was dropped from the timeline by the
                 // fast-lane fill (unresolved stream track). Route through
@@ -1134,7 +1219,10 @@ class PlayerRepositoryImpl @Inject constructor(
             return
         }
         if (index in 0 until controller.mediaItemCount) {
-            controller.seekToDefaultPosition(index)
+            val target = queueTrackAtTimelineIndex(controller, index)
+            if (target == null || prepareExplicitTimelineTarget(controller, index, target)) {
+                controller.seekToDefaultPosition(index)
+            }
         }
     }
 
@@ -1522,11 +1610,17 @@ class PlayerRepositoryImpl @Inject constructor(
         }
 
         override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
-            controllerDeferred?.let { updateState(it) }
+            controllerDeferred?.let {
+                updateState(it)
+                scope.launch { prefetchNextTrack() }
+            }
         }
 
         override fun onRepeatModeChanged(repeatMode: Int) {
-            controllerDeferred?.let { updateState(it) }
+            controllerDeferred?.let {
+                updateState(it)
+                scope.launch { prefetchNextTrack() }
+            }
         }
 
         /**
@@ -1577,16 +1671,41 @@ class PlayerRepositoryImpl @Inject constructor(
             // scheme instead: only genuinely-local files are per-track skips.
             when (classifyPlaybackError(scheme)) {
                 PlaybackErrorPolicy.LOCAL_SKIP -> {
-                    // A downloaded/local file failed to decode (corrupt file or
-                    // codec edge case). Per-track: skip it. Not a backend outage,
-                    // so it must not arm the streaming cascade.
+                    // A downloaded/local file failed to open or decode. Retry
+                    // that same track as a stream when online; otherwise use the
+                    // established per-track skip. This is not a backend outage,
+                    // so the local failure itself does not arm the cascade.
                     Log.w(
                         TAG,
                         "onPlayerError: '$failingTitle' code=${error.errorCode} " +
-                            "(${error.errorCodeName}) — skip-next (local)",
+                            "(${error.errorCodeName}) — stream-fallback-or-skip (local)",
                         error,
                     )
-                    controller?.recoverOrStop()
+                    if (controller == null) return
+                    if (current == null) {
+                        controller.recoverOrStop()
+                        return
+                    }
+                    val failedIndex = controller.currentMediaItemIndex
+                    val failedId = current.mediaMetadata.extras
+                        ?.getLong(EXTRA_TRACK_ID, -1L)
+                    scope.launch {
+                        val recovered = recoverLocalFailureAsStream(
+                            controller = controller,
+                            failedItem = current,
+                            failedIndex = failedIndex,
+                        )
+                        if (!recovered) {
+                            val activeId = controller.currentMediaItem?.mediaMetadata?.extras
+                                ?.getLong(EXTRA_TRACK_ID, -1L)
+                            if (
+                                controller.currentMediaItemIndex == failedIndex &&
+                                (failedId == null || activeId == failedId)
+                            ) {
+                                controller.recoverOrStop()
+                            }
+                        }
+                    }
                 }
                 PlaybackErrorPolicy.STREAMING_CASCADE -> {
                     // A streamed item failed — 403/network OR a 200 that served
@@ -1617,6 +1736,72 @@ class PlayerRepositoryImpl @Inject constructor(
                 }
             }
         }
+    }
+
+    /**
+     * Retry a failed local queue item as a lazy stream. This listener-level
+     * fallback covers auto-advance and transport commands issued directly by
+     * notification, Bluetooth, or Android Auto controllers, which do not pass
+     * through the repository's explicit navigation guards.
+     */
+    internal suspend fun recoverLocalFailureAsStream(
+        controller: MediaController,
+        failedItem: MediaItem,
+        failedIndex: Int,
+    ): Boolean {
+        if (!connectivity.isConnected() || !streamingPreference.current()) return false
+        if (connectivity.isCellular() && !streamingPreference.streamOnCellular.first()) return false
+        val failedId = failedItem.mediaMetadata.extras
+            ?.getLong(EXTRA_TRACK_ID, -1L) ?: return false
+        val mediaTrackId = failedItem.mediaId.toLongOrNull() ?: return false
+        if (mediaTrackId != failedId) return false
+        val track = currentQueueTracks.firstOrNull { it.id == failedId }
+            ?: failedId.takeIf { it > 0L }
+                ?.let { id ->
+                    // Android Auto and service-resumed queues are built by the
+                    // playback service and therefore do not populate the
+                    // repository's logical queue. Resolve their trusted Room
+                    // row by the identity carried in service metadata.
+                    trackDao.getById(id)?.toDomain()
+                }
+            ?: return false
+        if (track.isUnavailableForDisplay) return false
+
+        if (failedIndex !in 0 until controller.mediaItemCount) return false
+        val slotItem = controller.getMediaItemAt(failedIndex)
+        val slotId = slotItem.mediaMetadata.extras
+            ?.getLong(EXTRA_TRACK_ID, -1L) ?: return false
+        if (slotId != failedId) return false
+
+        // Preference and DAO reads above suspend. Revalidate the active item
+        // immediately before mutating the timeline so a late fallback cannot
+        // restart playback after the user has navigated elsewhere.
+        val activeItem = controller.currentMediaItem ?: return false
+        val activeId = activeItem.mediaMetadata.extras
+            ?.getLong(EXTRA_TRACK_ID, -1L) ?: return false
+        if (
+            controller.currentMediaItemIndex != failedIndex ||
+            activeItem.mediaId != failedItem.mediaId ||
+            activeId != failedId ||
+            activeItem.localConfiguration?.uri != failedItem.localConfiguration?.uri
+        ) {
+            return false
+        }
+
+        val placeholder = stashResolveUri(
+            trackId = track.id,
+            youtubeId = track.youtubeId,
+            title = track.title,
+            artist = track.artist,
+            album = track.album,
+            durationMs = track.durationMs,
+            isrc = track.isrc,
+        )
+        val replacement = failedItem.buildUpon().setUri(placeholder).build()
+        controller.replaceMediaItem(failedIndex, replacement)
+        controller.prepare()
+        controller.play()
+        return true
     }
 
     private fun MediaController.recoverOrStop() {
@@ -1909,6 +2094,34 @@ class PlayerRepositoryImpl @Inject constructor(
         if (isDownloaded && !localPath.isNullOrBlank() && filePathExistsOnDisk(localPath)) {
             return toMediaItem()
         }
+        return toStreamPlaceholderMediaItem()
+    }
+
+    /**
+     * Queue-time item used by [setQueueInternal]. The selected item is verified
+     * against the filesystem so a tap can never silently substitute another
+     * track. Tail items deliberately trust persisted download metadata: their
+     * files are opened lazily by ExoPlayer, whose local-error policy skips a
+     * stale entry without crashing or draining a streaming backend.
+     */
+    private fun Track.toInitialQueueMediaItem(
+        streamingEnabled: Boolean,
+        validateLocalFile: Boolean,
+    ): MediaItem? {
+        val localPath = filePath
+        val hasRecordedDownload = isDownloaded && !localPath.isNullOrBlank()
+        val knownTooSmall = fileSizeBytes in 1 until StashConstants.MIN_PLAYABLE_LOCAL_BYTES
+        val hasUsableLocal = hasRecordedDownload && !knownTooSmall &&
+            (!validateLocalFile || filePathExistsOnDisk(localPath))
+
+        return when {
+            hasUsableLocal -> toMediaItem()
+            !streamingEnabled || isUnavailableForDisplay -> null
+            else -> toStreamPlaceholderMediaItem()
+        }
+    }
+
+    private fun Track.toStreamPlaceholderMediaItem(): MediaItem {
         // Resolver inputs ride the URI's query params so even a track with no
         // Room row (search-surface synthetic id) can resolve at open() time.
         val placeholder = stashResolveUri(

--- a/core/media/src/main/kotlin/com/stash/core/media/service/CrossfadeEngine.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/service/CrossfadeEngine.kt
@@ -232,18 +232,9 @@ class CrossfadeEngine(
             incoming.pauseAtEndOfMediaItems = false
             playerA = incoming
             playerB = outgoing
-            // The incoming's playWhenReady=true edge fired while it was a
-            // listener-less spare, so no focus request ever ran for it. If
-            // focus was lost/abandoned during the ramp, the new master would
-            // play focusless forever. Idempotent when focus is already held.
             requestFocus()
-            android.util.Log.i(
-                "Crossfade",
-                "swap: master=${tag(incoming)} spare=${tag(outgoing)} (resetting spare)",
-            )
             onSwap(playerA)
 
-            // Reset the old master to a clean spare.
             outgoing.pauseAtEndOfMediaItems = false
             outgoing.playWhenReady = false
             outgoing.stop()

--- a/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryFullTimelineTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/PlayerRepositoryFullTimelineTest.kt
@@ -1,10 +1,13 @@
 package com.stash.core.media
 
 import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
 import androidx.media3.session.MediaController
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.mapper.toEntity
 import com.stash.core.data.prefs.StreamingPreference
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.data.sync.TrackIdentityEvents
@@ -14,11 +17,13 @@ import com.stash.core.media.streaming.StreamSourceRegistry
 import com.stash.core.media.streaming.StreamUrlCache
 import com.stash.core.model.Track
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -84,6 +89,479 @@ class PlayerRepositoryFullTimelineTest {
     }
 
     @Test
+    fun `setQueue validates only the selected download before starting full library playback`() = runTest {
+        coEvery { streamingPreference.current() } returns false
+        val tracks = (1L..2_000L).map { id ->
+            Track(
+                id = id,
+                title = "t$id",
+                artist = "a",
+                filePath = "/library/$id.opus",
+                fileSizeBytes = 1_000_000L,
+                isDownloaded = true,
+            )
+        }
+        val checkedPaths = mutableListOf<String>()
+        var checkedPathsWhenPlaybackStarted = emptyList<String>()
+        var checksWhenPlaybackStarted = -1
+        repo.filePathExistsOnDisk = { path ->
+            checkedPaths += path
+            true
+        }
+        val items = slot<List<MediaItem>>()
+        every { controller.setMediaItems(capture(items), any<Int>(), any<Long>()) } returns Unit
+        every { controller.play() } answers {
+            checksWhenPlaybackStarted = checkedPaths.size
+            checkedPathsWhenPlaybackStarted = checkedPaths.toList()
+        }
+
+        repo.setQueue(tracks, startIndex = 999)
+
+        assertThat(items.captured.map { it.mediaId })
+            .containsExactlyElementsIn((1L..2_000L).map(Long::toString))
+            .inOrder()
+        assertThat(checksWhenPlaybackStarted).isEqualTo(1)
+        assertThat(checkedPathsWhenPlaybackStarted).containsExactly("/library/1000.opus")
+        verify { controller.setMediaItems(any(), 999, 0L) }
+    }
+
+    @Test
+    fun `setQueue falls back to a stream placeholder when the selected download is stale online`() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        val checkedPaths = mutableListOf<String>()
+        repo.filePathExistsOnDisk = { path ->
+            checkedPaths += path
+            path != "/storage/music/missing.flac"
+        }
+        val localBefore = Track(
+            id = 41L,
+            title = "Before",
+            artist = "Artist",
+            filePath = "/storage/music/before.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+        )
+        val staleDownload = Track(
+            id = 42L,
+            title = "Missing locally",
+            artist = "Artist",
+            filePath = "/storage/music/missing.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+            isStreamable = true,
+        )
+        val localAfter = localBefore.copy(
+            id = 43L,
+            title = "After",
+            filePath = "/storage/music/after.flac",
+        )
+        val items = slot<List<MediaItem>>()
+        every { controller.setMediaItems(capture(items), any<Int>(), any<Long>()) } returns Unit
+
+        repo.setQueue(listOf(localBefore, staleDownload, localAfter), startIndex = 1)
+
+        assertThat(items.captured.map { it.localConfiguration?.uri?.scheme })
+            .containsExactly("file", "stash-resolve", "file").inOrder()
+        assertThat(checkedPaths).containsExactly("/storage/music/missing.flac")
+        verify { controller.setMediaItems(any(), 1, 0L) }
+        verify { controller.prepare() }
+        verify { controller.play() }
+    }
+
+    @Test
+    fun `prefetch replaces the exact duplicate slot chosen as Media3 next`() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        every { streamUrlCache.get(3L) } returns null
+        coEvery { trackDao.getById(3L) } returns null
+        val checkedPaths = mutableListOf<String>()
+        repo.filePathExistsOnDisk = { path ->
+            checkedPaths += path
+            path != "/storage/music/stale-next.flac"
+        }
+        val current = Track(id = 1L, title = "Current", artist = "Artist")
+        val logicalNext = Track(
+            id = 2L,
+            title = "Logical next",
+            artist = "Artist",
+            filePath = "/storage/music/logical-next.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+        )
+        val shuffledNext = Track(
+            id = 3L,
+            title = "Next",
+            artist = "Artist",
+            filePath = "/storage/music/stale-next.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+            isStreamable = true,
+        )
+        val currentItem = MediaItem.Builder()
+            .setMediaId("1")
+            .setUri("stash-resolve://track/1")
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, 1L) },
+                ).build(),
+            )
+            .build()
+        val logicalNextItem = MediaItem.Builder()
+            .setMediaId("2")
+            .setUri("file:///storage/music/logical-next.flac")
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, 2L) },
+                ).build(),
+            )
+            .build()
+        val shuffledNextItem = MediaItem.Builder()
+            .setMediaId("3")
+            .setUri("file:///storage/music/stale-next.flac")
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, 3L) },
+                ).build(),
+            )
+            .build()
+        every { controller.currentMediaItem } returns currentItem
+        every { controller.nextMediaItemIndex } returns 3
+        every { controller.mediaItemCount } returns 4
+        every { controller.getMediaItemAt(0) } returns shuffledNextItem
+        every { controller.getMediaItemAt(1) } returns currentItem
+        every { controller.getMediaItemAt(2) } returns logicalNextItem
+        every { controller.getMediaItemAt(3) } returns shuffledNextItem
+        val resolved = com.stash.core.media.streaming.StreamUrl(
+            url = "https://cdn.example/next.flac",
+            expiresAtMs = Long.MAX_VALUE,
+            codec = "flac",
+        )
+        coEvery {
+            streamResolver.resolve(any(), allowYouTube = true, allowYtDlp = true)
+        } returns resolved
+        val replacement = slot<MediaItem>()
+        every { controller.replaceMediaItem(3, capture(replacement)) } returns Unit
+        repo.currentQueueTracks = listOf(shuffledNext, current, logicalNext, shuffledNext)
+
+        repo.prefetchNextTrack()
+
+        assertThat(checkedPaths).containsExactly("/storage/music/stale-next.flac")
+        assertThat(replacement.captured.mediaId).isEqualTo("3")
+        assertThat(replacement.captured.localConfiguration?.uri?.toString())
+            .isEqualTo("https://cdn.example/next.flac")
+        coVerify {
+            streamResolver.resolve(
+                match { it.id == 3L },
+                allowYouTube = true,
+                allowYtDlp = true,
+            )
+        }
+        verify(exactly = 0) { controller.replaceMediaItem(0, any()) }
+    }
+
+    @Test
+    fun `failed local item retries as a stream for external controller navigation`() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        every { connectivity.isConnected() } returns true
+        val failedTrack = Track(
+            id = 77L,
+            title = "Missing local",
+            artist = "Artist",
+            filePath = "/storage/music/missing.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+            isStreamable = true,
+        )
+        val failedItem = MediaItem.Builder()
+            .setMediaId("77")
+            .setUri("file:///storage/music/missing.flac")
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, 77L) },
+                ).build(),
+            )
+            .build()
+        every { controller.currentMediaItemIndex } returns 1
+        every { controller.currentMediaItem } returns failedItem
+        every { controller.mediaItemCount } returns 2
+        every { controller.getMediaItemAt(1) } returns failedItem
+        val replacement = slot<MediaItem>()
+        every { controller.replaceMediaItem(1, capture(replacement)) } returns Unit
+        repo.currentQueueTracks = listOf(
+            Track(id = 1L, title = "Before", artist = "Artist"),
+            failedTrack,
+        )
+
+        val recovered = repo.recoverLocalFailureAsStream(controller, failedItem, failedIndex = 1)
+
+        assertThat(recovered).isTrue()
+        assertThat(replacement.captured.mediaId).isEqualTo("77")
+        assertThat(replacement.captured.localConfiguration?.uri?.scheme)
+            .isEqualTo("stash-resolve")
+        verify { controller.prepare() }
+        verify { controller.play() }
+    }
+
+    @Test
+    fun `failed local item from a service-created queue retries from its database row`() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        every { connectivity.isConnected() } returns true
+        val failedTrack = Track(
+            id = 78L,
+            title = "Restored local",
+            artist = "Artist",
+            filePath = "/storage/music/restored-missing.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+            isStreamable = true,
+        )
+        val failedItem = MediaItem.Builder()
+            .setMediaId("78")
+            .setUri("file:///storage/music/restored-missing.flac")
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, 78L) },
+                ).build(),
+            )
+            .build()
+        every { controller.currentMediaItemIndex } returns 1
+        every { controller.currentMediaItem } returns failedItem
+        every { controller.mediaItemCount } returns 2
+        every { controller.getMediaItemAt(1) } returns failedItem
+        coEvery { trackDao.getById(78L) } returns failedTrack.toEntity()
+        val replacement = slot<MediaItem>()
+        every { controller.replaceMediaItem(1, capture(replacement)) } returns Unit
+        repo.currentQueueTracks = emptyList()
+
+        val recovered = repo.recoverLocalFailureAsStream(controller, failedItem, failedIndex = 1)
+
+        assertThat(recovered).isTrue()
+        assertThat(replacement.captured.mediaId).isEqualTo("78")
+        assertThat(replacement.captured.localConfiguration?.uri?.scheme)
+            .isEqualTo("stash-resolve")
+        verify { controller.prepare() }
+        verify { controller.play() }
+    }
+
+    @Test
+    fun `failed local recovery stops when the user navigates during preference lookup`() = runTest {
+        var activeIndex = 1
+        val failedTrack = Track(
+            id = 79L,
+            title = "Failed local",
+            artist = "Artist",
+            filePath = "/storage/music/failed.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+            isStreamable = true,
+        )
+        val failedItem = MediaItem.Builder()
+            .setMediaId("79")
+            .setUri("file:///storage/music/failed.flac")
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, 79L) },
+                ).build(),
+            )
+            .build()
+        val newCurrentItem = MediaItem.Builder()
+            .setMediaId("80")
+            .setUri("file:///storage/music/current.flac")
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, 80L) },
+                ).build(),
+            )
+            .build()
+        every { connectivity.isConnected() } returns true
+        coEvery { streamingPreference.current() } coAnswers {
+            activeIndex = 0
+            true
+        }
+        every { controller.currentMediaItemIndex } answers { activeIndex }
+        every { controller.currentMediaItem } answers {
+            if (activeIndex == 1) failedItem else newCurrentItem
+        }
+        every { controller.mediaItemCount } returns 2
+        every { controller.getMediaItemAt(1) } returns failedItem
+        repo.currentQueueTracks = listOf(
+            Track(id = 80L, title = "Current", artist = "Artist"),
+            failedTrack,
+        )
+
+        val recovered = repo.recoverLocalFailureAsStream(controller, failedItem, failedIndex = 1)
+
+        assertThat(recovered).isFalse()
+        verify(exactly = 0) { controller.replaceMediaItem(any(), any()) }
+        verify(exactly = 0) { controller.prepare() }
+        verify(exactly = 0) { controller.play() }
+    }
+
+    @Test
+    fun `failed local recovery honors disabled cellular streaming`() = runTest {
+        val failedTrack = Track(
+            id = 81L,
+            title = "Metered local",
+            artist = "Artist",
+            filePath = "/storage/music/metered.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+            isStreamable = true,
+        )
+        val failedItem = MediaItem.Builder()
+            .setMediaId("81")
+            .setUri("file:///storage/music/metered.flac")
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, 81L) },
+                ).build(),
+            )
+            .build()
+        every { connectivity.isConnected() } returns true
+        every { connectivity.isCellular() } returns true
+        coEvery { streamingPreference.current() } returns true
+        every { streamingPreference.streamOnCellular } returns flowOf(false)
+        every { controller.currentMediaItemIndex } returns 0
+        every { controller.currentMediaItem } returns failedItem
+        every { controller.mediaItemCount } returns 1
+        every { controller.getMediaItemAt(0) } returns failedItem
+        repo.currentQueueTracks = listOf(failedTrack)
+
+        val recovered = repo.recoverLocalFailureAsStream(controller, failedItem, failedIndex = 0)
+
+        assertThat(recovered).isFalse()
+        verify(exactly = 0) { controller.replaceMediaItem(any(), any()) }
+        verify(exactly = 0) { controller.prepare() }
+        verify(exactly = 0) { controller.play() }
+    }
+
+    @Test
+    fun `failed local recovery rejects mismatched media and metadata identities`() = runTest {
+        val failedTrack = Track(
+            id = 82L,
+            title = "Identity local",
+            artist = "Artist",
+            filePath = "/storage/music/identity.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+            isStreamable = true,
+        )
+        val malformedItem = MediaItem.Builder()
+            .setMediaId("999")
+            .setUri("file:///storage/music/identity.flac")
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, 82L) },
+                ).build(),
+            )
+            .build()
+        every { connectivity.isConnected() } returns true
+        every { connectivity.isCellular() } returns false
+        coEvery { streamingPreference.current() } returns true
+        every { controller.currentMediaItemIndex } returns 0
+        every { controller.currentMediaItem } returns malformedItem
+        every { controller.mediaItemCount } returns 1
+        every { controller.getMediaItemAt(0) } returns malformedItem
+        repo.currentQueueTracks = listOf(failedTrack)
+
+        val recovered = repo.recoverLocalFailureAsStream(controller, malformedItem, failedIndex = 0)
+
+        assertThat(recovered).isFalse()
+        verify(exactly = 0) { controller.replaceMediaItem(any(), any()) }
+        verify(exactly = 0) { controller.prepare() }
+        verify(exactly = 0) { controller.play() }
+    }
+
+    @Test
+    fun `prefetch leaves an existing downloaded next track local`() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        val checkedPaths = mutableListOf<String>()
+        repo.filePathExistsOnDisk = { path ->
+            checkedPaths += path
+            true
+        }
+        val current = Track(id = 31L, title = "Current", artist = "Artist")
+        val localNext = Track(
+            id = 32L,
+            title = "Local next",
+            artist = "Artist",
+            filePath = "/storage/music/local-next.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+        )
+        fun item(track: Track, uri: String) = MediaItem.Builder()
+            .setMediaId(track.id.toString())
+            .setUri(uri)
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, track.id) },
+                ).build(),
+            )
+            .build()
+        val currentItem = item(current, "stash-resolve://track/31")
+        val nextItem = item(localNext, "file:///storage/music/local-next.flac")
+        every { controller.nextMediaItemIndex } returns 1
+        every { controller.mediaItemCount } returns 2
+        every { controller.getMediaItemAt(1) } returns nextItem
+        repo.currentQueueTracks = listOf(current, localNext)
+
+        repo.prefetchNextTrack()
+
+        assertThat(checkedPaths).containsExactly("/storage/music/local-next.flac")
+        coVerify(exactly = 0) {
+            streamResolver.resolve(any(), allowYouTube = true, allowYtDlp = true)
+        }
+        verify(exactly = 0) { controller.replaceMediaItem(any(), any()) }
+    }
+
+    @Test
+    fun `direct queue jump replaces a stale downloaded target with a stream placeholder`() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        repo.filePathExistsOnDisk = { false }
+        val current = Track(id = 10L, title = "Current", artist = "Artist")
+        val staleTarget = Track(
+            id = 20L,
+            title = "Target",
+            artist = "Artist",
+            filePath = "/storage/music/stale-target.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+            isStreamable = true,
+        )
+        val currentItem = MediaItem.Builder()
+            .setMediaId("10")
+            .setUri("stash-resolve://track/10")
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, 10L) },
+                ).build(),
+            )
+            .build()
+        val staleTargetItem = MediaItem.Builder()
+            .setMediaId("20")
+            .setUri("file:///storage/music/stale-target.flac")
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, 20L) },
+                ).build(),
+            )
+            .build()
+        every { controller.currentMediaItem } returns currentItem
+        every { controller.mediaItemCount } returns 2
+        every { controller.getMediaItemAt(0) } returns currentItem
+        every { controller.getMediaItemAt(1) } returns staleTargetItem
+        val replacement = slot<MediaItem>()
+        every { controller.replaceMediaItem(1, capture(replacement)) } returns Unit
+        repo.currentQueueTracks = listOf(current, staleTarget)
+
+        repo.skipToQueueIndex(1)
+
+        assertThat(replacement.captured.mediaId).isEqualTo("20")
+        assertThat(replacement.captured.localConfiguration?.uri?.scheme)
+            .isEqualTo("stash-resolve")
+        verify { controller.seekToDefaultPosition(1) }
+    }
+
+    @Test
     fun `offline addToQueue rejects consecutive stream-only tracks without starting playback`() = runTest {
         coEvery { streamingPreference.current() } returns false
         every { controller.mediaItemCount } returns 0
@@ -146,21 +624,42 @@ class PlayerRepositoryFullTimelineTest {
     @Test
     fun `offline setQueue rejects a downloaded row whose local file is unusable`() = runTest {
         coEvery { streamingPreference.current() } returns false
-        repo.filePathExistsOnDisk = { false }
+        val checkedPaths = mutableListOf<String>()
+        repo.filePathExistsOnDisk = { path ->
+            checkedPaths += path
+            path != "/storage/music/missing.flac"
+        }
+        val localBefore = Track(
+            id = 504L,
+            title = "Before",
+            artist = "Artist",
+            filePath = "/storage/music/before.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+        )
         val staleDownload = Track(
             id = 505L,
             title = "Missing",
             artist = "Artist",
             filePath = "/storage/music/missing.flac",
+            fileSizeBytes = 1_000_000L,
             isDownloaded = true,
             isStreamable = true,
         )
+        val localAfter = localBefore.copy(
+            id = 506L,
+            title = "After",
+            filePath = "/storage/music/after.flac",
+        )
 
-        repo.setQueue(listOf(staleDownload))
+        repo.setQueue(listOf(localBefore, staleDownload, localAfter), startIndex = 1)
 
+        assertThat(checkedPaths).containsExactly("/storage/music/missing.flac")
         verify(exactly = 0) {
             controller.setMediaItems(any<List<MediaItem>>(), any<Int>(), any<Long>())
         }
+        verify(exactly = 0) { controller.prepare() }
+        verify(exactly = 0) { controller.play() }
     }
 
     @Test
@@ -278,21 +777,171 @@ class PlayerRepositoryFullTimelineTest {
     }
 
     @Test
-    fun `skipNext is always a native seek`() = runTest {
+    fun `skipNext replaces a stale downloaded target online before native seek`() = runTest {
+        coEvery { streamingPreference.current() } returns true
+        repo.filePathExistsOnDisk = { false }
+        val current = Track(id = 901L, title = "Current", artist = "Artist")
+        val staleNext = Track(
+            id = 902L,
+            title = "Next",
+            artist = "Artist",
+            filePath = "/storage/music/stale-next.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+            isStreamable = true,
+        )
+        fun item(track: Track, uri: String) = MediaItem.Builder()
+            .setMediaId(track.id.toString())
+            .setUri(uri)
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, track.id) },
+                ).build(),
+            )
+            .build()
+        val nextItem = item(staleNext, "file:///storage/music/stale-next.flac")
         every { controller.hasNextMediaItem() } returns true
+        every { controller.nextMediaItemIndex } returns 1
+        every { controller.mediaItemCount } returns 2
+        every { controller.getMediaItemAt(1) } returns nextItem
+        val replacement = slot<MediaItem>()
+        every { controller.replaceMediaItem(1, capture(replacement)) } returns Unit
+        repo.currentQueueTracks = listOf(current, staleNext)
 
         repo.skipNext()
 
+        assertThat(replacement.captured.mediaId).isEqualTo("902")
+        assertThat(replacement.captured.localConfiguration?.uri?.scheme)
+            .isEqualTo("stash-resolve")
         verify { controller.seekToNextMediaItem() }
     }
 
     @Test
-    fun `skipPrevious is always a native seek`() = runTest {
+    fun `skipPrevious traverses past a stale downloaded target offline`() = runTest {
+        coEvery { streamingPreference.current() } returns false
+        val checkedPaths = mutableListOf<String>()
+        repo.filePathExistsOnDisk = { path ->
+            checkedPaths += path
+            path == "/storage/music/valid-previous.flac"
+        }
+        val validPrevious = Track(
+            id = 902L,
+            title = "Valid previous",
+            artist = "Artist",
+            filePath = "/storage/music/valid-previous.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+        )
+        val stalePrevious = Track(
+            id = 903L,
+            title = "Previous",
+            artist = "Artist",
+            filePath = "/storage/music/stale-previous.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+            isStreamable = true,
+        )
+        val current = Track(id = 904L, title = "Current", artist = "Artist")
+        fun item(track: Track, uri: String) = MediaItem.Builder()
+            .setMediaId(track.id.toString())
+            .setUri(uri)
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, track.id) },
+                ).build(),
+            )
+            .build()
+        val validPreviousItem = item(validPrevious, "file:///storage/music/valid-previous.flac")
+        val previousItem = MediaItem.Builder()
+            .setMediaId("903")
+            .setUri("file:///storage/music/stale-previous.flac")
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, 903L) },
+                ).build(),
+            )
+            .build()
+        val timeline: Timeline = mockk()
         every { controller.hasPreviousMediaItem() } returns true
+        every { controller.previousMediaItemIndex } returns 1
+        every { controller.currentMediaItemIndex } returns 2
+        every { controller.currentTimeline } returns timeline
+        every { controller.repeatMode } returns Player.REPEAT_MODE_OFF
+        every { controller.shuffleModeEnabled } returns false
+        every {
+            timeline.getPreviousWindowIndex(1, Player.REPEAT_MODE_OFF, false)
+        } returns 0
+        every { controller.mediaItemCount } returns 3
+        every { controller.getMediaItemAt(0) } returns validPreviousItem
+        every { controller.getMediaItemAt(1) } returns previousItem
+        repo.currentQueueTracks = listOf(validPrevious, stalePrevious, current)
 
         repo.skipPrevious()
 
-        verify { controller.seekToPreviousMediaItem() }
+        verify(exactly = 0) { controller.replaceMediaItem(any(), any()) }
+        verify { controller.seekToDefaultPosition(0) }
+        verify(exactly = 0) { controller.seekToPreviousMediaItem() }
+        assertThat(checkedPaths).containsExactly(
+            "/storage/music/stale-previous.flac",
+            "/storage/music/valid-previous.flac",
+        ).inOrder()
+    }
+
+    @Test
+    fun `skipPrevious does not wrap to the current item when every predecessor is stale`() = runTest {
+        coEvery { streamingPreference.current() } returns false
+        repo.filePathExistsOnDisk = { false }
+        val firstStale = Track(
+            id = 905L,
+            title = "First stale",
+            artist = "Artist",
+            filePath = "/storage/music/first-stale.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+        )
+        val secondStale = Track(
+            id = 906L,
+            title = "Second stale",
+            artist = "Artist",
+            filePath = "/storage/music/second-stale.flac",
+            fileSizeBytes = 1_000_000L,
+            isDownloaded = true,
+        )
+        val current = Track(id = 907L, title = "Current", artist = "Artist")
+        fun item(track: Track, uri: String) = MediaItem.Builder()
+            .setMediaId(track.id.toString())
+            .setUri(uri)
+            .setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder().setExtras(
+                    android.os.Bundle().apply { putLong(EXTRA_TRACK_ID, track.id) },
+                ).build(),
+            )
+            .build()
+        val timeline: Timeline = mockk()
+        every { controller.hasPreviousMediaItem() } returns true
+        every { controller.previousMediaItemIndex } returns 1
+        every { controller.currentMediaItemIndex } returns 2
+        every { controller.currentTimeline } returns timeline
+        every { controller.repeatMode } returns Player.REPEAT_MODE_ALL
+        every { controller.shuffleModeEnabled } returns false
+        every {
+            timeline.getPreviousWindowIndex(1, Player.REPEAT_MODE_ALL, false)
+        } returns 0
+        every {
+            timeline.getPreviousWindowIndex(0, Player.REPEAT_MODE_ALL, false)
+        } returns 2
+        every { controller.mediaItemCount } returns 3
+        every { controller.getMediaItemAt(0) } returns
+            item(firstStale, "file:///storage/music/first-stale.flac")
+        every { controller.getMediaItemAt(1) } returns
+            item(secondStale, "file:///storage/music/second-stale.flac")
+        every { controller.getMediaItemAt(2) } returns item(current, "stash-resolve://track/907")
+        repo.currentQueueTracks = listOf(firstStale, secondStale, current)
+
+        repo.skipPrevious()
+
+        verify(exactly = 0) { controller.seekToDefaultPosition(any()) }
+        verify(exactly = 0) { controller.seekToPreviousMediaItem() }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- remove the O(queue-size) filesystem/SAF scan from full-library playback startup by validating only the selected download before `play()`
- preserve the complete Media3 timeline while validating tail downloads just in time for Next, Previous, queue jumps, shuffle/repeat changes, and auto-advance
- recover stale local files as streams for app, notification, Bluetooth, Android Auto, and resumed service queues while respecting offline/cellular preferences and guarding identity/races
- add regression coverage for a 2,000-track library, exact queue order/start index, stale local files, duplicates, shuffle/repeat, external controllers, and service-owned queues

## Verification
- `:core:media:testDebugUnitTest :feature:library:testDebugUnitTest --rerun-tasks`
- 437 tests, 0 failures, 0 errors, 1 skipped
- 230 Gradle tasks executed
- `git diff --check` clean

## Known follow-ups / concerns
- Filesystem work before playback is now O(1), but full-queue `MediaItem` allocation and MediaController timeline work remain O(N). An affected-device tap-to-first-audio trace with a 2k–2.6k library is still recommended.
- Project lint currently has 43 pre-existing errors and 13 warnings (first error is the existing `ACCESS_NETWORK_STATE` warning in `ConnectivityMonitor.kt`); this change adds no lint error in modified lines.
- A separate pre-existing library-shuffle auto-grow state reset was identified during review and intentionally left out of this focused fix.

Closes https://github.com/ParaliyzedEvo/Stash/issues/114

PR Originally made by @JoshDui 