### PR TITLE
Add Portuguese (Brazil) strings for the app

### DIFF
--- a/​app/src/main/res/values-pt-rBR/strings.xml
+++ b/​app/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Stash</string>
+    <string name="resume_playback_short">Continuar</string>
+    <string name="resume_playback_long">Continuar reprodução</string>
+</resources>


### PR DESCRIPTION
<!--
Thanks for contributing to Stash! Please fill this out so review goes quickly.
For anything substantial, please open an issue first so we can agree on the approach before you sink time into a PR.
-->

## What does this PR do?

<!-- A short, clear description of the change and why it's needed. -->

## Related issue

<!-- e.g. "Closes #123". If there's no issue, briefly explain the motivation. -->

## How was this tested?

<!-- "It compiles" is not testing. Tell us what you actually verified, and on what. -->

- [ ] `./gradlew test` passes
- [ ] Installed on a device and manually verified the change
- [ ] Device / Android version tested:

## Checklist

- [ ] My code follows the style of the surrounding code
- [ ] This PR does **one thing** (unrelated changes belong in separate PRs)
- [ ] I updated docs or comments where it made sense

## What does this PR do?
Adds Brazilian Portuguese (`pt-rBR`) translation for the app.

## Related issue
N/A

## How was this tested?
- [x] Manually verified translation strings in `values-pt-rBR/strings.xml`.

---
Thanks a lot for developing this amazing app, keep up the great work! 🇧🇷🚀
