### PR TITLE
Skip home items without owner data to prevent mislabeling

### DIFF
--- a/data/spotify/src/main/kotlin/com/stash/data/spotify/SpotifyApiClient.kt
+++ b/data/spotify/src/main/kotlin/com/stash/data/spotify/SpotifyApiClient.kt
@@ -120,8 +120,9 @@ class SpotifyApiClient @Inject constructor(
          * Blend, Made-For-You mood mixes, "This Is <artist>": names vary by
          * locale but all are spotify-owned).
          *
-         * Note the caller defaults [ownerId] to "spotify" when the home item
-         * carries no owner data, so owner-less items also take the catch-all.
+         * The caller now SKIPS home items with no owner data entirely (fail-closed)
+         * rather than defaulting [ownerId] to "spotify" — that default used to sweep
+         * user-owned playlists from non-mix home sections into this catch-all.
          *
          * ponytail: owner rule first; add a deny-set only if device shows
          * editorial leakage (e.g. "Today's Top Hits" surfacing in the home feed).
@@ -601,7 +602,15 @@ class SpotifyApiClient @Inject constructor(
                         val ownerData = data["ownerV2"]?.jsonObject?.get("data")?.jsonObject
                         val ownerId = ownerData?.get("username")?.jsonPrimitive?.contentOrNull
                             ?: ownerData?.get("id")?.jsonPrimitive?.contentOrNull
-                            ?: "spotify"
+                        // Unknown owner is NOT the "spotify" catch-all — that used to sweep in
+                        // user-owned playlists surfaced in non-mix home feed sections (e.g.
+                        // "Jump back in") whose cards omit ownerV2. Fail closed: no owner data
+                        // means we can't confirm this is a real mix, so skip it rather than
+                        // mislabel someone's own playlist as a DAILY_MIX.
+                        if (ownerId == null) {
+                            Log.d(TAG, "parseHomeFeedForSpotifyMixes: skipping '$name' — no owner data")
+                            continue
+                        }
                         val ownerName = ownerData?.get("name")?.jsonPrimitive?.contentOrNull ?: "Spotify"
 
                         if (!isSpotifyMix(name, ownerId, uri.removePrefix("spotify:playlist:"))) continue


### PR DESCRIPTION
## Summary
- `parseHomeFeedForSpotifyMixes` previously defaulted `ownerId` to `"spotify"` whenever a home feed item's `ownerV2` data was missing. That default was meant to catch editorial mixes (Daily Mix, Discover Weekly, Made-For-You, "This Is <artist>") that legitimately have no owner, but it also swept in user-owned playlists from non-mix home sections (e.g. "Jump back in") whose cards simply omit `ownerV2` for other reasons — causing those to be mislabeled as `DAILY_MIX`.
- Fix: fail closed. If `ownerId` can't be resolved from `ownerV2.username` or `ownerV2.id`, skip the item entirely (`continue`) instead of assuming it's Spotify-owned. A debug log records the skip with the item's `name` for traceability.
- Updated the surrounding doc comment to describe the new skip behavior instead of the old default-to-`"spotify"` behavior.

## Changes
- `data/spotify/src/main/kotlin/com/stash/data/spotify/SpotifyApiClient.kt`
  - Removed `?: "spotify"` fallback when resolving `ownerId`
  - Added early `continue` (with debug log) when `ownerId` is null
  - Updated kdoc above `isSpotifyMix` usage to reflect fail-closed behavior

## Test plan
- [x] `./gradlew :data:spotify:compileDebugKotlin`
- [x] `./gradlew :data:spotify:test`
- [x] Device / Android version tested: S26u/Android 16

Closes https://github.com/ParaliyzedEvo/Stash/issues/124