### PR TITLE
Feat/library artists searchartistui

### DIFF
--- a/app/src/main/kotlin/com/stash/app/StashApplication.kt
+++ b/app/src/main/kotlin/com/stash/app/StashApplication.kt
@@ -28,6 +28,7 @@ import com.stash.core.data.sync.SyncNotificationManager
 import com.stash.data.download.backfill.MetadataBackfillScheduler
 import com.stash.data.download.ytdlp.YtDlpManager
 import com.stash.core.data.sync.workers.ArtBackfillWorker
+import com.stash.core.data.sync.workers.ArtistImageBackfillWorker
 import com.stash.core.data.sync.workers.AutoSaveScrobbler
 import com.stash.core.data.sync.workers.DiscoveryDownloadWorker
 import com.stash.core.data.sync.workers.QualityInfoBackfillWorker
@@ -392,6 +393,10 @@ class StashApplication : Application(), Configuration.Provider {
         // no thumbnail (see ArtBackfillWorker KDoc). KEEP policy means the
         // worker is a no-op on every subsequent launch once it completes.
         ArtBackfillWorker.enqueueOneTime(this)
+        // Artist photos for the Library Artists tab: resolve each displayed
+        // artist's official avatar via YT Music search into artist_images.
+        // KEEP — one launch's enqueue is enough; a re-launch is a no-op.
+        ArtistImageBackfillWorker.enqueueOneTime(this)
         // v0.9.11: kick a background sweep that fills in bit-depth +
         // sample-rate for tracks downloaded before the columns existed.
         // The flag is set immediately on enqueue (not after success) so

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -6,4 +6,6 @@ android {
 }
 dependencies {
     implementation(libs.kotlinx.coroutines.android)
+
+    testImplementation("junit:junit:4.13.2")
 }

--- a/core/common/src/main/kotlin/com/stash/core/common/ArtistCredits.kt
+++ b/core/common/src/main/kotlin/com/stash/core/common/ArtistCredits.kt
@@ -1,24 +1,26 @@
 package com.stash.core.common
 
 /**
- * Act names whose spelling contains characters the credit parser would
- * otherwise treat as separators (",", "&", "+", "/") but that describe a
- * SINGLE act, not a collaboration. Matched case-insensitively against the
- * whole candidate string, before any splitting happens.
+ * Single acts whose names happen to contain the characters the credit parser
+ * otherwise treats as separators (",", "&", "+", "/", a leading "x"), but
+ * that describe ONE act, not a collaboration. A literal split would fabricate
+ * artists that don't exist ("Earth" / "Wind" / "Fire", "AC" / "DC", ...).
  *
- * The list is deliberately small and curated: the parser's only job is to
- * turn a combined credit string into its constituent acts, and these are
- * the well-known names where a literal split would fabricate artists that
- * don't exist ("Earth" / "Wind" / "Fire", "AC" / "DC", ...).
+ * The list is small and deliberately *generic* — well-known, timeless acts,
+ * so it reads as a general music-world fact rather than anything tailored to
+ * a particular library. It is not meant to be exhaustive; it only covers the
+ * names that would be visibly broken by splitting.
  */
 val ARTIST_CREDIT_ALLOWLIST: Set<String> = setOf(
     "AC/DC",
     "Earth, Wind & Fire",
-    "Dan + Shay",
-    "Hall & Oates",
-    "Chase & Status",
     "Simon & Garfunkel",
+    "Hall & Oates",
     "Sam & Dave",
+    "Sonny & Cher",
+    "Peaches & Herb",
+    "Dan + Shay",
+    "Chase & Status",
     "X Ambassadors",
     "X Japan",
 )

--- a/core/common/src/main/kotlin/com/stash/core/common/ArtistCredits.kt
+++ b/core/common/src/main/kotlin/com/stash/core/common/ArtistCredits.kt
@@ -1,0 +1,140 @@
+package com.stash.core.common
+
+/**
+ * Act names whose spelling contains characters the credit parser would
+ * otherwise treat as separators (",", "&", "+", "/") but that describe a
+ * SINGLE act, not a collaboration. Matched case-insensitively against the
+ * whole candidate string, before any splitting happens.
+ *
+ * The list is deliberately small and curated: the parser's only job is to
+ * turn a combined credit string into its constituent acts, and these are
+ * the well-known names where a literal split would fabricate artists that
+ * don't exist ("Earth" / "Wind" / "Fire", "AC" / "DC", ...).
+ */
+val ARTIST_CREDIT_ALLOWLIST: Set<String> = setOf(
+    "AC/DC",
+    "Earth, Wind & Fire",
+    "Dan + Shay",
+    "Hall & Oates",
+    "Chase & Status",
+    "Simon & Garfunkel",
+    "Sam & Dave",
+    "X Ambassadors",
+    "X Japan",
+)
+
+/**
+ * Splits a combined artist credit string into its individual acts.
+ *
+ * Understands the separators that actually appear in music metadata:
+ * feature clauses ("feat.", "ft.", "featuring", "with"), commas,
+ * ampersands, plus signs, slashes, and a standalone "x" ("Travis Scott
+ * x Lil Baby"). Returns the distinct, trimmed acts in original order.
+ *
+ * Entries in [ARTIST_CREDIT_ALLOWLIST] are never split — neither on their
+ * own nor as a segment inside a wider collaboration ("AC/DC & Guns N'
+ * Roses" stays ["AC/DC", "Guns N' Roses"]).
+ *
+ * A single-artist string ("Metro Boomin") round-trips to a single-element
+ * list, so callers can always iterate the result instead of special-casing
+ * separators.
+ */
+fun String.splitArtistCredits(): List<String> {
+    val trimmed = trim()
+    if (trimmed.isEmpty()) return emptyList()
+    if (trimmed.isAllowlistedCredit()) return listOf(trimmed)
+
+    // "Post Malone (feat. 21 Savage)" / "[ft. X]" → "Post Malone feat. 21 Savage"
+    // so the feature-connective splitter sees the clause.
+    val text = trimmed
+        .replace(
+            Regex("[(\\[]\\s*(featuring|feat\\.|feat|ft\\.|ft)(?=\\s|\\]|\\))", RegexOption.IGNORE_CASE),
+            "$1 ",
+        )
+        .replace(Regex("[)\\]\\n]"), "")
+
+    return text
+        .split(FEATURE_CONNECTIVES)
+        .flatMap { segment -> segment.splitPunctuationCredits() }
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .distinct()
+}
+
+/**
+ * Every distinct act credited across a track's [artist] and [albumArtist]
+ * fields. Used by library queries that need to answer "does this track
+ * belong to artist X?" — a collaboration credit ("Metro Boomin, Travis
+ * Scott") counts for both "Metro Boomin" and "Travis Scott".
+ */
+fun expandArtistCredits(artist: String, albumArtist: String): List<String> =
+    buildList {
+        addAll(artist.splitArtistCredits())
+        addAll(albumArtist.splitArtistCredits())
+    }.distinct()
+
+/**
+ * True when [query] is one of the acts credited on a track carrying
+ * [artist] + [albumArtist]. Exact whole-string matches are included, so a
+ * combined-credit row ("Drake, 21 Savage") still matches its own display
+ * name as well as each individual act.
+ */
+fun matchesArtistCredits(artist: String, albumArtist: String, query: String): Boolean =
+    artist.equals(query, ignoreCase = true) ||
+        albumArtist.equals(query, ignoreCase = true) ||
+        expandArtistCredits(artist, albumArtist).any { it.equals(query, ignoreCase = true) }
+
+/**
+ * The primary act credited on a combined artist string — the first act in
+ * [splitArtistCredits]. Lets display surfaces (Now Playing, album cards, the
+ * Artists grid) render "Aarne" for a collaboration credit like "Aarne, Toxi$,
+ * Big Baby Tape" instead of the full run-on credit. Falls back to the trimmed
+ * input when nothing can be split.
+ */
+fun String.primaryArtist(): String =
+    splitArtistCredits().firstOrNull() ?: trim()
+
+/**
+ * `feat.` / `ft.` / `featuring` / `with` clauses. Non-capturing so the
+ * connective token never leaks into the split result (String.split keeps
+ * capture-group matches otherwise). Longest token first ("featuring" before
+ * "feat") and a required trailing space, so the shorter "feat" can never
+ * eat the prefix of "featuring" and strand "uring".
+ */
+private val FEATURE_CONNECTIVES =
+    Regex("\\s*(?:featuring|feat\\.|feat|ft\\.|ft|with)\\s+", RegexOption.IGNORE_CASE)
+
+/** Comma, ampersand, plus, slash, and standalone "x" separators. */
+private val PUNCTUATION_SEPARATORS =
+    Regex("\\s*(?:,|&|\\+|/|\\bx\\b)\\s*", RegexOption.IGNORE_CASE)
+
+private fun String.isAllowlistedCredit(): Boolean =
+    ARTIST_CREDIT_ALLOWLIST.any { it.equals(this, ignoreCase = true) }
+
+/**
+ * Splits a single segment on punctuation separators, but first shields any
+ * [ARTIST_CREDIT_ALLOWLIST] name appearing as a substring (case-insensitively)
+ * with a placeholder. That keeps "AC/DC & Guns N' Roses" → ["AC/DC",
+ * "Guns N' Roses"] instead of splitting AC/DC on its slash.
+ */
+private fun String.splitPunctuationCredits(): List<String> {
+    if (isAllowlistedCredit()) return listOf(this)
+
+    val placeholders = mutableListOf<String>()
+    var working = this
+    ARTIST_CREDIT_ALLOWLIST.forEach { name ->
+        val token = "\u0001${placeholders.size}\u0001"
+        working = working.replace(name, token, ignoreCase = true)
+        placeholders.add(name)
+    }
+
+    return working
+        .split(PUNCTUATION_SEPARATORS)
+        .mapNotNull { part ->
+            var restored = part
+            placeholders.forEachIndexed { index, name ->
+                restored = restored.replace("\u0001$index\u0001", name)
+            }
+            restored.trim().ifEmpty { null }
+        }
+}

--- a/core/common/src/test/kotlin/com/stash/core/common/ArtistCreditsTest.kt
+++ b/core/common/src/test/kotlin/com/stash/core/common/ArtistCreditsTest.kt
@@ -72,7 +72,11 @@ class ArtistCreditsTest {
         assertEquals(listOf("Earth, Wind & Fire"), "Earth, Wind & Fire".splitArtistCredits())
         assertEquals(listOf("Dan + Shay"), "Dan + Shay".splitArtistCredits())
         assertEquals(listOf("Hall & Oates"), "Hall & Oates".splitArtistCredits())
+        assertEquals(listOf("Simon & Garfunkel"), "Simon & Garfunkel".splitArtistCredits())
+        assertEquals(listOf("Sonny & Cher"), "Sonny & Cher".splitArtistCredits())
+        assertEquals(listOf("Peaches & Herb"), "Peaches & Herb".splitArtistCredits())
         assertEquals(listOf("X Ambassadors"), "X Ambassadors".splitArtistCredits())
+        assertEquals(listOf("X Japan"), "X Japan".splitArtistCredits())
         // Allowlist match is case-insensitive.
         assertEquals(listOf("ac/dc"), "ac/dc".splitArtistCredits())
     }

--- a/core/common/src/test/kotlin/com/stash/core/common/ArtistCreditsTest.kt
+++ b/core/common/src/test/kotlin/com/stash/core/common/ArtistCreditsTest.kt
@@ -1,0 +1,146 @@
+package com.stash.core.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ArtistCreditsTest {
+
+    @Test
+    fun `single artist round-trips to one element`() {
+        assertEquals(listOf("Metro Boomin"), "Metro Boomin".splitArtistCredits())
+    }
+
+    @Test
+    fun `comma separated collaboration splits`() {
+        assertEquals(
+            listOf("Metro Boomin", "Travis Scott"),
+            "Metro Boomin, Travis Scott".splitArtistCredits(),
+        )
+    }
+
+    @Test
+    fun `ampersand collaboration splits`() {
+        assertEquals(
+            listOf("Kendrick Lamar", "SZA"),
+            "Kendrick Lamar & SZA".splitArtistCredits(),
+        )
+    }
+
+    @Test
+    fun `feat clause splits into a separate credit`() {
+        assertEquals(
+            listOf("Drake", "Lil Wayne"),
+            "Drake feat. Lil Wayne".splitArtistCredits(),
+        )
+    }
+
+    @Test
+    fun `ft and featuring variants split`() {
+        assertEquals(listOf("A", "B"), "A ft. B".splitArtistCredits())
+        assertEquals(listOf("A", "B"), "A featuring B".splitArtistCredits())
+    }
+
+    @Test
+    fun `parenthesised feat clause is unwrapped before splitting`() {
+        assertEquals(
+            listOf("Post Malone", "21 Savage"),
+            "Post Malone (feat. 21 Savage)".splitArtistCredits(),
+        )
+    }
+
+    @Test
+    fun `x collaboration splits`() {
+        assertEquals(
+            listOf("Travis Scott", "Lil Baby"),
+            "Travis Scott x Lil Baby".splitArtistCredits(),
+        )
+    }
+
+    @Test
+    fun `slash collaboration splits`() {
+        assertEquals(
+            listOf("Halsey", "Bleachers"),
+            "Halsey / Bleachers".splitArtistCredits(),
+        )
+    }
+
+    @Test
+    fun `allowlisted acts are never split`() {
+        assertEquals(listOf("AC/DC"), "AC/DC".splitArtistCredits())
+        assertEquals(listOf("Earth, Wind & Fire"), "Earth, Wind & Fire".splitArtistCredits())
+        assertEquals(listOf("Dan + Shay"), "Dan + Shay".splitArtistCredits())
+        assertEquals(listOf("Hall & Oates"), "Hall & Oates".splitArtistCredits())
+        assertEquals(listOf("X Ambassadors"), "X Ambassadors".splitArtistCredits())
+        // Allowlist match is case-insensitive.
+        assertEquals(listOf("ac/dc"), "ac/dc".splitArtistCredits())
+    }
+
+    @Test
+    fun `allowlisted act survives inside a wider collaboration`() {
+        assertEquals(
+            listOf("AC/DC", "Guns N' Roses"),
+            "AC/DC & Guns N' Roses".splitArtistCredits(),
+        )
+    }
+
+    @Test
+    fun `results are distinct and trimmed`() {
+        assertEquals(listOf("A", "B"), "A, B, A".splitArtistCredits())
+        assertEquals(listOf("A", "B"), " A , B ".splitArtistCredits())
+    }
+
+    @Test
+    fun `blank inputs split to empty`() {
+        assertEquals(emptyList<String>(), "".splitArtistCredits())
+        assertEquals(emptyList<String>(), "   ".splitArtistCredits())
+    }
+
+    @Test
+    fun `expandArtistCredits merges track and album artist credits`() {
+        assertEquals(
+            listOf("Drake", "21 Savage", "Metro Boomin"),
+            expandArtistCredits("Drake, 21 Savage", "Metro Boomin"),
+        )
+        // Album artist that already appears as a track credit is de-duped.
+        assertEquals(
+            listOf("Metro Boomin", "Travis Scott"),
+            expandArtistCredits("Metro Boomin, Travis Scott", "Metro Boomin"),
+        )
+    }
+
+    @Test
+    fun `matchesArtistCredits includes exact whole-string matches`() {
+        assertTrue(matchesArtistCredits("Drake, 21 Savage", "", "Drake, 21 Savage"))
+        assertTrue(matchesArtistCredits("Drake", "Metro Boomin", "Metro Boomin"))
+    }
+
+    @Test
+    fun `matchesArtistCredits matches individual collaboration credits`() {
+        assertTrue(matchesArtistCredits("Metro Boomin, Travis Scott", "", "Metro Boomin"))
+        assertTrue(matchesArtistCredits("Metro Boomin, Travis Scott", "", "Travis Scott"))
+        assertTrue(matchesArtistCredits("Drake feat. Lil Wayne", "", "Lil Wayne"))
+        assertTrue(matchesArtistCredits("Metro Boomin, Travis Scott", "", "metro boomin"))
+        assertFalse(matchesArtistCredits("Metro Boomin, Travis Scott", "", "Kanye West"))
+    }
+
+    @Test
+    fun `primaryArtist takes the first act from a collaboration credit`() {
+        assertEquals("Aarne", "Aarne, Toxi$, Big Baby Tape".primaryArtist())
+        assertEquals("Aarne", "Aarne, Платина".primaryArtist())
+        assertEquals("Aarne", "Aarne & Big Baby Tape".primaryArtist())
+        assertEquals("Drake", "Drake, 21 Savage".primaryArtist())
+        assertEquals("Travis Scott", "Travis Scott x Lil Baby".primaryArtist())
+        assertEquals("Post Malone", "Post Malone (feat. 21 Savage)".primaryArtist())
+    }
+
+    @Test
+    fun `primaryArtist passes through a single artist and handles allowlist`() {
+        assertEquals("Aarne", "Aarne".primaryArtist())
+        assertEquals("AC/DC", "AC/DC".primaryArtist())
+        assertEquals("Earth, Wind & Fire", "Earth, Wind & Fire".primaryArtist())
+        assertEquals("Drake", "  Drake, 21 Savage ".primaryArtist())
+        assertEquals("", "   ".primaryArtist())
+    }
+}

--- a/core/data/schemas/com.stash.core.data.db.StashDatabase/42.json
+++ b/core/data/schemas/com.stash.core.data.db.StashDatabase/42.json
@@ -1,0 +1,2163 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 42,
+    "identityHash": "45bd1084a57237ff797db8e3f6cea0b8",
+    "entities": [
+      {
+        "tableName": "tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_artist` TEXT NOT NULL DEFAULT '', `duration_ms` INTEGER NOT NULL, `file_path` TEXT, `file_format` TEXT NOT NULL, `quality_kbps` INTEGER NOT NULL, `file_size_bytes` INTEGER NOT NULL, `source` TEXT NOT NULL, `spotify_uri` TEXT, `youtube_id` TEXT, `album_art_url` TEXT, `album_art_path` TEXT, `date_added` INTEGER NOT NULL, `last_played` INTEGER, `play_count` INTEGER NOT NULL, `is_downloaded` INTEGER NOT NULL, `canonical_title` TEXT NOT NULL, `canonical_artist` TEXT NOT NULL, `match_confidence` REAL NOT NULL, `match_dismissed` INTEGER NOT NULL, `match_flagged` INTEGER NOT NULL DEFAULT 0, `isrc` TEXT, `explicit` INTEGER, `music_video_type` TEXT, `yt_canonical_video_id` TEXT, `bits_per_sample` INTEGER, `sample_rate_hz` INTEGER, `spotify_saved_at` INTEGER, `ytmusic_saved_at` INTEGER, `lastfm_loved_at` INTEGER, `stash_liked_at` INTEGER, `mbid` TEXT, `lastfm_user_playcount` INTEGER, `lastfm_listeners` INTEGER, `lastfm_user_loved` INTEGER NOT NULL DEFAULT 0, `loudness_lufs` REAL, `true_peak_dbfs` REAL, `loudness_measured_at` INTEGER, `is_streamable` INTEGER NOT NULL DEFAULT 0, `is_streamable_checked_at` INTEGER, `metadata_embedded_at` INTEGER, `lyrics_fetched_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileFormat",
+            "columnName": "file_format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "qualityKbps",
+            "columnName": "quality_kbps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "file_size_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotify_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeId",
+            "columnName": "youtube_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtUrl",
+            "columnName": "album_art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtPath",
+            "columnName": "album_art_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayed",
+            "columnName": "last_played",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDownloaded",
+            "columnName": "is_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalTitle",
+            "columnName": "canonical_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalArtist",
+            "columnName": "canonical_artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchConfidence",
+            "columnName": "match_confidence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchDismissed",
+            "columnName": "match_dismissed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchFlagged",
+            "columnName": "match_flagged",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "musicVideoType",
+            "columnName": "music_video_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ytCanonicalVideoId",
+            "columnName": "yt_canonical_video_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitsPerSample",
+            "columnName": "bits_per_sample",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRateHz",
+            "columnName": "sample_rate_hz",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "spotifySavedAt",
+            "columnName": "spotify_saved_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "ytMusicSavedAt",
+            "columnName": "ytmusic_saved_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastFmLovedAt",
+            "columnName": "lastfm_loved_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "stashLikedAt",
+            "columnName": "stash_liked_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mbid",
+            "columnName": "mbid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastfmUserPlaycount",
+            "columnName": "lastfm_user_playcount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastfmListeners",
+            "columnName": "lastfm_listeners",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastfmUserLoved",
+            "columnName": "lastfm_user_loved",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "loudnessLufs",
+            "columnName": "loudness_lufs",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "truePeakDbfs",
+            "columnName": "true_peak_dbfs",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "loudnessMeasuredAt",
+            "columnName": "loudness_measured_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isStreamable",
+            "columnName": "is_streamable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isStreamableCheckedAt",
+            "columnName": "is_streamable_checked_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "metadataEmbeddedAt",
+            "columnName": "metadata_embedded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lyricsFetchedAt",
+            "columnName": "lyrics_fetched_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tracks_spotify_uri",
+            "unique": true,
+            "columnNames": [
+              "spotify_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tracks_spotify_uri` ON `${TABLE_NAME}` (`spotify_uri`)"
+          },
+          {
+            "name": "index_tracks_youtube_id",
+            "unique": true,
+            "columnNames": [
+              "youtube_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tracks_youtube_id` ON `${TABLE_NAME}` (`youtube_id`)"
+          },
+          {
+            "name": "index_tracks_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_artist` ON `${TABLE_NAME}` (`artist`)"
+          },
+          {
+            "name": "index_tracks_album",
+            "unique": false,
+            "columnNames": [
+              "album"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_album` ON `${TABLE_NAME}` (`album`)"
+          },
+          {
+            "name": "index_tracks_date_added",
+            "unique": false,
+            "columnNames": [
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_date_added` ON `${TABLE_NAME}` (`date_added`)"
+          },
+          {
+            "name": "index_tracks_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_last_played` ON `${TABLE_NAME}` (`last_played`)"
+          },
+          {
+            "name": "index_tracks_play_count",
+            "unique": false,
+            "columnNames": [
+              "play_count"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_play_count` ON `${TABLE_NAME}` (`play_count`)"
+          },
+          {
+            "name": "index_tracks_title_artist",
+            "unique": false,
+            "columnNames": [
+              "title",
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_title_artist` ON `${TABLE_NAME}` (`title`, `artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `source` TEXT NOT NULL, `source_id` TEXT NOT NULL, `type` TEXT NOT NULL, `mix_number` INTEGER, `last_synced` INTEGER, `track_count` INTEGER NOT NULL, `is_active` INTEGER NOT NULL, `art_url` TEXT, `snapshot_id` TEXT, `sync_enabled` INTEGER NOT NULL DEFAULT 1, `date_added` INTEGER NOT NULL DEFAULT 0, `hide_from_home` INTEGER NOT NULL DEFAULT 0, `pinned` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mixNumber",
+            "columnName": "mix_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastSynced",
+            "columnName": "last_synced",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artUrl",
+            "columnName": "art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snapshotId",
+            "columnName": "snapshot_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncEnabled",
+            "columnName": "sync_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hideFromHome",
+            "columnName": "hide_from_home",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_source_id",
+            "unique": true,
+            "columnNames": [
+              "source_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playlists_source_id` ON `${TABLE_NAME}` (`source_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `track_id` INTEGER NOT NULL, `position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `removed_at` INTEGER, `locally_added` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`playlist_id`, `track_id`), FOREIGN KEY(`playlist_id`) REFERENCES `playlists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "removedAt",
+            "columnName": "removed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "locallyAdded",
+            "columnName": "locally_added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "track_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_tracks_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_tracks_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `started_at` INTEGER NOT NULL, `completed_at` INTEGER, `status` TEXT NOT NULL, `playlists_checked` INTEGER NOT NULL, `new_tracks_found` INTEGER NOT NULL, `tracks_downloaded` INTEGER NOT NULL, `tracks_failed` INTEGER NOT NULL, `bytes_downloaded` INTEGER NOT NULL, `error_message` TEXT, `diagnostics` TEXT, `trigger` TEXT NOT NULL, `streaming_mode` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistsChecked",
+            "columnName": "playlists_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newTracksFound",
+            "columnName": "new_tracks_found",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tracksDownloaded",
+            "columnName": "tracks_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tracksFailed",
+            "columnName": "tracks_failed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bytesDownloaded",
+            "columnName": "bytes_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "diagnostics",
+            "columnName": "diagnostics",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trigger",
+            "columnName": "trigger",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamingMode",
+            "columnName": "streaming_mode",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "download_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `track_id` INTEGER NOT NULL, `sync_id` INTEGER, `status` TEXT NOT NULL, `search_query` TEXT NOT NULL, `youtube_url` TEXT, `retry_count` INTEGER NOT NULL, `error_message` TEXT, `failure_type` TEXT NOT NULL, `rejected_video_id` TEXT, `created_at` INTEGER NOT NULL, `completed_at` INTEGER, FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`sync_id`) REFERENCES `sync_history`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchQuery",
+            "columnName": "search_query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeUrl",
+            "columnName": "youtube_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retry_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "failureType",
+            "columnName": "failure_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rejectedVideoId",
+            "columnName": "rejected_video_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_queue_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          },
+          {
+            "name": "index_download_queue_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          },
+          {
+            "name": "index_download_queue_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sync_history",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sync_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "source_accounts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `source` TEXT NOT NULL, `display_name` TEXT NOT NULL, `email` TEXT NOT NULL, `avatar_url` TEXT, `is_connected` INTEGER NOT NULL, `connected_at` INTEGER, `last_sync_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatar_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isConnected",
+            "columnName": "is_connected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connectedAt",
+            "columnName": "connected_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastSyncAt",
+            "columnName": "last_sync_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_source_accounts_source",
+            "unique": true,
+            "columnNames": [
+              "source"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_source_accounts_source` ON `${TABLE_NAME}` (`source`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tracks_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, tokenize=unicode61, content=`tracks`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "tracks",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_BEFORE_UPDATE BEFORE UPDATE ON `tracks` BEGIN DELETE FROM `tracks_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_BEFORE_DELETE BEFORE DELETE ON `tracks` BEGIN DELETE FROM `tracks_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_AFTER_UPDATE AFTER UPDATE ON `tracks` BEGIN INSERT INTO `tracks_fts`(`docid`, `title`, `artist`, `album`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`artist`, NEW.`album`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_AFTER_INSERT AFTER INSERT ON `tracks` BEGIN INSERT INTO `tracks_fts`(`docid`, `title`, `artist`, `album`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`artist`, NEW.`album`); END"
+        ]
+      },
+      {
+        "tableName": "remote_playlist_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `source_playlist_id` TEXT NOT NULL, `playlist_name` TEXT NOT NULL, `playlist_type` TEXT NOT NULL, `mix_number` INTEGER, `snapshot_id` TEXT, `track_count` INTEGER NOT NULL, `art_url` TEXT, `fetched_at` INTEGER NOT NULL, `partial` INTEGER NOT NULL, `expected_count` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePlaylistId",
+            "columnName": "source_playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistName",
+            "columnName": "playlist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistType",
+            "columnName": "playlist_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mixNumber",
+            "columnName": "mix_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "snapshotId",
+            "columnName": "snapshot_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artUrl",
+            "columnName": "art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partial",
+            "columnName": "partial",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedCount",
+            "columnName": "expected_count",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_playlist_snapshots_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_playlist_snapshots_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          },
+          {
+            "name": "index_remote_playlist_snapshots_sync_id_source_playlist_id",
+            "unique": true,
+            "columnNames": [
+              "sync_id",
+              "source_playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_remote_playlist_snapshots_sync_id_source_playlist_id` ON `${TABLE_NAME}` (`sync_id`, `source_playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "remote_track_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_id` INTEGER NOT NULL, `snapshot_playlist_id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT, `duration_ms` INTEGER NOT NULL, `spotify_uri` TEXT, `youtube_id` TEXT, `album_art_url` TEXT, `position` INTEGER NOT NULL, `isrc` TEXT, `explicit` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snapshotPlaylistId",
+            "columnName": "snapshot_playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotify_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeId",
+            "columnName": "youtube_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtUrl",
+            "columnName": "album_art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_track_snapshots_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_track_snapshots_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          },
+          {
+            "name": "index_remote_track_snapshots_snapshot_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "snapshot_playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_track_snapshots_snapshot_playlist_id` ON `${TABLE_NAME}` (`snapshot_playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist_profile_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artist_id` TEXT NOT NULL, `json` TEXT NOT NULL, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`artist_id`))",
+        "fields": [
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artist_id"
+          ]
+        }
+      },
+      {
+        "tableName": "listening_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `track_id` INTEGER NOT NULL, `started_at` INTEGER NOT NULL, `scrobbled` INTEGER NOT NULL, `yt_scrobbled` INTEGER NOT NULL DEFAULT 0, `completed_at` INTEGER, FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrobbled",
+            "columnName": "scrobbled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ytScrobbled",
+            "columnName": "yt_scrobbled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_listening_events_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          },
+          {
+            "name": "index_listening_events_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          },
+          {
+            "name": "index_listening_events_scrobbled",
+            "unique": false,
+            "columnNames": [
+              "scrobbled"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_scrobbled` ON `${TABLE_NAME}` (`scrobbled`)"
+          },
+          {
+            "name": "index_listening_events_yt_scrobbled",
+            "unique": false,
+            "columnNames": [
+              "yt_scrobbled"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_yt_scrobbled` ON `${TABLE_NAME}` (`yt_scrobbled`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "track_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`track_id` INTEGER NOT NULL, `tag` TEXT NOT NULL, `weight` REAL NOT NULL, `source` TEXT NOT NULL, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`track_id`, `tag`), FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "track_id",
+            "tag"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_tags_tag",
+            "unique": false,
+            "columnNames": [
+              "tag"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_tags_tag` ON `${TABLE_NAME}` (`tag`)"
+          },
+          {
+            "name": "index_track_tags_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_tags_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stash_mix_recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `include_tags_csv` TEXT NOT NULL, `exclude_tags_csv` TEXT NOT NULL, `era_start_year` INTEGER, `era_end_year` INTEGER, `affinity_bias` REAL NOT NULL, `discovery_ratio` REAL NOT NULL, `freshness_window_days` INTEGER NOT NULL, `target_length` INTEGER NOT NULL, `is_builtin` INTEGER NOT NULL, `is_active` INTEGER NOT NULL, `playlist_id` INTEGER, `created_at` INTEGER NOT NULL, `last_refreshed_at` INTEGER, `seed_strategy` TEXT NOT NULL DEFAULT 'ARTIST_SIMILAR', `mood_keys_csv` TEXT NOT NULL DEFAULT '', `tag_sample_depth` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`playlist_id`) REFERENCES `playlists`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "includeTagsCsv",
+            "columnName": "include_tags_csv",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeTagsCsv",
+            "columnName": "exclude_tags_csv",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eraStartYear",
+            "columnName": "era_start_year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "eraEndYear",
+            "columnName": "era_end_year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "affinityBias",
+            "columnName": "affinity_bias",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discoveryRatio",
+            "columnName": "discovery_ratio",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "freshnessWindowDays",
+            "columnName": "freshness_window_days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetLength",
+            "columnName": "target_length",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBuiltin",
+            "columnName": "is_builtin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastRefreshedAt",
+            "columnName": "last_refreshed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seedStrategy",
+            "columnName": "seed_strategy",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ARTIST_SIMILAR'"
+          },
+          {
+            "fieldPath": "moodKeysCsv",
+            "columnName": "mood_keys_csv",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "tagSampleDepth",
+            "columnName": "tag_sample_depth",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stash_mix_recipes_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stash_mix_recipes_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          },
+          {
+            "name": "index_stash_mix_recipes_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stash_mix_recipes_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "discovery_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `recipe_id` INTEGER NOT NULL, `artist` TEXT NOT NULL, `title` TEXT NOT NULL, `seed_artist` TEXT NOT NULL, `status` TEXT NOT NULL, `track_id` INTEGER, `queued_at` INTEGER NOT NULL, `completed_at` INTEGER, `error_message` TEXT, FOREIGN KEY(`recipe_id`) REFERENCES `stash_mix_recipes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipe_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seedArtist",
+            "columnName": "seed_artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queued_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_discovery_queue_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_queue_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_discovery_queue_recipe_id",
+            "unique": false,
+            "columnNames": [
+              "recipe_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_queue_recipe_id` ON `${TABLE_NAME}` (`recipe_id`)"
+          },
+          {
+            "name": "index_discovery_queue_queued_at",
+            "unique": false,
+            "columnNames": [
+              "queued_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_queue_queued_at` ON `${TABLE_NAME}` (`queued_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stash_mix_recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipe_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "track_blocklist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`canonical_key` TEXT NOT NULL, `artist` TEXT NOT NULL, `title` TEXT NOT NULL, `spotify_uri` TEXT, `youtube_id` TEXT, `blocked_at` INTEGER NOT NULL, `blocked_from` TEXT NOT NULL, PRIMARY KEY(`canonical_key`))",
+        "fields": [
+          {
+            "fieldPath": "canonicalKey",
+            "columnName": "canonical_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotify_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeId",
+            "columnName": "youtube_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "blockedAt",
+            "columnName": "blocked_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockedFrom",
+            "columnName": "blocked_from",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "canonical_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_blocklist_spotify_uri",
+            "unique": false,
+            "columnNames": [
+              "spotify_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_blocklist_spotify_uri` ON `${TABLE_NAME}` (`spotify_uri`)"
+          },
+          {
+            "name": "index_track_blocklist_youtube_id",
+            "unique": false,
+            "columnNames": [
+              "youtube_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_blocklist_youtube_id` ON `${TABLE_NAME}` (`youtube_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "track_skip_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `track_id` INTEGER NOT NULL, `skipped_at` INTEGER NOT NULL, `position_ms` INTEGER NOT NULL, FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skippedAt",
+            "columnName": "skipped_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_skip_events_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_skip_events_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          },
+          {
+            "name": "index_track_skip_events_skipped_at",
+            "unique": false,
+            "columnNames": [
+              "skipped_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_skip_events_skipped_at` ON `${TABLE_NAME}` (`skipped_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lyrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`track_id` INTEGER NOT NULL, `plain_text` TEXT, `synced_lrc` TEXT, `instrumental` INTEGER NOT NULL, `language` TEXT, `source` TEXT NOT NULL, `source_lyrics_id` TEXT, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`track_id`), FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plainText",
+            "columnName": "plain_text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedLrc",
+            "columnName": "synced_lrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "instrumental",
+            "columnName": "instrumental",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceLyricsId",
+            "columnName": "source_lyrics_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "track_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lyrics_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lyrics_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lastfm_response_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cache_key` TEXT NOT NULL, `json` TEXT NOT NULL, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`cache_key`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cache_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cache_key"
+          ]
+        }
+      },
+      {
+        "tableName": "spotify_resolution",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`trackId` INTEGER NOT NULL, `status` TEXT NOT NULL, `spotifyUri` TEXT, `matchedIsrc` TEXT, `titleSim` REAL, `durDeltaSec` INTEGER, `resolvedAtMs` INTEGER NOT NULL, `expiresAtMs` INTEGER NOT NULL, `attempts` INTEGER NOT NULL, PRIMARY KEY(`trackId`))",
+        "fields": [
+          {
+            "fieldPath": "trackId",
+            "columnName": "trackId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotifyUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedIsrc",
+            "columnName": "matchedIsrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleSim",
+            "columnName": "titleSim",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "durDeltaSec",
+            "columnName": "durDeltaSec",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "resolvedAtMs",
+            "columnName": "resolvedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAtMs",
+            "columnName": "expiresAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "trackId"
+          ]
+        }
+      },
+      {
+        "tableName": "flac_upgrade_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`track_id` INTEGER NOT NULL, `status` TEXT NOT NULL, `enqueued_at` INTEGER NOT NULL, PRIMARY KEY(`track_id`), FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enqueuedAt",
+            "columnName": "enqueued_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "track_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_flac_upgrade_queue_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flac_upgrade_queue_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "listen_submissions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`event_id` INTEGER NOT NULL, `target` TEXT NOT NULL, `state` TEXT NOT NULL, `attempts` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`event_id`, `target`), FOREIGN KEY(`event_id`) REFERENCES `listening_events`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "eventId",
+            "columnName": "event_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target",
+            "columnName": "target",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "event_id",
+            "target"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_listen_submissions_target_state",
+            "unique": false,
+            "columnNames": [
+              "target",
+              "state"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listen_submissions_target_state` ON `${TABLE_NAME}` (`target`, `state`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "listening_events",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "event_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_undo_points",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sync_id` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `playlist_count` INTEGER NOT NULL, `membership_count` INTEGER NOT NULL, PRIMARY KEY(`sync_id`))",
+        "fields": [
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtEpochMs",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistCount",
+            "columnName": "playlist_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "membershipCount",
+            "columnName": "membership_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sync_id"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_undo_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sync_id` INTEGER NOT NULL, `playlist_id` INTEGER NOT NULL, `is_active` INTEGER NOT NULL, `sync_enabled` INTEGER NOT NULL, PRIMARY KEY(`sync_id`, `playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncEnabled",
+            "columnName": "sync_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sync_id",
+            "playlist_id"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_undo_memberships",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sync_id` INTEGER NOT NULL, `playlist_id` INTEGER NOT NULL, `track_id` INTEGER NOT NULL, `position` INTEGER NOT NULL, `added_at` INTEGER, `removed_at` INTEGER, `locally_added` INTEGER NOT NULL, PRIMARY KEY(`sync_id`, `playlist_id`, `track_id`))",
+        "fields": [
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "removedAt",
+            "columnName": "removed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "locallyAdded",
+            "columnName": "locally_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sync_id",
+            "playlist_id",
+            "track_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_undo_memberships_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_undo_memberships_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artist_name` TEXT NOT NULL, `image_url` TEXT, `attempted_at` INTEGER NOT NULL, PRIMARY KEY(`artist_name`))",
+        "fields": [
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attemptedAt",
+            "columnName": "attempted_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artist_name"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '45bd1084a57237ff797db8e3f6cea0b8')"
+    ]
+  }
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/db/StashDatabase.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/StashDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.stash.core.data.db.converter.Converters
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.db.dao.ArtistProfileCacheDao
 import com.stash.core.data.db.dao.DiscoveryQueueDao
 import com.stash.core.data.db.dao.DownloadQueueDao
@@ -25,6 +26,7 @@ import com.stash.core.data.db.dao.TrackBlocklistDao
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.db.dao.TrackSkipEventDao
 import com.stash.core.data.db.dao.TrackTagDao
+import com.stash.core.data.db.entity.ArtistImageEntity
 import com.stash.core.data.db.entity.ArtistProfileCacheEntity
 import com.stash.core.data.db.entity.DiscoveryQueueEntity
 import com.stash.core.data.db.entity.DownloadQueueEntity
@@ -91,8 +93,9 @@ import com.stash.core.data.db.entity.TrackTagEntity
         SyncUndoPointEntity::class,
         SyncUndoPlaylistEntity::class,
         SyncUndoMembershipEntity::class,
+        ArtistImageEntity::class,
     ],
-    version = 41,
+    version = 42,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -135,6 +138,8 @@ abstract class StashDatabase : RoomDatabase() {
     abstract fun listenSubmissionDao(): ListenSubmissionDao
 
     abstract fun syncUndoDao(): SyncUndoDao
+
+    abstract fun artistImageDao(): ArtistImageDao
 
 
     companion object {
@@ -1031,6 +1036,29 @@ abstract class StashDatabase : RoomDatabase() {
                         loudness_measured_at = NULL
                     WHERE loudness_lufs IS NOT NULL
                       AND loudness_lufs <= -69.9
+                    """.trimIndent(),
+                )
+            }
+        }
+
+        /**
+         * v41 → v42: artist-photo cache table for the Library Artists tab.
+         *
+         * `ArtistImageBackfillWorker` resolves each displayed artist's official
+         * photo via the YT Music artists search and stores it here (one row per
+         * primary artist name). A row with a NULL `image_url` is a permanent
+         * "unresolvable" sentinel so the worker never re-polls local-only rips.
+         */
+        val MIGRATION_41_42 = object : Migration(41, 42) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `artist_images` (
+                        `artist_name` TEXT NOT NULL,
+                        `image_url` TEXT,
+                        `attempted_at` INTEGER NOT NULL,
+                        PRIMARY KEY(`artist_name`)
+                    )
                     """.trimIndent(),
                 )
             }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/ArtistImageDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/ArtistImageDao.kt
@@ -1,0 +1,43 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.stash.core.data.db.entity.ArtistImageEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Storage for the cached artist photos backing the Library Artists tab.
+ *
+ * The write path is entirely worker-owned ([ArtistImageBackfillWorker]); the
+ * Library only ever reads, so every query here is cheap and reactive.
+ */
+@Dao
+interface ArtistImageDao {
+
+    /** All cached artist photos — keyed by primary artist name. */
+    @Query("SELECT * FROM artist_images")
+    fun observeAll(): Flow<List<ArtistImageEntity>>
+
+    /** Every artist name that has already been attempted (photo or sentinel). */
+    @Query("SELECT artist_name FROM artist_images")
+    suspend fun observedNames(): List<String>
+
+    /**
+     * All distinct track artist credits the Library could show, matching the
+     * same downloaded-or-streamable scope as `TrackDao.getAllArtists`.
+     */
+    @Query(
+        """
+        SELECT DISTINCT artist FROM tracks
+        WHERE artist != ''
+          AND (is_downloaded = 1 OR is_streamable = 1)
+        """,
+    )
+    suspend fun distinctArtistNames(): List<String>
+
+    /** Insert or replace a photo row ([ArtistImageEntity.artistName] is the key). */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: ArtistImageEntity)
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/db/entity/ArtistImageEntity.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/entity/ArtistImageEntity.kt
@@ -1,0 +1,33 @@
+package com.stash.core.data.db.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Cached artist photo for the Library Artists tab.
+ *
+ * Keyed by the *display* artist name — the primary artist after
+ * [com.stash.core.common.primaryArtist] collapses collaboration credits
+ * ("Aarne, Toxi$, Big Baby Tape" → "Aarne"), so the backfill resolves and
+ * stores one row per card the tab actually renders.
+ *
+ * - [imageUrl] is the artist's official avatar from the YT Music artists
+ *   search, run through `ArtUrlUpgrader` for a high-res URL. Null when the
+ *   name could not be resolved (local-only rips, obscure acts) — the UI then
+ *   falls back to the album-art proxy / gradient initial.
+ * - [attemptedAt] marks that a resolution was TRIED. A null [imageUrl] with a
+ *   non-null [attemptedAt] is a permanent "no photo" sentinel, so the worker
+ *   never re-polls unresolvable names on every run.
+ *
+ * Not part of any foreign-key graph — artist names are free-text tags on
+ * `tracks`, and the table is a small pure cache (one row per artist, a few
+ * hundred max). Stale rows are harmless: the Library only looks names up, and
+ * orphaned entries simply never match.
+ */
+@Entity(tableName = "artist_images")
+data class ArtistImageEntity(
+    @PrimaryKey @ColumnInfo(name = "artist_name") val artistName: String,
+    @ColumnInfo(name = "image_url") val imageUrl: String? = null,
+    @ColumnInfo(name = "attempted_at") val attemptedAt: Long = 0L,
+)

--- a/core/data/src/main/kotlin/com/stash/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/di/DatabaseModule.kt
@@ -71,7 +71,8 @@ object DatabaseModule {
                 StashDatabase.MIGRATION_37_38,
                 StashDatabase.MIGRATION_38_39,
                 StashDatabase.MIGRATION_39_40,
-                StashDatabase.MIGRATION_40_41
+                StashDatabase.MIGRATION_40_41,
+                StashDatabase.MIGRATION_41_42
             )
             // No fallbackToDestructiveMigration() — if a migration is missing,
             // the app will crash on startup instead of silently wiping the
@@ -149,4 +150,8 @@ object DatabaseModule {
     @Provides
     fun provideSyncUndoDao(db: StashDatabase): com.stash.core.data.db.dao.SyncUndoDao =
         db.syncUndoDao()
+
+    @Provides
+    fun provideArtistImageDao(db: StashDatabase): com.stash.core.data.db.dao.ArtistImageDao =
+        db.artistImageDao()
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
@@ -251,7 +251,16 @@ class MusicRepositoryImpl @Inject constructor(
             .map { rows -> rows.map { it.toDomain() } }
 
     override fun getTracksByArtist(artist: String): Flow<List<Track>> =
-        trackDao.getByArtist(artist).map { entities -> entities.map { it.toDomain() } }
+        trackDao.getAllByDateAdded().map { entities ->
+            entities
+                .map { it.toDomain() }
+                // Collaboration credits: "Metro Boomin, Travis Scott" counts
+                // for BOTH "Metro Boomin" and "Travis Scott" (plus the exact
+                // combined string, so a multi-artist row still matches its own
+                // display name). Exact whole-string equality is preserved.
+                .filter { com.stash.core.common.matchesArtistCredits(it.artist, it.albumArtist, artist) }
+                .sortedWith(compareBy({ it.album.lowercase() }, { it.title.lowercase() }))
+        }
 
     // v0.9.30 Path A: Library Songs/Albums/Artists views are curated =
     // downloaded-only, always. Streaming mode does NOT change what shows

--- a/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
@@ -251,8 +251,8 @@ class MusicRepositoryImpl @Inject constructor(
             .map { rows -> rows.map { it.toDomain() } }
 
     override fun getTracksByArtist(artist: String): Flow<List<Track>> =
-        trackDao.getAllByDateAdded().map { entities ->
-            entities
+        trackDao.getLibraryByDateAdded().map { rows ->
+            rows
                 .map { it.toDomain() }
                 // Collaboration credits: "Metro Boomin, Travis Scott" counts
                 // for BOTH "Metro Boomin" and "Travis Scott" (plus the exact

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorker.kt
@@ -1,0 +1,148 @@
+package com.stash.core.data.sync.workers
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.stash.core.common.primaryArtist
+import com.stash.core.data.db.dao.ArtistImageDao
+import com.stash.core.data.db.entity.ArtistImageEntity
+import com.stash.data.ytmusic.YTMusicApiClient
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.delay
+import java.util.concurrent.TimeUnit
+
+/**
+ * Background backfill that resolves the official artist photo for every
+ * artist shown on the Library Artists tab.
+ *
+ * ## Why
+ * Before this worker, the Artists tab rendered album art (or a gradient
+ * initial) for every artist — there was no source of *artist* images. YT
+ * Music's artists search returns the official avatar, so this worker walks
+ * the distinct artist credits in `tracks`, collapses them to their primary
+ * act ([primaryArtist], matching the Library regroup), and stores each
+ * resolved avatar in the `artist_images` table. The Library then renders
+ * photo → album-art proxy → gradient initial, in that order.
+ *
+ * ## Idempotency / sentinel
+ * Each name is upserted with an `attempted_at` stamp whether or not a photo
+ * resolved. A NULL `image_url` with a stamp is a permanent "no photo" row, so
+ * local-only rips and unresolvable acts are never re-polled on later runs —
+ * the candidate set is `names NOT IN artist_images`, which shrinks to zero
+ * once every act has been attempted.
+ *
+ * ## Scheduling & throttling
+ * Enqueued once per install from [StashApplication] (`KEEP`) and re-fired
+ * after each sync (`REPLACE`), so newly-synced artists are picked up. Each
+ * run handles [BATCH_SIZE] names at ~[REQUEST_INTERVAL_MS]ms apart to stay
+ * well under InnerTube's rate limits; a fresh sync (or app relaunch) drains
+ * the remainder. Network is gated to UNMETERED so a full library walk
+ * (~hundreds of small searches) never burns cellular data.
+ */
+@HiltWorker
+class ArtistImageBackfillWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val artistImageDao: ArtistImageDao,
+    private val ytMusicApiClient: YTMusicApiClient,
+) : CoroutineWorker(appContext, params) {
+
+    companion object {
+        private const val TAG = "ArtistImgBackfill"
+        private const val WORK_NAME = "stash_artist_image_backfill"
+        private const val BATCH_SIZE = 150
+        private const val REQUEST_INTERVAL_MS = 400L
+
+        /**
+         * Schedule the artist-photo backfill. `KEEP`: a queued or running pass
+         * is left alone, so a re-launch before the worker completes is a no-op.
+         */
+        fun enqueueOneTime(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.UNMETERED)
+                .build()
+            val work = OneTimeWorkRequestBuilder<ArtistImageBackfillWorker>()
+                .setConstraints(constraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                WORK_NAME,
+                ExistingWorkPolicy.KEEP,
+                work,
+            )
+        }
+
+        /**
+         * Post-sync re-fire. `REPLACE` so a freshly-finished sync immediately
+         * re-runs the backfill for any artists the sync just added, instead of
+         * waiting for the next app launch's `KEEP` request to be a no-op.
+         */
+        fun enqueueAfterSync(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.UNMETERED)
+                .build()
+            val work = OneTimeWorkRequestBuilder<ArtistImageBackfillWorker>()
+                .setConstraints(constraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                work,
+            )
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        // Names already resolved OR marked unresolvable (NULL image + stamp).
+        val observed = artistImageDao.observedNames().toHashSet()
+
+        // Distinct raw track credits → primary acts, matching exactly what the
+        // Artists tab groups by — a photo keyed on the displayed name is a
+        // clean 1:1 lookup for the UI.
+        val missing = artistImageDao.distinctArtistNames()
+            .asSequence()
+            .map { it.primaryArtist() }
+            .filter { it.isNotBlank() && it !in observed }
+            .distinct()
+            .toList()
+
+        if (missing.isEmpty()) {
+            Log.d(TAG, "no artists need a photo")
+            return Result.success()
+        }
+
+        var filled = 0
+        var unresolved = 0
+        for (name in missing.take(BATCH_SIZE)) {
+            val avatar = runCatching { ytMusicApiClient.resolveArtist(name)?.avatarUrl }
+                .getOrNull()
+            artistImageDao.upsert(
+                ArtistImageEntity(
+                    artistName = name,
+                    imageUrl = avatar?.takeIf { it.isNotBlank() },
+                    attemptedAt = System.currentTimeMillis(),
+                ),
+            )
+            if (avatar.isNullOrBlank()) unresolved++ else filled++
+            // Rate limit — one YT Music search per candidate.
+            delay(REQUEST_INTERVAL_MS)
+        }
+
+        Log.i(
+            TAG,
+            "artist-photo backfill: processed=${minOf(BATCH_SIZE, missing.size)} " +
+                "filled=$filled unresolved=$unresolved remaining=${missing.size - BATCH_SIZE}",
+        )
+        return Result.success()
+    }
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/SyncFinalizeWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/SyncFinalizeWorker.kt
@@ -79,6 +79,11 @@ class SyncFinalizeWorker @AssistedInject constructor(
             // Transition to completed state.
             syncStateManager.onCompleted()
 
+            // Re-fire the artist-photo backfill so artists a sync just added
+            // get avatars without waiting for the next app launch (whose KEEP
+            // request would be a no-op after the install-time run succeeded).
+            ArtistImageBackfillWorker.enqueueAfterSync(applicationContext)
+
             Log.i(
                 TAG,
                 "Sync $syncId complete: $playlistsChecked playlists, " +

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorkerTest.kt
@@ -1,0 +1,166 @@
+package com.stash.core.data.sync.workers
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import com.stash.core.data.db.dao.ArtistImageDao
+import com.stash.core.data.db.entity.ArtistImageEntity
+import com.stash.data.ytmusic.YTMusicApiClient
+import com.stash.data.ytmusic.model.ArtistSummary
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * MockK tests for [ArtistImageBackfillWorker] — the worker that resolves the
+ * official artist photo for every artist shown on the Library Artists tab.
+ *
+ * Mirrors [LoudnessBackfillWorkerTest]'s constructor-injection + mocked
+ * WorkerParameters pattern. The assertions focus on the two contracts that
+ * keep the backfill safe to re-run: candidate collapse via
+ * [com.stash.core.common.primaryArtist] and the "no photo" sentinel that
+ * stops unresolvable names being re-polled.
+ */
+class ArtistImageBackfillWorkerTest {
+
+    private val appContext: Context = mockk(relaxed = true)
+    private val workerParams: WorkerParameters = mockk(relaxed = true)
+    private val artistImageDao: ArtistImageDao = mockk(relaxed = true)
+    private val ytMusicApiClient: YTMusicApiClient = mockk(relaxed = true)
+
+    private fun newWorker() =
+        ArtistImageBackfillWorker(appContext, workerParams, artistImageDao, ytMusicApiClient)
+
+    private fun summary(id: String, name: String, avatar: String?) =
+        ArtistSummary(id = id, name = name, avatarUrl = avatar)
+
+    @Test fun `empty candidate set returns success without any resolution or write`() = runTest {
+        coEvery { artistImageDao.distinctArtistNames() } returns emptyList()
+
+        val result = newWorker().doWork()
+
+        assertTrue(result is ListenableWorker.Result.Success)
+        coVerify(exactly = 0) { ytMusicApiClient.resolveArtist(any()) }
+        coVerify(exactly = 0) { artistImageDao.upsert(any()) }
+    }
+
+    @Test fun `collapses raw credits to primary acts and stores photos keyed by display name`() =
+        runTest {
+            coEvery { artistImageDao.distinctArtistNames() } returns
+                listOf("Aarne, Toxi$", "Kozak System")
+            coEvery { ytMusicApiClient.resolveArtist("Aarne") } returns
+                summary("aarne", "Aarne", "https://photo/aarne.jpg")
+            coEvery { ytMusicApiClient.resolveArtist("Kozak System") } returns
+                summary("kozak", "Kozak System", "https://photo/kozak.jpg")
+
+            val result = newWorker().doWork()
+
+            assertTrue(result is ListenableWorker.Result.Success)
+            coVerify(exactly = 1) {
+                artistImageDao.upsert(
+                    match {
+                        it.artistName == "Aarne" &&
+                            it.imageUrl == "https://photo/aarne.jpg" &&
+                            it.attemptedAt > 0L
+                    },
+                )
+            }
+            coVerify(exactly = 1) {
+                artistImageDao.upsert(
+                    match {
+                        it.artistName == "Kozak System" &&
+                            it.imageUrl == "https://photo/kozak.jpg" &&
+                            it.attemptedAt > 0L
+                    },
+                )
+            }
+        }
+
+    @Test fun `unresolvable and throwing names are stamped as sentinels without aborting batch`() =
+        runTest {
+            coEvery { artistImageDao.distinctArtistNames() } returns
+                listOf("Mystery Band", "Aarne", "Null Act")
+            coEvery { ytMusicApiClient.resolveArtist("Mystery Band") } returns
+                summary("mystery", "Mystery Band", null)
+            coEvery { ytMusicApiClient.resolveArtist("Aarne") } returns
+                summary("aarne", "Aarne", "https://photo/aarne.jpg")
+            coEvery { ytMusicApiClient.resolveArtist("Null Act") } throws RuntimeException("down")
+
+            val result = newWorker().doWork()
+
+            assertTrue(result is ListenableWorker.Result.Success)
+            // The failed search must not stop the Aarne photo from being written.
+            coVerify(exactly = 1) {
+                artistImageDao.upsert(
+                    match { it.artistName == "Aarne" && it.imageUrl == "https://photo/aarne.jpg" },
+                )
+            }
+            // Null avatar + stamp = permanent sentinel, so "Mystery Band" is
+            // never re-polled on a later run.
+            coVerify(exactly = 1) {
+                artistImageDao.upsert(
+                    match { it.artistName == "Mystery Band" && it.imageUrl == null && it.attemptedAt > 0L },
+                )
+            }
+            coVerify(exactly = 1) {
+                artistImageDao.upsert(
+                    match { it.artistName == "Null Act" && it.imageUrl == null && it.attemptedAt > 0L },
+                )
+            }
+        }
+
+    @Test fun `skips names already attempted so they are never re-polled`() = runTest {
+        coEvery { artistImageDao.observedNames() } returns listOf("Aarne", "Mystery Band")
+        coEvery { artistImageDao.distinctArtistNames() } returns
+            listOf("Aarne, Toxi$", "Mystery Band", "Kozak System")
+        coEvery { ytMusicApiClient.resolveArtist("Kozak System") } returns
+            summary("kozak", "Kozak System", "https://photo/kozak.jpg")
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) { ytMusicApiClient.resolveArtist("Kozak System") }
+        coVerify(exactly = 0) { ytMusicApiClient.resolveArtist("Aarne") }
+        coVerify(exactly = 0) { ytMusicApiClient.resolveArtist("Mystery Band") }
+        coVerify(exactly = 1) { artistImageDao.upsert(any()) }
+    }
+
+    @Test fun `caps each run at BATCH_SIZE names leaving the remainder for a later run`() = runTest {
+        val manyNames = (1..200).map { "Artist $it" }
+        coEvery { artistImageDao.distinctArtistNames() } returns manyNames
+
+        val result = newWorker().doWork()
+
+        assertTrue(result is ListenableWorker.Result.Success)
+        coVerify(exactly = 150) { artistImageDao.upsert(any()) }
+        coVerify(exactly = 150) { ytMusicApiClient.resolveArtist(any()) }
+        coVerify(exactly = 1) {
+            artistImageDao.upsert(
+                match { it.artistName == "Artist 1" && it.imageUrl == null },
+            )
+        }
+    }
+
+    @Test fun `primary-artist collapse keeps the written rows aligned with the UI grouping`() =
+        runTest {
+            // Two different raw credits that both collapse to the same primary
+            // act must produce a single deduplicated photo row.
+            coEvery { artistImageDao.distinctArtistNames() } returns
+                listOf("Aarne, Toxi$", "Aarne, Big Baby Tape")
+            coEvery { ytMusicApiClient.resolveArtist("Aarne") } returns
+                summary("aarne", "Aarne", "https://photo/aarne.jpg")
+
+            newWorker().doWork()
+
+            coVerify(exactly = 1) { ytMusicApiClient.resolveArtist("Aarne") }
+            coVerify(exactly = 1) {
+                artistImageDao.upsert(
+                    match { it.artistName == "Aarne" && it.imageUrl == "https://photo/aarne.jpg" },
+                )
+            }
+            coVerify(exactly = 1) { artistImageDao.upsert(any()) }
+        }
+}

--- a/feature/library/build.gradle.kts
+++ b/feature/library/build.gradle.kts
@@ -15,6 +15,8 @@ android {
 }
 dependencies {
     implementation(project(":core:auth"))
+    // Artist-credit parsing for the primary-artist display helper.
+    implementation(project(":core:common"))
     implementation(project(":core:data"))
     implementation(project(":core:media"))
     // LocalImportCoordinator for "Import from device" flow.

--- a/feature/library/src/main/kotlin/com/stash/feature/library/AlbumDetailScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/AlbumDetailScreen.kt
@@ -180,6 +180,24 @@ fun AlbumDetailScreen(
                     }
                 }
 
+                // ── No local tracks on this album ──────────────────────
+                if (state.tracks.isEmpty() && state.searchQuery.isEmpty()) {
+                    item(key = "empty-album") {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 48.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = "No songs in your library yet",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+
                 // -- Track list --
                 itemsIndexed(
                     items = state.tracks,

--- a/feature/library/src/main/kotlin/com/stash/feature/library/AlbumDetailViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/AlbumDetailViewModel.kt
@@ -88,14 +88,21 @@ class AlbumDetailViewModel @Inject constructor(
     }
 
     /**
-     * Filtered track flow: all tracks matching this album + artist combination.
-     * Uses case-insensitive matching to be resilient against metadata variations.
+     * Filtered track flow: all tracks matching this album.
+     *
+     * Matched by album NAME only, deliberately NOT by artist name. The
+     * track-level `artist` tag is a per-track credit, so a multi-artist
+     * album's rows disagree on it ("Metro Boomin", "Metro Boomin, Travis
+     * Scott", "Travis Scott") — pinning on `artistName` (the album's
+     * primary artist, as the Albums grid shows it) silently drops every
+     * track whose credit doesn't include the primary act. The album name
+     * is the one stable grouping key across the whole release.
+     *
+     * [artistName] is still surfaced in the header for context / to
+     * disambiguate same-named releases at a glance.
      */
     private val albumTracks = musicRepository.getAllTracks().map { allTracks ->
-        allTracks.filter {
-            it.album.equals(albumName, ignoreCase = true)
-                && it.artist.equals(artistName, ignoreCase = true)
-        }
+        allTracks.filter { it.album.equals(albumName, ignoreCase = true) }
     }
 
     /**

--- a/feature/library/src/main/kotlin/com/stash/feature/library/ArtistDetailScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/ArtistDetailScreen.kt
@@ -2,6 +2,7 @@ package com.stash.feature.library
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -47,6 +48,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -55,11 +57,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImagePainter
+import coil3.compose.rememberAsyncImagePainter
 import com.stash.core.media.BulkPlayAction
 import com.stash.core.model.Track
 import com.stash.core.ui.components.DetailTrackRow
@@ -395,7 +400,12 @@ private fun ArtistDetailHeader(
                 .padding(horizontal = 20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // Circular artist icon placeholder
+            // Circular artist icon — real photo from the artist_images cache
+            // (ArtistImageBackfillWorker output), else the gradient placeholder.
+            // The painter state is collected in composition so the circle
+            // upgrades to the photo the moment the request succeeds and never
+            // renders blank when the URL fails (Coil draws nothing outside a
+            // Success state, so everything else keeps the placeholder).
             Box(
                 modifier = Modifier
                     .size(96.dp)
@@ -410,12 +420,23 @@ private fun ArtistDetailHeader(
                     ),
                 contentAlignment = Alignment.Center,
             ) {
-                Icon(
-                    imageVector = Icons.Default.Person,
-                    contentDescription = null,
-                    modifier = Modifier.size(48.dp),
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
-                )
+                val photoUrl = state.photoUrl
+                if (photoUrl != null) {
+                    val painter = rememberAsyncImagePainter(model = photoUrl)
+                    val painterState by painter.state.collectAsState()
+                    if (painterState is AsyncImagePainter.State.Success) {
+                        Image(
+                            painter = painter,
+                            contentDescription = state.artistName,
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop,
+                        )
+                    } else {
+                        ArtistHeaderPlaceholder()
+                    }
+                } else {
+                    ArtistHeaderPlaceholder()
+                }
             }
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -506,4 +527,15 @@ private fun ArtistDetailHeader(
 
         Spacer(modifier = Modifier.height(16.dp))
     }
+}
+
+/** The no-photo fallback for the artist header — a soft Person icon. */
+@Composable
+private fun ArtistHeaderPlaceholder() {
+    Icon(
+        imageVector = Icons.Default.Person,
+        contentDescription = null,
+        modifier = Modifier.size(48.dp),
+        tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+    )
 }

--- a/feature/library/src/main/kotlin/com/stash/feature/library/ArtistDetailViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/ArtistDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.stash.feature.library
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.BulkPlayAction
 import com.stash.core.media.PlayerRepository
@@ -40,6 +41,7 @@ data class ArtistDetailUiState(
     val currentlyPlayingTrackId: Long? = null,
     val searchQuery: String = "",
     val showSearch: Boolean = false,
+    val photoUrl: String? = null,
 )
 
 /**
@@ -57,6 +59,7 @@ class ArtistDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val musicRepository: MusicRepository,
     private val playerRepository: PlayerRepository,
+    private val artistImageDao: ArtistImageDao,
 ) : ViewModel() {
 
     /** The artist name extracted from the navigation route arguments. */
@@ -100,7 +103,15 @@ class ArtistDetailViewModel @Inject constructor(
         playerRepository.playerState,
         _searchQuery,
         _showSearch,
-    ) { tracks, playerState, query, showSearch ->
+        artistImageDao.observeAll(),
+    ) { tracks, playerState, query, showSearch, images ->
+        // Photo cache is keyed by the SAME primary-artist name the Library
+        // Artists tab groups by, so a case-insensitive name lookup lines the
+        // header up with the grid photo regardless of which entry point
+        // (grid, album hero, Now Playing) navigated here.
+        val photoUrl = images.firstOrNull {
+            it.artistName.equals(artistName, ignoreCase = true)
+        }?.imageUrl
         ArtistDetailUiState(
             artistName = artistName,
             tracks = tracks,
@@ -108,6 +119,7 @@ class ArtistDetailViewModel @Inject constructor(
             currentlyPlayingTrackId = playerState.currentTrack?.id,
             searchQuery = query,
             showSearch = showSearch,
+            photoUrl = photoUrl,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
@@ -7,6 +7,7 @@ import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
@@ -80,6 +81,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -101,6 +103,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stash.core.model.Playlist
 import com.stash.core.model.PlaylistType
 import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.compose.rememberAsyncImagePainter
+import androidx.compose.ui.unit.Dp
 import com.stash.core.model.Track
 import com.stash.core.ui.components.GlassCard
 import com.stash.core.ui.components.SourceIndicator
@@ -199,6 +204,9 @@ fun LibraryScreen(
             onDeleteArtist = viewModel::deleteArtist,
             onPlayAlbum = viewModel::playAlbum,
             onAddAlbumToQueue = viewModel::addAlbumToQueue,
+            onOpenAlbum = { album ->
+                onNavigateToAlbum(album.name, album.name, album.artUrl, album.artist)
+            },
             onStartImport = viewModel::startLocalImport,
             onCancelImport = viewModel::cancelLocalImport,
             onDismissImport = viewModel::dismissLocalImport,
@@ -446,6 +454,7 @@ private fun LibraryContent(
     onDeleteArtist: (String) -> Unit,
     onPlayAlbum: (String, String) -> Unit,
     onAddAlbumToQueue: (String, String) -> Unit,
+    onOpenAlbum: (AlbumInfo) -> Unit,
     onStartImport: (List<Uri>) -> Unit,
     onCancelImport: () -> Unit,
     onDismissImport: () -> Unit,
@@ -676,6 +685,7 @@ private fun LibraryContent(
                         anyServiceConnected = anyServiceConnected,
                         onPlayAlbum = onPlayAlbum,
                         onAddAlbumToQueue = onAddAlbumToQueue,
+                        onOpenAlbum = onOpenAlbum,
                         header = {},
                     )
                 }
@@ -1568,6 +1578,111 @@ private fun BottomSheetActionRow(
     }
 }
 
+// ── Shared artwork renderers with graceful load-failure fallbacks ───────────
+//
+// A dead URL (deleted CDN image, stale local path) used to render as an empty
+// box: AsyncImage only drew something while the request SUCCEEDED, and the
+// gradient/icon fallback was gated on `model == null`. These renderers observe
+// the painter state directly so a failed load degrades to the same fallback a
+// null model gets — nothing in the Library ever renders blank.
+
+/**
+ * Circular artist avatar. Prefers [photoUrl] (real artist photo), then
+ * [artUrl] (album-art proxy), and degrades to a name-gradient initial circle
+ * while loading or on failure.
+ */
+@Composable
+private fun ArtistAvatar(
+    name: String,
+    photoUrl: String?,
+    artUrl: String?,
+    size: Dp,
+) {
+    val model = photoUrl ?: artUrl
+    if (model != null) {
+        val painter = rememberAsyncImagePainter(model = model)
+        val state by painter.state.collectAsState()
+        Box(
+            modifier = Modifier
+                .size(size)
+                .clip(CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (state is AsyncImagePainter.State.Success) {
+                Image(
+                    painter = painter,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                )
+            } else {
+                ArtistInitialFallback(name, size)
+            }
+        }
+    } else {
+        ArtistInitialFallback(name, size)
+    }
+}
+
+/** Gradient circle with the artist's first letter — the no-photo fallback. */
+@Composable
+private fun ArtistInitialFallback(name: String, size: Dp) {
+    val gradientColors = remember(name) { artistGradient(name) }
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(Brush.linearGradient(gradientColors)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = name.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+    }
+}
+
+/**
+ * Square album artwork with a fallback icon when the local path or remote URL
+ * fails to decode. Callers layer the play button over [modifier].
+ */
+@Composable
+private fun AlbumArtwork(model: Any?, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.background(StashTheme.extendedColors.elevatedSurface),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (model != null) {
+            val painter = rememberAsyncImagePainter(model = model)
+            val state by painter.state.collectAsState()
+            if (state is AsyncImagePainter.State.Success) {
+                Image(
+                    painter = painter,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Default.Album,
+                    contentDescription = null,
+                    tint = StashTheme.extendedColors.textTertiary,
+                    modifier = Modifier.size(40.dp),
+                )
+            }
+        } else {
+            Icon(
+                imageVector = Icons.Default.Album,
+                contentDescription = null,
+                tint = StashTheme.extendedColors.textTertiary,
+                modifier = Modifier.size(40.dp),
+            )
+        }
+    }
+}
+
 // ── Artists tab (2-column grid) ──────────────────────────────────────────────
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
@@ -1620,36 +1735,13 @@ private fun ArtistsGrid(
                             onLongClick = { selectedArtist = artist },
                         ),
                 ) {
-                    // Album art proxy or gradient circle fallback
-                    if (artist.artUrl != null) {
-                        coil3.compose.AsyncImage(
-                            model = artist.artUrl,
-                            contentDescription = null,
-                            modifier = Modifier
-                                .size(72.dp)
-                                .clip(CircleShape),
-                            contentScale = androidx.compose.ui.layout.ContentScale.Crop,
-                        )
-                    } else {
-                        val gradientColors = remember(artist.name) {
-                            artistGradient(artist.name)
-                        }
-                        Box(
-                            modifier = Modifier
-                                .size(72.dp)
-                                .clip(CircleShape)
-                                .background(Brush.linearGradient(gradientColors)),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Text(
-                                text = artist.name.firstOrNull()
-                                    ?.uppercaseChar()?.toString() ?: "?",
-                                style = MaterialTheme.typography.headlineMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = Color.White,
-                            )
-                        }
-                    }
+                    // Real artist photo → album art proxy → gradient initial
+                    ArtistAvatar(
+                        name = artist.name,
+                        photoUrl = artist.photoUrl,
+                        artUrl = artist.artUrl,
+                        size = 72.dp,
+                    )
                     Text(
                         text = artist.name,
                         style = MaterialTheme.typography.bodyMedium,
@@ -1802,6 +1894,7 @@ private fun AlbumsGrid(
     anyServiceConnected: Boolean,
     onPlayAlbum: (String, String) -> Unit,
     onAddAlbumToQueue: (String, String) -> Unit,
+    onOpenAlbum: (AlbumInfo) -> Unit,
     header: @Composable () -> Unit = {},
 ) {
     if (albums.isEmpty() && singleTrackAlbums.isEmpty()) {
@@ -1837,7 +1930,7 @@ private fun AlbumsGrid(
                         .fillMaxWidth()
                         .padding(vertical = 4.dp)
                         .combinedClickable(
-                            onClick = { onPlayAlbum(album.name, album.artist) },
+                            onClick = { onOpenAlbum(album) },
                             onLongClick = { selectedAlbum = album },
                         ),
                 ) {
@@ -1847,23 +1940,27 @@ private fun AlbumsGrid(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(120.dp)
-                            .clip(RoundedCornerShape(8.dp))
-                            .background(StashTheme.extendedColors.elevatedSurface),
-                        contentAlignment = Alignment.Center,
+                            .clip(RoundedCornerShape(8.dp)),
                     ) {
-                        if (artModel != null) {
-                            AsyncImage(
-                                model = artModel,
-                                contentDescription = "${album.name} album art",
-                                modifier = Modifier.fillMaxSize(),
-                                contentScale = ContentScale.Crop,
-                            )
-                        } else {
+                        AlbumArtwork(
+                            model = artModel,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                        Surface(
+                            modifier = Modifier
+                                .align(Alignment.BottomEnd)
+                                .padding(8.dp)
+                                .size(32.dp)
+                                .clip(CircleShape)
+                                .clickable { onPlayAlbum(album.name, album.artist) },
+                            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.85f),
+                            shape = CircleShape,
+                        ) {
                             Icon(
-                                imageVector = Icons.Default.Album,
-                                contentDescription = null,
-                                tint = StashTheme.extendedColors.textTertiary,
-                                modifier = Modifier.size(40.dp),
+                                imageVector = Icons.Default.PlayArrow,
+                                contentDescription = "Play ${album.name}",
+                                tint = MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.padding(4.dp),
                             )
                         }
                     }

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryUiState.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryUiState.kt
@@ -64,12 +64,14 @@ enum class SourceFilter { ALL, YOUTUBE, SPOTIFY, FLAC, NON_FLAC }
  * @property trackCount     Number of tracks by this artist in the library.
  * @property totalDurationMs Combined duration of all tracks in milliseconds.
  * @property artUrl         Remote artwork URL (album art proxy from their top track).
+ * @property photoUrl       Real artist photo (from the artist-image backfill), or null.
  */
 data class ArtistInfo(
     val name: String,
     val trackCount: Int,
     val totalDurationMs: Long,
     val artUrl: String? = null,
+    val photoUrl: String? = null,
 )
 
 /**

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
+import com.stash.core.common.primaryArtist
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.prefs.StreamingPreference
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.data.sync.FlacUpgradeEnqueuer
@@ -97,6 +99,7 @@ class LibraryViewModel @Inject constructor(
     private val ytMusicApiClient: com.stash.data.ytmusic.YTMusicApiClient,
     private val flacUpgradeEnqueuer: FlacUpgradeEnqueuer,
     private val libraryPreferencesStore: LibraryPreferencesStore,
+    private val artistImageDao: ArtistImageDao,
 ) : ViewModel() {
 
     /** Live progress for "Import from device". Observed by LibraryScreen. */
@@ -217,9 +220,31 @@ class LibraryViewModel @Inject constructor(
         val query = controls.searchQuery.trim().lowercase()
 
         // -- Map DAO projections to UI models --
-        val artists = allArtists.map { ArtistInfo(it.artist, it.trackCount, it.totalDurationMs, it.artUrl) }
+        // Artists are regrouped by PRIMARY act so a track credit like
+        // "Aarne, Toxi$, Big Baby Tape" lands under a single "Aarne" card
+        // instead of fragmenting the artist across a wall of "Aarne …" rows.
+        val artists = allArtists
+            .map { ArtistInfo(it.artist, it.trackCount, it.totalDurationMs, it.artUrl) }
+            .groupBy { it.name.primaryArtist() }
+            .map { (primary, group) ->
+                ArtistInfo(
+                    name = primary,
+                    trackCount = group.sumOf { it.trackCount },
+                    totalDurationMs = group.sumOf { it.totalDurationMs },
+                    // Prefer art from a release credited to the primary act
+                    // alone (their own album), falling back to any collab art —
+                    // "Aarne" shows his own cover, not SLAANG's.
+                    artUrl = group.firstOrNull { it.name == primary }?.artUrl
+                        ?: group.firstNotNullOfOrNull { it.artUrl },
+                )
+            }
+        // Album cards show the album's PRIMARY act ("Aarne" for SLAANG's
+        // "Aarne, Toxi$") — the release itself is still grouped by its full
+        // (album, albumArtist) key so distinct albums never collide.
         val albums = mergeDuplicateAlbums(
-            allAlbums.map { AlbumInfo(it.album, it.artist, it.trackCount, it.artPath, it.artUrl) }
+            allAlbums.map {
+                AlbumInfo(it.album, it.artist.primaryArtist(), it.trackCount, it.artPath, it.artUrl)
+            }
         )
 
         // -- Apply source filter --
@@ -320,6 +345,16 @@ class LibraryViewModel @Inject constructor(
         // Overlay the currently-playing track ID so the UI can highlight it.
         libraryState.copy(
             currentlyPlayingTrackId = playerState.currentTrack?.id,
+        )
+    }.combine(artistImageDao.observeAll()) { libraryState, images ->
+        // Overlay real artist photos (ArtistImageBackfillWorker output) keyed
+        // by the SAME primary-artist name the Artists tab groups by. Artists
+        // without a photo keep photoUrl = null → UI falls back to artUrl.
+        val photoByName = images.associate { it.artistName to it.imageUrl }
+        libraryState.copy(
+            artists = libraryState.artists.map { it.copy(photoUrl = photoByName[it.name]) },
+            singleTrackArtists = libraryState.singleTrackArtists
+                .map { it.copy(photoUrl = photoByName[it.name]) },
         )
     }
         // The whole filter+sort+lowercase pipeline above re-runs on every
@@ -865,15 +900,21 @@ class LibraryViewModel @Inject constructor(
     // ── Album actions ───────────────────────────────────────────────────
 
     /**
-     * Load all downloaded tracks matching [albumName] by [artist] and begin playback.
+     * Load all downloaded tracks matching [albumName] and begin playback.
      * Filters from allTracks since there is no dedicated getTracksByAlbum query.
+     *
+     * Matched by album NAME only (not [artist]): the track-level `artist`
+     * credit varies across a multi-artist album's rows, so pinning on it
+     * would play a partial album — e.g. "HEROES & VILLAINS" (Metro Boomin)
+     * whose tracks are credited "Metro Boomin, Travis Scott", "Travis
+     * Scott", etc. — or nothing at all when every row's credit differs
+     * from the album's primary artist.
      */
     fun playAlbum(albumName: String, artist: String) {
         viewModelScope.launch {
             val allTracks = musicRepository.getAllTracks().first()
             val downloaded = allTracks.filter {
                 it.album.equals(albumName, ignoreCase = true)
-                    && it.artist.equals(artist, ignoreCase = true)
                     && it.filePath != null
             }
             if (downloaded.isNotEmpty()) {
@@ -887,14 +928,14 @@ class LibraryViewModel @Inject constructor(
     }
 
     /**
-     * Load all downloaded tracks matching [albumName] by [artist] and append each to the queue.
+     * Load all downloaded tracks matching [albumName] and append each to the queue.
+     * Album-name-only matching, same rationale as [playAlbum].
      */
     fun addAlbumToQueue(albumName: String, artist: String) {
         viewModelScope.launch {
             val allTracks = musicRepository.getAllTracks().first()
             val downloaded = allTracks.filter {
                 it.album.equals(albumName, ignoreCase = true)
-                    && it.artist.equals(artist, ignoreCase = true)
                     && it.filePath != null
             }
             downloaded.forEach { playerRepository.addToQueue(it) }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/AlbumDetailViewModelTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/AlbumDetailViewModelTest.kt
@@ -8,6 +8,7 @@ import com.stash.core.model.Track
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -155,6 +156,54 @@ class AlbumDetailViewModelTest {
         assertEquals(listOf("Queued 2 songs for download."), messages)
     }
 
+    @Test
+    fun albumTracks_match_by_album_name_so_multi_artist_rows_all_appear() = runTest {
+        val album = "HEROES & VILLAINS"
+        val tracks = listOf(
+            Track(1L, "Superhero", "Metro Boomin, Future", album = album),
+            Track(2L, "Niagara Falls", "Metro Boomin, Travis Scott, 21 Savage", album = album),
+            Track(3L, "Trance", "Metro Boomin, Travis Scott", album = album),
+            Track(4L, "Around Me", "Metro Boomin, Don Toliver", album = album),
+        )
+        // A different album must not leak in.
+        val otherAlbum = Track(5L, "Highest in the Room", "Travis Scott", album = "JACKBOYS")
+        val musicRepo = musicRepoMockWithTracks(tracks + otherAlbum)
+
+        val vm = buildVm(
+            musicRepository = musicRepo,
+            savedStateHandle = SavedStateHandle(
+                mapOf("albumName" to album, "artistName" to "Metro Boomin"),
+            ),
+        )
+
+        val state = vm.uiState.first { !it.isLoading }
+        assertEquals(listOf(1L, 2L, 3L, 4L), state.tracks.map { it.id })
+        // The route's artist is still surfaced in the header for context.
+        assertEquals("Metro Boomin", state.artistName)
+    }
+
+    @Test
+    fun albumTracks_show_tracks_even_when_no_row_matches_the_primary_artist() = runTest {
+        // Regression for the multi-artist album: pinning the filter on the
+        // primary artist ("Metro Boomin") used to drop every row whose credit
+        // names an extra act — here the ONLY track would have vanished.
+        val album = "HEROES & VILLAINS"
+        val tracks = listOf(
+            Track(1L, "Trance", "Metro Boomin, Travis Scott", album = album),
+        )
+        val musicRepo = musicRepoMockWithTracks(tracks)
+
+        val vm = buildVm(
+            musicRepository = musicRepo,
+            savedStateHandle = SavedStateHandle(
+                mapOf("albumName" to album, "artistName" to "Metro Boomin"),
+            ),
+        )
+
+        val state = vm.uiState.first { !it.isLoading }
+        assertEquals(listOf(1L), state.tracks.map { it.id })
+    }
+
     // ------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------
@@ -177,6 +226,12 @@ class AlbumDetailViewModelTest {
 
     private fun musicRepoMock(): MusicRepository = mock {
         on { getAllTracks() } doReturn flowOf(emptyList())
+        on { getUserCreatedPlaylists() } doReturn flowOf(emptyList())
+        onBlocking { queueDownload(any()) } doReturn true
+    }
+
+    private fun musicRepoMockWithTracks(tracks: List<Track>): MusicRepository = mock {
+        on { getAllTracks() } doReturn flowOf(tracks)
         on { getUserCreatedPlaylists() } doReturn flowOf(emptyList())
         onBlocking { queueDownload(any()) } doReturn true
     }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/ArtistDetailViewModelTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/ArtistDetailViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.stash.feature.library
 
 import androidx.lifecycle.SavedStateHandle
+import com.stash.core.data.db.dao.ArtistImageDao
+import com.stash.core.data.db.entity.ArtistImageEntity
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.PlayerRepository
 import com.stash.core.model.PlayerState
@@ -8,6 +10,7 @@ import com.stash.core.model.Track
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -155,6 +158,24 @@ class ArtistDetailViewModelTest {
         assertEquals(listOf("Queued 2 songs for download."), messages)
     }
 
+    @Test
+    fun photoUrl_is_overlaid_from_artist_image_cache_case_insensitively() = runTest {
+        val images = listOf(
+            ArtistImageEntity(
+                artistName = "artist",
+                imageUrl = "https://photo/artist.jpg",
+                attemptedAt = 1L,
+            ),
+        )
+        val artistImageDao = mock<ArtistImageDao> {
+            on { observeAll() } doReturn flowOf(images)
+        }
+        val vm = buildVm(artistImageDao = artistImageDao)
+        val state = vm.uiState.first { !it.isLoading }
+
+        assertEquals("https://photo/artist.jpg", state.photoUrl)
+    }
+
     // ------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------
@@ -197,9 +218,13 @@ class ArtistDetailViewModelTest {
         savedStateHandle: SavedStateHandle = SavedStateHandle(
             mapOf("artistName" to "Artist"),
         ),
+        artistImageDao: ArtistImageDao = mock {
+            on { observeAll() } doReturn flowOf(emptyList())
+        },
     ): ArtistDetailViewModel = ArtistDetailViewModel(
         savedStateHandle = savedStateHandle,
         musicRepository = musicRepository,
         playerRepository = playerRepository,
+        artistImageDao = artistImageDao,
     )
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibrarySearchFieldQueryTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibrarySearchFieldQueryTest.kt
@@ -3,6 +3,7 @@ package com.stash.feature.library
 import com.google.common.truth.Truth.assertThat
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.model.PlayerState
 import com.stash.core.model.PlaylistType
@@ -106,6 +107,7 @@ class LibrarySearchFieldQueryTest {
                 onBlocking { getSortOrder() } doReturn SortOrder.RECENT
                 onBlocking { getSourceFilter() } doReturn SourceFilter.ALL
             },
+            artistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
         )
     }
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelLikedSearchTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelLikedSearchTest.kt
@@ -3,6 +3,7 @@ package com.stash.feature.library
 import com.google.common.truth.Truth.assertThat
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.model.MusicSource
 import com.stash.core.model.PlayerState
@@ -105,6 +106,7 @@ class LibraryViewModelLikedSearchTest {
                 onBlocking { getSortOrder() } doReturn SortOrder.RECENT
                 onBlocking { getSourceFilter() } doReturn SourceFilter.ALL
             },
+            artistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
         )
     }
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelMixTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelMixTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
 import com.stash.core.data.prefs.StreamingPreference
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.PlayerRepository
 import com.stash.core.model.MusicSource
@@ -146,9 +147,10 @@ class LibraryViewModelMixTest {
         tokenManager = tokenManager,
         playlistImageHelper = playlistImageHelper,
         localImportCoordinator = localImportCoordinator,
-        streamingPreference = streamingPreference,
+streamingPreference = streamingPreference,
         flacUpgradeEnqueuer = org.mockito.kotlin.mock(),
         ytMusicApiClient = org.mockito.kotlin.mock(),
         libraryPreferencesStore = libraryPreferencesStore,
+        artistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
     )
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelShuffleLikedTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelShuffleLikedTest.kt
@@ -144,6 +144,7 @@ class LibraryViewModelShuffleLikedTest {
                 onBlocking { getSortOrder() } doReturn SortOrder.RECENT
                 onBlocking { getSourceFilter() } doReturn SourceFilter.ALL
             },
+            artistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
         )
     }
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelSortTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelSortTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
 import com.stash.core.data.prefs.StreamingPreference
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.PlayerRepository
 import com.stash.core.model.PlayerState
@@ -97,5 +98,6 @@ class LibraryViewModelSortTest {
             onBlocking { getSortOrder() } doReturn SortOrder.RECENT
             onBlocking { getSourceFilter() } doReturn SourceFilter.ALL
         },
+        artistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
     )
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelSourceFilterTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelSourceFilterTest.kt
@@ -3,6 +3,7 @@ package com.stash.feature.library
 import com.google.common.truth.Truth.assertThat
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.model.PlayerState
 import com.stash.core.model.Track
@@ -73,5 +74,6 @@ class LibraryViewModelSourceFilterTest {
             onBlocking { getSortOrder() } doReturn SortOrder.RECENT
             onBlocking { getSourceFilter() } doReturn SourceFilter.ALL
         },
+        artistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
     )
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelTest.kt
@@ -220,7 +220,11 @@ class LibraryViewModelTest {
 
         // Album matched by NAME only — the per-track credit variation across a
         // multi-artist album must not drop rows.
-        verify(playerRepo).setQueue(listOf(onAlbum[0], onAlbum[1]), 0)
+        verify(playerRepo).setQueue(
+            listOf(onAlbum[0], onAlbum[1]),
+            0,
+            source = com.stash.core.model.PlaybackSource.Album(album, "Metro Boomin"),
+        )
     }
 
     @Test

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelTest.kt
@@ -2,6 +2,9 @@ package com.stash.feature.library
 
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
+import com.stash.core.data.db.dao.ArtistImageDao
+import com.stash.core.data.db.dao.ArtistSummary
+import com.stash.core.data.db.entity.ArtistImageEntity
 import com.stash.core.data.prefs.StreamingPreference
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.PlayerRepository
@@ -12,6 +15,7 @@ import com.stash.data.download.files.LocalImportState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -193,6 +197,107 @@ class LibraryViewModelTest {
         assertEquals(listOf("Queued 2 songs for download."), messages)
     }
 
+    @Test
+    fun playAlbum_queues_every_downloaded_track_with_matching_album_name() = runTest {
+        val album = "HEROES & VILLAINS"
+        val onAlbum = listOf(
+            Track(1L, "Superhero", "Metro Boomin, Future", album = album, filePath = "/a"),
+            Track(2L, "Trance", "Metro Boomin, Travis Scott", album = album, filePath = "/b"),
+            // Same album but not downloaded — must NOT be queued.
+            Track(3L, "Creepin'", "Metro Boomin, The Weeknd, 21 Savage", album = album, filePath = null),
+        )
+        // Different album by a different artist — must NOT leak in.
+        val offAlbum = Track(4L, "Highest in the Room", "Travis Scott", album = "JACKBOYS", filePath = "/d")
+        val musicRepo = mock<MusicRepository> {
+            on { getAllTracks() } doReturn flowOf(onAlbum + offAlbum)
+        }
+
+        val playerRepo = playerRepoMock()
+        val vm = buildVm(musicRepository = musicRepo, playerRepository = playerRepo)
+
+        vm.playAlbum(album, "Metro Boomin")
+        runCurrent()
+
+        // Album matched by NAME only — the per-track credit variation across a
+        // multi-artist album must not drop rows.
+        verify(playerRepo).setQueue(listOf(onAlbum[0], onAlbum[1]), 0)
+    }
+
+    @Test
+    fun addAlbumToQueue_appends_every_downloaded_track_with_matching_album_name() = runTest {
+        val album = "HEROES & VILLAINS"
+        val onAlbum = listOf(
+            Track(1L, "Superhero", "Metro Boomin, Future", album = album, filePath = "/a"),
+            Track(2L, "Trance", "Metro Boomin, Travis Scott", album = album, filePath = "/b"),
+            Track(3L, "Creepin'", "Metro Boomin, The Weeknd, 21 Savage", album = album, filePath = null),
+        )
+        val offAlbum = Track(4L, "Highest in the Room", "Travis Scott", album = "JACKBOYS", filePath = "/d")
+        val musicRepo = mock<MusicRepository> {
+            on { getAllTracks() } doReturn flowOf(onAlbum + offAlbum)
+        }
+
+        val playerRepo = playerRepoMock()
+        val vm = buildVm(musicRepository = musicRepo, playerRepository = playerRepo)
+
+        vm.addAlbumToQueue(album, "Metro Boomin")
+        runCurrent()
+
+        verify(playerRepo).addToQueue(onAlbum[0])
+        verify(playerRepo).addToQueue(onAlbum[1])
+        verify(playerRepo, org.mockito.kotlin.never()).addToQueue(onAlbum[2])
+        verify(playerRepo, org.mockito.kotlin.never()).addToQueue(offAlbum)
+    }
+
+    @Test
+    fun artistRegroup_prefers_primary_artists_own_album_art() = runTest {
+        val musicRepo = mock<MusicRepository> {
+            on { getAllArtists() } doReturn flowOf(
+                listOf(
+                    ArtistSummary("Aarne", 5, 1000L, "own-album.jpg"),
+                    // Collab credit lands under the same "Aarne" card — its art
+                    // must NOT win when Aarne has a solo credit.
+                    ArtistSummary("Aarne, Toxi$", 3, 600L, "collab-album.jpg"),
+                ),
+            )
+            on { getAllAlbums() } doReturn flowOf(emptyList())
+            on { getAllTracks() } doReturn flowOf(emptyList())
+            on { getAllPlaylists() } doReturn flowOf(emptyList())
+            on { getUserCreatedPlaylists() } doReturn flowOf(emptyList())
+            on { getRecentlyAdded(any()) } doReturn flowOf(emptyList())
+        }
+
+        val vm = buildVm(musicRepository = musicRepo)
+        val state = vm.uiState.first { !it.isLoading }
+
+        val aarne = state.artists.single { it.name == "Aarne" }
+        assertEquals(8, aarne.trackCount)
+        assertEquals("own-album.jpg", aarne.artUrl)
+    }
+
+    @Test
+    fun artistPhotos_are_applied_from_artist_image_cache() = runTest {
+        val musicRepo = mock<MusicRepository> {
+            on { getAllArtists() } doReturn flowOf(
+                listOf(ArtistSummary("Aarne", 5, 1000L, null)),
+            )
+            on { getAllAlbums() } doReturn flowOf(emptyList())
+            on { getAllTracks() } doReturn flowOf(emptyList())
+            on { getAllPlaylists() } doReturn flowOf(emptyList())
+            on { getUserCreatedPlaylists() } doReturn flowOf(emptyList())
+            on { getRecentlyAdded(any()) } doReturn flowOf(emptyList())
+        }
+        val artistImageDao = mock<ArtistImageDao> {
+            on { observeAll() } doReturn flowOf(
+                listOf(ArtistImageEntity(artistName = "Aarne", imageUrl = "photo.jpg", attemptedAt = 1L)),
+            )
+        }
+
+        val vm = buildVm(musicRepository = musicRepo, artistImageDao = artistImageDao)
+        val state = vm.uiState.first { !it.isLoading }
+
+        assertEquals("photo.jpg", state.artists.single { it.name == "Aarne" }.photoUrl)
+    }
+
     // ------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------
@@ -249,6 +354,7 @@ class LibraryViewModelTest {
         },
         streamingPreference: StreamingPreference = mock { on { enabled } doReturn flowOf(false) },
         libraryPreferencesStore: LibraryPreferencesStore = libraryPreferencesStoreMock(),
+        artistImageDao: ArtistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
     ): LibraryViewModel = LibraryViewModel(
         musicRepository = musicRepository,
         playerRepository = playerRepository,
@@ -259,5 +365,6 @@ class LibraryViewModelTest {
         flacUpgradeEnqueuer = org.mockito.kotlin.mock(),
         ytMusicApiClient = org.mockito.kotlin.mock(),
         libraryPreferencesStore = libraryPreferencesStore,
+        artistImageDao = artistImageDao,
     )
 }

--- a/feature/nowplaying/build.gradle.kts
+++ b/feature/nowplaying/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     implementation(project(":core:media"))
     implementation(project(":core:data"))
     implementation(project(":core:auth"))
+    // Artist-credit parsing for the primary-artist display helper.
+    implementation(project(":core:common"))
     // v0.9.36 — Now Playing lyrics sheet observes LyricsRepository and
     // enqueues the priority on-open LyricsFetchWorker. work-runtime gives
     // us WorkManager + OneTimeWorkRequestBuilder for the priority enqueue.

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/MiniPlayer.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/MiniPlayer.kt
@@ -1,5 +1,6 @@
 package com.stash.feature.nowplaying
 
+import com.stash.core.common.primaryArtist
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -126,7 +127,7 @@ fun MiniPlayer(
                             overflow = TextOverflow.Ellipsis,
                         )
                         Text(
-                            text = track?.artist ?: "",
+                            text = track?.artist?.primaryArtist() ?: "",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 1,

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Close
 import com.stash.core.media.SleepTimerController
+import com.stash.core.common.primaryArtist
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.CircularProgressIndicator
@@ -544,7 +545,7 @@ fun NowPlayingScreen(
                     Text(
                         text = buildString {
                             if (track != null) {
-                                append(track.artist)
+                                append(track.artist.primaryArtist())
                                 if (track.album.isNotBlank()) {
                                     append(" \u2022 ")
                                     append(track.album)

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/QueueBottomSheet.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/ui/QueueBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.stash.feature.nowplaying.ui
 
+import com.stash.core.common.primaryArtist
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
@@ -320,7 +321,7 @@ fun QueueBottomSheet(
                                     )
                                 }
                                 Text(
-                                    text = track.artist,
+                                    text = track.artist.primaryArtist(),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     maxLines = 1,
@@ -541,7 +542,7 @@ private fun CurrentTrackRow(track: Track, accentColor: Color) {
                 )
             }
             Text(
-                track.artist,
+                track.artist.primaryArtist(),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,

--- a/feature/search/src/main/kotlin/com/stash/feature/search/AlbumHero.kt
+++ b/feature/search/src/main/kotlin/com/stash/feature/search/AlbumHero.kt
@@ -4,8 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -80,6 +81,7 @@ import com.stash.core.ui.util.formatTotalDuration
  *                      queue without interrupting playback, routed through
  *                      `PlayerRepository.addToQueue(List)`.
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun AlbumHero(
     hero: AlbumHeroState,
@@ -231,7 +233,10 @@ fun AlbumHero(
 
             Spacer(Modifier.height(16.dp))
 
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 Button(
                     onClick = onPlayAlbum,
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp),


### PR DESCRIPTION
> **Note:** This is the original author's first PR (and first ever). To make
> it reviewable, the work has been split into focused PRs. Please review the
> pieces below instead of this superseded PR — its content is now spread
> across the four:

| # | PR | Scope |
|---|----|-------|
| 441 | `pr1-albumhero-flowrow` | Album-hero action row wraps instead of clipping on narrow screens (#385) |
| 442 | `pr2-album-open-navigation` | Album card tap opens the album instead of silently playing; dedicated play button over the art (#386) |
| 439 | `pr3-artist-photos` | Official artist photos: backfill worker, `artist_images` table (DB v43), ArtistAvatar in the Artists grid + Artist Detail header |
| 440 | `pr4-display-album-match` | Artist-credit parser in `core:common`; display surfaces collapse to the primary act; album/artist matching via `matchesArtistCredits`; album-art fallback on load/error |

## Original description (kept for history)

Fixes how artists are represented across the app: every surface shows the
primary act instead of run-on credits, artists get real photos (cached from
a YT Music backfill worker), and failed artwork never renders blank.
Also fixed download button properties (sizing) breaking after pressing
download all at album (in search).

## Related issues

- #386 (album card tap) — addressed by PR #442
- #388 (artist text + list-scroll shuffle) — NOT fixed; the animateItem/drag-reorder shuffle is a separate follow-up

## How was this tested?

- [x] `./gradlew test` passes (per-module suites re-run green on each PR)
- [x] Installed on a device and manually verified the change
- [x] Device / Android version tested: POCO X7 Pro / Android 16