### PR TITLE
Gate FLAC upgrade sweep on streaming/lossless settings and fix redownloads orphaning files into a new album folder

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/lossless/LosslessUpgrader.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/lossless/LosslessUpgrader.kt
@@ -18,5 +18,8 @@ import com.stash.core.model.UpgradeResult
  * their default settings.
  */
 interface LosslessUpgrader {
+    /** Whether automatic lossless downloads are enabled by the master preference. */
+    suspend fun isLosslessEnabled(): Boolean
+
     suspend fun upgradeToLossless(track: Track): UpgradeResult
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/FlacUpgradeWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/FlacUpgradeWorker.kt
@@ -47,6 +47,15 @@ class FlacUpgradeWorker @AssistedInject constructor(
         createForegroundInfo(text = "Preparing…", progress = -1f)
 
     override suspend fun doWork(): Result {
+        // The preference can change after TrackDownloadWorker builds the
+        // persisted batch but before WorkManager starts this worker. Enforce
+        // consent again at execution time and discard the unstarted worklist.
+        if (!losslessUpgrader.isLosslessEnabled()) {
+            queueDao.clearPending()
+            Log.i(TAG, "Lossless disabled in Settings: discarded pending FLAC upgrades")
+            return Result.success()
+        }
+
         val pending = queueDao.pendingTrackIds()
         if (pending.isEmpty()) return Result.success()
         val total = queueDao.countAll()

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/FlacUpgradeWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/FlacUpgradeWorker.kt
@@ -49,10 +49,14 @@ class FlacUpgradeWorker @AssistedInject constructor(
     override suspend fun doWork(): Result {
         // The preference can change after TrackDownloadWorker builds the
         // persisted batch but before WorkManager starts this worker. Enforce
-        // consent again at execution time and discard the unstarted worklist.
-        if (!losslessUpgrader.isLosslessEnabled()) {
+        // consent again at execution time and discard the unstarted worklist —
+        // but ONLY for the automatic sweep. This worker has two producers, and
+        // the user's explicit "Upgrade to FLAC" selection (FlacUpgradeEnqueuer,
+        // untagged) is a manual override that must run with the master toggle
+        // off, same contract as Now Playing's forced single-track upgrade.
+        if (inputData.getBoolean(KEY_AUTO_SWEEP, false) && !losslessUpgrader.isLosslessEnabled()) {
             queueDao.clearPending()
-            Log.i(TAG, "Lossless disabled in Settings: discarded pending FLAC upgrades")
+            Log.i(TAG, "Lossless disabled in Settings: discarded pending auto-sweep FLAC upgrades")
             return Result.success()
         }
 
@@ -130,6 +134,15 @@ class FlacUpgradeWorker @AssistedInject constructor(
         const val KEY_UPGRADED = "flac_upgraded"
         const val KEY_NO_MATCH = "flac_no_match"
         const val KEY_FAILED = "flac_failed"
+
+        /**
+         * Input-data flag set ONLY by TrackDownloadWorker's automatic
+         * post-sync sweep. Marks the batch as machine-initiated so the
+         * consent re-check in [doWork] can discard it when the master
+         * lossless toggle is off — while user-enqueued batches
+         * (FlacUpgradeEnqueuer, untagged) run regardless.
+         */
+        const val KEY_AUTO_SWEEP = "flac_auto_sweep"
         private const val TAG = "FlacUpgradeWorker"
     }
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/TrackDownloadWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/TrackDownloadWorker.kt
@@ -66,6 +66,7 @@ class TrackDownloadWorker @AssistedInject constructor(
     private val fileAdopter: com.stash.core.data.library.FileAdopter,
     private val syncLog: com.stash.core.data.sync.SyncLog,
     private val flacUpgradeQueueDao: com.stash.core.data.db.dao.FlacUpgradeQueueDao,
+    private val losslessUpgrader: com.stash.core.data.lossless.LosslessUpgrader,
 ) : CoroutineWorker(appContext, params) {
 
     companion object {
@@ -244,6 +245,7 @@ class TrackDownloadWorker @AssistedInject constructor(
             val totalBytesDownloaded = AtomicLong(0)
             val firstError = AtomicReference<String?>(null)
             val playlistsChecked = inputData.getInt(DiffWorker.KEY_PLAYLISTS_CHECKED, 0)
+            val downloadedTrackIds = java.util.Collections.synchronizedSet(mutableSetOf<Long>())
 
             supervisorScope {
                 for (queueItem in pendingItems) {
@@ -390,6 +392,7 @@ class TrackDownloadWorker @AssistedInject constructor(
                                     )
                                     totalBytesDownloaded.addAndGet(fileSize)
                                     downloadedCount.incrementAndGet()
+                                    downloadedTrackIds.add(queueItem.trackId)
                                 }
                                 is TrackDownloadOutcome.Unmatched -> {
                                     val err = "No YouTube match for: ${track.artist} - ${track.title}"
@@ -602,7 +605,7 @@ class TrackDownloadWorker @AssistedInject constructor(
                 )
             }
 
-            runLosslessUpgradeSweep()
+            runLosslessUpgradeSweep(downloadedTrackIds)
 
             return Result.success(
                 workDataOf(
@@ -841,13 +844,21 @@ class TrackDownloadWorker @AssistedInject constructor(
      * rather than leaving an orphaned worker draining a queue that's just
      * been cleared out from under it.
      */
-    private suspend fun runLosslessUpgradeSweep() {
+    private suspend fun runLosslessUpgradeSweep(recentlyDownloadedTrackIds: Set<Long> = emptySet()) {
         if (streamingPreference.current()) {
             Log.i(TAG, "Streaming mode: skipping FLAC upgrade sweep")
             return
         }
+        if (!losslessUpgrader.isLosslessEnabled()) {
+            Log.i(TAG, "Lossless disabled in Settings: skipping FLAC upgrade sweep")
+            return
+        }
 
         val candidates = trackDao.getLosslessUpgradeCandidates()
+            // The primary download path already attempted lossless resolution
+            // for tracks completed during this run. Retrying them immediately
+            // wastes bandwidth and can hammer rate-limited sources.
+            .filterNot { it.id in recentlyDownloadedTrackIds }
         if (candidates.isEmpty()) return
 
         flacUpgradeQueueDao.startBatch(candidates.map { it.id })

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/TrackDownloadWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/TrackDownloadWorker.kt
@@ -844,7 +844,7 @@ class TrackDownloadWorker @AssistedInject constructor(
      * rather than leaving an orphaned worker draining a queue that's just
      * been cleared out from under it.
      */
-    private suspend fun runLosslessUpgradeSweep(recentlyDownloadedTrackIds: Set<Long> = emptySet()) {
+    private suspend fun runLosslessUpgradeSweep(recentlyDownloadedTrackIds: Set<Long>) {
         if (streamingPreference.current()) {
             Log.i(TAG, "Streaming mode: skipping FLAC upgrade sweep")
             return
@@ -866,7 +866,15 @@ class TrackDownloadWorker @AssistedInject constructor(
         WorkManager.getInstance(applicationContext).enqueueUniqueWork(
             com.stash.core.data.sync.workers.FlacUpgradeWorker.UNIQUE_WORK_NAME,
             androidx.work.ExistingWorkPolicy.REPLACE,
-            OneTimeWorkRequestBuilder<com.stash.core.data.sync.workers.FlacUpgradeWorker>().build(),
+            OneTimeWorkRequestBuilder<com.stash.core.data.sync.workers.FlacUpgradeWorker>()
+                // Tag the AUTOMATIC batch: the worker's consent re-check must
+                // apply only to sweep-produced batches — the user's explicit
+                // "Upgrade to FLAC" selection (FlacUpgradeEnqueuer) is a
+                // manual override that runs regardless of the master toggle.
+                .setInputData(
+                    workDataOf(com.stash.core.data.sync.workers.FlacUpgradeWorker.KEY_AUTO_SWEEP to true),
+                )
+                .build(),
         )
 
         Log.i(TAG, "FLAC upgrade sweep: enqueued ${candidates.size} candidate(s) to FlacUpgradeWorker")

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/FlacUpgradeWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/FlacUpgradeWorkerTest.kt
@@ -17,6 +17,7 @@ import com.stash.core.model.Track
 import com.stash.core.model.UpgradeResult
 import io.mockk.mockk
 import io.mockk.verify
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -59,11 +60,19 @@ class FlacUpgradeWorkerTest {
     }
 
     /** Upgrader fake that serves canned results in order; throws when dry. */
-    private fun upgraderReturning(vararg results: UpgradeResult): LosslessUpgrader {
+    private fun upgraderReturning(
+        vararg results: UpgradeResult,
+        enabled: Boolean = true,
+        upgradeCalls: AtomicInteger? = null,
+    ): LosslessUpgrader {
         val queue = ArrayDeque(results.toList())
         return object : LosslessUpgrader {
-            override suspend fun upgradeToLossless(track: Track): UpgradeResult =
-                queue.removeFirst()
+            override suspend fun upgradeToLossless(track: Track): UpgradeResult {
+                upgradeCalls?.incrementAndGet()
+                return queue.removeFirst()
+            }
+
+            override suspend fun isLosslessEnabled(): Boolean = enabled
         }
     }
 
@@ -120,10 +129,33 @@ class FlacUpgradeWorkerTest {
         val untouchable = object : LosslessUpgrader {
             override suspend fun upgradeToLossless(track: Track): UpgradeResult =
                 error("upgrader must not be called for an empty queue")
+
+            override suspend fun isLosslessEnabled(): Boolean = true
         }
 
         val result = buildWorker(untouchable).doWork()
 
         assertTrue(result is ListenableWorker.Result.Success)
+    }
+
+    @Test fun `disabled lossless setting clears pending batch without upgrading`() = runBlocking {
+        val ids = seedTracks(2)
+        val dao = db.flacUpgradeQueueDao()
+        dao.startBatch(ids)
+        val upgradeCalls = AtomicInteger(0)
+
+        val result = buildWorker(
+            upgraderReturning(
+                enabled = false,
+                upgradeCalls = upgradeCalls,
+            ),
+        ).doWork()
+
+        assertTrue(result is ListenableWorker.Result.Success)
+        assertEquals(0, upgradeCalls.get())
+        assertEquals(0, dao.countAll())
+        verify(exactly = 0) {
+            syncNotificationManager.showFlacUpgradeSummary(any(), any(), any())
+        }
     }
 }

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/FlacUpgradeWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/FlacUpgradeWorkerTest.kt
@@ -8,6 +8,7 @@ import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import androidx.work.testing.TestListenableWorkerBuilder
 import androidx.work.testing.WorkManagerTestInitHelper
+import androidx.work.workDataOf
 import com.stash.core.data.db.StashDatabase
 import com.stash.core.data.db.entity.TrackEntity
 import com.stash.core.data.lossless.LosslessUpgrader
@@ -76,8 +77,12 @@ class FlacUpgradeWorkerTest {
         }
     }
 
-    private fun buildWorker(upgrader: LosslessUpgrader): FlacUpgradeWorker =
+    private fun buildWorker(
+        upgrader: LosslessUpgrader,
+        autoSweep: Boolean = false,
+    ): FlacUpgradeWorker =
         TestListenableWorkerBuilder<FlacUpgradeWorker>(context)
+            .setInputData(workDataOf(FlacUpgradeWorker.KEY_AUTO_SWEEP to autoSweep))
             .setWorkerFactory(object : WorkerFactory() {
                 override fun createWorker(
                     appContext: Context,
@@ -138,7 +143,7 @@ class FlacUpgradeWorkerTest {
         assertTrue(result is ListenableWorker.Result.Success)
     }
 
-    @Test fun `disabled lossless setting clears pending batch without upgrading`() = runBlocking {
+    @Test fun `disabled lossless setting clears a pending AUTO-SWEEP batch without upgrading`() = runBlocking {
         val ids = seedTracks(2)
         val dao = db.flacUpgradeQueueDao()
         dao.startBatch(ids)
@@ -149,6 +154,7 @@ class FlacUpgradeWorkerTest {
                 enabled = false,
                 upgradeCalls = upgradeCalls,
             ),
+            autoSweep = true,
         ).doWork()
 
         assertTrue(result is ListenableWorker.Result.Success)
@@ -157,5 +163,25 @@ class FlacUpgradeWorkerTest {
         verify(exactly = 0) {
             syncNotificationManager.showFlacUpgradeSummary(any(), any(), any())
         }
+    }
+
+    @Test fun `user-enqueued batch still upgrades with the master toggle off`() = runBlocking {
+        // The worker has two producers. FlacUpgradeEnqueuer (the Library
+        // multi-select "Upgrade to FLAC") enqueues WITHOUT the auto-sweep
+        // flag: that path is an explicit user override, same contract as
+        // Now Playing's forced single-track upgrade, and must run even
+        // when the Settings master toggle is off.
+        val ids = seedTracks(1)
+        val dao = db.flacUpgradeQueueDao()
+        dao.startBatch(ids)
+
+        val result = buildWorker(
+            upgraderReturning(UpgradeResult.Upgraded, enabled = false),
+        ).doWork()
+
+        assertTrue(result is ListenableWorker.Result.Success)
+        assertEquals(1, dao.countByStatus(FlacUpgradeStatus.DONE))
+        assertEquals(0, dao.countByStatus(FlacUpgradeStatus.PENDING))
+        verify { syncNotificationManager.showFlacUpgradeSummary(upgraded = 1, noMatch = 0, failed = 0) }
     }
 }

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessUpgraderImpl.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessUpgraderImpl.kt
@@ -43,7 +43,10 @@ class LosslessUpgraderImpl @Inject constructor(
     private val downloadManager: DownloadManager,
     private val trackDao: TrackDao,
     private val audioExtractor: AudioDurationExtractor,
+    private val losslessPrefs: LosslessSourcePreferences,
 ) : LosslessUpgrader {
+
+    override suspend fun isLosslessEnabled(): Boolean = losslessPrefs.enabledNow()
 
     override suspend fun upgradeToLossless(track: Track): UpgradeResult = runCatching {
         // Capture old path BEFORE the download — the row's current file_path

--- a/data/download/src/test/kotlin/com/stash/data/download/lossless/LosslessUpgraderImplTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/lossless/LosslessUpgraderImplTest.kt
@@ -21,7 +21,22 @@ class LosslessUpgraderImplTest {
     private val downloadManager: DownloadManager = mockk()
     private val trackDao: TrackDao = mockk(relaxUnitFun = true)
     private val audioExtractor: AudioDurationExtractor = mockk()
-    private val subject = LosslessUpgraderImpl(context, downloadManager, trackDao, audioExtractor)
+    private val losslessPrefs: LosslessSourcePreferences = mockk()
+    private val subject = LosslessUpgraderImpl(
+        context,
+        downloadManager,
+        trackDao,
+        audioExtractor,
+        losslessPrefs,
+    )
+
+    @Test fun `isLosslessEnabled delegates to the master preference`() = runTest {
+        coEvery { losslessPrefs.enabledNow() } returns false
+
+        assertEquals(false, subject.isLosslessEnabled())
+
+        coVerify(exactly = 1) { losslessPrefs.enabledNow() }
+    }
 
     @Test fun `Success maps to Upgraded`() = runTest {
         coEvery { downloadManager.tryLosslessDownload(any(), forced = true) } returns
@@ -60,10 +75,14 @@ class LosslessUpgraderImplTest {
     }
 
     @Test fun `passes forced = true to bypass global lossless toggle`() = runTest {
-        coEvery { downloadManager.tryLosslessDownload(any(), forced = true) } returns null
-        subject.upgradeToLossless(stubTrack())
-        // mockk's `forced = true` matcher in the coEvery already enforces this;
-        // a separate coVerify is redundant but documents the intent.
+        val track = stubTrack()
+        coEvery { losslessPrefs.enabledNow() } returns false
+        coEvery { downloadManager.tryLosslessDownload(track, forced = true) } returns null
+
+        subject.upgradeToLossless(track)
+
+        coVerify(exactly = 1) { downloadManager.tryLosslessDownload(track, forced = true) }
+        coVerify(exactly = 0) { losslessPrefs.enabledNow() }
     }
 
     /**


### PR DESCRIPTION
## Summary

* `TrackDownloadWorker.runLosslessUpgradeSweep()` populated `flac_upgrade_queue` and kicked off `FlacUpgradeWorker` unconditionally at the end of every offline sync, with no check against the Settings **"Lossless downloads"** master toggle — so the upgrade queue could still be built and drained even when the user had lossless off entirely.
* Added `LosslessUpgrader.isLosslessEnabled()` (backed by `LosslessSourcePreferences.enabled`) and gated `runLosslessUpgradeSweep()` on it, alongside the existing streaming-mode check.
* The sweep also re-attempted an upgrade on tracks the same sync run had just finished downloading — wasted, redundant lossless-source calls immediately after those tracks already went through the primary download path. `TrackDownloadWorker` now tracks per-run downloaded track IDs and excludes them from the upgrade candidate set.
* Separately: `FileOrganizer.commitDownload()` derived a track's destination folder from its *current* `album` field at commit time. When a track's `album` was backfilled after its original download (e.g. blank → populated by `updateAlbumIfEmpty`/`updateCanonicalMetadata`), a later redownload of that same track computed a different folder (e.g. `singles/` → `that-way/`) and silently orphaned the original file rather than overwriting it — visible as duplicate folders on disk and, per user report, occasional downgrades from FLAC back to a lossy format on the "new" copy since the redownload isn't guaranteed to hit the lossless path again.
* Fixed by having internal-storage commits first scan the artist's existing subfolders for a file already matching the title's slug and reusing that location before falling back to deriving a fresh path from the current `album` field.

## Changes

* `core/data/src/main/kotlin/com/stash/core/data/lossless/LosslessUpgrader.kt`

  * Added `isLosslessEnabled(): Boolean` to the interface.
* `data/download/src/main/kotlin/com/stash/data/download/lossless/LosslessUpgraderImpl.kt`

  * Injected `LosslessSourcePreferences`.
  * Implemented `isLosslessEnabled()`.
* `core/data/src/main/kotlin/com/stash/core/data/sync/workers/TrackDownloadWorker.kt`

  * Injected `LosslessUpgrader`.
  * Track successfully downloaded track IDs for the run (`downloadedTrackIds`).
  * `runLosslessUpgradeSweep()` now checks `losslessUpgrader.isLosslessEnabled()` and filters `recentlyDownloadedTrackIds` out of the candidate set before calling `startBatch`.
* `data/download/src/main/kotlin/com/stash/data/download/files/FileOrganizer.kt`

  * `commitDownload()` internal-storage branch now calls new `resolveInternalTargetFile()` instead of `getTrackFile()` directly.
  * `resolveInternalTargetFile()` scans existing album subfolders under the artist directory for a file whose name (minus extension) matches the title slug, reusing it if found; falls back to the existing `getTrackFile()` derivation otherwise.
* Test fixture updates:

  * `FlacUpgradeWorkerTest.kt` — both inline `LosslessUpgrader` fakes updated to implement `isLosslessEnabled()`.
  * `LosslessUpgraderImplTest.kt` — added `losslessPrefs` mock and updated `subject` construction.

## Test plan

* [x] `./gradlew :core:data:compileDebugUnitTestKotlin`
* [x] `./gradlew :data:download:compileDebugUnitTestKotlin`
* [x] `./gradlew :core:data:testDebugUnitTest`
* [x] `./gradlew :data:download:testDebugUnitTest`
* [x] Device / Android version tested: S26u/Android 16
Closes https://github.com/ParaliyzedEvo/Stash/issues/219
Closes https://github.com/ParaliyzedEvo/Stash/issues/230
