### PR TITLE
feat: add JioSaavn AAC fallback before YouTube

### DIFF
--- a/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/service/StashPlaybackService.kt
@@ -404,6 +404,15 @@ class StashPlaybackService : MediaLibraryService() {
                 val origin = item.mediaMetadata.extras?.getString(EXTRA_STREAM_ORIGIN)
                 (scheme == "http" || scheme == "https") && origin == "amz"
             },
+            // JioSaavn media is accepted only from its exact HTTPS CDN host.
+            // Its playback client disables redirects so a later range request
+            // cannot pivot from that validated host to another destination.
+            isJioSaavnOrigin = { item ->
+                val scheme = item.localConfiguration?.uri?.scheme?.lowercase()
+                val origin = item.mediaMetadata.extras?.getString(EXTRA_STREAM_ORIGIN)
+                (scheme == "http" || scheme == "https") &&
+                    origin == com.stash.core.media.streaming.JioSaavnStreamResolver.ORIGIN
+            },
             amzHttpClient = okHttpClient,
             // Full-timeline queue: stash-resolve:// placeholders resolve
             // just-in-time inside LazyResolvingDataSource at open().

--- a/core/media/src/main/kotlin/com/stash/core/media/streaming/JioSaavnStreamResolver.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/streaming/JioSaavnStreamResolver.kt
@@ -1,0 +1,44 @@
+package com.stash.core.media.streaming
+
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.data.download.jiosaavn.JioSaavnResolver
+import com.stash.data.download.lossless.TrackQuery
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.withTimeoutOrNull
+
+/** Adapts the shared JioSaavn AAC-320 resolver to the player stream contract. */
+@Singleton
+class JioSaavnStreamResolver @Inject constructor(
+    private val resolver: JioSaavnResolver,
+) {
+    suspend fun resolve(track: TrackEntity): StreamUrl? =
+        withTimeoutOrNull(RESOLVE_TIMEOUT_MS) {
+            resolver.resolve(
+                TrackQuery(
+                    artist = track.artist,
+                    title = track.title,
+                    album = track.album.takeIf { it.isNotBlank() },
+                    durationMs = track.durationMs.takeIf { it > 0 },
+                    explicit = track.explicit,
+                ),
+                bypassRateLimit = false,
+            )?.let { result ->
+                StreamUrl(
+                    url = result.downloadUrl,
+                    expiresAtMs = System.currentTimeMillis() + CACHE_TTL_MS,
+                    codec = result.format.codec,
+                    sampleRateHz = result.format.sampleRateHz.takeIf { it > 0 },
+                    bitrateKbps = result.format.bitrateKbps,
+                    coverArtUrl = result.coverArtUrl,
+                    origin = ORIGIN,
+                )
+            }
+        }
+
+    companion object {
+        const val ORIGIN = "jiosaavn"
+        private const val RESOLVE_TIMEOUT_MS = 7_000L
+        private const val CACHE_TTL_MS = 60 * 60_000L
+    }
+}

--- a/core/media/src/main/kotlin/com/stash/core/media/streaming/KennyyStreamResolver.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/streaming/KennyyStreamResolver.kt
@@ -48,6 +48,7 @@ data class StreamUrl(
      * so the user knows quality has degraded from the Qobuz baseline.
      *
      * Conventional values:
+     *  - `"jiosaavn"`            - JioSaavn AAC-320 fallback (lossy)
      *  - `"kennyy"` / `"squid"`  — Qobuz catalog (lossless)
      *  - `"youtube"`             — yt-dlp/InnerTube extraction (lossy)
      */

--- a/core/media/src/main/kotlin/com/stash/core/media/streaming/LazyResolvingDataSource.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/streaming/LazyResolvingDataSource.kt
@@ -85,6 +85,7 @@ class LazyResolvingDataSource(
     private val trackDao: TrackDao,
     private val httpDelegate: () -> DataSource,
     private val amzDelegate: () -> DataSource,
+    private val jioSaavnDelegate: () -> DataSource,
     private val resolveDeadlineMs: Long = RESOLVE_DEADLINE_MS,
 ) : DataSource {
 
@@ -111,7 +112,11 @@ class LazyResolvingDataSource(
             ?: throw IOException("stream resolve failed for track $trackId")
 
         val realSpec = dataSpec.buildUpon().setUri(Uri.parse(fresh.url)).build()
-        val delegate = if (fresh.origin == "amz") amzDelegate() else httpDelegate()
+        val delegate = when (fresh.origin) {
+            "amz" -> amzDelegate()
+            JioSaavnStreamResolver.ORIGIN -> jioSaavnDelegate()
+            else -> httpDelegate()
+        }
         return delegateTo(delegate, realSpec)
     }
 

--- a/core/media/src/main/kotlin/com/stash/core/media/streaming/StashMediaSourceFactory.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/streaming/StashMediaSourceFactory.kt
@@ -50,6 +50,7 @@ class StashMediaSourceFactory(
     private val streamingFactory: StreamingMediaSourceFactory,
     private val streamingTrackId: (MediaItem) -> Long?,
     private val isAmzOrigin: (MediaItem) -> Boolean,
+    private val isJioSaavnOrigin: (MediaItem) -> Boolean,
     amzHttpClient: okhttp3.OkHttpClient,
     resolver: StreamSourceRegistry,
     urlCache: StreamUrlCache,
@@ -66,6 +67,13 @@ class StashMediaSourceFactory(
     // how lossless Kennyy/Squid already streams).
     private val amzFactory = DefaultMediaSourceFactory(
         androidx.media3.datasource.okhttp.OkHttpDataSource.Factory(amzHttpClient),
+    )
+    internal val jioSaavnHttpClient = amzHttpClient.newBuilder()
+        .followRedirects(false)
+        .followSslRedirects(false)
+        .build()
+    private val jioSaavnFactory = DefaultMediaSourceFactory(
+        androidx.media3.datasource.okhttp.OkHttpDataSource.Factory(jioSaavnHttpClient),
     )
 
     // Full-timeline placeholders: stash-resolve://track/<id> items resolve
@@ -87,6 +95,10 @@ class StashMediaSourceFactory(
                     androidx.media3.datasource.okhttp.OkHttpDataSource.Factory(amzHttpClient)
                         .createDataSource()
                 },
+                jioSaavnDelegate = {
+                    androidx.media3.datasource.okhttp.OkHttpDataSource.Factory(jioSaavnHttpClient)
+                        .createDataSource()
+                },
             )
         },
     )
@@ -96,6 +108,7 @@ class StashMediaSourceFactory(
     ): MediaSource.Factory {
         localFactory.setDrmSessionManagerProvider(provider)
         amzFactory.setDrmSessionManagerProvider(provider)
+        jioSaavnFactory.setDrmSessionManagerProvider(provider)
         lazyFactory.setDrmSessionManagerProvider(provider)
         return this
     }
@@ -105,6 +118,7 @@ class StashMediaSourceFactory(
     ): MediaSource.Factory {
         localFactory.setLoadErrorHandlingPolicy(policy)
         amzFactory.setLoadErrorHandlingPolicy(policy)
+        jioSaavnFactory.setLoadErrorHandlingPolicy(policy)
         lazyFactory.setLoadErrorHandlingPolicy(policy)
         return this
     }
@@ -126,6 +140,9 @@ class StashMediaSourceFactory(
         }
         if (isAmzOrigin(mediaItem)) {
             return amzFactory.createMediaSource(mediaItem)
+        }
+        if (isJioSaavnOrigin(mediaItem)) {
+            return jioSaavnFactory.createMediaSource(mediaItem)
         }
         return localFactory.createMediaSource(mediaItem)
     }

--- a/core/media/src/main/kotlin/com/stash/core/media/streaming/StreamSourceRegistry.kt
+++ b/core/media/src/main/kotlin/com/stash/core/media/streaming/StreamSourceRegistry.kt
@@ -69,18 +69,18 @@ class StreamSourceRegistry @Inject constructor(
     private val arcod: ArcodStreamResolver,
     private val amz: AmzStreamResolver,
     private val qbdlx: QbdlxStreamResolver,
+    private val jiosaavn: JioSaavnStreamResolver,
     private val youtube: YouTubeStreamResolver,
     private val streamingPreference: StreamingPreference,
     private val losslessSourceHealth: LosslessSourceHealth,
 ) {
-
     /**
      * Try each resolver in priority order; return the first non-null
      * [StreamUrl]. Returns null when no source produced a match — caller
      * should surface this as [StreamRoutingResult.NotAvailable].
      *
-     * @param allowYouTube pass `false` to skip the YouTube fallback
-     *   resolver, leaving only the two Qobuz operators. Used by
+     * @param allowYouTube pass `false` to skip lossy fallbacks (JioSaavn
+     *   and YouTube), leaving only configured lossless sources. Used by
      *   [PlayerRepositoryImpl.setQueue]'s background-fill path so
      *   yt-dlp's limited 2-slot extraction semaphore stays available
      *   for the foreground user-tap critical path. Foreground (tapped
@@ -125,6 +125,7 @@ class StreamSourceRegistry @Inject constructor(
                 // visibly" sharpness and buys back the guarantee that no
                 // preference, however stale, can leave a user unable to play music.
                 // That trade is not close.
+                if (allowYouTube && allowYtDlp) add("jiosaavn" to jiosaavn::resolve)
                 if (allowYouTube) add("youtube" to { t: TrackEntity -> youtube.resolve(t, allowYtDlp) })
                 // NOTE: the force-amz branch is deliberately gone (2026-07-31).
                 //
@@ -192,6 +193,13 @@ class StreamSourceRegistry @Inject constructor(
                 // can only 403, so skipping it avoids a guaranteed-wasted round trip.
                 if (allowYtDlp && BuildConfig.ARCOD_CONFIGURED) {
                     add("arcod" to arcod::resolve)
+                }
+                // Fixed-quality AAC 320 fallback. Foreground/next-up only: a
+                // speculative full-queue fill must not turn into one metadata
+                // search + media probe per track. Any miss/outage continues to
+                // the existing YouTube fallback below.
+                if (allowYouTube && allowYtDlp) {
+                    add("jiosaavn" to jiosaavn::resolve)
                 }
                 if (allowYouTube) add("youtube" to { t: TrackEntity -> youtube.resolve(t, allowYtDlp) })
             }

--- a/core/media/src/test/kotlin/com/stash/core/media/streaming/LazyResolvingDataSourceTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/streaming/LazyResolvingDataSourceTest.kt
@@ -35,6 +35,7 @@ class LazyResolvingDataSourceTest {
     private val trackDao: TrackDao = mockk()
     private val httpSource: DataSource = mockk(relaxed = true)
     private val amzSource: DataSource = mockk(relaxed = true)
+    private val jioSaavnSource: DataSource = mockk(relaxed = true)
 
     private fun source(deadlineMs: Long = 45_000L) = LazyResolvingDataSource(
         resolver = resolver,
@@ -42,6 +43,7 @@ class LazyResolvingDataSourceTest {
         trackDao = trackDao,
         httpDelegate = { httpSource },
         amzDelegate = { amzSource },
+        jioSaavnDelegate = { jioSaavnSource },
         resolveDeadlineMs = deadlineMs,
     )
 
@@ -87,6 +89,18 @@ class LazyResolvingDataSourceTest {
         source().open(placeholderSpec(7L))
 
         verify(exactly = 1) { amzSource.open(any()) }
+        verify(exactly = 0) { httpSource.open(any()) }
+    }
+
+    @Test
+    fun `jiosaavn origin routes to its no-redirect delegate`() {
+        every { urlCache.get(8L) } returns
+            stream("https://aac.saavncdn.com/song_320.mp4", JioSaavnStreamResolver.ORIGIN)
+        every { jioSaavnSource.open(any()) } returns 100L
+
+        source().open(placeholderSpec(8L))
+
+        verify(exactly = 1) { jioSaavnSource.open(any()) }
         verify(exactly = 0) { httpSource.open(any()) }
     }
 

--- a/core/media/src/test/kotlin/com/stash/core/media/streaming/StashMediaSourceFactoryTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/streaming/StashMediaSourceFactoryTest.kt
@@ -38,11 +38,13 @@ class StashMediaSourceFactoryTest {
     private fun newFactory(
         streamingTrackId: (MediaItem) -> Long?,
         isAmzOrigin: (MediaItem) -> Boolean,
+        isJioSaavnOrigin: (MediaItem) -> Boolean = { false },
     ): StashMediaSourceFactory = StashMediaSourceFactory(
         context = ApplicationProvider.getApplicationContext(),
         streamingFactory = streamingFactory,
         streamingTrackId = streamingTrackId,
         isAmzOrigin = isAmzOrigin,
+        isJioSaavnOrigin = isJioSaavnOrigin,
         amzHttpClient = OkHttpClient(),
         resolver = mockk(relaxed = true),
         urlCache = mockk(relaxed = true),
@@ -77,6 +79,23 @@ class StashMediaSourceFactoryTest {
         // DefaultMediaSourceFactory yields a ProgressiveMediaSource for a plain
         // progressive (FLAC) URI — backed here by the amz OkHttpDataSource.Factory.
         assertThat(source).isInstanceOf(ProgressiveMediaSource::class.java)
+    }
+
+    @Test
+    fun jioSaavnItem_routesToDedicatedProgressiveSource_notStreamingChain() {
+        val jio = item("https://aac.saavncdn.com/song_320.mp4")
+        val factory = newFactory(
+            streamingTrackId = { null },
+            isAmzOrigin = { false },
+            isJioSaavnOrigin = { it === jio },
+        )
+
+        val source = factory.createMediaSource(jio)
+
+        verify(exactly = 0) { streamingFactory.create(any()) }
+        assertThat(source).isInstanceOf(ProgressiveMediaSource::class.java)
+        assertThat(factory.jioSaavnHttpClient.followRedirects).isFalse()
+        assertThat(factory.jioSaavnHttpClient.followSslRedirects).isFalse()
     }
 
     @Test

--- a/core/media/src/test/kotlin/com/stash/core/media/streaming/StreamSourceRegistryTest.kt
+++ b/core/media/src/test/kotlin/com/stash/core/media/streaming/StreamSourceRegistryTest.kt
@@ -6,6 +6,7 @@ import com.stash.core.data.prefs.StreamingPreference
 import com.stash.data.download.BuildConfig
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -43,6 +44,9 @@ class StreamSourceRegistryTest {
     private val arcod: ArcodStreamResolver = mockk()
     private val amz: AmzStreamResolver = mockk()
     private val qbdlx: QbdlxStreamResolver = mockk()
+    private val jiosaavn: JioSaavnStreamResolver = mockk {
+        coEvery { resolve(any()) } returns null
+    }
     private val youtube: YouTubeStreamResolver = mockk()
     private val streamingPreference: StreamingPreference = mockk {
         // Default: no test toggle on. Individual tests override as needed.
@@ -52,7 +56,7 @@ class StreamSourceRegistryTest {
     }
 
     private fun registry() = StreamSourceRegistry(
-        kennyy, qobuz, arcod, amz, qbdlx, youtube, streamingPreference,
+        kennyy, qobuz, arcod, amz, qbdlx, jiosaavn, youtube, streamingPreference,
         LosslessSourceHealth(),
     )
 
@@ -361,6 +365,67 @@ class StreamSourceRegistryTest {
         // Falls through to the normal chain instead of being trapped on amz.
         assertThat(result!!.origin).isEqualTo(YouTubeStreamResolver.ORIGIN)
         coVerify(exactly = 0) { amz.resolve(any()) }
+    }
+
+    @Test
+    fun `normal foreground chain tries jiosaavn before youtube`() = runTest {
+        coEvery { streamingPreference.isForceYouTubeFallback() } returns false
+        coEvery { qbdlx.resolve(any()) } returns null
+        coEvery { arcod.resolve(any()) } returns null
+        coEvery { jiosaavn.resolve(any()) } returns null
+        coEvery { youtube.resolve(any(), any()) } returns null
+        val track = stubTrack()
+
+        registry().resolve(track, allowYouTube = true, allowYtDlp = true)
+
+        coVerifyOrder {
+            jiosaavn.resolve(track)
+            youtube.resolve(track, allowYtDlp = true)
+        }
+    }
+
+    @Test
+    fun `jiosaavn hit prevents youtube fallback`() = runTest {
+        coEvery { streamingPreference.isForceYouTubeFallback() } returns false
+        coEvery { qbdlx.resolve(any()) } returns null
+        coEvery { arcod.resolve(any()) } returns null
+        coEvery { jiosaavn.resolve(any()) } returns StreamUrl(
+            url = "https://aac.saavncdn.com/song_320.mp4",
+            expiresAtMs = Long.MAX_VALUE,
+            codec = "aac",
+            bitrateKbps = 320,
+            origin = JioSaavnStreamResolver.ORIGIN,
+        )
+        val track = stubTrack()
+
+        val result = registry().resolve(track, allowYouTube = true, allowYtDlp = true)
+
+        assertThat(result!!.origin).isEqualTo(JioSaavnStreamResolver.ORIGIN)
+        coVerify(exactly = 0) { youtube.resolve(any(), any()) }
+    }
+
+    @Test
+    fun `speculative background fill skips jiosaavn`() = runTest {
+        coEvery { streamingPreference.isForceYouTubeFallback() } returns false
+        coEvery { youtube.resolve(any(), any()) } returns null
+        val track = stubTrack()
+
+        registry().resolve(track, allowYouTube = true, allowYtDlp = false)
+
+        coVerify(exactly = 0) { jiosaavn.resolve(any()) }
+        coVerify { youtube.resolve(track, allowYtDlp = false) }
+    }
+
+    @Test
+    fun `force youtube diagnostic branch bypasses jiosaavn`() = runTest {
+        coEvery { streamingPreference.isForceYouTubeFallback() } returns true
+        coEvery { youtube.resolve(any(), any()) } returns null
+        val track = stubTrack()
+
+        registry().resolve(track, allowYouTube = true, allowYtDlp = true)
+
+        coVerify(exactly = 0) { jiosaavn.resolve(any()) }
+        coVerify { youtube.resolve(track, allowYtDlp = true) }
     }
 
     private fun stubTrack(): TrackEntity = TrackEntity(

--- a/data/download/src/main/kotlin/com/stash/data/download/DownloadManager.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/DownloadManager.kt
@@ -13,6 +13,7 @@ import com.stash.data.download.files.AlbumArtCache
 import com.stash.data.download.files.FileOrganizer
 import com.stash.data.download.files.MetadataEmbedder
 import com.stash.data.download.lyrics.LyricsFetchTrigger
+import com.stash.data.download.jiosaavn.JioSaavnResolver
 import com.stash.data.download.shared.TrackFinalizer
 import com.stash.core.data.audio.AudioDurationExtractor
 import com.stash.data.download.lossless.LosslessSourceHealthGate
@@ -108,6 +109,7 @@ class DownloadManager @Inject constructor(
     private val losslessRegistry: LosslessSourceRegistry,
     private val losslessUrlDownloader: LosslessUrlDownloader,
     private val losslessPrefs: LosslessSourcePreferences,
+    private val jioSaavnResolver: JioSaavnResolver,
     private val trackFinalizer: TrackFinalizer,
     private val loudnessMeasurer: com.stash.core.data.audio.LoudnessMeasurer,
     private val metadataEmbedder: MetadataEmbedder,
@@ -129,7 +131,7 @@ class DownloadManager @Inject constructor(
     private val losslessHealthGate: LosslessSourceHealthGate,
 ) {
     /**
-     * Test/build seam for the debug-build YT-fallback carve-out below.
+     * Test/build seam for the debug-build lossy-fallback carve-out below.
      * Defaults to the real [BuildConfig.DEBUG] so production behavior is
      * unchanged, but unit tests — which always run under the debug test
      * variant, where BuildConfig.DEBUG is unconditionally true — can flip
@@ -157,6 +159,9 @@ class DownloadManager @Inject constructor(
          * (kennyy, squid, + headroom) so it can't spin.
          */
         internal const val MAX_LOSSLESS_FAILOVER_ATTEMPTS = 3
+        internal const val MIN_JIOSAAVN_BITRATE_KBPS = 256
+        private const val JIOSAAVN_DURATION_TOLERANCE_MS = 8_000L
+        private const val JIOSAAVN_DURATION_TOLERANCE_FRACTION = 0.03
     }
 
     /**
@@ -227,11 +232,12 @@ class DownloadManager @Inject constructor(
                 // ARCOD_CONFIGURED are false, amz needs none but is proxy-outage-prone) —
                 // respecting "fallback off" here would permanently strand every beta
                 // tester's tracks in WAITING_FOR_LOSSLESS regardless of their toggle.
-                // Force YT fallback on debug builds; release keeps real strict-FLAC.
+                // Force the lossy fallback chain on debug builds; release keeps
+                // real strict-FLAC. The chain is JioSaavn first, then YouTube.
                 if (forceYoutubeFallbackOnDebugBuilds) {
                     Log.i(
                         TAG,
-                        "debug build: forcing YT fallback for '${track.artist} - ${track.title}' " +
+                        "debug build: forcing lossy fallback for '${track.artist} - ${track.title}' " +
                             "despite fallback-off (no lossless tokens on beta builds)",
                     )
                 } else {
@@ -244,7 +250,14 @@ class DownloadManager @Inject constructor(
             }
         }
 
-        // Step 1: Resolve YouTube URL
+        // Step 1: Try the high-bitrate AAC fallback before YouTube. This is
+        // deliberately outside the lossless registry: AAC is lossy, and must
+        // never satisfy a strict-lossless request. If strict fallback is off,
+        // the branch above already returned Deferred before reaching here.
+        val jioSaavnResult = tryJioSaavnDownload(track)
+        if (jioSaavnResult != null) return jioSaavnResult
+
+        // Step 2: Resolve YouTube URL
         val resolveResult = if (preResolvedUrl != null) ResolveResult(url = preResolvedUrl) else resolveUrl(track)
         if (resolveResult.url == null) {
             emitProgress(track.id, 0f, DownloadStatus.UNMATCHED)
@@ -389,6 +402,106 @@ class DownloadManager @Inject constructor(
             .onFailure { Log.w(TAG, "isTrackInStashMix lookup failed for $trackId", it) }
             .getOrDefault(false)
 
+    internal suspend fun tryJioSaavnDownload(track: Track): TrackDownloadResult? {
+        val query = TrackQuery(
+            artist = track.artist,
+            title = track.title,
+            album = track.album.takeIf { it.isNotBlank() },
+            durationMs = track.durationMs.takeIf { it > 0 },
+            explicit = track.explicit,
+            trackId = track.id,
+        )
+
+        val match = try {
+            jioSaavnResolver.resolve(query)
+        } catch (cancelled: kotlinx.coroutines.CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            Log.w(TAG, "JioSaavn resolve failed for '${track.artist} - ${track.title}'", error)
+            null
+        } ?: return null
+
+        emitProgress(track.id, 0.1f, DownloadStatus.DOWNLOADING)
+        val tempFile = File(fileOrganizer.getTempDir(), "jiosaavn_${track.id}.m4a")
+        val fetched = losslessUrlDownloader.download(
+            source = match,
+            destination = tempFile,
+            onProgress = { read, total ->
+                val fraction = if (total > 0L) read.toFloat() / total else 0f
+                emitProgress(track.id, 0.1f + fraction * 0.7f, DownloadStatus.DOWNLOADING)
+            },
+        ).getOrElse { error ->
+            if (error is kotlinx.coroutines.CancellationException) throw error
+            Log.w(TAG, "JioSaavn fetch failed for '${track.artist} - ${track.title}': ${error.message}")
+            runCatching { tempFile.delete() }
+            return null
+        }
+
+        val metadata = audioDurationExtractor.extract(fetched.absolutePath)
+        val durationTolerance = maxOf(
+            JIOSAAVN_DURATION_TOLERANCE_MS,
+            (track.durationMs * JIOSAAVN_DURATION_TOLERANCE_FRACTION).toLong(),
+        )
+        val durationValid = track.durationMs <= 0L ||
+            (metadata != null && kotlin.math.abs(metadata.durationMs - track.durationMs) <= durationTolerance)
+        val codecValid = metadata?.format == "aac"
+        val bitrateValid = metadata != null && metadata.bitrateKbps >= MIN_JIOSAAVN_BITRATE_KBPS
+        if (!codecValid || !bitrateValid || !durationValid) {
+            Log.w(
+                TAG,
+                "JioSaavn media rejected for '${track.artist} - ${track.title}': " +
+                    "format=${metadata?.format}, bitrate=${metadata?.bitrateKbps}, " +
+                    "duration=${metadata?.durationMs}, expected=${track.durationMs}",
+            )
+            runCatching { fetched.delete() }
+            return null
+        }
+
+        emitProgress(track.id, 0.85f, DownloadStatus.PROCESSING)
+        val effectiveTrack = trackDao.getById(track.id)?.toDomain() ?: track
+        return when (
+            val finalized = trackFinalizer.finalizeFile(
+                sourceFile = fetched,
+                track = effectiveTrack,
+                format = match.format,
+            )
+        ) {
+            is TrackFinalizer.FinalizeResult.Success -> {
+                Log.i(
+                    TAG,
+                    "JioSaavn AAC downloaded: ${effectiveTrack.artist} - ${effectiveTrack.title} " +
+                        "-> ${finalized.committed.filePath}",
+                )
+                match.coverArtUrl?.let { url ->
+                    runCatching {
+                        val existingArt = trackDao.getById(effectiveTrack.id)?.albumArtUrl
+                        if (existingArt.isNullOrBlank() ||
+                            com.stash.core.common.ArtUrlUpgrader.isYouTubeVideoThumbnail(existingArt)
+                        ) {
+                            trackDao.updateAlbumArtUrl(effectiveTrack.id, url)
+                        }
+                    }.onFailure { error ->
+                        Log.w(TAG, "JioSaavn album-art update failed for ${effectiveTrack.id}: ${error.message}")
+                    }
+                }
+                loudnessMeasurer.measureAndPersistInBackground(
+                    trackId = track.id,
+                    file = File(finalized.committed.filePath),
+                )
+                runCatching { trackDao.setMetadataEmbeddedAt(track.id, System.currentTimeMillis()) }
+                    .onFailure { Log.w(TAG, "setMetadataEmbeddedAt failed for ${track.id}: ${it.message}") }
+                lyricsFetchTrigger.enqueueFor(track.id)
+                emitProgress(track.id, 1f, DownloadStatus.COMPLETED)
+                TrackDownloadResult.Success(finalized.committed.filePath)
+            }
+            is TrackFinalizer.FinalizeResult.Failed -> {
+                Log.w(TAG, "JioSaavn finalize failed for ${track.id}: ${finalized.message}")
+                runCatching { fetched.delete() }
+                null
+            }
+        }
+    }
+
     internal suspend fun tryLosslessDownload(track: Track, forced: Boolean = false): TrackDownloadResult? {
         val query = TrackQuery(
             artist = track.artist,
@@ -396,6 +509,7 @@ class DownloadManager @Inject constructor(
             album = track.album.takeIf { it.isNotBlank() },
             isrc = track.isrc,
             durationMs = track.durationMs.takeIf { it > 0 },
+            explicit = track.explicit,
             spotifyUri = track.spotifyUri,
             trackId = track.id,
         )
@@ -424,7 +538,8 @@ class DownloadManager @Inject constructor(
         // Choose extension from the source's stated codec rather than
         // hardcoding "flac" — sources may legitimately return "alac",
         // "mp3", etc. and the file organizer just plumbs through.
-        val ext = match.format.codec.lowercase().ifBlank { "flac" }
+        val ext = match.format.fileExtension.lowercase()
+            .ifBlank { match.format.codec.lowercase().ifBlank { "flac" } }
         val tempFile = File(fileOrganizer.getTempDir(), "lossless_${track.id}.$ext")
 
         val fetched = losslessUrlDownloader.download(

--- a/data/download/src/main/kotlin/com/stash/data/download/jiosaavn/JioSaavnClient.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/jiosaavn/JioSaavnClient.kt
@@ -1,0 +1,256 @@
+package com.stash.data.download.jiosaavn
+
+import android.util.Log
+import java.io.IOException
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+
+/** Narrow on-device adapter for JioSaavn search and its encrypted media template. */
+@Singleton
+class JioSaavnClient @Inject constructor(sharedClient: OkHttpClient) {
+    private val httpClient = sharedClient.newBuilder()
+        .connectTimeout(4, TimeUnit.SECONDS)
+        .readTimeout(5, TimeUnit.SECONDS)
+        .callTimeout(7, TimeUnit.SECONDS)
+        .followRedirects(false)
+        .build()
+
+    /** Test seam for MockWebServer. */
+    internal var baseUrl = "https://www.jiosaavn.com"
+
+    suspend fun search(query: String, limit: Int = 10): JioSaavnSearchOutcome {
+        val url = baseUrl.toHttpUrl().newBuilder()
+            .addPathSegment("api.php")
+            .addQueryParameter("__call", "search.getResults")
+            .addQueryParameter("_format", "json")
+            .addQueryParameter("_marker", "0")
+            .addQueryParameter("ctx", "web6dot0")
+            .addQueryParameter("n", limit.coerceIn(1, 20).toString())
+            .addQueryParameter("p", "1")
+            .addQueryParameter("q", query)
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("User-Agent", USER_AGENT)
+            .header("Referer", "https://www.jiosaavn.com/")
+            .get()
+            .build()
+        return try {
+            executeCancellable(request) { response ->
+                when {
+                    response.code == 429 -> JioSaavnSearchOutcome.RateLimited
+                    !response.isSuccessful -> JioSaavnSearchOutcome.Failure("HTTP ${response.code}")
+                    else -> {
+                        val parsed = JSON.decodeFromString<NativeSearchResponse>(
+                            response.body?.string().orEmpty(),
+                        )
+                        JioSaavnSearchOutcome.Success(parsed.results.mapNotNull(::normalize))
+                    }
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            currentCoroutineContext().ensureActive()
+            Log.d(TAG, "search failed: ${e.javaClass.simpleName}: ${e.message}")
+            JioSaavnSearchOutcome.Failure(e.message ?: e.javaClass.simpleName)
+        }
+    }
+
+    /** Validate the synthesized 320 URL before it enters playback. */
+    suspend fun isPlayable320(url: String): JioSaavnProbeOutcome {
+        if (!isTrustedMediaUrl(url)) return JioSaavnProbeOutcome.Unavailable
+        val request = Request.Builder().url(url).header("Range", "bytes=0-4095").get().build()
+        return try {
+            executeCancellable(request) { response ->
+                if (response.code == 429) {
+                    return@executeCancellable JioSaavnProbeOutcome.RateLimited
+                }
+                if (response.code >= 500) {
+                    return@executeCancellable JioSaavnProbeOutcome.Failure("HTTP ${response.code}")
+                }
+                if (response.code != 206) return@executeCancellable JioSaavnProbeOutcome.Unavailable
+                val range = response.header("Content-Range")
+                    ?: return@executeCancellable JioSaavnProbeOutcome.Unavailable
+                if (!range.startsWith("bytes 0-", ignoreCase = true)) {
+                    return@executeCancellable JioSaavnProbeOutcome.Unavailable
+                }
+                val type = response.body?.contentType()?.toString().orEmpty().lowercase()
+                if (!type.startsWith("audio/mp4") && !type.startsWith("application/octet-stream")) {
+                    return@executeCancellable JioSaavnProbeOutcome.Unavailable
+                }
+                val prefix = ByteArray(12)
+                val stream = response.body?.byteStream()
+                    ?: return@executeCancellable JioSaavnProbeOutcome.Unavailable
+                var offset = 0
+                while (offset < prefix.size) {
+                    val read = stream.read(prefix, offset, prefix.size - offset)
+                    if (read < 0) break
+                    offset += read
+                }
+                if (offset >= 8 && prefix.copyOfRange(4, 8).contentEquals("ftyp".toByteArray())) {
+                    JioSaavnProbeOutcome.Playable
+                } else {
+                    JioSaavnProbeOutcome.Unavailable
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            currentCoroutineContext().ensureActive()
+            JioSaavnProbeOutcome.Failure(e.message ?: e.javaClass.simpleName)
+        }
+    }
+
+    /**
+     * OkHttp's synchronous execute ignores coroutine cancellation. The async
+     * bridge binds cancellation to Call.cancel(), making the resolver's outer
+     * seven-second deadline a real end-to-end deadline.
+     */
+    private suspend fun <T> executeCancellable(
+        request: Request,
+        block: (Response) -> T,
+    ): T = coroutineScope {
+        val call = httpClient.newCall(request)
+        val cancellationWatcher = launch(
+            context = Dispatchers.IO,
+            start = CoroutineStart.UNDISPATCHED,
+        ) {
+            try {
+                awaitCancellation()
+            } finally {
+                call.cancel()
+            }
+        }
+        try {
+            withContext(Dispatchers.IO) {
+                awaitResponse(call).use(block)
+            }
+        } finally {
+            cancellationWatcher.cancel()
+        }
+    }
+
+    private suspend fun awaitResponse(call: Call): Response =
+        suspendCancellableCoroutine { continuation ->
+            continuation.invokeOnCancellation { call.cancel() }
+            call.enqueue(
+                object : Callback {
+                    override fun onFailure(call: Call, e: IOException) {
+                        continuation.resumeWith(Result.failure(e))
+                    }
+
+                    override fun onResponse(call: Call, response: Response) {
+                        continuation.resume(response) { _, unclaimedResponse, _ ->
+                            unclaimedResponse.close()
+                        }
+                    }
+                },
+            )
+        }
+
+    internal fun isTrustedMediaUrl(value: String): Boolean {
+        val url = value.toHttpUrlOrNull() ?: return false
+        return url.isHttps && url.host == AAC_CDN_HOST && url.encodedPath.contains("_320")
+    }
+
+    internal fun decrypt320Url(encryptedMediaUrl: String): String? = runCatching {
+        if (encryptedMediaUrl.isBlank()) return null
+        val cipher = Cipher.getInstance("DES/ECB/PKCS5Padding")
+        cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(DES_KEY.toByteArray(), "DES"))
+        val template = String(
+            cipher.doFinal(Base64.getDecoder().decode(encryptedMediaUrl)),
+            Charsets.UTF_8,
+        )
+        if (!template.contains("_96")) return null
+        template.replace("_96", "_320")
+    }.getOrNull()
+
+    private fun normalize(raw: NativeSong): JioSaavnSong? {
+        val id = raw.id?.takeIf { it.isNotBlank() } ?: return null
+        val name = decodeEntities(raw.song.orEmpty()).takeIf { it.isNotBlank() } ?: return null
+        val primary = raw.primaryArtists.orEmpty().split(',')
+            .map { decodeEntities(it).trim() }
+            .filter { it.isNotBlank() }
+            .map(::JioSaavnArtist)
+        if (primary.isEmpty()) return null
+        val media = if (raw.has320.equals("true", ignoreCase = true)) {
+            decrypt320Url(raw.encryptedMediaUrl.orEmpty())
+                ?.let { listOf(JioSaavnMediaLink("320kbps", it)) }
+                .orEmpty()
+        } else emptyList()
+        val images = raw.image?.takeIf { it.isNotBlank() }?.let { value ->
+            val high = value.replace(Regex("(?:50|150)x(?:50|150)"), "500x500")
+                .replace(Regex("^http://"), "https://")
+            listOf(JioSaavnImage("500x500", high))
+        }.orEmpty()
+        return JioSaavnSong(
+            id = id,
+            name = name,
+            duration = raw.duration?.toIntOrNull(),
+            explicitContent = raw.explicitContent == 1,
+            album = raw.album?.let { JioSaavnAlbum(decodeEntities(it)) },
+            artists = JioSaavnArtists(primary),
+            image = images,
+            downloadUrl = media,
+        )
+    }
+
+    private fun decodeEntities(value: String): String = value
+        .replace("&amp;", "&", ignoreCase = true)
+        .replace("&quot;", "\"", ignoreCase = true)
+        .replace("&#039;", "'", ignoreCase = true)
+        .replace("&apos;", "'", ignoreCase = true)
+        .replace("&lt;", "<", ignoreCase = true)
+        .replace("&gt;", ">", ignoreCase = true)
+
+    @Serializable
+    private data class NativeSearchResponse(val results: List<NativeSong> = emptyList())
+
+    @Serializable
+    private data class NativeSong(
+        val id: String? = null,
+        val song: String? = null,
+        val album: String? = null,
+        val duration: String? = null,
+        val image: String? = null,
+        @SerialName("primary_artists") val primaryArtists: String? = null,
+        @SerialName("explicit_content") val explicitContent: Int? = null,
+        @SerialName("320kbps") val has320: String? = null,
+        @SerialName("encrypted_media_url") val encryptedMediaUrl: String? = null,
+    )
+
+    private companion object {
+        const val TAG = "JioSaavnClient"
+        const val DES_KEY = "38346591"
+        const val AAC_CDN_HOST = "aac.saavncdn.com"
+        const val USER_AGENT = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 " +
+            "(KHTML, like Gecko) Chrome/124.0 Mobile Safari/537.36"
+        val JSON = Json { ignoreUnknownKeys = true; isLenient = true }
+    }
+}

--- a/data/download/src/main/kotlin/com/stash/data/download/jiosaavn/JioSaavnMatcher.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/jiosaavn/JioSaavnMatcher.kt
@@ -36,7 +36,13 @@ object JioSaavnMatcher {
         }
         if (query.explicit != null && query.explicit != song.explicitContent) return null
 
-        val title = similarity(normalize(query.title), normalize(song.name))
+        // Compare CORE titles: parenthetical decorations — '(From "Bhediya")',
+        // "(Official Video)" — tank token similarity for what is the same
+        // recording (device-verified 2026-08-13: Apna Bana Le scored 0.6 and
+        // fell to YouTube). Safe to strip here because version identity
+        // ("live", "remix", …) is enforced by the versionSignature gate above,
+        // which sees the FULL title.
+        val title = similarity(coreTitle(query.title), coreTitle(song.name))
         val artist = artistSimilarity(normalize(query.artist), normalize(candidateArtist))
         if (title < MIN_TITLE || artist < MIN_ARTIST) return null
         val duration = durationSimilarity(query.durationMs, song.duration) ?: return null
@@ -89,6 +95,10 @@ object JioSaavnMatcher {
             Regex("(?:^|\\s)${Regex.escape(marker)}(?:$|\\s)").containsMatchIn(normalized)
         }
     }
+
+    /** [normalize] with parenthesized/bracketed decorations removed first. */
+    private fun coreTitle(value: String): String =
+        normalize(value.replace(Regex("[(\\[][^)\\]]*[)\\]]"), " "))
 
     private fun normalize(value: String): String = Normalizer.normalize(value, Normalizer.Form.NFKC)
         .lowercase()

--- a/data/download/src/main/kotlin/com/stash/data/download/jiosaavn/JioSaavnMatcher.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/jiosaavn/JioSaavnMatcher.kt
@@ -1,0 +1,146 @@
+package com.stash.data.download.jiosaavn
+
+import com.stash.data.download.lossless.TrackQuery
+import java.text.Normalizer
+import kotlin.math.abs
+
+data class JioSaavnMatch(
+    val song: JioSaavnSong,
+    val media: JioSaavnMediaLink,
+    val confidence: Float,
+)
+
+/** Conservative matcher: an uncertain result must fall through to YouTube. */
+object JioSaavnMatcher {
+    fun best(query: TrackQuery, songs: List<JioSaavnSong>): JioSaavnMatch? {
+        val ranked = songs.mapNotNull { score(query, it) }.sortedByDescending { it.rankScore }
+        val top = ranked.firstOrNull() ?: return null
+        val runnerUp = ranked.getOrNull(1)
+        if (
+            runnerUp != null &&
+            top.rankScore - runnerUp.rankScore < MIN_MARGIN &&
+            !albumDisambiguates(query, top.match.song, runnerUp.match.song)
+        ) return null
+        return top.match
+    }
+
+    private fun score(query: TrackQuery, song: JioSaavnSong): RankedMatch? {
+        val media = song.downloadUrl.firstOrNull {
+            it.quality.equals("320kbps", ignoreCase = true) && it.url.startsWith("https://")
+        } ?: return null
+        val candidateArtist = song.artists.primary.joinToString(" ") { it.name }
+        if (candidateArtist.isBlank()) return null
+        if (versionSignature(query.title) != versionSignature(song.name)) return null
+        if ((artistImpersonationMarkers(candidateArtist) - artistImpersonationMarkers(query.artist)).isNotEmpty()) {
+            return null
+        }
+        if (query.explicit != null && query.explicit != song.explicitContent) return null
+
+        val title = similarity(normalize(query.title), normalize(song.name))
+        val artist = artistSimilarity(normalize(query.artist), normalize(candidateArtist))
+        if (title < MIN_TITLE || artist < MIN_ARTIST) return null
+        val duration = durationSimilarity(query.durationMs, song.duration) ?: return null
+        val albumBonus = (albumSimilarity(query, song) ?: 0f) * ALBUM_WEIGHT
+        // Keep the uncapped score for ranking so a strong album match can
+        // disambiguate otherwise-identical recordings. Cap only the public
+        // confidence value exposed to downstream callers.
+        val rankScore = title * TITLE_WEIGHT + artist * ARTIST_WEIGHT +
+            duration * DURATION_WEIGHT + albumBonus
+        val threshold = if (query.durationMs != null && song.duration != null) {
+            MIN_WITH_DURATION
+        } else {
+            MIN_WITHOUT_DURATION
+        }
+        if (rankScore < threshold) return null
+        return RankedMatch(
+            match = JioSaavnMatch(song, media, rankScore.coerceAtMost(0.99f)),
+            rankScore = rankScore,
+        )
+    }
+
+    private fun durationSimilarity(targetMs: Long?, candidateSec: Int?): Float? {
+        if (targetMs == null || targetMs <= 0 || candidateSec == null || candidateSec <= 0) return 1f
+        val targetSec = targetMs / 1000.0
+        val difference = abs(targetSec - candidateSec)
+        val tolerance = maxOf(8.0, targetSec * 0.03)
+        if (difference > tolerance) return null
+        return (1.0 - difference / tolerance).toFloat().coerceIn(0f, 1f)
+    }
+
+    private fun albumDisambiguates(
+        query: TrackQuery,
+        top: JioSaavnSong,
+        runnerUp: JioSaavnSong,
+    ): Boolean {
+        val topAlbum = albumSimilarity(query, top) ?: return false
+        val runnerUpAlbum = albumSimilarity(query, runnerUp) ?: 0f
+        return topAlbum >= MIN_EXACT_ALBUM && topAlbum - runnerUpAlbum >= MIN_ALBUM_ADVANTAGE
+    }
+
+    private fun albumSimilarity(query: TrackQuery, song: JioSaavnSong): Float? {
+        val requestedAlbum = query.album?.takeIf { it.isNotBlank() } ?: return null
+        val candidateAlbum = song.album?.name?.takeIf { it.isNotBlank() } ?: return null
+        return similarity(normalize(requestedAlbum), normalize(candidateAlbum))
+    }
+
+    private fun versionSignature(value: String): Set<String> {
+        val normalized = normalize(value)
+        return VERSION_MARKERS.filterTo(linkedSetOf()) { marker ->
+            Regex("(?:^|\\s)${Regex.escape(marker)}(?:$|\\s)").containsMatchIn(normalized)
+        }
+    }
+
+    private fun normalize(value: String): String = Normalizer.normalize(value, Normalizer.Form.NFKC)
+        .lowercase()
+        .replace(Regex("(?i)\\b(feat\\.?|ft\\.?|featuring)\\b.*"), " ")
+        .replace(Regex("[^\\p{L}\\p{N}\\p{S}\\s]"), " ")
+        .replace(Regex("\\s+"), " ")
+        .trim()
+
+    private fun similarity(a: String, b: String): Float {
+        val left = a.split(' ').filter { it.isNotBlank() }.toSet()
+        val right = b.split(' ').filter { it.isNotBlank() }.toSet()
+        if (left.isEmpty() || right.isEmpty()) return 0f
+        return left.intersect(right).size.toFloat() / left.union(right).size.toFloat()
+    }
+
+    private fun artistSimilarity(a: String, b: String): Float {
+        val left = a.split(' ').filter { it.isNotBlank() }.toSet()
+        val right = b.split(' ').filter { it.isNotBlank() }.toSet()
+        if (left.isEmpty() || right.isEmpty()) return 0f
+        val overlap = left.intersect(right)
+        val jaccard = overlap.size.toFloat() / left.union(right).size.toFloat()
+        // A source may omit featured artists from its primary credit, but a
+        // candidate must not add arbitrary identity words (for example,
+        // "Journey Tribute Band" for Journey). Only allow candidateâŠ†target.
+        val subset = overlap.size == right.size && overlap.any {
+            it.length > 3 || it.any { ch -> !ch.isLetterOrDigit() }
+        }
+        return if (subset) 1f else jaccard
+    }
+
+    private fun artistImpersonationMarkers(value: String): Set<String> {
+        val normalized = normalize(value)
+        return ARTIST_IMPERSONATION_MARKERS.filterTo(linkedSetOf()) { marker ->
+            Regex("(?:^|\\s)${Regex.escape(marker)}(?:$|\\s)").containsMatchIn(normalized)
+        }
+    }
+
+    private const val MIN_TITLE = 0.82f
+    private const val MIN_ARTIST = 0.78f
+    private const val TITLE_WEIGHT = 0.50f
+    private const val ARTIST_WEIGHT = 0.35f
+    private const val DURATION_WEIGHT = 0.15f
+    private const val ALBUM_WEIGHT = 0.03f
+    private const val MIN_WITH_DURATION = 0.88f
+    private const val MIN_WITHOUT_DURATION = 0.93f
+    private const val MIN_MARGIN = 0.06f
+    private const val MIN_EXACT_ALBUM = 0.90f
+    private const val MIN_ALBUM_ADVANTAGE = 0.35f
+    private data class RankedMatch(val match: JioSaavnMatch, val rankScore: Float)
+    private val VERSION_MARKERS = listOf(
+        "karaoke", "instrumental", "cover", "tribute", "live", "concert",
+        "remix", "acoustic", "sped up", "slowed", "nightcore", "edit", "extended",
+    )
+    private val ARTIST_IMPERSONATION_MARKERS = listOf("karaoke", "cover", "tribute", "impersonator")
+}

--- a/data/download/src/main/kotlin/com/stash/data/download/jiosaavn/JioSaavnModels.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/jiosaavn/JioSaavnModels.kt
@@ -1,0 +1,36 @@
+package com.stash.data.download.jiosaavn
+
+/** Normalized subset of a JioSaavn search result used by Stash's matcher. */
+data class JioSaavnSong(
+    val id: String,
+    val name: String,
+    val duration: Int?,
+    val explicitContent: Boolean,
+    val album: JioSaavnAlbum?,
+    val artists: JioSaavnArtists,
+    val image: List<JioSaavnImage>,
+    val downloadUrl: List<JioSaavnMediaLink>,
+)
+
+data class JioSaavnAlbum(val name: String?)
+
+data class JioSaavnArtists(val primary: List<JioSaavnArtist> = emptyList())
+
+data class JioSaavnArtist(val name: String)
+
+data class JioSaavnImage(val quality: String, val url: String)
+
+data class JioSaavnMediaLink(val quality: String, val url: String)
+
+sealed interface JioSaavnSearchOutcome {
+    data class Success(val songs: List<JioSaavnSong>) : JioSaavnSearchOutcome
+    data object RateLimited : JioSaavnSearchOutcome
+    data class Failure(val message: String) : JioSaavnSearchOutcome
+}
+
+sealed interface JioSaavnProbeOutcome {
+    data object Playable : JioSaavnProbeOutcome
+    data object Unavailable : JioSaavnProbeOutcome
+    data object RateLimited : JioSaavnProbeOutcome
+    data class Failure(val message: String) : JioSaavnProbeOutcome
+}

--- a/data/download/src/main/kotlin/com/stash/data/download/jiosaavn/JioSaavnResolver.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/jiosaavn/JioSaavnResolver.kt
@@ -1,0 +1,84 @@
+package com.stash.data.download.jiosaavn
+
+import android.util.Log
+import com.stash.data.download.lossless.AggregatorRateLimiter
+import com.stash.data.download.lossless.AudioFormat
+import com.stash.data.download.lossless.SourceResult
+import com.stash.data.download.lossless.TrackQuery
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class JioSaavnResolver @Inject constructor(
+    private val client: JioSaavnClient,
+    private val rateLimiter: AggregatorRateLimiter,
+) {
+    suspend fun resolve(query: TrackQuery, bypassRateLimit: Boolean = false): SourceResult? {
+        if (rateLimiter.stateOf(SOURCE_ID).isCircuitBroken) return null
+        if (!bypassRateLimit && !rateLimiter.acquire(SOURCE_ID)) return null
+
+        val searchQueries = listOf(
+            "${query.artist} ${query.title}".trim(),
+            "${query.artist.substringBefore(',').trim()} ${query.title}".trim(),
+        ).filter { it.isNotBlank() }.distinct()
+
+        for (searchQuery in searchQueries) {
+            when (val outcome = client.search(searchQuery, SEARCH_LIMIT)) {
+                JioSaavnSearchOutcome.RateLimited -> {
+                    rateLimiter.reportRateLimited(SOURCE_ID)
+                    return null
+                }
+                is JioSaavnSearchOutcome.Failure -> {
+                    rateLimiter.reportFailure(SOURCE_ID)
+                    Log.d(TAG, "search failed: ${outcome.message}")
+                    return null
+                }
+                is JioSaavnSearchOutcome.Success -> {
+                    val match = JioSaavnMatcher.best(query, outcome.songs) ?: continue
+                    when (val probe = client.isPlayable320(match.media.url)) {
+                        JioSaavnProbeOutcome.Playable -> Unit
+                        JioSaavnProbeOutcome.Unavailable -> {
+                            Log.d(TAG, "320 candidate unavailable for ${match.song.id}")
+                            continue
+                        }
+                        JioSaavnProbeOutcome.RateLimited -> {
+                            rateLimiter.reportRateLimited(SOURCE_ID)
+                            return null
+                        }
+                        is JioSaavnProbeOutcome.Failure -> {
+                            rateLimiter.reportFailure(SOURCE_ID)
+                            Log.d(TAG, "320 probe transport failed: ${probe.message}")
+                            return null
+                        }
+                    }
+                    rateLimiter.reportSuccess(SOURCE_ID)
+                    return SourceResult(
+                        sourceId = SOURCE_ID,
+                        downloadUrl = match.media.url,
+                        format = AudioFormat(
+                            codec = "aac",
+                            bitrateKbps = 320,
+                            sampleRateHz = 44_100,
+                            fileExtension = "m4a",
+                        ),
+                        confidence = match.confidence,
+                        sourceTrackId = match.song.id,
+                        coverArtUrl = match.song.image.firstOrNull {
+                            it.quality == "500x500" && it.url.startsWith("https://")
+                        }?.url,
+                    )
+                }
+            }
+        }
+        // Search itself succeeded. An unavailable candidate URL is a catalog
+        // miss, not enough evidence to open the provider-wide circuit breaker.
+        rateLimiter.reportSuccess(SOURCE_ID)
+        return null
+    }
+
+    companion object {
+        const val SOURCE_ID = "jiosaavn"
+        private const val TAG = "JioSaavnResolver"
+        private const val SEARCH_LIMIT = 10
+    }
+}

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/AggregatorRateLimiter.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/AggregatorRateLimiter.kt
@@ -149,6 +149,19 @@ class AggregatorRateLimiter @Inject constructor() {
             circuitBreakDurationMs = 10 * 60_000L,
             rateLimitTripsBreaker = false, // a Qobuz 429 = "slow down", not "broken"
         )
+
+        // JioSaavn is an opportunistic lossy fallback. A small burst keeps a
+        // foreground tap responsive, while the steady rate prevents an album
+        // sync from hammering the unofficial web endpoint. Any 429 or repeated
+        // transport/media-probe failures should cool it quickly so YouTube can
+        // take over without adding latency to every track.
+        configs["jiosaavn"] = Config(
+            tokensPerSecond = 1.0 / 2.0,
+            burstCapacity = 3.0,
+            backoff429Ms = 60_000L,
+            circuitBreakAfter = 3,
+            circuitBreakDurationMs = 10 * 60_000L,
+        )
     }
 
     companion object {

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessSource.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessSource.kt
@@ -89,6 +89,8 @@ data class TrackQuery(
     val album: String? = null,
     val isrc: String? = null,
     val durationMs: Long? = null,
+    /** Explicit-content identity when known; null means the source cannot verify it. */
+    val explicit: Boolean? = null,
     /**
      * The track's Spotify URI (`spotify:track:<id>`, a bare id, or an
      * `open.spotify.com/track/<id>` URL), when known. Used only by sources
@@ -242,6 +244,8 @@ data class AudioFormat(
     val sampleRateHz: Int = 0,
     /** Bits per sample for lossless; 0 if unknown / lossy. */
     val bitsPerSample: Int = 0,
+    /** On-disk container extension; differs from [codec] for AAC in MP4/M4A. */
+    val fileExtension: String = codec,
 ) {
     /**
      * True for codecs that encode audio without information loss —

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessUrlDownloader.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessUrlDownloader.kt
@@ -5,7 +5,14 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -43,6 +50,14 @@ class LosslessUrlDownloader @Inject constructor(
     private val fetchClient: OkHttpClient = httpClient.newBuilder()
         .readTimeout(FETCH_STALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         .writeTimeout(FETCH_STALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .build()
+
+    // JioSaavn URLs are accepted only on the exact aac.saavncdn.com host.
+    // Disable redirects for the actual whole-file fetch so a URL that was
+    // safe during the range probe cannot later pivot to an arbitrary host.
+    private val noRedirectFetchClient: OkHttpClient = fetchClient.newBuilder()
+        .followRedirects(false)
+        .followSslRedirects(false)
         .build()
 
     // Caps concurrent ENCRYPTED (amz) whole-file fetches. The DownloadManager
@@ -86,15 +101,36 @@ class LosslessUrlDownloader @Inject constructor(
         // a permit and wedge the source.
         if (key != null) amzFetchGate.acquire()
         try {
-            fetchClient.newCall(request).execute().use { response ->
+            val client = if (source.sourceId == NO_REDIRECT_SOURCE_ID) {
+                noRedirectFetchClient
+            } else {
+                fetchClient
+            }
+            val call = client.newCall(request)
+            coroutineScope {
+                // A blocking response-body read does not observe coroutine
+                // cancellation itself. This child is started immediately and
+                // cancels the OkHttp call as soon as the parent is cancelled.
+                val cancellationWatcher = launch(
+                    context = Dispatchers.IO,
+                    start = CoroutineStart.UNDISPATCHED,
+                ) {
+                    try {
+                        awaitCancellation()
+                    } finally {
+                        call.cancel()
+                    }
+                }
+                try {
+                    call.execute().use { response ->
                 if (!response.isSuccessful) {
-                    return@withContext Result.failure(
+                    return@use Result.failure(
                         IllegalStateException(
                             "fetch ${source.sourceId} failed: HTTP ${response.code} ${response.message}",
                         ),
                     )
                 }
-                val body = response.body ?: return@withContext Result.failure(
+                val body = response.body ?: return@use Result.failure(
                     IllegalStateException("fetch ${source.sourceId} failed: empty body"),
                 )
                 val totalBytes = body.contentLength().coerceAtLeast(0L)
@@ -108,6 +144,7 @@ class LosslessUrlDownloader @Inject constructor(
                     var bytesRead = 0L
                     val buf = okio.Buffer()
                     while (true) {
+                        currentCoroutineContext().ensureActive()
                         val read = bodySource.read(buf, 64 * 1024)
                         if (read == -1L) break
                         sink.write(buf, read)
@@ -119,7 +156,7 @@ class LosslessUrlDownloader @Inject constructor(
 
                 if (fetchTarget.length() == 0L) {
                     runCatching { if (fetchTarget.exists()) fetchTarget.delete() }
-                    return@withContext Result.failure(
+                    return@use Result.failure(
                         IllegalStateException("fetch ${source.sourceId} produced empty file"),
                     )
                 }
@@ -141,7 +178,15 @@ class LosslessUrlDownloader @Inject constructor(
                         IllegalStateException("decrypt ${source.sourceId} failed for ${destination.name}"),
                     )
                 }
+                    }
+                } finally {
+                    cancellationWatcher.cancel()
+                }
             }
+        } catch (e: CancellationException) {
+            runCatching { if (fetchTarget.exists()) fetchTarget.delete() }
+            runCatching { if (destination.exists()) destination.delete() }
+            throw e
         } catch (e: Exception) {
             Log.w(TAG, "fetch ${source.sourceId} threw: ${e.javaClass.simpleName}: ${e.message}")
             // Best-effort cleanup of any partial files so the caller's
@@ -166,5 +211,6 @@ class LosslessUrlDownloader @Inject constructor(
         // client). amz ultrahd whole-file pulls stalled past 30 s on a congested
         // hotspot; 90 s tolerates the pause without masking a truly dead socket.
         const val FETCH_STALL_TIMEOUT_SECONDS = 90L
+        const val NO_REDIRECT_SOURCE_ID = "jiosaavn"
     }
 }

--- a/data/download/src/main/kotlin/com/stash/data/download/search/SearchDownloadCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/search/SearchDownloadCoordinator.kt
@@ -9,13 +9,17 @@ import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.CacheKeyFactory
 import androidx.media3.datasource.cache.SimpleCache
 import com.stash.core.data.db.dao.DownloadQueueDao
+import com.stash.core.data.audio.AudioDurationExtractor
 import com.stash.core.model.DownloadStatus
 import com.stash.core.model.TrackItem
 import com.stash.data.download.DownloadExecutor
 import com.stash.data.download.DownloadResult
+import com.stash.data.download.DownloadManager
+import com.stash.data.download.jiosaavn.JioSaavnResolver
 import com.stash.data.download.lossless.AudioFormat
 import com.stash.data.download.lossless.LosslessSourcePreferences
 import com.stash.data.download.lossless.LosslessSourceRegistry
+import com.stash.data.download.lossless.LosslessUrlDownloader
 import com.stash.data.download.lossless.SourceResult
 import com.stash.data.download.lossless.TrackQuery
 import com.stash.data.download.lyrics.LyricsFetchTrigger
@@ -29,6 +33,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.io.File
@@ -78,6 +83,9 @@ class SearchDownloadCoordinator @Inject constructor(
      * of falling through to yt-dlp.
      */
     private val losslessPrefs: LosslessSourcePreferences,
+    private val jioSaavnResolver: JioSaavnResolver,
+    private val losslessUrlDownloader: LosslessUrlDownloader,
+    private val audioDurationExtractor: AudioDurationExtractor,
     private val downloadQueueDao: DownloadQueueDao,
     private val localFileOps: com.stash.core.data.files.LocalFileOps,
     private val loudnessMeasurer: com.stash.core.data.audio.LoudnessMeasurer,
@@ -129,29 +137,34 @@ class SearchDownloadCoordinator @Inject constructor(
         emit(SearchDownloadStatus.Resolving)
 
         val deferred = mutex.withLock {
-            inFlight.getOrPut(key) { scope.async { performDownload(track) } }
-        }
-
-        try {
-            when (val job = deferred.await()) {
-                is DownloadJobResult.Resolved -> {
-                    // Signal which source is delivering bytes now that resolution is done.
-                    emit(SearchDownloadStatus.Downloading(job.source))
-                    emit(
-                        when (val r = job.outcome) {
-                            is TrackFinalizer.FinalizeResult.Success -> SearchDownloadStatus.Completed
-                            is TrackFinalizer.FinalizeResult.Failed -> SearchDownloadStatus.Failed(r.message)
+            inFlight[key] ?: scope.async { performDownload(track) }.also { created ->
+                inFlight[key] = created
+                // The producer belongs to the singleton scope, not to any one
+                // collector. Remove it only when the producer completes.
+                created.invokeOnCompletion {
+                    scope.launch {
+                        mutex.withLock {
+                            if (inFlight[key] === created) inFlight.remove(key)
                         }
-                    )
-                }
-                is DownloadJobResult.Deferred -> {
-                    emit(SearchDownloadStatus.WaitingForLossless)
+                    }
                 }
             }
-        } finally {
-            // Remove on completion OR cancellation — ensures the map never
-            // holds a reference to a completed/cancelled Deferred.
-            mutex.withLock { inFlight.remove(key) }
+        }
+
+        when (val job = deferred.await()) {
+            is DownloadJobResult.Resolved -> {
+                // Signal which source is delivering bytes now that resolution is done.
+                emit(SearchDownloadStatus.Downloading(job.source))
+                emit(
+                    when (val r = job.outcome) {
+                        is TrackFinalizer.FinalizeResult.Success -> SearchDownloadStatus.Completed
+                        is TrackFinalizer.FinalizeResult.Failed -> SearchDownloadStatus.Failed(r.message)
+                    }
+                )
+            }
+            is DownloadJobResult.Deferred -> {
+                emit(SearchDownloadStatus.WaitingForLossless)
+            }
         }
     }
 
@@ -167,10 +180,7 @@ class SearchDownloadCoordinator @Inject constructor(
         // and — with fallback also off — deferred to WAITING_FOR_LOSSLESS, so
         // artist-page / search downloads hung on "waiting for lossless" forever.
         if (!losslessPrefs.enabledNow()) {
-            return DownloadJobResult.Resolved(
-                source = SearchDownloadStatus.Source.YOUTUBE,
-                outcome = finalizeFromYtDlp(track),
-            )
+            return finalizeFromLossyFallback(track)
         }
 
         val match = runCatching { registry.resolve(track.toQuery()) }
@@ -218,6 +228,39 @@ class SearchDownloadCoordinator @Inject constructor(
             return DownloadJobResult.Deferred
         }
 
+        return finalizeFromLossyFallback(track)
+    }
+
+    /** Resolves the preferred lossy fallback, then preserves YouTube as the last resort. */
+    private suspend fun finalizeFromLossyFallback(track: TrackItem): DownloadJobResult.Resolved {
+        val match = runCatching { jioSaavnResolver.resolve(track.toQuery()) }
+            .onFailure { error ->
+                if (error is CancellationException) throw error
+                Log.w(TAG, "JioSaavn resolve threw for ${track.videoId}: ${error.message}")
+            }
+            .getOrNull()
+
+        if (match != null) {
+            when (val attempt = finalizeFromSource(track, match)) {
+                is SourceFinalizeAttempt.BeforeCommitFailure -> {
+                    Log.w(
+                        TAG,
+                        "JioSaavn failed before commit for ${track.videoId}; falling through to YouTube: " +
+                            attempt.message,
+                    )
+                }
+                is SourceFinalizeAttempt.AfterCommit -> {
+                    // Once the file reaches permanent storage, any persistence
+                    // failure is terminal. Starting YouTube here could leave an
+                    // orphaned m4a and partially-mutated library rows.
+                    return DownloadJobResult.Resolved(
+                        source = SearchDownloadStatus.Source.JIOSAAVN,
+                        outcome = attempt.outcome,
+                    )
+                }
+            }
+        }
+
         return DownloadJobResult.Resolved(
             source = SearchDownloadStatus.Source.YOUTUBE,
             outcome = finalizeFromYtDlp(track),
@@ -231,51 +274,84 @@ class SearchDownloadCoordinator @Inject constructor(
     private suspend fun finalizeFromLossless(
         track: TrackItem,
         match: SourceResult,
-    ): TrackFinalizer.FinalizeResult {
+    ): TrackFinalizer.FinalizeResult = when (val attempt = finalizeFromSource(track, match)) {
+        is SourceFinalizeAttempt.BeforeCommitFailure ->
+            TrackFinalizer.FinalizeResult.Failed(attempt.message)
+        is SourceFinalizeAttempt.AfterCommit -> attempt.outcome
+    }
+
+    private suspend fun finalizeFromSource(
+        track: TrackItem,
+        match: SourceResult,
+    ): SourceFinalizeAttempt {
         // Cache key mirrors what SearchPreviewMediaSource uses so any bytes
         // already streamed during preview are reused here.
-        val cacheKey = "lossless:${track.videoId}"
+        val cacheNamespace = if (match.sourceId == JioSaavnResolver.SOURCE_ID) "jiosaavn" else "lossless"
+        val cacheKey = "$cacheNamespace:${track.videoId}"
         val tempFile = File(
             context.cacheDir,
-            "search_lossless_${track.videoId}.${match.format.codec}",
+            "search_lossless_${track.videoId}.${match.format.fileExtension}",
         )
         runCatching { tempFile.delete() }
 
-        // CacheDataSource with FLAG_BLOCK_ON_CACHE reads cached spans first,
-        // then fills missing byte ranges from upstream HTTP. Returns bytes
-        // contiguously regardless of which spans the preview pre-filled.
-        val dataSource = CacheDataSource.Factory()
-            .setCache(previewCache)
-            .setUpstreamDataSourceFactory(httpDataSourceFactory)
-            .setCacheKeyFactory(cacheKeyFactory)
-            .setFlags(CacheDataSource.FLAG_BLOCK_ON_CACHE)
-            .createDataSource()
-
-        runCatching {
-            val spec = DataSpec.Builder()
-                .setUri(match.downloadUrl)
-                // media3 1.9.2 API: DataSpec.Builder.setKey (NOT setCustomCacheKey).
-                // The CacheKeyFactory reads spec.key and returns it as the cache key.
-                .setKey(cacheKey)
-                .build()
-
-            dataSource.open(spec)
-            tempFile.outputStream().use { out ->
-                val buf = ByteArray(64 * 1024)
-                while (true) {
-                    val n = dataSource.read(buf, 0, buf.size)
-                    // C.RESULT_END_OF_INPUT (-1) signals EOF from the data source.
-                    if (n == C.RESULT_END_OF_INPUT) break
-                    out.write(buf, 0, n)
-                }
+        if (match.sourceId == JioSaavnResolver.SOURCE_ID) {
+            // Use the shared OkHttp downloader rather than Media3's redirect-
+            // following HTTP source. The Jio transport disables redirects so
+            // the trusted aac.saavncdn.com URL cannot pivot to another host.
+            val fetched = losslessUrlDownloader.download(match, tempFile)
+            fetched.exceptionOrNull()?.let { error ->
+                if (error is CancellationException) throw error
+                runCatching { tempFile.delete() }
+                return SourceFinalizeAttempt.BeforeCommitFailure(
+                    "JioSaavn fetch failed: ${error.message}",
+                )
             }
-        }.onFailure { e ->
+        } else {
+            // CacheDataSource with FLAG_BLOCK_ON_CACHE reads cached spans first,
+            // then fills missing byte ranges from upstream HTTP. Returns bytes
+            // contiguously regardless of which spans the preview pre-filled.
+            val dataSource = CacheDataSource.Factory()
+                .setCache(previewCache)
+                .setUpstreamDataSourceFactory(httpDataSourceFactory)
+                .setCacheKeyFactory(cacheKeyFactory)
+                .setFlags(CacheDataSource.FLAG_BLOCK_ON_CACHE)
+                .createDataSource()
+
+            runCatching {
+                val spec = DataSpec.Builder()
+                    .setUri(match.downloadUrl)
+                    .setKey(cacheKey)
+                    .build()
+
+                dataSource.open(spec)
+                tempFile.outputStream().use { out ->
+                    val buf = ByteArray(64 * 1024)
+                    while (true) {
+                        val n = dataSource.read(buf, 0, buf.size)
+                        if (n == C.RESULT_END_OF_INPUT) break
+                        out.write(buf, 0, n)
+                    }
+                }
+            }.onFailure { error ->
+                runCatching { dataSource.close() }
+                if (error is CancellationException) throw error
+                Log.w(TAG, "lossless cache->file copy failed for $cacheKey: ${error.message}")
+                return SourceFinalizeAttempt.BeforeCommitFailure(
+                    "Cache fill failed: ${error.message}",
+                )
+            }
             runCatching { dataSource.close() }
-            if (e is CancellationException) throw e
-            Log.w(TAG, "lossless cache->file copy failed for $cacheKey: ${e.message}")
-            return TrackFinalizer.FinalizeResult.Failed("Cache fill failed: ${e.message}")
         }
-        runCatching { dataSource.close() }
+
+        if (match.sourceId == JioSaavnResolver.SOURCE_ID) {
+            val metadata = audioDurationExtractor.extract(tempFile.absolutePath)
+            if (!isValidJioSaavnMedia(metadata, track)) {
+                runCatching { tempFile.delete() }
+                return SourceFinalizeAttempt.BeforeCommitFailure(
+                    "JioSaavn media failed AAC quality validation",
+                )
+            }
+        }
 
         val finalized = trackFinalizer.finalizeFile(
             sourceFile = tempFile,
@@ -306,7 +382,21 @@ class SearchDownloadCoordinator @Inject constructor(
         runCatching { previewCache.removeResource(cacheKey) }
             .onFailure { e -> Log.w(TAG, "removeResource failed for $cacheKey: ${e.message}") }
 
-        return outcome
+        return SourceFinalizeAttempt.AfterCommit(outcome)
+    }
+
+    private fun isValidJioSaavnMedia(
+        metadata: com.stash.core.data.audio.AudioMetadata?,
+        track: TrackItem,
+    ): Boolean {
+        metadata ?: return false
+        if (metadata.format != "aac" || metadata.bitrateKbps < DownloadManager.MIN_JIOSAAVN_BITRATE_KBPS) {
+            return false
+        }
+        if (track.durationSeconds <= 0) return true
+        val expectedMs = (track.durationSeconds * 1_000).toLong()
+        val toleranceMs = maxOf(8_000L, (expectedMs * 0.03).toLong())
+        return kotlin.math.abs(metadata.durationMs - expectedMs) <= toleranceMs
     }
 
     // -------------------------------------------------------------------------
@@ -614,6 +704,14 @@ class SearchDownloadCoordinator @Inject constructor(
 
         /** v0.9.17: lossless unavailable + fallback off → WaitingForLossless. */
         data object Deferred : DownloadJobResult
+    }
+
+    /** Distinguishes fallback-safe temp failures from terminal post-commit outcomes. */
+    private sealed interface SourceFinalizeAttempt {
+        data class BeforeCommitFailure(val message: String) : SourceFinalizeAttempt
+        data class AfterCommit(
+            val outcome: TrackFinalizer.FinalizeResult,
+        ) : SourceFinalizeAttempt
     }
 
     /** Expected policy/file rejection while converting a committed file into durable library state. */

--- a/data/download/src/main/kotlin/com/stash/data/download/search/SearchDownloadStatus.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/search/SearchDownloadStatus.kt
@@ -30,5 +30,5 @@ sealed interface SearchDownloadStatus {
     data object WaitingForLossless : SearchDownloadStatus
 
     /** Which path delivered the bytes, for UI labelling. */
-    enum class Source { LOSSLESS, YOUTUBE }
+    enum class Source { LOSSLESS, JIOSAAVN, YOUTUBE }
 }

--- a/data/download/src/main/kotlin/com/stash/data/download/shared/TrackFinalizer.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/shared/TrackFinalizer.kt
@@ -76,7 +76,7 @@ class TrackFinalizer @Inject constructor(
             artist = track.artist,
             album = track.album.takeIf { it.isNotBlank() },
             title = track.title,
-            format = format.codec.ifBlank { "flac" },
+            format = format.fileExtension.ifBlank { format.codec.ifBlank { "flac" } },
         )
         val meta: AudioMetadata? = audioExtractor.extract(committed.filePath)
         FinalizeResult.Success(committed, meta)

--- a/data/download/src/test/kotlin/com/stash/data/download/DownloadManagerDeferTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/DownloadManagerDeferTest.kt
@@ -11,6 +11,7 @@ import com.stash.data.download.files.AlbumArtCache
 import com.stash.data.download.files.FileOrganizer
 import com.stash.data.download.files.MetadataEmbedder
 import com.stash.data.download.lyrics.LyricsFetchTrigger
+import com.stash.data.download.jiosaavn.JioSaavnResolver
 import com.stash.data.download.lossless.LosslessSourcePreferences
 import com.stash.data.download.lossless.LosslessSourceRegistry
 import com.stash.data.download.lossless.LosslessUrlDownloader
@@ -60,6 +61,9 @@ class DownloadManagerDeferTest {
     private val losslessRegistry: LosslessSourceRegistry = mockk()
     private val losslessUrlDownloader: LosslessUrlDownloader = mockk(relaxed = true)
     private val losslessPrefs: LosslessSourcePreferences = mockk(relaxed = true)
+    private val jioSaavnResolver: JioSaavnResolver = mockk {
+        coEvery { resolve(any(), any()) } returns null
+    }
     private val trackFinalizer: TrackFinalizer = mockk(relaxed = true)
     private val loudnessMeasurer: com.stash.core.data.audio.LoudnessMeasurer = mockk(relaxed = true)
     private val metadataEmbedder: MetadataEmbedder = mockk(relaxed = true)
@@ -86,6 +90,7 @@ class DownloadManagerDeferTest {
         losslessRegistry = losslessRegistry,
         losslessUrlDownloader = losslessUrlDownloader,
         losslessPrefs = losslessPrefs,
+        jioSaavnResolver = jioSaavnResolver,
         trackFinalizer = trackFinalizer,
         loudnessMeasurer = loudnessMeasurer,
         metadataEmbedder = metadataEmbedder,

--- a/data/download/src/test/kotlin/com/stash/data/download/DownloadManagerDurationBackstopTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/DownloadManagerDurationBackstopTest.kt
@@ -10,6 +10,7 @@ import com.stash.core.model.Track
 import com.stash.data.download.files.AlbumArtCache
 import com.stash.data.download.files.FileOrganizer
 import com.stash.data.download.files.MetadataEmbedder
+import com.stash.data.download.jiosaavn.JioSaavnResolver
 import com.stash.data.download.lossless.AudioFormat
 import com.stash.data.download.lossless.LosslessSourceHealthGate
 import com.stash.data.download.lossless.LosslessSourcePreferences
@@ -80,6 +81,9 @@ class DownloadManagerDurationBackstopTest {
     private val losslessRegistry: LosslessSourceRegistry = mockk()
     private val losslessUrlDownloader: LosslessUrlDownloader = mockk()
     private val losslessPrefs: LosslessSourcePreferences = mockk(relaxed = true)
+    private val jioSaavnResolver: JioSaavnResolver = mockk {
+        coEvery { resolve(any(), any()) } returns null
+    }
     private val trackFinalizer: TrackFinalizer = mockk()
     private val loudnessMeasurer: com.stash.core.data.audio.LoudnessMeasurer = mockk(relaxed = true)
     private val metadataEmbedder: MetadataEmbedder = mockk(relaxed = true)
@@ -104,6 +108,7 @@ class DownloadManagerDurationBackstopTest {
         losslessRegistry = losslessRegistry,
         losslessUrlDownloader = losslessUrlDownloader,
         losslessPrefs = losslessPrefs,
+        jioSaavnResolver = jioSaavnResolver,
         trackFinalizer = trackFinalizer,
         loudnessMeasurer = loudnessMeasurer,
         metadataEmbedder = metadataEmbedder,

--- a/data/download/src/test/kotlin/com/stash/data/download/DownloadManagerEmbedStampTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/DownloadManagerEmbedStampTest.kt
@@ -1,6 +1,7 @@
 package com.stash.data.download
 
 import com.stash.core.data.db.dao.PlaylistDao
+import com.stash.core.data.audio.AudioMetadata
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.lastfm.LastFmApiClient
 import com.stash.core.data.lastfm.LastFmCredentials
@@ -8,6 +9,7 @@ import com.stash.core.model.Track
 import com.stash.data.download.files.AlbumArtCache
 import com.stash.data.download.files.FileOrganizer
 import com.stash.data.download.files.MetadataEmbedder
+import com.stash.data.download.jiosaavn.JioSaavnResolver
 import com.stash.data.download.lossless.AudioFormat
 import com.stash.data.download.lossless.LosslessSourcePreferences
 import com.stash.data.download.lossless.LosslessSourceRegistry
@@ -23,6 +25,7 @@ import com.stash.data.download.prefs.QualityPreferencesManager
 import com.stash.data.download.shared.TrackFinalizer
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
@@ -67,6 +70,9 @@ class DownloadManagerEmbedStampTest {
     private val losslessRegistry: LosslessSourceRegistry = mockk()
     private val losslessUrlDownloader: LosslessUrlDownloader = mockk()
     private val losslessPrefs: LosslessSourcePreferences = mockk(relaxed = true)
+    private val jioSaavnResolver: JioSaavnResolver = mockk {
+        coEvery { resolve(any(), any()) } returns null
+    }
     private val trackFinalizer: TrackFinalizer = mockk()
     private val loudnessMeasurer: com.stash.core.data.audio.LoudnessMeasurer = mockk(relaxed = true)
     private val metadataEmbedder: MetadataEmbedder = mockk(relaxed = true)
@@ -93,6 +99,7 @@ class DownloadManagerEmbedStampTest {
         losslessRegistry = losslessRegistry,
         losslessUrlDownloader = losslessUrlDownloader,
         losslessPrefs = losslessPrefs,
+        jioSaavnResolver = jioSaavnResolver,
         trackFinalizer = trackFinalizer,
         loudnessMeasurer = loudnessMeasurer,
         metadataEmbedder = metadataEmbedder,
@@ -115,6 +122,72 @@ class DownloadManagerEmbedStampTest {
         format = AudioFormat(codec = "flac", bitrateKbps = 1000, bitsPerSample = 16, sampleRateHz = 44100),
         confidence = 0.95f,
     )
+
+    private fun jioSaavnResult() = SourceResult(
+        sourceId = JioSaavnResolver.SOURCE_ID,
+        downloadUrl = "https://aac.saavncdn.com/song_320.mp4",
+        format = AudioFormat(
+            codec = "aac",
+            bitrateKbps = 320,
+            sampleRateHz = 44_100,
+            fileExtension = "m4a",
+        ),
+        confidence = 0.94f,
+    )
+
+    @Test
+    fun `JioSaavn AAC 320 is committed as m4a before YouTube fallback`() = runTest {
+        val track = stubTrack().copy(durationMs = 200_000L)
+        val tempDir = File.createTempFile("tmp", "").apply { delete(); mkdirs() }
+        coEvery { fileOrganizer.getTempDir() } returns tempDir
+        coEvery { jioSaavnResolver.resolve(any(), any()) } returns jioSaavnResult()
+        coEvery { losslessUrlDownloader.download(any(), any(), any()) } answers {
+            val destination = secondArg<File>()
+            destination.writeText("fake-m4a-bytes")
+            Result.success(destination)
+        }
+        every { audioDurationExtractor.extract(any()) } returns AudioMetadata(
+            durationMs = 200_000L,
+            bitrateKbps = 313,
+            format = "aac",
+            sampleRateHz = 44_100,
+        )
+        val committed = FileOrganizer.CommittedTrack(
+            filePath = "/library/Sample Artist/Sample.m4a",
+            sizeBytes = 1234L,
+        )
+        coEvery { trackFinalizer.finalizeFile(any(), any(), any()) } returns
+            TrackFinalizer.FinalizeResult.Success(committed, meta = null)
+
+        val result = newSubject().tryJioSaavnDownload(track)
+
+        assertTrue("expected Success, got $result", result is TrackDownloadResult.Success)
+        assertEquals(committed.filePath, (result as TrackDownloadResult.Success).filePath)
+        coVerify { trackFinalizer.finalizeFile(any(), any(), match { it.fileExtension == "m4a" }) }
+    }
+
+    @Test
+    fun `JioSaavn media below 256 kbps is rejected before commit`() = runTest {
+        val track = stubTrack().copy(durationMs = 200_000L)
+        val tempDir = File.createTempFile("tmp", "").apply { delete(); mkdirs() }
+        coEvery { fileOrganizer.getTempDir() } returns tempDir
+        coEvery { jioSaavnResolver.resolve(any(), any()) } returns jioSaavnResult()
+        coEvery { losslessUrlDownloader.download(any(), any(), any()) } answers {
+            val destination = secondArg<File>()
+            destination.writeText("fake-low-bitrate-m4a")
+            Result.success(destination)
+        }
+        every { audioDurationExtractor.extract(any()) } returns AudioMetadata(
+            durationMs = 200_000L,
+            bitrateKbps = 160,
+            format = "aac",
+        )
+
+        val result = newSubject().tryJioSaavnDownload(track)
+
+        assertEquals(null, result)
+        coVerify(exactly = 0) { trackFinalizer.finalizeFile(any(), any(), any()) }
+    }
 
     @Test
     fun `lossless success path stamps metadata_embedded_at with non-zero timestamp`() = runTest {

--- a/data/download/src/test/kotlin/com/stash/data/download/jiosaavn/JioSaavnClientTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/jiosaavn/JioSaavnClientTest.kt
@@ -1,0 +1,117 @@
+package com.stash.data.download.jiosaavn
+
+import com.google.common.truth.Truth.assertThat
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class JioSaavnClientTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: JioSaavnClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().also { it.start() }
+        client = JioSaavnClient(OkHttpClient()).apply {
+            baseUrl = server.url("/").toString()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `known native encrypted media template decrypts to AAC 320 MP4`() {
+        val decrypted = client.decrypt320Url(KNOWN_ENCRYPTED_MEDIA_URL)
+
+        assertThat(decrypted).isEqualTo(KNOWN_320_URL)
+    }
+
+    @Test
+    fun `native search encodes query and normalizes a flagged 320 result`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(nativeResponse(has320 = "true")))
+
+        val outcome = client.search("Arijit Singh Kesariya", limit = 10)
+
+        assertThat(outcome).isInstanceOf(JioSaavnSearchOutcome.Success::class.java)
+        val song = (outcome as JioSaavnSearchOutcome.Success).songs.single()
+        assertThat(song.name).isEqualTo("Kesariya & Love")
+        assertThat(song.artists.primary.single().name).isEqualTo("Arijit Singh")
+        assertThat(song.downloadUrl.single().url).isEqualTo(KNOWN_320_URL)
+        assertThat(song.image.single().url).contains("500x500")
+
+        val request = server.takeRequest()
+        assertThat(request.requestUrl?.queryParameter("__call")).isEqualTo("search.getResults")
+        assertThat(request.requestUrl?.queryParameter("q")).isEqualTo("Arijit Singh Kesariya")
+        assertThat(request.getHeader("User-Agent")).isNotEmpty()
+    }
+
+    @Test
+    fun `native result without 320 flag never synthesizes a media URL`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(nativeResponse(has320 = "false")))
+
+        val outcome = client.search("Arijit Singh Kesariya")
+
+        val song = (outcome as JioSaavnSearchOutcome.Success).songs.single()
+        assertThat(song.downloadUrl).isEmpty()
+    }
+
+    @Test
+    fun `cancelling search aborts a stalled response body promptly`() = runBlocking {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(nativeResponse(has320 = "true"))
+                .setBodyDelay(5, TimeUnit.SECONDS),
+        )
+
+        val startedAt = System.nanoTime()
+        val outcome = withTimeoutOrNull(200L) {
+            client.search("Arijit Singh Kesariya")
+        }
+        val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt)
+
+        assertThat(outcome).isNull()
+        assertThat(elapsedMs).isLessThan(2_000L)
+    }
+
+    @Test
+    fun `media URL trust gate requires HTTPS exact CDN and 320 path`() {
+        assertThat(client.isTrustedMediaUrl(KNOWN_320_URL)).isTrue()
+        assertThat(client.isTrustedMediaUrl(KNOWN_320_URL.replace("https://", "http://"))).isFalse()
+        assertThat(client.isTrustedMediaUrl("https://evil.example/song_320.mp4")).isFalse()
+        assertThat(client.isTrustedMediaUrl(KNOWN_320_URL.replace("_320", "_160"))).isFalse()
+    }
+
+    private fun nativeResponse(has320: String): String =
+        """{
+          "results": [{
+            "id": "rjkrTnma",
+            "song": "Kesariya &amp; Love",
+            "album": "Brahmastra",
+            "duration": "268",
+            "image": "http://c.saavncdn.com/871/cover-150x150.jpg",
+            "primary_artists": "Arijit Singh",
+            "explicit_content": 0,
+            "320kbps": "$has320",
+            "encrypted_media_url": "$KNOWN_ENCRYPTED_MEDIA_URL",
+            "ignored_field": "safe"
+          }]
+        }""".trimIndent()
+
+    private companion object {
+        const val KNOWN_ENCRYPTED_MEDIA_URL =
+            "ID2ieOjCrwfgWvL5sXl4B1ImC5QfbsDyryhkSYK5IH2E7FCO52VR6yhNbcEbes5iCcja4+W8xhE0SwtCJToN4Bw7tS9a8Gtq"
+        const val KNOWN_320_URL =
+            "https://aac.saavncdn.com/871/c2febd353f3a076a406fa37510f31f9f_320.mp4"
+    }
+}

--- a/data/download/src/test/kotlin/com/stash/data/download/jiosaavn/JioSaavnMatcherTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/jiosaavn/JioSaavnMatcherTest.kt
@@ -1,0 +1,101 @@
+package com.stash.data.download.jiosaavn
+
+import com.google.common.truth.Truth.assertThat
+import com.stash.data.download.lossless.TrackQuery
+import org.junit.Test
+
+class JioSaavnMatcherTest {
+    @Test
+    fun `exact artist title and duration selects 320kbps media`() {
+        val result = JioSaavnMatcher.best(
+            TrackQuery("Arijit Singh", "Kesariya", album = "Brahmastra", durationMs = 268_000L),
+            listOf(song()),
+        )
+        assertThat(result).isNotNull()
+        assertThat(result!!.media.quality).isEqualTo("320kbps")
+        assertThat(result.media.url).endsWith("_320.mp4")
+    }
+
+    @Test
+    fun `karaoke candidate is rejected when target is the studio song`() {
+        val result = JioSaavnMatcher.best(
+            TrackQuery("Imagine Dragons", "Believer", durationMs = 204_000L),
+            listOf(song(name = "Believer (Karaoke Version)", artist = "Imagine Dragons Karaoke Band", duration = 204)),
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `version qualifier must agree in both directions`() {
+        val query = TrackQuery("Pandera", "Terranova (Pandera Airplay Edit)", durationMs = 220_000L)
+        assertThat(JioSaavnMatcher.best(query, listOf(song(name = "Terranova", artist = "Pandera", duration = 220)))).isNull()
+        assertThat(
+            JioSaavnMatcher.best(
+                query,
+                listOf(song(name = "Terranova (Pandera Airplay Edit)", artist = "Pandera", duration = 220)),
+            ),
+        ).isNotNull()
+    }
+
+    @Test
+    fun `large duration mismatch is rejected even with exact text`() {
+        val result = JioSaavnMatcher.best(
+            TrackQuery("Radiohead", "Karma Police", durationMs = 261_000L),
+            listOf(song(name = "Karma Police", artist = "Radiohead", duration = 410)),
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `non-https 320 media is rejected`() {
+        val result = JioSaavnMatcher.best(
+            TrackQuery("Arijit Singh", "Kesariya", durationMs = 268_000L),
+            listOf(song(mediaUrl = "http://aac.saavncdn.com/song_320.mp4")),
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `equally exact recordings are rejected when album cannot disambiguate`() {
+        val result = JioSaavnMatcher.best(
+            TrackQuery("Artist", "Song", durationMs = 200_000L),
+            listOf(
+                song(id = "a", name = "Song", artist = "Artist", duration = 200, album = "Album A"),
+                song(id = "b", name = "Song", artist = "Artist", duration = 200, album = "Different Record"),
+            ),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `exact album breaks an otherwise exact recording tie`() {
+        val result = JioSaavnMatcher.best(
+            TrackQuery("Artist", "Song", album = "Album A", durationMs = 200_000L),
+            listOf(
+                song(id = "b", name = "Song", artist = "Artist", duration = 200, album = "Different Record"),
+                song(id = "a", name = "Song", artist = "Artist", duration = 200, album = "Album A"),
+            ),
+        )
+
+        assertThat(result?.song?.id).isEqualTo("a")
+    }
+
+    private fun song(
+        id: String = "rjkrTnma",
+        name: String = "Kesariya",
+        artist: String = "Arijit Singh",
+        duration: Int = 268,
+        mediaUrl: String = "https://aac.saavncdn.com/song_320.mp4",
+        album: String = "Brahmastra",
+    ) = JioSaavnSong(
+        id = id,
+        name = name,
+        duration = duration,
+        explicitContent = false,
+        album = JioSaavnAlbum(album),
+        artists = JioSaavnArtists(listOf(JioSaavnArtist(artist))),
+        image = listOf(JioSaavnImage("500x500", "https://c.saavncdn.com/cover.jpg")),
+        downloadUrl = listOf(JioSaavnMediaLink("320kbps", mediaUrl)),
+    )
+}

--- a/data/download/src/test/kotlin/com/stash/data/download/jiosaavn/JioSaavnMatcherTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/jiosaavn/JioSaavnMatcherTest.kt
@@ -17,6 +17,17 @@ class JioSaavnMatcherTest {
     }
 
     @Test
+    fun `parenthetical decoration on the query title still matches the plain title`() {
+        // Device-verified miss 2026-08-13: Spotify names the track
+        // 'Apna Bana Le (From "Bhediya")', JioSaavn names it 'Apna Bana Le'.
+        val result = JioSaavnMatcher.best(
+            TrackQuery("Arijit Singh, Sachin-Jigar", "Apna Bana Le (From \"Bhediya\")", durationMs = 261_000L),
+            listOf(song(name = "Apna Bana Le", artist = "Sachin-Jigar, Arijit Singh", duration = 261)),
+        )
+        assertThat(result).isNotNull()
+    }
+
+    @Test
     fun `karaoke candidate is rejected when target is the studio song`() {
         val result = JioSaavnMatcher.best(
             TrackQuery("Imagine Dragons", "Believer", durationMs = 204_000L),

--- a/data/download/src/test/kotlin/com/stash/data/download/jiosaavn/JioSaavnResolverTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/jiosaavn/JioSaavnResolverTest.kt
@@ -1,0 +1,91 @@
+package com.stash.data.download.jiosaavn
+
+import com.google.common.truth.Truth.assertThat
+import com.stash.data.download.lossless.AggregatorRateLimiter
+import com.stash.data.download.lossless.RateLimitState
+import com.stash.data.download.lossless.TrackQuery
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class JioSaavnResolverTest {
+    private val client: JioSaavnClient = mockk()
+    private val limiter: AggregatorRateLimiter = mockk(relaxUnitFun = true)
+
+    @Test
+    fun `exact playable result becomes 320kbps AAC in an m4a container`() = runTest {
+        ready()
+        coEvery { client.search(any(), any()) } returns JioSaavnSearchOutcome.Success(listOf(song()))
+        coEvery { client.isPlayable320(any()) } returns JioSaavnProbeOutcome.Playable
+
+        val result = JioSaavnResolver(client, limiter).resolve(query(), bypassRateLimit = true)
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.sourceId).isEqualTo(JioSaavnResolver.SOURCE_ID)
+        assertThat(result.format.codec).isEqualTo("aac")
+        assertThat(result.format.fileExtension).isEqualTo("m4a")
+        assertThat(result.format.bitrateKbps).isEqualTo(320)
+        coVerify { limiter.reportSuccess(JioSaavnResolver.SOURCE_ID) }
+    }
+
+    @Test
+    fun `fabricated 320 url that fails media probe falls through`() = runTest {
+        ready()
+        coEvery { client.search(any(), any()) } returns JioSaavnSearchOutcome.Success(listOf(song()))
+        coEvery { client.isPlayable320(any()) } returns JioSaavnProbeOutcome.Unavailable
+
+        assertThat(JioSaavnResolver(client, limiter).resolve(query(), true)).isNull()
+        coVerify(exactly = 0) { limiter.reportFailure(JioSaavnResolver.SOURCE_ID) }
+        coVerify { limiter.reportSuccess(JioSaavnResolver.SOURCE_ID) }
+    }
+
+    @Test
+    fun `probe transport failure records provider failure`() = runTest {
+        ready()
+        coEvery { client.search(any(), any()) } returns JioSaavnSearchOutcome.Success(listOf(song()))
+        coEvery { client.isPlayable320(any()) } returns JioSaavnProbeOutcome.Failure("HTTP 503")
+
+        assertThat(JioSaavnResolver(client, limiter).resolve(query(), true)).isNull()
+        coVerify { limiter.reportFailure(JioSaavnResolver.SOURCE_ID) }
+    }
+
+    @Test
+    fun `probe rate limit records backoff`() = runTest {
+        ready()
+        coEvery { client.search(any(), any()) } returns JioSaavnSearchOutcome.Success(listOf(song()))
+        coEvery { client.isPlayable320(any()) } returns JioSaavnProbeOutcome.RateLimited
+
+        assertThat(JioSaavnResolver(client, limiter).resolve(query(), true)).isNull()
+        coVerify { limiter.reportRateLimited(JioSaavnResolver.SOURCE_ID) }
+    }
+
+    @Test
+    fun `rate limited search records backoff and returns null`() = runTest {
+        ready()
+        coEvery { client.search(any(), any()) } returns JioSaavnSearchOutcome.RateLimited
+
+        assertThat(JioSaavnResolver(client, limiter).resolve(query(), true)).isNull()
+        coVerify { limiter.reportRateLimited(JioSaavnResolver.SOURCE_ID) }
+    }
+
+    private fun ready() {
+        coEvery { limiter.stateOf(JioSaavnResolver.SOURCE_ID) } returns
+            RateLimitState(4.0, 0, false, 0, 0)
+        coEvery { limiter.acquire(JioSaavnResolver.SOURCE_ID) } returns true
+    }
+
+    private fun query() = TrackQuery("Arijit Singh", "Kesariya", album = "Brahmastra", durationMs = 268_000L)
+
+    private fun song() = JioSaavnSong(
+        id = "rjkrTnma",
+        name = "Kesariya",
+        duration = 268,
+        explicitContent = false,
+        album = JioSaavnAlbum("Brahmastra"),
+        artists = JioSaavnArtists(listOf(JioSaavnArtist("Arijit Singh"))),
+        image = listOf(JioSaavnImage("500x500", "https://c.saavncdn.com/cover.jpg")),
+        downloadUrl = listOf(JioSaavnMediaLink("320kbps", "https://aac.saavncdn.com/song_320.mp4")),
+    )
+}

--- a/data/download/src/test/kotlin/com/stash/data/download/search/SearchDownloadCoordinatorAlbumTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/search/SearchDownloadCoordinatorAlbumTest.kt
@@ -14,6 +14,7 @@ import com.stash.core.model.MusicSource
 import com.stash.core.model.Track
 import com.stash.core.model.TrackItem
 import com.stash.data.download.DownloadExecutor
+import com.stash.data.download.jiosaavn.JioSaavnResolver
 import com.stash.data.download.DownloadResult
 import com.stash.data.download.files.FileOrganizer.CommittedTrack
 import com.stash.data.download.lossless.LosslessSourcePreferences
@@ -56,6 +57,11 @@ class SearchDownloadCoordinatorAlbumTest {
     private val blocklistGuard: BlocklistGuard = mockk(relaxed = true)
     private val context: Context = mockk(relaxed = true)
     private val losslessPrefs: LosslessSourcePreferences = mockk(relaxed = true)
+    private val jioSaavnResolver: JioSaavnResolver = mockk {
+        coEvery { resolve(any(), any()) } returns null
+    }
+    private val losslessUrlDownloader: com.stash.data.download.lossless.LosslessUrlDownloader = mockk()
+    private val audioDurationExtractor: com.stash.core.data.audio.AudioDurationExtractor = mockk()
     private val downloadQueueDao: DownloadQueueDao = mockk(relaxed = true)
     private val loudnessMeasurer: com.stash.core.data.audio.LoudnessMeasurer = mockk(relaxed = true)
     private val lyricsFetchTrigger: LyricsFetchTrigger = mockk(relaxed = true)
@@ -77,6 +83,9 @@ class SearchDownloadCoordinatorAlbumTest {
         blocklistGuard = blocklistGuard,
         context = context,
         losslessPrefs = losslessPrefs,
+        jioSaavnResolver = jioSaavnResolver,
+        losslessUrlDownloader = losslessUrlDownloader,
+        audioDurationExtractor = audioDurationExtractor,
         downloadQueueDao = downloadQueueDao,
         localFileOps = mockk(relaxed = true) { every { acceptDownloadOrDelete(any()) } returns true },
         loudnessMeasurer = loudnessMeasurer,

--- a/data/download/src/test/kotlin/com/stash/data/download/search/SearchDownloadCoordinatorCompletionTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/search/SearchDownloadCoordinatorCompletionTest.kt
@@ -15,18 +15,27 @@ import com.stash.core.data.repository.MusicRepository
 import com.stash.core.model.MusicSource
 import com.stash.core.model.TrackItem
 import com.stash.data.download.DownloadExecutor
+import com.stash.data.download.jiosaavn.JioSaavnResolver
 import com.stash.data.download.DownloadResult
 import com.stash.data.download.files.FileOrganizer.CommittedTrack
 import com.stash.data.download.lossless.LosslessSourcePreferences
 import com.stash.data.download.lossless.LosslessSourceRegistry
+import com.stash.data.download.lossless.AudioFormat
+import com.stash.data.download.lossless.SourceResult
 import com.stash.data.download.lyrics.LyricsFetchTrigger
 import com.stash.data.download.shared.TrackFinalizer
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -48,6 +57,11 @@ class SearchDownloadCoordinatorCompletionTest {
     private val blocklistGuard: BlocklistGuard = mockk(relaxed = true)
     private val context: Context = mockk(relaxed = true)
     private val losslessPrefs: LosslessSourcePreferences = mockk(relaxed = true)
+    private val jioSaavnResolver: JioSaavnResolver = mockk {
+        coEvery { resolve(any(), any()) } returns null
+    }
+    private val losslessUrlDownloader: com.stash.data.download.lossless.LosslessUrlDownloader = mockk()
+    private val audioDurationExtractor: com.stash.core.data.audio.AudioDurationExtractor = mockk()
     private val downloadQueueDao: DownloadQueueDao = mockk(relaxed = true)
     private val localFileOps: LocalFileOps = mockk()
     private val loudnessMeasurer: LoudnessMeasurer = mockk(relaxed = true)
@@ -70,6 +84,9 @@ class SearchDownloadCoordinatorCompletionTest {
         blocklistGuard = blocklistGuard,
         context = context,
         losslessPrefs = losslessPrefs,
+        jioSaavnResolver = jioSaavnResolver,
+        losslessUrlDownloader = losslessUrlDownloader,
+        audioDurationExtractor = audioDurationExtractor,
         downloadQueueDao = downloadQueueDao,
         localFileOps = localFileOps,
         loudnessMeasurer = loudnessMeasurer,
@@ -129,11 +146,147 @@ class SearchDownloadCoordinatorCompletionTest {
         } returns 1
     }
 
+    private fun arrangeFinalizedJioSaavnDownload() {
+        coEvery { losslessPrefs.enabledNow() } returns false
+        coEvery { jioSaavnResolver.resolve(any(), any()) } returns SourceResult(
+            sourceId = JioSaavnResolver.SOURCE_ID,
+            downloadUrl = "https://aac.saavncdn.com/song_320.mp4",
+            format = AudioFormat(
+                codec = "aac",
+                bitrateKbps = 320,
+                sampleRateHz = 44_100,
+                fileExtension = "m4a",
+            ),
+            confidence = 0.97f,
+        )
+        coEvery { losslessUrlDownloader.download(any(), any(), any()) } coAnswers {
+            Result.success(arg<File>(1))
+        }
+        coEvery { audioDurationExtractor.extract(any()) } returns AudioMetadata(
+            durationMs = 200_000L,
+            bitrateKbps = 313,
+            format = "aac",
+            sampleRateHz = 44_100,
+            bitsPerSample = 16,
+        )
+        coEvery { trackFinalizer.finalizeFile(any(), any(), any(), any()) } returns
+            TrackFinalizer.FinalizeResult.Success(
+                committed = CommittedTrack(
+                    filePath = "/library/Sample Artist/Sample.m4a",
+                    sizeBytes = 4096L,
+                ),
+                meta = AudioMetadata(
+                    durationMs = 200_000L,
+                    bitrateKbps = 313,
+                    format = "aac",
+                    sampleRateHz = 44_100,
+                    bitsPerSample = 16,
+                ),
+            )
+        coEvery { trackDao.findByYoutubeId("vid42") } returns existingTrack()
+        coEvery {
+            trackDao.markAsDownloaded(any(), any(), any(), any(), any(), any())
+        } returns 1
+    }
+
     private fun assertFailedNeverCompleted(statuses: List<SearchDownloadStatus>) {
         assertTrue("terminal status must be Failed, got $statuses", statuses.last() is SearchDownloadStatus.Failed)
         assertFalse("Completed must never be emitted after persistence failure, got $statuses", statuses.any {
             it is SearchDownloadStatus.Completed
         })
+    }
+
+    @Test
+    fun `lossless disabled still tries JioSaavn before YouTube`() = runTest {
+        arrangeFinalizedYtDlpDownload()
+
+        val statuses = newSubject().download(track()).toList()
+
+        assertTrue(statuses.last() is SearchDownloadStatus.Completed)
+        coVerifyOrder {
+            jioSaavnResolver.resolve(any(), any())
+            downloadExecutor.download(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `valid JioSaavn AAC commits and never starts YouTube`() = runTest {
+        arrangeFinalizedJioSaavnDownload()
+
+        val statuses = newSubject().download(track()).toList()
+
+        assertTrue(statuses.last() is SearchDownloadStatus.Completed)
+        assertTrue(
+            statuses.any {
+                it == SearchDownloadStatus.Downloading(SearchDownloadStatus.Source.JIOSAAVN)
+            },
+        )
+        coVerify(exactly = 0) { downloadExecutor.download(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `invalid JioSaavn media falls through to YouTube before commit`() = runTest {
+        arrangeFinalizedYtDlpDownload()
+        coEvery { jioSaavnResolver.resolve(any(), any()) } returns SourceResult(
+            sourceId = JioSaavnResolver.SOURCE_ID,
+            downloadUrl = "https://aac.saavncdn.com/song_320.mp4",
+            format = AudioFormat("aac", 320, 44_100, fileExtension = "m4a"),
+            confidence = 0.97f,
+        )
+        coEvery { losslessUrlDownloader.download(any(), any(), any()) } coAnswers {
+            Result.success(arg<File>(1))
+        }
+        coEvery { audioDurationExtractor.extract(any()) } returns AudioMetadata(
+            durationMs = 200_000L,
+            bitrateKbps = 160,
+            format = "aac",
+            sampleRateHz = 44_100,
+            bitsPerSample = 16,
+        )
+
+        val statuses = newSubject().download(track()).toList()
+
+        assertTrue(statuses.last() is SearchDownloadStatus.Completed)
+        coVerify(exactly = 1) { downloadExecutor.download(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 1) { trackFinalizer.finalizeFile(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `JioSaavn persistence failure is terminal and never starts YouTube`() = runTest {
+        arrangeFinalizedJioSaavnDownload()
+        coEvery {
+            trackDao.markAsDownloaded(any(), any(), any(), any(), any(), any())
+        } throws IllegalStateException("database unavailable")
+
+        val statuses = newSubject().download(track()).toList()
+
+        assertFailedNeverCompleted(statuses)
+        coVerify(exactly = 0) { downloadExecutor.download(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `cancelling one collector keeps the shared producer deduplicated`() = runTest {
+        arrangeFinalizedYtDlpDownload()
+        val resolverStarted = CompletableDeferred<Unit>()
+        val releaseResolver = CompletableDeferred<Unit>()
+        coEvery { jioSaavnResolver.resolve(any(), any()) } coAnswers {
+            resolverStarted.complete(Unit)
+            releaseResolver.await()
+            null
+        }
+        val subject = newSubject()
+
+        val firstCollector = launch { subject.download(track()).collect() }
+        resolverStarted.await()
+        firstCollector.cancelAndJoin()
+
+        val secondCollector = async { subject.download(track()).toList() }
+        releaseResolver.complete(Unit)
+        val statuses = secondCollector.await()
+
+        assertTrue(statuses.last() is SearchDownloadStatus.Completed)
+        coVerify(exactly = 1) { jioSaavnResolver.resolve(any(), any()) }
+        coVerify(exactly = 1) { downloadExecutor.download(any(), any(), any(), any(), any()) }
     }
 
     @Test

--- a/data/download/src/test/kotlin/com/stash/data/download/search/SearchDownloadCoordinatorDeferTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/search/SearchDownloadCoordinatorDeferTest.kt
@@ -14,6 +14,7 @@ import com.stash.core.model.MusicSource
 import com.stash.core.model.DownloadStatus
 import com.stash.core.model.TrackItem
 import com.stash.data.download.DownloadExecutor
+import com.stash.data.download.jiosaavn.JioSaavnResolver
 import com.stash.data.download.DownloadResult
 import com.stash.data.download.lossless.LosslessSourcePreferences
 import com.stash.data.download.lossless.LosslessSourceRegistry
@@ -57,6 +58,11 @@ class SearchDownloadCoordinatorDeferTest {
     private val blocklistGuard: BlocklistGuard = mockk(relaxed = true)
     private val context: Context = mockk(relaxed = true)
     private val losslessPrefs: LosslessSourcePreferences = mockk(relaxed = true)
+    private val jioSaavnResolver: JioSaavnResolver = mockk {
+        coEvery { resolve(any(), any()) } returns null
+    }
+    private val losslessUrlDownloader: com.stash.data.download.lossless.LosslessUrlDownloader = mockk()
+    private val audioDurationExtractor: com.stash.core.data.audio.AudioDurationExtractor = mockk()
     private val downloadQueueDao: DownloadQueueDao = mockk(relaxed = true)
     private val loudnessMeasurer: com.stash.core.data.audio.LoudnessMeasurer = mockk(relaxed = true)
     private val lyricsFetchTrigger: LyricsFetchTrigger = mockk(relaxed = true)
@@ -73,6 +79,9 @@ class SearchDownloadCoordinatorDeferTest {
         blocklistGuard = blocklistGuard,
         context = context,
         losslessPrefs = losslessPrefs,
+        jioSaavnResolver = jioSaavnResolver,
+        losslessUrlDownloader = losslessUrlDownloader,
+        audioDurationExtractor = audioDurationExtractor,
         downloadQueueDao = downloadQueueDao,
         localFileOps = mockk(relaxed = true) { every { acceptDownloadOrDelete(any()) } returns true },
         loudnessMeasurer = loudnessMeasurer,

--- a/data/download/src/test/kotlin/com/stash/data/download/search/SearchDownloadCoordinatorEmbedStampTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/search/SearchDownloadCoordinatorEmbedStampTest.kt
@@ -14,6 +14,7 @@ import com.stash.core.model.MusicSource
 import com.stash.core.model.Track
 import com.stash.core.model.TrackItem
 import com.stash.data.download.DownloadExecutor
+import com.stash.data.download.jiosaavn.JioSaavnResolver
 import com.stash.data.download.DownloadResult
 import com.stash.data.download.files.FileOrganizer.CommittedTrack
 import com.stash.data.download.lossless.LosslessSourcePreferences
@@ -59,6 +60,11 @@ class SearchDownloadCoordinatorEmbedStampTest {
     private val blocklistGuard: BlocklistGuard = mockk(relaxed = true)
     private val context: Context = mockk(relaxed = true)
     private val losslessPrefs: LosslessSourcePreferences = mockk(relaxed = true)
+    private val jioSaavnResolver: JioSaavnResolver = mockk {
+        coEvery { resolve(any(), any()) } returns null
+    }
+    private val losslessUrlDownloader: com.stash.data.download.lossless.LosslessUrlDownloader = mockk()
+    private val audioDurationExtractor: com.stash.core.data.audio.AudioDurationExtractor = mockk()
     private val downloadQueueDao: DownloadQueueDao = mockk(relaxed = true)
     private val loudnessMeasurer: com.stash.core.data.audio.LoudnessMeasurer = mockk(relaxed = true)
     private val lyricsFetchTrigger: LyricsFetchTrigger = mockk(relaxed = true)
@@ -80,6 +86,9 @@ class SearchDownloadCoordinatorEmbedStampTest {
         blocklistGuard = blocklistGuard,
         context = context,
         losslessPrefs = losslessPrefs,
+        jioSaavnResolver = jioSaavnResolver,
+        losslessUrlDownloader = losslessUrlDownloader,
+        audioDurationExtractor = audioDurationExtractor,
         downloadQueueDao = downloadQueueDao,
         localFileOps = mockk(relaxed = true) { every { acceptDownloadOrDelete(any()) } returns true },
         loudnessMeasurer = loudnessMeasurer,

--- a/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
+++ b/feature/nowplaying/src/main/kotlin/com/stash/feature/nowplaying/NowPlayingScreen.kt
@@ -999,7 +999,10 @@ private fun trackQualityText(track: com.stash.core.model.Track): String? {
         // two. We don't badge "via Kennyy" / "via squid" because those
         // are the expected primary sources; only the lossy fallback
         // deserves a callout.
-        if (track.streamOrigin == "youtube") add("via YT")
+        when (track.streamOrigin) {
+            "jiosaavn" -> add("via JioSaavn")
+            "youtube" -> add("via YT")
+        }
     }.joinToString(" · ")
 }
 

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAudioQualityScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAudioQualityScreen.kt
@@ -111,6 +111,12 @@ fun SettingsAudioQualityScreen(
                         style = MaterialTheme.typography.titleSmall,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
+                    Text(
+                        text = "JioSaavn fallback uses AAC 320 kbps when available. " +
+                            "This picker controls the final YouTube fallback.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                     Spacer(modifier = Modifier.height(8.dp))
                     AudioQualityPicker(
                         selected = uiState.audioQuality,
@@ -461,7 +467,7 @@ fun SettingsAudioQualityScreen(
                             )
                             Spacer(modifier = Modifier.width(4.dp))
                             Text(
-                                text = "YouTube fallback",
+                                text = "Lossy fallback",
                                 style = MaterialTheme.typography.labelMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 modifier = Modifier.weight(1f),
@@ -487,13 +493,20 @@ fun SettingsAudioQualityScreen(
                                     )
                                     Spacer(modifier = Modifier.width(8.dp))
                                     Text(
-                                        text = "Use YouTube when lossless fails",
+                                        text = "Use JioSaavn, then YouTube when lossless fails",
                                         style = MaterialTheme.typography.bodyMedium,
                                         color = MaterialTheme.colorScheme.onSurface,
                                     )
                                 }
                                 if (uiState.youtubeFallbackEnabled) {
                                     Spacer(modifier = Modifier.height(8.dp))
+                                    Text(
+                                        text = "JioSaavn uses fixed AAC 320 kbps. " +
+                                            "The quality picker below applies to YouTube only.",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                    Spacer(modifier = Modifier.height(4.dp))
                                     AudioQualityPicker(
                                         selected = uiState.audioQuality,
                                         onSelected = viewModel::onQualityChanged,

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LosslessRoutingStatus.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/LosslessRoutingStatus.kt
@@ -71,7 +71,7 @@ internal fun LosslessRoutingStatus(
         )
         Spacer(modifier = Modifier.height(6.dp))
         Text(
-            text = "Lossless comes from Qobuz. Anything Qobuz doesn't carry falls " +
+            text = "Lossless comes from Qobuz. Misses try JioSaavn AAC 320 before falling " +
                 "back to YouTube, shown as \"via YT\" while it plays.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,


### PR DESCRIPTION
## Summary
- add a conservative JioSaavn 320 kbps AAC fallback after lossless sources and before YouTube for downloads and foreground streaming
- validate codec, bitrate, and duration before committing m4a files while preserving YouTube fallback for pre-commit misses
- add cancellation-aware, rate-limited, no-redirect transport, source attribution, and regression coverage
- prevent shared search-download cancellation races and post-commit double downloads

## Verification
- data download JioSaavn tests and SearchDownloadCoordinatorCompletionTest
- media StreamSourceRegistryTest, LazyResolvingDataSourceTest, and StashMediaSourceFactoryTest
- app compileDebugKotlin
- git diff --check

## Merge blocker
This integration uses an unofficial JioSaavn endpoint and media URL derivation. The current JioSaavn Terms of Use prohibit automated or unofficial access unless separately allowed: https://corporate.saavn.com/terms/. Confirm written provider authorization and applicable licensing before marking this ready to merge.

## Note
The existing force-YouTube diagnostic toggle behavior for already-resolved timeline items remains unchanged and is outside this PR.

Closes #104

Original PR by @JoshDui 