### PR TITLE
Add download management screen

### DIFF
--- a/app/src/main/kotlin/com/stash/app/navigation/StashNavHost.kt
+++ b/app/src/main/kotlin/com/stash/app/navigation/StashNavHost.kt
@@ -28,6 +28,7 @@ import com.stash.feature.settings.SettingsHubScreen
 import com.stash.feature.settings.equalizer.EqualizerScreen
 import com.stash.feature.settings.libraryhealth.LibraryHealthScreen
 import com.stash.feature.sync.FailedDownloadsScreen
+import com.stash.feature.sync.DownloadManagementScreen
 import com.stash.feature.sync.FailedMatchesScreen
 import com.stash.feature.sync.ManagePlaylistsScreen
 import com.stash.feature.sync.SyncScreen
@@ -179,6 +180,9 @@ fun StashNavHost(
                 onNavigateToBlockedSongs = { navController.navigate(BlockedSongsRoute) },
                 onNavigateToFailedDownloads = {
                     navController.navigate(FailedDownloadsRoute)
+                },
+                onNavigateToDownloads = {
+                    navController.navigate(DownloadManagementRoute)
                 },
                 onNavigateToSettings = {
                     navController.navigate(SettingsRoute) {
@@ -360,6 +364,9 @@ fun StashNavHost(
 
         composable<FailedDownloadsRoute> {
             FailedDownloadsScreen(onBack = { navController.popBackStack() })
+        }
+        composable<DownloadManagementRoute> {
+            DownloadManagementScreen(onBack = { navController.popBackStack() })
         }
 
         composable<SearchArtistRoute> {

--- a/app/src/main/kotlin/com/stash/app/navigation/TopLevelDestination.kt
+++ b/app/src/main/kotlin/com/stash/app/navigation/TopLevelDestination.kt
@@ -33,6 +33,7 @@ enum class TopLevelDestination(val selectedIcon: ImageVector, val unselectedIcon
 @Serializable data class LikedSongsDetailRoute(val source: String? = null)
 @Serializable data object FailedMatchesRoute
 @Serializable data object FailedDownloadsRoute
+@Serializable data object DownloadManagementRoute
 @Serializable data object BlockedSongsRoute
 @Serializable data object EqualizerRoute
 @Serializable data object LibraryHealthRoute

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt
@@ -24,6 +24,22 @@ data class SourceCount(
     val cnt: Int,
 )
 
+/** Joined queue/track row used by the download-management screen. */
+data class DownloadManagementRow(
+    val queueId: Long,
+    val trackId: Long,
+    val title: String,
+    val artist: String,
+    val album: String,
+    val albumArtUrl: String?,
+    val status: DownloadStatus,
+    val retryCount: Int,
+    val errorMessage: String?,
+    val failureType: DownloadFailureType,
+    val createdAt: Long,
+    val completedAt: Long?,
+)
+
 /**
  * Data-access object for [DownloadQueueEntity].
  *
@@ -52,6 +68,35 @@ interface DownloadQueueDao {
     /** Reactive stream of downloads filtered by [status]. */
     @Query("SELECT * FROM download_queue WHERE status = :status ORDER BY created_at ASC")
     fun getByStatus(status: DownloadStatus): Flow<List<DownloadQueueEntity>>
+
+    /** Active queue, including deliberate lossless deferrals, oldest first. */
+    @Query("""
+        SELECT dq.id AS queueId, dq.track_id AS trackId,
+               t.title, t.artist, t.album, t.album_art_url AS albumArtUrl,
+               dq.status, dq.retry_count AS retryCount,
+               dq.error_message AS errorMessage, dq.failure_type AS failureType,
+               dq.created_at AS createdAt, dq.completed_at AS completedAt
+          FROM download_queue dq
+          INNER JOIN tracks t ON t.id = dq.track_id
+         WHERE dq.status IN ('PENDING', 'IN_PROGRESS', 'WAITING_FOR_LOSSLESS')
+         ORDER BY dq.created_at ASC, dq.id ASC
+    """)
+    fun observeActiveDownloadRows(): Flow<List<DownloadManagementRow>>
+
+    /** Terminal download history, newest first and bounded for UI consumption. */
+    @Query("""
+        SELECT dq.id AS queueId, dq.track_id AS trackId,
+               t.title, t.artist, t.album, t.album_art_url AS albumArtUrl,
+               dq.status, dq.retry_count AS retryCount,
+               dq.error_message AS errorMessage, dq.failure_type AS failureType,
+               dq.created_at AS createdAt, dq.completed_at AS completedAt
+          FROM download_queue dq
+          INNER JOIN tracks t ON t.id = dq.track_id
+         WHERE dq.status IN ('COMPLETED', 'FAILED', 'SKIPPED')
+         ORDER BY COALESCE(dq.completed_at, dq.created_at) DESC, dq.id DESC
+         LIMIT :limit
+    """)
+    fun observeDownloadHistory(limit: Int): Flow<List<DownloadManagementRow>>
 
     /** Find a download queue entry by the associated track ID. */
     @Query("SELECT * FROM download_queue WHERE track_id = :trackId LIMIT 1")
@@ -217,6 +262,65 @@ interface DownloadQueueDao {
         failureType: DownloadFailureType = DownloadFailureType.NONE,
         rejectedVideoId: String? = null,
     )
+
+    /** Atomically claims a pending row for a worker. */
+    @Query("""
+        UPDATE download_queue
+           SET status = 'IN_PROGRESS', error_message = NULL,
+               failure_type = 'NONE', completed_at = NULL
+         WHERE id = :id AND status IN ('PENDING', 'FAILED')
+    """)
+    suspend fun claimForDownload(id: Long): Int
+
+    /** Cancels an active row without allowing a terminal state to be overwritten. */
+    @Query("""
+        UPDATE download_queue
+           SET status = 'SKIPPED', error_message = NULL,
+               failure_type = 'NONE', completed_at = :completedAt
+         WHERE id = :id
+           AND status IN ('PENDING', 'IN_PROGRESS', 'WAITING_FOR_LOSSLESS')
+    """)
+    suspend fun markCancelledIfActive(id: Long, completedAt: Long): Int
+
+    /** Completes only the worker claim that is still in progress. */
+    @Query("""
+        UPDATE download_queue
+           SET status = 'COMPLETED', error_message = NULL,
+               failure_type = 'NONE', rejected_video_id = NULL,
+               completed_at = :completedAt
+         WHERE id = :id AND status = 'IN_PROGRESS'
+    """)
+    suspend fun completeIfInProgress(id: Long, completedAt: Long): Int
+
+    /** Fails only the worker claim that is still in progress. */
+    @Query("""
+        UPDATE download_queue
+           SET status = 'FAILED', error_message = :errorMessage,
+               failure_type = :failureType,
+               rejected_video_id = :rejectedVideoId,
+               completed_at = :completedAt
+         WHERE id = :id AND status = 'IN_PROGRESS'
+    """)
+    suspend fun failIfInProgress(
+        id: Long,
+        errorMessage: String?,
+        failureType: DownloadFailureType,
+        completedAt: Long,
+        rejectedVideoId: String? = null,
+    ): Int
+
+    /** Defers only the worker claim that is still in progress. */
+    @Query("""
+        UPDATE download_queue
+           SET status = 'WAITING_FOR_LOSSLESS', error_message = NULL,
+               failure_type = 'NONE', completed_at = NULL
+         WHERE id = :id AND status = 'IN_PROGRESS'
+    """)
+    suspend fun deferIfInProgress(id: Long): Int
+
+    /** Lightweight status lookup used to resolve cancellation races. */
+    @Query("SELECT status FROM download_queue WHERE id = :id LIMIT 1")
+    suspend fun getStatusById(id: Long): DownloadStatus?
 
     // ── Failed Downloads viewer (Library Health phase 1) ────────────────
 

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/DownloadQueueDao.kt
@@ -69,7 +69,11 @@ interface DownloadQueueDao {
     @Query("SELECT * FROM download_queue WHERE status = :status ORDER BY created_at ASC")
     fun getByStatus(status: DownloadStatus): Flow<List<DownloadQueueEntity>>
 
-    /** Active queue, including deliberate lossless deferrals, oldest first. */
+    /** Active queue, including deliberate lossless deferrals, oldest first.
+     *  Bounded: a full-library sync queues thousands of rows and this feed
+     *  re-emits on every queue write — an unbounded join would rebuild the
+     *  whole list each tick. 500 is far past what the screen can scroll. */
+    @Transaction
     @Query("""
         SELECT dq.id AS queueId, dq.track_id AS trackId,
                t.title, t.artist, t.album, t.album_art_url AS albumArtUrl,
@@ -80,6 +84,7 @@ interface DownloadQueueDao {
           INNER JOIN tracks t ON t.id = dq.track_id
          WHERE dq.status IN ('PENDING', 'IN_PROGRESS', 'WAITING_FOR_LOSSLESS')
          ORDER BY dq.created_at ASC, dq.id ASC
+         LIMIT 500
     """)
     fun observeActiveDownloadRows(): Flow<List<DownloadManagementRow>>
 
@@ -375,11 +380,15 @@ interface DownloadQueueDao {
      * the classified failure_type / error_message in one UPDATE. Returns
      * the number of rows affected so the caller can detect lost races
      * (e.g. another worker already claimed the row).
+     *
+     * SKIPPED is accepted too: a user-cancelled row is otherwise a dead end
+     * (nothing re-enqueues it — see [getUnqueuedTrackIds]), so "Retry" on a
+     * cancelled download in the Downloads screen is the only way back.
      */
     @Query("""
         UPDATE download_queue
            SET status = 'PENDING', error_message = NULL, failure_type = 'NONE'
-         WHERE id = :queueId AND status = 'FAILED'
+         WHERE id = :queueId AND status IN ('FAILED', 'SKIPPED')
     """)
     suspend fun atomicallyClaimForRetry(queueId: Long): Int
 
@@ -553,8 +562,21 @@ interface DownloadQueueDao {
 
     // ── Cleanup ─────────────────────────────────────────────────────────
 
-    /** Delete all completed download entries to free up space. */
-    @Query("DELETE FROM download_queue WHERE status = 'COMPLETED'")
+    /**
+     * Delete terminal history rows to free up space: COMPLETED plus the
+     * user-cancelled SKIPPED rows the Downloads screen accumulates. Without
+     * SKIPPED here, cancelling is a one-way ratchet on table size — nothing
+     * else ever removes those rows.
+     *
+     * ponytail: a SKIPPED row doubles as the tombstone that keeps
+     * [getUnqueuedTrackIds] from re-enqueueing a cancelled track, so purging
+     * it makes the track eligible again on the next reconciliation. That is
+     * acceptable at history-sweep cadence (the user cancelled a while ago,
+     * the track is still in a sync-enabled playlist, so re-offering it is
+     * the sane default). If cancellation must be permanent, move the
+     * tombstone to a dedicated column instead of widening this sweep.
+     */
+    @Query("DELETE FROM download_queue WHERE status IN ('COMPLETED', 'SKIPPED')")
     suspend fun deleteCompleted()
 
     /** Reset retry count for all failed entries so they can be retried after a bug fix. */
@@ -639,7 +661,11 @@ interface DownloadQueueDao {
           )
           AND t.id NOT IN (
               SELECT dq.track_id FROM download_queue dq
-              WHERE dq.status IN ('PENDING', 'IN_PROGRESS', 'FAILED')
+              -- SKIPPED = the user cancelled this download on purpose. It is
+              -- an active statement of intent, not a hole to backfill, so it
+              -- suppresses the count exactly like a PENDING row would.
+              -- Must stay in lockstep with getUnqueuedTrackIds.
+              WHERE dq.status IN ('PENDING', 'IN_PROGRESS', 'FAILED', 'SKIPPED')
           )
         GROUP BY t.source
     """)
@@ -694,7 +720,12 @@ interface DownloadQueueDao {
           )
           AND t.id NOT IN (
               SELECT dq.track_id FROM download_queue dq
-              WHERE dq.status IN ('PENDING', 'IN_PROGRESS', 'FAILED')
+              -- SKIPPED must be here or per-item cancellation is cosmetic:
+              -- the row goes SKIPPED, the very next reconciliation sees the
+              -- track as "undownloaded with no active queue entry" and hands
+              -- it a fresh PENDING row, so the download the user just
+              -- cancelled restarts. Mirrored in getOrphanedTrackCounts.
+              WHERE dq.status IN ('PENDING', 'IN_PROGRESS', 'FAILED', 'SKIPPED')
           )
     """)
     suspend fun getUnqueuedTrackIds(sources: List<String>): List<Long>
@@ -718,11 +749,18 @@ interface DownloadQueueDao {
      * — they're queue entries with the same orphan semantics, just paused
      * waiting for a lossless source instead of actively pending.
      *
+     * SKIPPED joins them for the same reason: a cancelled row is kept
+     * around only as the tombstone that stops [getUnqueuedTrackIds]
+     * re-enqueueing the track. Once the track has no sync-enabled parent
+     * there is nothing left to suppress, so the tombstone is just garbage.
+     * (Only orphans are swept — a cancelled row whose track is still in a
+     * sync-enabled playlist survives here and keeps doing its job.)
+     *
      * @return Number of rows deleted.
      */
     @Query("""
         DELETE FROM download_queue
-        WHERE status IN ('PENDING', 'FAILED', 'WAITING_FOR_LOSSLESS')
+        WHERE status IN ('PENDING', 'FAILED', 'WAITING_FOR_LOSSLESS', 'SKIPPED')
           -- Sync partition only — see cancelDownloadsWithNoEnabledPlaylist. A
           -- manual (sync_id NULL) row is a download the user asked for; sweeping
           -- it is how search-tab downloads went missing on relaunch.

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/DownloadCancellationController.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/DownloadCancellationController.kt
@@ -1,0 +1,25 @@
+package com.stash.core.data.sync
+
+import android.content.Context
+import androidx.work.WorkManager
+import com.stash.core.data.db.dao.DownloadQueueDao
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Makes cancellation durable before stopping any best-effort runtime work. */
+@Singleton
+class DownloadCancellationController @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val downloadQueueDao: DownloadQueueDao,
+    private val jobs: DownloadJobRegistry,
+) {
+    suspend fun cancel(queueId: Long): Boolean {
+        val changed = downloadQueueDao.markCancelledIfActive(queueId, System.currentTimeMillis())
+        if (changed == 0) return false
+        jobs.cancel(queueId)
+        WorkManager.getInstance(context)
+            .cancelUniqueWork(SingleTrackDownloadEnqueuer.workName(queueId))
+        return true
+    }
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/DownloadJobRegistry.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/DownloadJobRegistry.kt
@@ -1,0 +1,24 @@
+package com.stash.core.data.sync
+
+import kotlinx.coroutines.Job
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** In-process handles for independently cancellable queue-item coroutines. */
+@Singleton
+class DownloadJobRegistry @Inject constructor() {
+    private val jobs = ConcurrentHashMap<Long, Job>()
+
+    fun register(queueId: Long, job: Job) {
+        jobs.put(queueId, job)?.cancel()
+    }
+
+    fun unregister(queueId: Long, job: Job) {
+        jobs.remove(queueId, job)
+    }
+
+    fun cancel(queueId: Long) {
+        jobs[queueId]?.cancel()
+    }
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/SingleTrackDownloadEnqueuer.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/SingleTrackDownloadEnqueuer.kt
@@ -46,6 +46,10 @@ class SingleTrackDownloadEnqueuer @Inject constructor(
     @ApplicationContext private val context: Context,
     private val downloadNetworkPreference: DownloadNetworkPreference,
 ) {
+    companion object {
+        fun workName(queueId: Long): String = "single_track_$queueId"
+    }
+
     suspend fun enqueue(queueId: Long) {
         val mode = downloadNetworkPreference.current()
         val request = OneTimeWorkRequestBuilder<TrackDownloadWorker>()
@@ -58,7 +62,7 @@ class SingleTrackDownloadEnqueuer @Inject constructor(
             .addTag("single_track_retry")
             .build()
         WorkManager.getInstance(context).enqueueUniqueWork(
-            "single_track_$queueId",
+            workName(queueId),
             ExistingWorkPolicy.KEEP,
             request,
         )

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorker.kt
@@ -30,10 +30,12 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.io.File
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.job
 import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withContext
 
 /**
  * Drains `download_queue` rows produced by [StashDiscoveryWorker]
@@ -136,7 +138,15 @@ class DiscoveryDownloadWorker @AssistedInject constructor(
             try {
                 if (processQueueItem(queueItem)) completed++
             } catch (cancelled: CancellationException) {
-                if (downloadQueueDao.getStatusById(queueItem.id) != DownloadStatus.SKIPPED) {
+                // NonCancellable around the status read ONLY. The child job is
+                // already cancelled, so a bare suspend DAO call throws instead
+                // of answering — and a per-item cancel would be indistinguishable
+                // from WorkManager stopping the whole worker. The rethrow below
+                // still propagates a genuine worker-wide cancellation.
+                val userCancelled = withContext(NonCancellable) {
+                    downloadQueueDao.getStatusById(queueItem.id) == DownloadStatus.SKIPPED
+                }
+                if (!userCancelled) {
                     throw cancelled
                 }
                 Log.i(TAG, "Cancelled discovery queue item ${queueItem.id}")
@@ -192,8 +202,17 @@ class DiscoveryDownloadWorker @AssistedInject constructor(
             }
             when (outcome) {
                 is TrackDownloadOutcome.Success -> {
-                    if (downloadQueueDao.getStatusById(queueItem.id) == DownloadStatus.SKIPPED) {
-                        runCatching { File(outcome.filePath).delete() }
+                    // NonCancellable: cancel() cancels this child, so an unwrapped
+                    // read would throw and strand the file that just landed.
+                    val cancelledMidFlight = withContext(NonCancellable) {
+                        if (downloadQueueDao.getStatusById(queueItem.id) != DownloadStatus.SKIPPED) {
+                            false
+                        } else {
+                            runCatching { File(outcome.filePath).delete() }
+                            true
+                        }
+                    }
+                    if (cancelledMidFlight) {
                         false
                     } else {
                         handleSuccess(queueItem, trackEntity, outcome)

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorker.kt
@@ -19,6 +19,7 @@ import com.stash.core.data.db.entity.DownloadQueueEntity
 import com.stash.core.data.db.entity.TrackEntity
 import com.stash.core.data.mapper.toDomain
 import com.stash.core.data.sync.SyncNotificationManager
+import com.stash.core.data.sync.DownloadJobRegistry
 import com.stash.core.data.sync.TrackDownloadOutcome
 import com.stash.core.data.sync.TrackDownloader
 import com.stash.core.data.sync.workers.StashMixRefreshWorker
@@ -28,6 +29,11 @@ import com.stash.core.model.Track
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.io.File
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.job
+import kotlinx.coroutines.supervisorScope
 
 /**
  * Drains `download_queue` rows produced by [StashDiscoveryWorker]
@@ -56,6 +62,7 @@ class DiscoveryDownloadWorker @AssistedInject constructor(
     private val audioDurationExtractor: AudioDurationExtractor,
     private val blocklistGuard: BlocklistGuard,
     private val syncNotificationManager: SyncNotificationManager,
+    private val downloadJobs: DownloadJobRegistry,
 ) : CoroutineWorker(appContext, params) {
 
     companion object {
@@ -126,65 +133,13 @@ class DiscoveryDownloadWorker @AssistedInject constructor(
                 progress = (index.toFloat() / pending.size),
             )
 
-            // v0.9.20: stamp IN_PROGRESS BEFORE invoking the downloader.
-            // REPLACE policy on UNIQUE_WORK_NAME prevents concurrent instances
-            // of THIS worker; the sync-side partition predicate prevents
-            // TrackDownloadWorker from touching the same row. Defense-in-depth:
-            // a stale IN_PROGRESS row left over from a crashed run gets reset
-            // to PENDING on the next sync (the existing `resetStaleInProgress`
-            // sweep in TrackDownloadWorker's startup) — that path is unchanged.
-            downloadQueueDao.updateStatus(
-                id = queueItem.id,
-                status = DownloadStatus.IN_PROGRESS,
-            )
-
-            val trackEntity = trackDao.getById(queueItem.trackId) ?: continue
-
-            if (blocklistGuard.isBlocked(
-                    artist = trackEntity.artist,
-                    title = trackEntity.title,
-                    spotifyUri = null,
-                    youtubeId = null,
-                )) {
-                Log.d(TAG, "Skipping blocked track ${trackEntity.id}")
-                downloadQueueDao.deleteByTrackId(trackEntity.id)
-                continue
-            }
-
-            if (trackEntity.isDownloaded && trackEntity.filePath != null) {
-                downloadQueueDao.updateStatus(
-                    id = queueItem.id,
-                    status = DownloadStatus.COMPLETED,
-                    completedAt = System.currentTimeMillis(),
-                )
-                // Already-on-disk → newly-COMPLETED queue row = new linkable
-                // playable membership. Counts as progress so the refresh chains.
-                completed++
-                continue
-            }
-
-            val track = trackEntity.toDomain()
-            val outcome = runCatching {
-                trackDownloader.downloadTrack(track = track, preResolvedUrl = queueItem.youtubeUrl)
-            }.getOrElse {
-                Log.e(TAG, "downloadTrack threw for ${track.artist} - ${track.title}", it)
-                TrackDownloadOutcome.Failed(error = it.message.orEmpty())
-            }
-
-            when (outcome) {
-                is TrackDownloadOutcome.Success -> {
-                    handleSuccess(queueItem, trackEntity, outcome)
-                    // New audio on disk + COMPLETED row = real progress.
-                    completed++
+            try {
+                if (processQueueItem(queueItem)) completed++
+            } catch (cancelled: CancellationException) {
+                if (downloadQueueDao.getStatusById(queueItem.id) != DownloadStatus.SKIPPED) {
+                    throw cancelled
                 }
-                is TrackDownloadOutcome.Unmatched -> handleUnmatched(queueItem, track, outcome)
-                is TrackDownloadOutcome.Failed -> handleFailed(queueItem, track, outcome)
-                is TrackDownloadOutcome.Deferred -> {
-                    // Lossless deferred — TrackDownloaderImpl already moved the row
-                    // to WAITING_FOR_LOSSLESS. LosslessRetryWorker owns the
-                    // re-attempt. No-op here.
-                    Log.i(TAG, "Deferred (waiting for lossless): ${track.artist} - ${track.title}")
-                }
+                Log.i(TAG, "Cancelled discovery queue item ${queueItem.id}")
             }
         }
 
@@ -198,6 +153,65 @@ class DiscoveryDownloadWorker @AssistedInject constructor(
             Log.d(TAG, "drained ${pending.size} row(s) but completed 0 — not chaining refresh")
         }
         return Result.success()
+    }
+
+    /** Runs one discovery row in its own cancellable child, never the worker Job. */
+    private suspend fun processQueueItem(queueItem: DownloadQueueEntity): Boolean = supervisorScope {
+        val child = async {
+            if (downloadQueueDao.claimForDownload(queueItem.id) == 0) return@async false
+            val itemJob = currentCoroutineContext().job
+            downloadJobs.register(queueItem.id, itemJob)
+            itemJob.invokeOnCompletion { downloadJobs.unregister(queueItem.id, itemJob) }
+            if (downloadQueueDao.getStatusById(queueItem.id) == DownloadStatus.SKIPPED) return@async false
+
+            val trackEntity = trackDao.getById(queueItem.trackId) ?: return@async false
+            if (blocklistGuard.isBlocked(
+                    artist = trackEntity.artist,
+                    title = trackEntity.title,
+                    spotifyUri = null,
+                    youtubeId = null,
+                )) {
+                downloadQueueDao.deleteByTrackId(trackEntity.id)
+                return@async false
+            }
+            if (trackEntity.isDownloaded && trackEntity.filePath != null) {
+                return@async downloadQueueDao.completeIfInProgress(
+                    id = queueItem.id,
+                    completedAt = System.currentTimeMillis(),
+                ) == 1
+            }
+
+            val track = trackEntity.toDomain()
+            val outcome = try {
+                trackDownloader.downloadTrack(track, queueItem.youtubeUrl)
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Exception) {
+                Log.e(TAG, "downloadTrack threw for ${track.artist} - ${track.title}", error)
+                TrackDownloadOutcome.Failed(error.message.orEmpty())
+            }
+            when (outcome) {
+                is TrackDownloadOutcome.Success -> {
+                    if (downloadQueueDao.getStatusById(queueItem.id) == DownloadStatus.SKIPPED) {
+                        runCatching { File(outcome.filePath).delete() }
+                        false
+                    } else {
+                        handleSuccess(queueItem, trackEntity, outcome)
+                        downloadQueueDao.getStatusById(queueItem.id) == DownloadStatus.COMPLETED
+                    }
+                }
+                is TrackDownloadOutcome.Unmatched -> {
+                    handleUnmatched(queueItem, track, outcome)
+                    false
+                }
+                is TrackDownloadOutcome.Failed -> {
+                    handleFailed(queueItem, track, outcome)
+                    false
+                }
+                is TrackDownloadOutcome.Deferred -> false
+            }
+        }
+        child.await()
     }
 
     private suspend fun handleSuccess(
@@ -236,9 +250,8 @@ class DiscoveryDownloadWorker @AssistedInject constructor(
                 .onFailure { Log.w(TAG, "fillMissingDuration failed for ${trackEntity.id}", it) }
         }
 
-        downloadQueueDao.updateStatus(
+        downloadQueueDao.completeIfInProgress(
             id = queueItem.id,
-            status = DownloadStatus.COMPLETED,
             completedAt = System.currentTimeMillis(),
         )
     }
@@ -251,12 +264,12 @@ class DiscoveryDownloadWorker @AssistedInject constructor(
         val err = "No YouTube match for: ${track.artist} - ${track.title}"
         Log.w(TAG, err)
         downloadQueueDao.incrementRetryCount(queueItem.id)
-        downloadQueueDao.updateStatus(
+        downloadQueueDao.failIfInProgress(
             id = queueItem.id,
-            status = DownloadStatus.FAILED,
             failureType = DownloadFailureType.NO_MATCH,
             errorMessage = err,
             rejectedVideoId = outcome.rejectedVideoId,
+            completedAt = System.currentTimeMillis(),
         )
     }
 
@@ -267,11 +280,11 @@ class DiscoveryDownloadWorker @AssistedInject constructor(
     ) {
         Log.e(TAG, "Download failed for ${track.artist} - ${track.title}: ${outcome.error}")
         downloadQueueDao.incrementRetryCount(queueItem.id)
-        downloadQueueDao.updateStatus(
+        downloadQueueDao.failIfInProgress(
             id = queueItem.id,
-            status = DownloadStatus.FAILED,
             failureType = DownloadFailureType.UNKNOWN,
             errorMessage = outcome.error.take(500),
+            completedAt = System.currentTimeMillis(),
         )
     }
 

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/TrackDownloadWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/TrackDownloadWorker.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
@@ -318,6 +320,24 @@ class TrackDownloadWorker @AssistedInject constructor(
 
                             when (outcome) {
                                 is TrackDownloadOutcome.Success -> {
+                                    // Cancellation can land between "file written" and
+                                    // "row marked COMPLETED". Mirrors the single-track
+                                    // guard below: a cancelled row must not become a
+                                    // downloaded track, and the bytes that arrived after
+                                    // the user said stop don't get to stay on disk.
+                                    // NonCancellable because cancel() also cancels this
+                                    // job — without it the status read throws instead of
+                                    // answering, and the file leaks.
+                                    val cancelledMidFlight = withContext(NonCancellable) {
+                                        if (downloadQueueDao.getStatusById(queueItem.id) != DownloadStatus.SKIPPED) {
+                                            false
+                                        } else {
+                                            runCatching { File(outcome.filePath).delete() }
+                                            true
+                                        }
+                                    }
+                                    if (cancelledMidFlight) return@launch
+
                                     val fileSize = try {
                                         File(outcome.filePath).length()
                                     } catch (_: Exception) { 0L }
@@ -479,7 +499,16 @@ class TrackDownloadWorker @AssistedInject constructor(
                             // it back to PENDING). Marking thousands of in-flight rows
                             // FAILED on cancel was the root cause of the "2325 failed
                             // rows after Stop" smoke-test crash.
-                            if (downloadQueueDao.getStatusById(queueItem.id) == DownloadStatus.SKIPPED) {
+                            //
+                            // NonCancellable around the read ONLY: this coroutine is
+                            // already cancelled, so a plain suspend DAO call throws
+                            // CancellationException instead of returning a status and
+                            // the per-item cancel could never be told apart from a
+                            // worker-wide stop. The worker body stays cancellable.
+                            val userCancelled = withContext(NonCancellable) {
+                                downloadQueueDao.getStatusById(queueItem.id) == DownloadStatus.SKIPPED
+                            }
+                            if (userCancelled) {
                                 return@launch
                             }
                             throw ce
@@ -729,7 +758,12 @@ class TrackDownloadWorker @AssistedInject constructor(
             // long). Don't mark the row FAILED — the queue stays in whatever
             // state IN_PROGRESS-with-cancel left it; the next sync's
             // resetStaleInProgress() will flip it back to PENDING.
-            if (downloadQueueDao.getStatusById(entry.id) == DownloadStatus.SKIPPED) {
+            //
+            // NonCancellable around the read ONLY — see the chain-mode guard.
+            val userCancelled = withContext(NonCancellable) {
+                downloadQueueDao.getStatusById(entry.id) == DownloadStatus.SKIPPED
+            }
+            if (userCancelled) {
                 return Result.success()
             }
             throw ce
@@ -766,8 +800,17 @@ class TrackDownloadWorker @AssistedInject constructor(
 
         when (outcome) {
             is TrackDownloadOutcome.Success -> {
-                if (downloadQueueDao.getStatusById(entry.id) == DownloadStatus.SKIPPED) {
-                    runCatching { File(outcome.filePath).delete() }
+                // NonCancellable: cancel() cancels this job too, so an unwrapped
+                // read would throw and leave the just-landed file behind.
+                val cancelledMidFlight = withContext(NonCancellable) {
+                    if (downloadQueueDao.getStatusById(entry.id) != DownloadStatus.SKIPPED) {
+                        false
+                    } else {
+                        runCatching { File(outcome.filePath).delete() }
+                        true
+                    }
+                }
+                if (cancelledMidFlight) {
                     return Result.success()
                 }
                 // Persist the downloaded state on the TRACK row, mirroring chain

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/TrackDownloadWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/TrackDownloadWorker.kt
@@ -12,6 +12,8 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.job
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
@@ -23,6 +25,7 @@ import com.stash.core.data.library.LibraryReconciliationUseCase
 import com.stash.core.data.mapper.toDomain
 import com.stash.core.data.sync.SyncNotificationManager
 import com.stash.core.data.sync.SyncStateManager
+import com.stash.core.data.sync.DownloadJobRegistry
 import com.stash.core.data.sync.TrackDownloadOutcome
 import com.stash.core.data.sync.TrackDownloader
 import com.stash.core.data.sync.classifier.DownloadFailureClassifier
@@ -67,6 +70,7 @@ class TrackDownloadWorker @AssistedInject constructor(
     private val syncLog: com.stash.core.data.sync.SyncLog,
     private val flacUpgradeQueueDao: com.stash.core.data.db.dao.FlacUpgradeQueueDao,
     private val losslessUpgrader: com.stash.core.data.lossless.LosslessUpgrader,
+    private val downloadJobs: DownloadJobRegistry,
 ) : CoroutineWorker(appContext, params) {
 
     companion object {
@@ -250,12 +254,14 @@ class TrackDownloadWorker @AssistedInject constructor(
             supervisorScope {
                 for (queueItem in pendingItems) {
                     launch {
+                        if (downloadQueueDao.claimForDownload(queueItem.id) == 0) return@launch
+                        val itemJob = currentCoroutineContext().job
+                        downloadJobs.register(queueItem.id, itemJob)
+                        itemJob.invokeOnCompletion { downloadJobs.unregister(queueItem.id, itemJob) }
+                        if (downloadQueueDao.getStatusById(queueItem.id) == DownloadStatus.SKIPPED) {
+                            return@launch
+                        }
                         try {
-                            downloadQueueDao.updateStatus(
-                                id = queueItem.id,
-                                status = DownloadStatus.IN_PROGRESS,
-                            )
-
                             val trackEntity = trackDao.getById(queueItem.trackId)
                             if (trackEntity == null) {
                                 Log.w(TAG, "Track ${queueItem.trackId} not found in DB, skipping")
@@ -268,10 +274,11 @@ class TrackDownloadWorker @AssistedInject constructor(
                                         causeChain = emptyList(),
                                     )
                                 )
-                                downloadQueueDao.markFailed(
-                                    queueId = queueItem.id,
+                                downloadQueueDao.failIfInProgress(
+                                    id = queueItem.id,
                                     errorMessage = err.take(1000),
                                     failureType = type,
+                                    completedAt = System.currentTimeMillis(),
                                 )
                                 failedCount.incrementAndGet()
                                 return@launch
@@ -295,9 +302,8 @@ class TrackDownloadWorker @AssistedInject constructor(
                             }
 
                             if (trackEntity.isDownloaded && trackEntity.filePath != null) {
-                                downloadQueueDao.updateStatus(
+                                downloadQueueDao.completeIfInProgress(
                                     id = queueItem.id,
-                                    status = DownloadStatus.COMPLETED,
                                     completedAt = System.currentTimeMillis(),
                                 )
                                 downloadedCount.incrementAndGet()
@@ -385,9 +391,8 @@ class TrackDownloadWorker @AssistedInject constructor(
                                             }
                                         }
                                     }
-                                    downloadQueueDao.updateStatus(
+                                    downloadQueueDao.completeIfInProgress(
                                         id = queueItem.id,
-                                        status = DownloadStatus.COMPLETED,
                                         completedAt = System.currentTimeMillis(),
                                     )
                                     totalBytesDownloaded.addAndGet(fileSize)
@@ -398,12 +403,12 @@ class TrackDownloadWorker @AssistedInject constructor(
                                     val err = "No YouTube match for: ${track.artist} - ${track.title}"
                                     Log.w(TAG, err)
                                     downloadQueueDao.incrementRetryCount(queueItem.id)
-                                    downloadQueueDao.updateStatus(
+                                    downloadQueueDao.failIfInProgress(
                                         id = queueItem.id,
-                                        status = DownloadStatus.FAILED,
                                         failureType = DownloadFailureType.NO_MATCH,
                                         errorMessage = err,
                                         rejectedVideoId = outcome.rejectedVideoId,
+                                        completedAt = System.currentTimeMillis(),
                                     )
                                     firstError.compareAndSet(null, err)
                                     failedCount.incrementAndGet()
@@ -428,10 +433,11 @@ class TrackDownloadWorker @AssistedInject constructor(
                                         // incremented separately to match prior tally
                                         // semantics for terminal failures.
                                         downloadQueueDao.incrementRetryCount(queueItem.id)
-                                        downloadQueueDao.markFailed(
-                                            queueId = queueItem.id,
+                                        downloadQueueDao.failIfInProgress(
+                                            id = queueItem.id,
                                             errorMessage = truncated,
                                             failureType = type,
+                                            completedAt = System.currentTimeMillis(),
                                         )
                                         firstError.compareAndSet(null, truncated)
                                         failedCount.incrementAndGet()
@@ -473,6 +479,9 @@ class TrackDownloadWorker @AssistedInject constructor(
                             // it back to PENDING). Marking thousands of in-flight rows
                             // FAILED on cancel was the root cause of the "2325 failed
                             // rows after Stop" smoke-test crash.
+                            if (downloadQueueDao.getStatusById(queueItem.id) == DownloadStatus.SKIPPED) {
+                                return@launch
+                            }
                             throw ce
                         } catch (e: Exception) {
                             Log.e(TAG, "Failed to download track ${queueItem.trackId}", e)
@@ -497,10 +506,11 @@ class TrackDownloadWorker @AssistedInject constructor(
                             if (isTerminal || exhausted) {
                                 // Real terminal failure OR transient that won't stop
                                 // happening — surface in Failed Downloads viewer.
-                                downloadQueueDao.markFailed(
-                                    queueId = queueItem.id,
+                                downloadQueueDao.failIfInProgress(
+                                    id = queueItem.id,
                                     errorMessage = truncated,
                                     failureType = type,
+                                    completedAt = System.currentTimeMillis(),
                                 )
                                 failedCount.incrementAndGet()
                             } else {
@@ -700,10 +710,13 @@ class TrackDownloadWorker @AssistedInject constructor(
         // can no-op on non-FAILED rows). Relies on updateStatus's defaults to
         // null out error_message / completed_at / rejected_video_id and reset
         // failure_type to NONE, matching the chain-mode IN_PROGRESS call.
-        downloadQueueDao.updateStatus(
-            id = entry.id,
-            status = DownloadStatus.IN_PROGRESS,
-        )
+        if (downloadQueueDao.claimForDownload(entry.id) == 0) return Result.success()
+        val itemJob = currentCoroutineContext().job
+        downloadJobs.register(entry.id, itemJob)
+        itemJob.invokeOnCompletion { downloadJobs.unregister(entry.id, itemJob) }
+        if (downloadQueueDao.getStatusById(entry.id) == DownloadStatus.SKIPPED) {
+            return Result.success()
+        }
 
         val outcome = try {
             trackDownloader.downloadTrack(
@@ -716,6 +729,9 @@ class TrackDownloadWorker @AssistedInject constructor(
             // long). Don't mark the row FAILED — the queue stays in whatever
             // state IN_PROGRESS-with-cancel left it; the next sync's
             // resetStaleInProgress() will flip it back to PENDING.
+            if (downloadQueueDao.getStatusById(entry.id) == DownloadStatus.SKIPPED) {
+                return Result.success()
+            }
             throw ce
         } catch (e: Exception) {
             Log.e(TAG, "Single-track downloader threw for queue ${entry.id}", e)
@@ -738,10 +754,11 @@ class TrackDownloadWorker @AssistedInject constructor(
             // chain-mode path uses revertToPendingAfterInterruption (a
             // sync passing through and leaving the row for the next sweep).
             // A failed manual retry should show the user what went wrong.
-            downloadQueueDao.markFailed(
-                queueId = entry.id,
+            downloadQueueDao.failIfInProgress(
+                id = entry.id,
                 errorMessage = truncated,
                 failureType = type,
+                completedAt = System.currentTimeMillis(),
             )
             // Catastrophe is handled; don't ask WorkManager to retry this row.
             return Result.success()
@@ -749,6 +766,10 @@ class TrackDownloadWorker @AssistedInject constructor(
 
         when (outcome) {
             is TrackDownloadOutcome.Success -> {
+                if (downloadQueueDao.getStatusById(entry.id) == DownloadStatus.SKIPPED) {
+                    runCatching { File(outcome.filePath).delete() }
+                    return Result.success()
+                }
                 // Persist the downloaded state on the TRACK row, mirroring chain
                 // mode (doWork). Without this the file lands on disk but
                 // tracks.is_downloaded / file_path stay unset, so the UI keeps
@@ -772,13 +793,9 @@ class TrackDownloadWorker @AssistedInject constructor(
                         )
                     }.onFailure { e -> Log.w(TAG, "setFormatAndQuality failed for ${entry.trackId}", e) }
                 }
-                downloadQueueDao.updateStatus(
+                downloadQueueDao.completeIfInProgress(
                     id = entry.id,
-                    status = DownloadStatus.COMPLETED,
-                    errorMessage = null,
                     completedAt = System.currentTimeMillis(),
-                    failureType = DownloadFailureType.NONE,
-                    rejectedVideoId = null,
                 )
                 Log.i(TAG, "Single-track mode: Success for queue ${entry.id}")
             }
@@ -792,10 +809,11 @@ class TrackDownloadWorker @AssistedInject constructor(
                         causeChain = emptyList(),
                     ),
                 )
-                downloadQueueDao.markFailed(
-                    queueId = entry.id,
+                downloadQueueDao.failIfInProgress(
+                    id = entry.id,
                     errorMessage = truncated,
                     failureType = type,
+                    completedAt = System.currentTimeMillis(),
                 )
                 Log.w(
                     TAG,
@@ -804,9 +822,8 @@ class TrackDownloadWorker @AssistedInject constructor(
             }
             is TrackDownloadOutcome.Unmatched -> {
                 val err = "No YouTube match for: ${track.artist} - ${track.title}"
-                downloadQueueDao.updateStatus(
+                downloadQueueDao.failIfInProgress(
                     id = entry.id,
-                    status = DownloadStatus.FAILED,
                     errorMessage = err,
                     completedAt = System.currentTimeMillis(),
                     failureType = DownloadFailureType.NO_MATCH,

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoManagementTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoManagementTest.kt
@@ -5,9 +5,13 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import com.stash.core.data.db.StashDatabase
 import com.stash.core.data.db.entity.DownloadQueueEntity
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.PlaylistTrackCrossRef
+import com.stash.core.data.db.entity.SyncHistoryEntity
 import com.stash.core.data.db.entity.TrackEntity
 import com.stash.core.model.DownloadFailureType
 import com.stash.core.model.DownloadStatus
+import com.stash.core.model.MusicSource
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -157,6 +161,88 @@ class DownloadQueueDaoManagementTest {
         assertEquals(DownloadStatus.PENDING, dao.getStatusById(3))
     }
 
+    // ── Cancellation durability ─────────────────────────────────────────
+    //
+    // Cancelling a download is only real if nothing puts it back. The
+    // reconciliation pass re-queues any undownloaded track that has no
+    // active queue row, so a SKIPPED row must read as "active intent" there
+    // — otherwise Cancel just restarts the download on the next sync.
+
+    @Test fun `cancelled row is not re-enqueued by reconciliation`() = runTest {
+        seedTrack(1, "Cancelled", "Artist", "Album", null)
+        seedPlaylistMembership(trackId = 1)
+        seedQueue(1, 1, DownloadStatus.PENDING, createdAt = 100)
+
+        // Still PENDING: already queued, so not an "unqueued" track either.
+        assertEquals(emptyList<Long>(), dao.getUnqueuedTrackIds(listOf("SPOTIFY")))
+
+        assertEquals(1, dao.markCancelledIfActive(1, completedAt = 700))
+
+        assertEquals(emptyList<Long>(), dao.getUnqueuedTrackIds(listOf("SPOTIFY")))
+        assertEquals(0, dao.getOrphanedTrackCounts().size)
+    }
+
+    @Test fun `retry claim un-cancels a skipped row`() = runTest {
+        seedTrack(1, "Cancelled", "Artist", "Album", null)
+        seedQueue(1, 1, DownloadStatus.SKIPPED, createdAt = 100, completedAt = 700)
+
+        assertEquals(1, dao.atomicallyClaimForRetry(1))
+        assertEquals(DownloadStatus.PENDING, dao.getStatusById(1))
+        // And the un-cancelled row is claimable by a worker again.
+        assertEquals(1, dao.claimForDownload(1))
+    }
+
+    @Test fun `history sweep purges cancelled rows alongside completed ones`() = runTest {
+        (1L..3L).forEach { seedTrack(it, "Track $it", "Artist", "Album", null) }
+        seedQueue(1, 1, DownloadStatus.COMPLETED, createdAt = 10, completedAt = 200)
+        seedQueue(2, 2, DownloadStatus.SKIPPED, createdAt = 20, completedAt = 300)
+        seedQueue(3, 3, DownloadStatus.FAILED, createdAt = 30, completedAt = 400)
+
+        dao.deleteCompleted()
+
+        // FAILED survives — it is still retryable and drives the Failed
+        // Downloads viewer. COMPLETED and SKIPPED are dead history.
+        assertNull(dao.getById(1))
+        assertNull(dao.getById(2))
+        assertEquals(DownloadStatus.FAILED, dao.getStatusById(3))
+    }
+
+    @Test fun `orphan sweep evicts a cancelled row once its track loses every playlist`() = runTest {
+        // sync_id is FK-constrained and the sweep only touches sync-created
+        // rows, so the run has to exist.
+        val syncId = db.syncHistoryDao().insert(SyncHistoryEntity())
+        seedTrack(1, "Kept", "Artist", "Album", null)
+        seedTrack(2, "Orphan", "Artist", "Album", null)
+        seedPlaylistMembership(trackId = 1)
+        seedQueue(1, 1, DownloadStatus.SKIPPED, createdAt = 100, completedAt = 700, syncId = syncId)
+        seedQueue(2, 2, DownloadStatus.SKIPPED, createdAt = 100, completedAt = 700, syncId = syncId)
+
+        assertEquals(1, dao.deleteOrphanedQueueEntries())
+
+        // Track 1 still lives in a sync-enabled playlist, so its tombstone
+        // stays and keeps suppressing re-enqueue.
+        assertEquals(DownloadStatus.SKIPPED, dao.getStatusById(1))
+        assertNull(dao.getById(2))
+    }
+
+    /** A sync-enabled, active, non-mix parent — the shape every "is this
+     *  track wanted?" predicate in the DAO checks for. */
+    private suspend fun seedPlaylistMembership(trackId: Long) {
+        val playlistDao = db.playlistDao()
+        playlistDao.insert(
+            PlaylistEntity(
+                id = trackId * 1000,
+                name = "Playlist $trackId",
+                source = MusicSource.SPOTIFY,
+                syncEnabled = true,
+                isActive = true,
+            )
+        )
+        playlistDao.insertCrossRef(
+            PlaylistTrackCrossRef(playlistId = trackId * 1000, trackId = trackId)
+        )
+    }
+
     private suspend fun seedTrack(
         id: Long,
         title: String,
@@ -185,6 +271,7 @@ class DownloadQueueDaoManagementTest {
         completedAt: Long? = null,
         error: String? = null,
         failureType: DownloadFailureType = DownloadFailureType.NONE,
+        syncId: Long? = null,
     ) {
         dao.insert(
             DownloadQueueEntity(
@@ -196,6 +283,7 @@ class DownloadQueueDaoManagementTest {
                 completedAt = completedAt?.let(Instant::ofEpochMilli),
                 errorMessage = error,
                 failureType = failureType,
+                syncId = syncId,
             )
         )
     }

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoManagementTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/DownloadQueueDaoManagementTest.kt
@@ -1,0 +1,202 @@
+package com.stash.core.data.db.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.DownloadQueueEntity
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.model.DownloadFailureType
+import com.stash.core.model.DownloadStatus
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DownloadQueueDaoManagementTest {
+    private lateinit var db: StashDatabase
+    private lateinit var dao: DownloadQueueDao
+    private lateinit var trackDao: TrackDao
+
+    @Before fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, StashDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.downloadQueueDao()
+        trackDao = db.trackDao()
+    }
+
+    @After fun tearDown() = db.close()
+
+    @Test fun active_feed_joins_metadata_and_orders_oldest_first() = runTest {
+        seedTrack(1, "Newest", "Artist C", "Album C", "art-c")
+        seedTrack(2, "Oldest", "Artist A", "Album A", "art-a")
+        seedTrack(3, "Middle", "Artist B", "Album B", null)
+        seedQueue(1, 1, DownloadStatus.PENDING, createdAt = 300)
+        seedQueue(2, 2, DownloadStatus.IN_PROGRESS, createdAt = 100)
+        seedQueue(3, 3, DownloadStatus.WAITING_FOR_LOSSLESS, createdAt = 200)
+
+        val rows = dao.observeActiveDownloadRows().first()
+
+        assertEquals(listOf(2L, 3L, 1L), rows.map { it.queueId })
+        assertEquals("Oldest", rows[0].title)
+        assertEquals("Artist A", rows[0].artist)
+        assertEquals("Album A", rows[0].album)
+        assertEquals("art-a", rows[0].albumArtUrl)
+        assertEquals(DownloadStatus.WAITING_FOR_LOSSLESS, rows[1].status)
+    }
+
+    @Test fun history_orders_by_terminal_time_with_created_fallback_and_honors_limit() = runTest {
+        (1L..4L).forEach { seedTrack(it, "Track $it", "Artist", "Album", null) }
+        seedQueue(1, 1, DownloadStatus.COMPLETED, createdAt = 10, completedAt = 200)
+        seedQueue(2, 2, DownloadStatus.FAILED, createdAt = 20, completedAt = 400)
+        seedQueue(3, 3, DownloadStatus.SKIPPED, createdAt = 300, completedAt = null)
+        seedQueue(4, 4, DownloadStatus.COMPLETED, createdAt = 100, completedAt = 300)
+
+        val rows = dao.observeDownloadHistory(limit = 3).first()
+
+        assertEquals(listOf(2L, 4L, 3L), rows.map { it.queueId })
+    }
+
+    @Test fun active_and_history_are_disjoint_and_react_to_terminal_transition() = runTest {
+        seedTrack(1, "Track", "Artist", "Album", null)
+        seedQueue(1, 1, DownloadStatus.IN_PROGRESS, createdAt = 100)
+        assertEquals(listOf(1L), dao.observeActiveDownloadRows().first().map { it.queueId })
+        assertEquals(emptyList<Long>(), dao.observeDownloadHistory(20).first().map { it.queueId })
+
+        assertEquals(1, dao.completeIfInProgress(1, completedAt = 500))
+
+        assertEquals(emptyList<Long>(), dao.observeActiveDownloadRows().first().map { it.queueId })
+        assertEquals(listOf(1L), dao.observeDownloadHistory(20).first().map { it.queueId })
+    }
+
+    @Test fun claim_is_atomic_and_idempotent() = runTest {
+        seedTrack(1, "Track", "Artist", "Album", null)
+        seedQueue(1, 1, DownloadStatus.PENDING, createdAt = 100)
+
+        assertEquals(1, dao.claimForDownload(1))
+        assertEquals(0, dao.claimForDownload(1))
+        assertEquals(DownloadStatus.IN_PROGRESS, dao.getStatusById(1))
+    }
+
+    @Test fun claim_accepts_failed_retry_and_clears_terminal_failure() = runTest {
+        seedTrack(1, "Track", "Artist", "Album", null)
+        seedQueue(
+            1, 1, DownloadStatus.FAILED, createdAt = 100, completedAt = 200,
+            error = "retry me", failureType = DownloadFailureType.NETWORK,
+        )
+
+        assertEquals(1, dao.claimForDownload(1))
+        val row = dao.getById(1)!!
+        assertEquals(DownloadStatus.IN_PROGRESS, row.status)
+        assertNull(row.errorMessage)
+        assertNull(row.completedAt)
+        assertEquals(DownloadFailureType.NONE, row.failureType)
+    }
+
+    @Test fun cancel_is_atomic_idempotent_and_clears_failure_fields() = runTest {
+        seedTrack(1, "Track", "Artist", "Album", null)
+        seedQueue(
+            1, 1, DownloadStatus.IN_PROGRESS, createdAt = 100,
+            error = "old", failureType = DownloadFailureType.NETWORK,
+        )
+
+        assertEquals(1, dao.markCancelledIfActive(1, completedAt = 700))
+        assertEquals(0, dao.markCancelledIfActive(1, completedAt = 900))
+        val row = dao.getById(1)!!
+        assertEquals(DownloadStatus.SKIPPED, row.status)
+        assertEquals(Instant.ofEpochMilli(700), row.completedAt)
+        assertNull(row.errorMessage)
+        assertEquals(DownloadFailureType.NONE, row.failureType)
+    }
+
+    @Test fun cancel_then_late_terminal_writes_are_noops() = runTest {
+        seedTrack(1, "Track", "Artist", "Album", null)
+        seedQueue(1, 1, DownloadStatus.IN_PROGRESS, createdAt = 100)
+        assertEquals(1, dao.markCancelledIfActive(1, completedAt = 700))
+
+        assertEquals(0, dao.completeIfInProgress(1, completedAt = 800))
+        assertEquals(0, dao.failIfInProgress(1, "late", DownloadFailureType.NETWORK, 800))
+        assertEquals(0, dao.deferIfInProgress(1))
+        assertEquals(DownloadStatus.SKIPPED, dao.getStatusById(1))
+    }
+
+    @Test fun completion_then_cancel_preserves_completion() = runTest {
+        seedTrack(1, "Track", "Artist", "Album", null)
+        seedQueue(1, 1, DownloadStatus.IN_PROGRESS, createdAt = 100)
+        assertEquals(1, dao.completeIfInProgress(1, completedAt = 800))
+
+        assertEquals(0, dao.markCancelledIfActive(1, completedAt = 900))
+        assertEquals(DownloadStatus.COMPLETED, dao.getStatusById(1))
+        assertEquals(Instant.ofEpochMilli(800), dao.getById(1)?.completedAt)
+    }
+
+    @Test fun fail_and_defer_only_transition_in_progress_rows() = runTest {
+        seedTrack(1, "Failed", "Artist", "Album", null)
+        seedTrack(2, "Deferred", "Artist", "Album", null)
+        seedTrack(3, "Pending", "Artist", "Album", null)
+        seedQueue(1, 1, DownloadStatus.IN_PROGRESS, createdAt = 100)
+        seedQueue(2, 2, DownloadStatus.IN_PROGRESS, createdAt = 200)
+        seedQueue(3, 3, DownloadStatus.PENDING, createdAt = 300)
+
+        assertEquals(1, dao.failIfInProgress(1, "boom", DownloadFailureType.NETWORK, 500))
+        assertEquals(1, dao.deferIfInProgress(2))
+        assertEquals(0, dao.failIfInProgress(3, "no", DownloadFailureType.NETWORK, 500))
+        assertEquals(DownloadStatus.FAILED, dao.getStatusById(1))
+        assertEquals(DownloadStatus.WAITING_FOR_LOSSLESS, dao.getStatusById(2))
+        assertEquals(DownloadStatus.PENDING, dao.getStatusById(3))
+    }
+
+    private suspend fun seedTrack(
+        id: Long,
+        title: String,
+        artist: String,
+        album: String,
+        art: String?,
+    ) {
+        trackDao.insert(
+            TrackEntity(
+                id = id,
+                title = title,
+                artist = artist,
+                album = album,
+                albumArtUrl = art,
+                canonicalTitle = title.lowercase(),
+                canonicalArtist = artist.lowercase(),
+            )
+        )
+    }
+
+    private suspend fun seedQueue(
+        id: Long,
+        trackId: Long,
+        status: DownloadStatus,
+        createdAt: Long,
+        completedAt: Long? = null,
+        error: String? = null,
+        failureType: DownloadFailureType = DownloadFailureType.NONE,
+    ) {
+        dao.insert(
+            DownloadQueueEntity(
+                id = id,
+                trackId = trackId,
+                status = status,
+                searchQuery = "query",
+                createdAt = Instant.ofEpochMilli(createdAt),
+                completedAt = completedAt?.let(Instant::ofEpochMilli),
+                errorMessage = error,
+                failureType = failureType,
+            )
+        )
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorkerTest.kt
@@ -12,6 +12,7 @@ import com.stash.core.data.sync.SyncNotificationManager
 import com.stash.core.data.sync.TrackDownloadOutcome
 import com.stash.core.data.sync.TrackDownloader
 import com.stash.core.data.sync.DownloadJobRegistry
+import com.stash.core.model.DownloadFailureType
 import com.stash.core.model.DownloadStatus
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -22,6 +23,7 @@ import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 
 /**
@@ -43,6 +45,20 @@ class DiscoveryDownloadWorkerTest {
     }
     private val syncNotificationManager: SyncNotificationManager = mockk(relaxed = true)
     private val downloadJobs = DownloadJobRegistry()
+
+    /**
+     * The worker now gates every row on an atomic claim and reads the row
+     * status back to settle cancellation races. A relaxed mock answers 0 /
+     * null to both, which reads as "another worker took this row" and
+     * "cancelled" — so without these stubs the worker correctly skips every
+     * item and no behavioural assertion below can fire. Default = the happy
+     * path: this worker owns the row and the row is not cancelled.
+     */
+    @Before fun stubClaimAndStatus() {
+        coEvery { downloadQueueDao.claimForDownload(any()) } returns 1
+        coEvery { downloadQueueDao.completeIfInProgress(any(), any()) } returns 1
+        coEvery { downloadQueueDao.getStatusById(any()) } returns DownloadStatus.COMPLETED
+    }
 
     private fun newWorker() = DiscoveryDownloadWorker(
         appContext, workerParams,
@@ -151,11 +167,7 @@ class DiscoveryDownloadWorkerTest {
             )
         }
         coVerify(exactly = 1) {
-            downloadQueueDao.updateStatus(
-                id = 100L,
-                status = DownloadStatus.COMPLETED,
-                completedAt = any(),
-            )
+            downloadQueueDao.completeIfInProgress(id = 100L, completedAt = any())
         }
     }
 
@@ -171,11 +183,11 @@ class DiscoveryDownloadWorkerTest {
 
         coVerify(exactly = 1) { downloadQueueDao.incrementRetryCount(100L) }
         coVerify(exactly = 1) {
-            downloadQueueDao.updateStatus(
+            downloadQueueDao.failIfInProgress(
                 id = 100L,
-                status = DownloadStatus.FAILED,
-                failureType = any(),
                 errorMessage = any(),
+                failureType = DownloadFailureType.NO_MATCH,
+                completedAt = any(),
                 rejectedVideoId = "abc123",
             )
         }
@@ -193,11 +205,12 @@ class DiscoveryDownloadWorkerTest {
 
         coVerify(exactly = 1) { downloadQueueDao.incrementRetryCount(100L) }
         coVerify(exactly = 1) {
-            downloadQueueDao.updateStatus(
+            downloadQueueDao.failIfInProgress(
                 id = 100L,
-                status = DownloadStatus.FAILED,
-                failureType = any(),
                 errorMessage = match { it.contains("yt-dlp timeout") },
+                failureType = DownloadFailureType.UNKNOWN,
+                completedAt = any(),
+                rejectedVideoId = any(),
             )
         }
     }
@@ -210,8 +223,8 @@ class DiscoveryDownloadWorkerTest {
 
         newWorker().doWork()
 
-        coVerify(exactly = 0) { downloadQueueDao.updateStatus(id = 100L, status = DownloadStatus.FAILED, any(), any(), any(), any()) }
-        coVerify(exactly = 0) { downloadQueueDao.updateStatus(id = 100L, status = DownloadStatus.COMPLETED, completedAt = any()) }
+        coVerify(exactly = 0) { downloadQueueDao.failIfInProgress(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { downloadQueueDao.completeIfInProgress(any(), any()) }
         coVerify(exactly = 0) { downloadQueueDao.incrementRetryCount(any()) }
     }
 
@@ -235,12 +248,12 @@ class DiscoveryDownloadWorkerTest {
         newWorker().doWork()
 
         coVerify(exactly = 1) {
-            downloadQueueDao.updateStatus(id = 100L, status = DownloadStatus.COMPLETED, completedAt = any())
+            downloadQueueDao.completeIfInProgress(id = 100L, completedAt = any())
         }
         coVerify(exactly = 0) { trackDownloader.downloadTrack(any(), any()) }
     }
 
-    @Test fun `IN_PROGRESS stamp is written BEFORE invoking TrackDownloader`() = runTest {
+    @Test fun `row is claimed IN_PROGRESS BEFORE invoking TrackDownloader`() = runTest {
         val entry = entry(id = 100L, trackId = 1L)
         coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
         coEvery { trackDao.getById(1L) } returns stubTrack(1L)
@@ -248,12 +261,36 @@ class DiscoveryDownloadWorkerTest {
 
         newWorker().doWork()
 
-        // The order matters — IN_PROGRESS must land before the downloader runs.
-        // coVerifyOrder enforces sequence; plain coVerify only checks existence.
+        // The order matters — the IN_PROGRESS claim must land before the
+        // downloader runs. coVerifyOrder enforces sequence; plain coVerify
+        // only checks existence.
         coVerifyOrder {
-            downloadQueueDao.updateStatus(id = 100L, status = DownloadStatus.IN_PROGRESS)
+            downloadQueueDao.claimForDownload(100L)
             trackDownloader.downloadTrack(any(), any())
         }
+    }
+
+    @Test fun `a row claimed by another worker is skipped entirely`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { downloadQueueDao.claimForDownload(100L) } returns 0
+
+        newWorker().doWork()
+
+        coVerify(exactly = 0) { trackDownloader.downloadTrack(any(), any()) }
+    }
+
+    @Test fun `a cancelled row is not downloaded even after a successful claim`() = runTest {
+        val entry = entry(id = 100L, trackId = 1L)
+        coEvery { downloadQueueDao.pendingDiscoveryDownloads() } returns listOf(entry)
+        coEvery { trackDao.getById(1L) } returns stubTrack(1L)
+        coEvery { downloadQueueDao.getStatusById(100L) } returns DownloadStatus.SKIPPED
+
+        newWorker().doWork()
+
+        coVerify(exactly = 0) { trackDownloader.downloadTrack(any(), any()) }
+        coVerify(exactly = 0) { downloadQueueDao.completeIfInProgress(any(), any()) }
     }
 
     private fun entry(id: Long, trackId: Long) = DownloadQueueEntity(

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiscoveryDownloadWorkerTest.kt
@@ -11,6 +11,7 @@ import com.stash.core.data.db.entity.TrackEntity
 import com.stash.core.data.sync.SyncNotificationManager
 import com.stash.core.data.sync.TrackDownloadOutcome
 import com.stash.core.data.sync.TrackDownloader
+import com.stash.core.data.sync.DownloadJobRegistry
 import com.stash.core.model.DownloadStatus
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -41,11 +42,12 @@ class DiscoveryDownloadWorkerTest {
         coEvery { isBlocked(any(), any(), any(), any()) } returns false
     }
     private val syncNotificationManager: SyncNotificationManager = mockk(relaxed = true)
+    private val downloadJobs = DownloadJobRegistry()
 
     private fun newWorker() = DiscoveryDownloadWorker(
         appContext, workerParams,
         downloadQueueDao, trackDao, trackDownloader,
-        audioDurationExtractor, blocklistGuard, syncNotificationManager,
+        audioDurationExtractor, blocklistGuard, syncNotificationManager, downloadJobs,
     )
 
     @Test fun `empty queue returns success and does not invoke TrackDownloader`() = runTest {

--- a/data/download/src/main/kotlin/com/stash/data/download/TrackDownloaderImpl.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/TrackDownloaderImpl.kt
@@ -5,7 +5,6 @@ import com.stash.core.data.db.dao.DownloadQueueDao
 import com.stash.core.data.files.LocalFileOps
 import com.stash.core.data.sync.TrackDownloadOutcome
 import com.stash.core.data.sync.TrackDownloader
-import com.stash.core.model.DownloadStatus
 import com.stash.core.model.Track
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -54,10 +53,7 @@ class TrackDownloaderImpl @Inject constructor(
             TrackDownloadResult.Deferred -> {
                 val queueEntry = downloadQueueDao.getByTrackId(track.id)
                 queueEntry?.let {
-                    downloadQueueDao.updateStatus(
-                        id = it.id,
-                        status = DownloadStatus.WAITING_FOR_LOSSLESS,
-                    )
+                    downloadQueueDao.deferIfInProgress(it.id)
                 }
                 TrackDownloadOutcome.Deferred
             }

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/DownloadManagementScreen.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/DownloadManagementScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -158,10 +159,10 @@ private fun QueueContent(
         }
         if (state.queued.isNotEmpty()) {
             item(key = "queued_label") { SectionLabel("Up next") }
-            items(state.queued, key = { "queued_${it.queueId}" }) { item ->
+            itemsIndexed(state.queued, key = { _, item -> "queued_${item.queueId}" }) { index, item ->
                 DownloadRowCard(
                     item = item,
-                    queuePosition = state.queued.indexOf(item) + 1,
+                    queuePosition = index + 1,
                     onCancel = onCancel,
                     onRetry = onRetry,
                 )

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/DownloadManagementScreen.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/DownloadManagementScreen.kt
@@ -1,0 +1,249 @@
+package com.stash.feature.sync
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.stash.core.ui.theme.StashTheme
+import com.stash.feature.sync.components.DownloadManagementRow
+
+@Composable
+fun DownloadManagementScreen(
+    onBack: () -> Unit,
+    viewModel: DownloadManagementViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    LaunchedEffect(state.message) {
+        state.message?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.dismissMessage()
+        }
+    }
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            DownloadsHeader(
+                state = state,
+                onBack = onBack,
+                onSelectTab = viewModel::selectTab,
+            )
+            when (state.selectedTab) {
+                DownloadManagementTab.QUEUE -> QueueContent(
+                    state = state,
+                    onCancel = viewModel::cancel,
+                    onRetry = viewModel::retry,
+                )
+                DownloadManagementTab.HISTORY -> HistoryContent(
+                    state = state,
+                    onRetry = viewModel::retry,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DownloadsHeader(
+    state: DownloadManagementUiState,
+    onBack: () -> Unit,
+    onSelectTab: (DownloadManagementTab) -> Unit,
+) {
+    val extendedColors = StashTheme.extendedColors
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        IconButton(
+            onClick = onBack,
+            modifier = Modifier
+                .size(48.dp)
+                .background(extendedColors.glassBackground, CircleShape),
+        ) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+        }
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = "Downloads",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Text(
+            text = when {
+                state.downloading.isNotEmpty() -> "${state.downloading.size} downloading · ${state.queued.size} queued"
+                state.queued.isNotEmpty() -> "${state.queued.size} queued"
+                else -> "Queue and recent download history"
+            },
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(12.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(
+                selected = state.selectedTab == DownloadManagementTab.QUEUE,
+                onClick = { onSelectTab(DownloadManagementTab.QUEUE) },
+                label = { Text("Queue (${state.active.size})") },
+            )
+            FilterChip(
+                selected = state.selectedTab == DownloadManagementTab.HISTORY,
+                onClick = { onSelectTab(DownloadManagementTab.HISTORY) },
+                label = { Text("History (${state.history.size})") },
+            )
+        }
+    }
+}
+
+@Composable
+private fun QueueContent(
+    state: DownloadManagementUiState,
+    onCancel: (Long) -> Unit,
+    onRetry: (Long) -> Unit,
+) {
+    if (!state.isLoading && state.active.isEmpty()) {
+        EmptyDownloads(
+            title = "No downloads in progress",
+            subtitle = "New downloads will appear here.",
+        )
+        return
+    }
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 120.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        if (state.downloading.isNotEmpty()) {
+            item(key = "downloading_label") { SectionLabel("Downloading") }
+            items(state.downloading, key = { "active_${it.queueId}" }) { item ->
+                DownloadRowCard(item, onCancel = onCancel, onRetry = onRetry)
+            }
+        }
+        if (state.queued.isNotEmpty()) {
+            item(key = "queued_label") { SectionLabel("Up next") }
+            items(state.queued, key = { "queued_${it.queueId}" }) { item ->
+                DownloadRowCard(
+                    item = item,
+                    queuePosition = state.queued.indexOf(item) + 1,
+                    onCancel = onCancel,
+                    onRetry = onRetry,
+                )
+            }
+        }
+        if (state.waiting.isNotEmpty()) {
+            item(key = "waiting_label") { SectionLabel("Waiting for lossless") }
+            items(state.waiting, key = { "waiting_${it.queueId}" }) { item ->
+                DownloadRowCard(item, onCancel = onCancel, onRetry = onRetry)
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryContent(
+    state: DownloadManagementUiState,
+    onRetry: (Long) -> Unit,
+) {
+    if (!state.isLoading && state.history.isEmpty()) {
+        EmptyDownloads(title = "No download history yet", subtitle = "Completed and failed downloads will appear here.")
+        return
+    }
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 120.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item(key = "recent_label") { SectionLabel("Recent") }
+        items(state.history, key = { "history_${it.queueId}" }) { item ->
+            DownloadRowCard(item, onCancel = {}, onRetry = onRetry)
+        }
+    }
+}
+
+@Composable
+private fun DownloadRowCard(
+    item: DownloadManagementItem,
+    queuePosition: Int? = null,
+    onCancel: (Long) -> Unit,
+    onRetry: (Long) -> Unit,
+) {
+    val extendedColors = StashTheme.extendedColors
+    Surface(
+        shape = RoundedCornerShape(14.dp),
+        color = extendedColors.glassBackground,
+        border = androidx.compose.foundation.BorderStroke(0.5.dp, extendedColors.glassBorder),
+    ) {
+        DownloadManagementRow(
+            item = item,
+            queuePosition = queuePosition,
+            onCancel = onCancel,
+            onRetry = onRetry,
+        )
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text = text,
+        modifier = Modifier.padding(top = 4.dp),
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun EmptyDownloads(title: String, subtitle: String) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(32.dp)) {
+            Icon(
+                imageVector = Icons.Default.CheckCircle,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
+            )
+            Spacer(Modifier.height(16.dp))
+            Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Spacer(Modifier.height(4.dp))
+            Text(subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/DownloadManagementViewModel.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/DownloadManagementViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -67,9 +68,16 @@ class DownloadManagementViewModel @Inject constructor(
     private val progressByTrackId = MutableStateFlow<Map<Long, DownloadProgress>>(emptyMap())
     private val message = MutableStateFlow<String?>(null)
 
+    // Mapped once per history emission, not once per progress tick. Progress
+    // updates arrive several times a second per active download and history
+    // never depends on them, so mapping 100 rows inside the combine below was
+    // pure waste on every tick.
+    private val historyItems = downloadQueueDao.observeDownloadHistory(100)
+        .map { rows -> rows.map { it.toItem(null) } }
+
     val uiState: StateFlow<DownloadManagementUiState> = combine(
         downloadQueueDao.observeActiveDownloadRows(),
-        downloadQueueDao.observeDownloadHistory(100),
+        historyItems,
         selectedTab,
         progressByTrackId,
         message,
@@ -78,7 +86,7 @@ class DownloadManagementViewModel @Inject constructor(
             isLoading = false,
             selectedTab = tab,
             active = active.map { it.toItem(progress[it.trackId]) },
-            history = history.map { it.toItem(null) },
+            history = history,
             message = currentMessage,
         )
     }.stateIn(
@@ -151,7 +159,16 @@ private fun DownloadManagementRow.toItem(progress: DownloadProgress?): DownloadM
         completedAt = completedAt,
         errorMessage = errorMessage,
         action = when {
-            status == QueueStatus.PENDING || status == QueueStatus.IN_PROGRESS -> DownloadManagementAction.CANCEL
+            // WAITING_FOR_LOSSLESS is an active queue row the user can be
+            // parked on indefinitely (no lossless source has it yet) — it
+            // needs a way out, and markCancelledIfActive already accepts it.
+            status == QueueStatus.PENDING ||
+                status == QueueStatus.IN_PROGRESS ||
+                status == QueueStatus.WAITING_FOR_LOSSLESS -> DownloadManagementAction.CANCEL
+            // Un-cancel. Without this a cancelled row is a dead end: nothing
+            // re-enqueues it (getUnqueuedTrackIds skips SKIPPED on purpose),
+            // so a mis-tap on Cancel was unrecoverable from this screen.
+            status == QueueStatus.SKIPPED -> DownloadManagementAction.RETRY
             status == QueueStatus.FAILED && failureType != DownloadFailureType.NO_MATCH -> DownloadManagementAction.RETRY
             else -> DownloadManagementAction.NONE
         },

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/DownloadManagementViewModel.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/DownloadManagementViewModel.kt
@@ -1,0 +1,159 @@
+package com.stash.feature.sync
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.stash.core.data.db.dao.DownloadManagementRow
+import com.stash.core.data.db.dao.DownloadQueueDao
+import com.stash.core.data.sync.DownloadCancellationController
+import com.stash.core.data.sync.SingleTrackDownloadEnqueuer
+import com.stash.core.model.DownloadFailureType
+import com.stash.core.model.DownloadStatus as QueueStatus
+import com.stash.data.download.DownloadManager
+import com.stash.data.download.model.DownloadProgress
+import com.stash.data.download.model.DownloadStatus as PipelineStatus
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+enum class DownloadManagementTab { QUEUE, HISTORY }
+
+enum class DownloadManagementAction { CANCEL, RETRY, NONE }
+
+data class DownloadManagementItem(
+    val queueId: Long,
+    val trackId: Long,
+    val title: String,
+    val artist: String,
+    val albumArtUrl: String?,
+    val playlistName: String?,
+    val status: QueueStatus,
+    val progress: Float?,
+    val phaseLabel: String,
+    val createdAt: Long,
+    val completedAt: Long?,
+    val errorMessage: String?,
+    val action: DownloadManagementAction,
+)
+
+data class DownloadManagementUiState(
+    val isLoading: Boolean = true,
+    val selectedTab: DownloadManagementTab = DownloadManagementTab.QUEUE,
+    val active: List<DownloadManagementItem> = emptyList(),
+    val history: List<DownloadManagementItem> = emptyList(),
+    val message: String? = null,
+) {
+    val downloading: List<DownloadManagementItem>
+        get() = active.filter { it.status == QueueStatus.IN_PROGRESS }
+    val queued: List<DownloadManagementItem>
+        get() = active.filter { it.status == QueueStatus.PENDING }
+    val waiting: List<DownloadManagementItem>
+        get() = active.filter { it.status == QueueStatus.WAITING_FOR_LOSSLESS }
+}
+
+@HiltViewModel
+class DownloadManagementViewModel @Inject constructor(
+    private val downloadQueueDao: DownloadQueueDao,
+    private val downloadManager: DownloadManager,
+    private val downloadEnqueuer: SingleTrackDownloadEnqueuer,
+    private val cancellationController: DownloadCancellationController,
+) : ViewModel() {
+    private val selectedTab = MutableStateFlow(DownloadManagementTab.QUEUE)
+    private val progressByTrackId = MutableStateFlow<Map<Long, DownloadProgress>>(emptyMap())
+    private val message = MutableStateFlow<String?>(null)
+
+    val uiState: StateFlow<DownloadManagementUiState> = combine(
+        downloadQueueDao.observeActiveDownloadRows(),
+        downloadQueueDao.observeDownloadHistory(100),
+        selectedTab,
+        progressByTrackId,
+        message,
+    ) { active, history, tab, progress, currentMessage ->
+        DownloadManagementUiState(
+            isLoading = false,
+            selectedTab = tab,
+            active = active.map { it.toItem(progress[it.trackId]) },
+            history = history.map { it.toItem(null) },
+            message = currentMessage,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = DownloadManagementUiState(),
+    )
+
+    init {
+        viewModelScope.launch {
+            downloadManager.progress.collect { update ->
+                progressByTrackId.value = when (update.status) {
+                    PipelineStatus.COMPLETED,
+                    PipelineStatus.FAILED,
+                    PipelineStatus.UNMATCHED,
+                    -> progressByTrackId.value - update.trackId
+                    else -> progressByTrackId.value + (update.trackId to update)
+                }
+            }
+        }
+    }
+
+    fun selectTab(tab: DownloadManagementTab) {
+        selectedTab.value = tab
+    }
+
+    fun cancel(queueId: Long) = viewModelScope.launch {
+        val cancelled = cancellationController.cancel(queueId)
+        message.value = if (cancelled) "Download cancelled" else "Download could not be cancelled"
+    }
+
+    fun retry(queueId: Long) = viewModelScope.launch {
+        if (downloadQueueDao.atomicallyClaimForRetry(queueId) == 1) {
+            downloadEnqueuer.enqueue(queueId)
+            message.value = "Download queued"
+        }
+    }
+
+    fun dismissMessage() {
+        message.value = null
+    }
+}
+
+private fun DownloadManagementRow.toItem(progress: DownloadProgress?): DownloadManagementItem {
+    val pipeline = progress?.status
+    return DownloadManagementItem(
+        queueId = queueId,
+        trackId = trackId,
+        title = title,
+        artist = artist,
+        albumArtUrl = albumArtUrl,
+        playlistName = album.takeIf(String::isNotBlank),
+        status = status,
+        progress = progress?.progress?.coerceIn(0f, 1f),
+        phaseLabel = when {
+            status == QueueStatus.SKIPPED -> "Cancelled"
+            pipeline == PipelineStatus.MATCHING -> "Finding a match"
+            pipeline == PipelineStatus.DOWNLOADING -> "Downloading"
+            pipeline == PipelineStatus.PROCESSING -> "Processing"
+            pipeline == PipelineStatus.TAGGING -> "Adding metadata"
+            status == QueueStatus.IN_PROGRESS -> "In progress"
+            status == QueueStatus.PENDING -> "Queued"
+            status == QueueStatus.WAITING_FOR_LOSSLESS -> "Waiting for a lossless source"
+            status == QueueStatus.COMPLETED -> "Downloaded"
+            status == QueueStatus.FAILED && failureType == DownloadFailureType.NO_MATCH -> "Needs review"
+            status == QueueStatus.FAILED -> "Failed"
+            else -> status.name.lowercase().replaceFirstChar(Char::titlecase)
+        },
+        createdAt = createdAt,
+        completedAt = completedAt,
+        errorMessage = errorMessage,
+        action = when {
+            status == QueueStatus.PENDING || status == QueueStatus.IN_PROGRESS -> DownloadManagementAction.CANCEL
+            status == QueueStatus.FAILED && failureType != DownloadFailureType.NO_MATCH -> DownloadManagementAction.RETRY
+            else -> DownloadManagementAction.NONE
+        },
+    )
+}

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncScreen.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Restore
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.LaunchedEffect
@@ -77,6 +78,7 @@ fun SyncScreen(
     onNavigateToFailedMatches: () -> Unit = {},
     onNavigateToBlockedSongs: () -> Unit = {},
     onNavigateToFailedDownloads: () -> Unit = {},
+    onNavigateToDownloads: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
     onManageSource: (SyncSource) -> Unit = {},
     viewModel: SyncViewModel = hiltViewModel(),
@@ -158,6 +160,10 @@ fun SyncScreen(
                     )
                 },
             )
+        }
+
+        item(key = "download_management") {
+            DownloadManagementCard(onClick = onNavigateToDownloads)
         }
 
         // -- Songs that need review card --------------------------------------
@@ -425,6 +431,51 @@ fun SyncScreen(
                 TextButton(onClick = viewModel::onUndoResultShown) { Text("OK") }
             },
         )
+    }
+}
+
+/** Permanent entry point for the queue and recent download history. */
+@Composable
+private fun DownloadManagementCard(onClick: () -> Unit) {
+    val extendedColors = StashTheme.extendedColors
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        color = extendedColors.glassBackground,
+        border = BorderStroke(0.5.dp, extendedColors.glassBorder),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Download,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Downloads",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = "View current downloads, queue, and history",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = "Open downloads",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/components/DownloadManagementRow.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/components/DownloadManagementRow.kt
@@ -1,0 +1,121 @@
+package com.stash.feature.sync.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.stash.core.model.DownloadStatus
+import com.stash.feature.sync.DownloadManagementAction
+import com.stash.feature.sync.DownloadManagementItem
+
+@Composable
+fun DownloadManagementRow(
+    item: DownloadManagementItem,
+    queuePosition: Int? = null,
+    onCancel: (Long) -> Unit,
+    onRetry: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(
+                    Brush.linearGradient(
+                        listOf(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.tertiary.copy(alpha = 0.6f)),
+                    ),
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (item.albumArtUrl.isNullOrBlank()) {
+                Icon(Icons.Default.MusicNote, null, tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.55f))
+            } else {
+                AsyncImage(
+                    model = item.albumArtUrl,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                )
+            }
+        }
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = buildString {
+                    append(item.artist)
+                    item.playlistName?.takeIf(String::isNotBlank)?.let { append(" · "); append(it) }
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(Modifier.height(3.dp))
+            Text(
+                text = if (queuePosition != null) "#$queuePosition · ${item.phaseLabel}" else item.phaseLabel,
+                style = MaterialTheme.typography.labelSmall,
+                color = if (item.status == DownloadStatus.FAILED) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+            )
+            if (item.status == DownloadStatus.IN_PROGRESS) {
+                Spacer(Modifier.height(5.dp))
+                if (item.progress == null) {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                } else {
+                    LinearProgressIndicator(progress = { item.progress }, modifier = Modifier.fillMaxWidth())
+                }
+            }
+        }
+        Spacer(Modifier.width(8.dp))
+        when (item.action) {
+            DownloadManagementAction.CANCEL -> IconButton(onClick = { onCancel(item.queueId) }) {
+                Icon(Icons.Default.Close, "Cancel ${item.title}")
+            }
+            DownloadManagementAction.RETRY -> IconButton(onClick = { onRetry(item.queueId) }) {
+                Icon(Icons.Default.Refresh, "Retry ${item.title}")
+            }
+            DownloadManagementAction.NONE -> if (item.status == DownloadStatus.IN_PROGRESS) {
+                CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+            }
+        }
+    }
+}

--- a/feature/sync/src/test/kotlin/com/stash/feature/sync/DownloadManagementViewModelTest.kt
+++ b/feature/sync/src/test/kotlin/com/stash/feature/sync/DownloadManagementViewModelTest.kt
@@ -58,6 +58,49 @@ class DownloadManagementViewModelTest {
         assertEquals(null, state.downloading.single().progress)
     }
 
+    @Test fun `every actionable status offers a way out`() = runTest {
+        every { dao.observeActiveDownloadRows() } returns flowOf(
+            listOf(
+                row(1, DownloadStatus.IN_PROGRESS),
+                row(2, DownloadStatus.PENDING),
+                // Parked with no lossless source in sight — cancellable, or
+                // the user is stuck watching it forever.
+                row(3, DownloadStatus.WAITING_FOR_LOSSLESS),
+            ),
+        )
+        every { dao.observeDownloadHistory(100) } returns flowOf(
+            listOf(
+                // Un-cancel: nothing else re-enqueues a SKIPPED row.
+                row(4, DownloadStatus.SKIPPED),
+                row(5, DownloadStatus.FAILED),
+                row(6, DownloadStatus.FAILED, failureType = DownloadFailureType.NO_MATCH),
+                row(7, DownloadStatus.COMPLETED),
+            ),
+        )
+        val vm = DownloadManagementViewModel(dao, manager, enqueuer, cancellation)
+        val state = vm.uiState.first { !it.isLoading }
+
+        assertEquals(
+            listOf(
+                DownloadManagementAction.CANCEL,
+                DownloadManagementAction.CANCEL,
+                DownloadManagementAction.CANCEL,
+            ),
+            state.active.map { it.action },
+        )
+        assertEquals(
+            listOf(
+                DownloadManagementAction.RETRY,
+                DownloadManagementAction.RETRY,
+                // NO_MATCH has its own Failed Matches review flow.
+                DownloadManagementAction.NONE,
+                DownloadManagementAction.NONE,
+            ),
+            state.history.map { it.action },
+        )
+        assertEquals("Cancelled", state.history.first().phaseLabel)
+    }
+
     @Test fun `retry enqueues only after atomic claim`() = runTest {
         coEvery { dao.atomicallyClaimForRetry(9) } returns 1
         val vm = DownloadManagementViewModel(dao, manager, enqueuer, cancellation)
@@ -72,7 +115,11 @@ class DownloadManagementViewModelTest {
         coVerify(exactly = 1) { cancellation.cancel(7) }
     }
 
-    private fun row(id: Long, status: DownloadStatus) = DownloadManagementRow(
+    private fun row(
+        id: Long,
+        status: DownloadStatus,
+        failureType: DownloadFailureType = DownloadFailureType.NONE,
+    ) = DownloadManagementRow(
         queueId = id,
         trackId = id + 100,
         title = "Title $id",
@@ -82,7 +129,7 @@ class DownloadManagementViewModelTest {
         status = status,
         retryCount = 0,
         errorMessage = null,
-        failureType = DownloadFailureType.NONE,
+        failureType = failureType,
         createdAt = id,
         completedAt = null,
     )

--- a/feature/sync/src/test/kotlin/com/stash/feature/sync/DownloadManagementViewModelTest.kt
+++ b/feature/sync/src/test/kotlin/com/stash/feature/sync/DownloadManagementViewModelTest.kt
@@ -1,0 +1,89 @@
+package com.stash.feature.sync
+
+import com.stash.core.data.db.dao.DownloadManagementRow
+import com.stash.core.data.db.dao.DownloadQueueDao
+import com.stash.core.data.sync.DownloadCancellationController
+import com.stash.core.data.sync.SingleTrackDownloadEnqueuer
+import com.stash.core.model.DownloadFailureType
+import com.stash.core.model.DownloadStatus
+import com.stash.data.download.DownloadManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadManagementViewModelTest {
+    private val dao: DownloadQueueDao = mockk(relaxed = true)
+    private val manager: DownloadManager = mockk(relaxed = true)
+    private val enqueuer: SingleTrackDownloadEnqueuer = mockk(relaxed = true)
+    private val cancellation: DownloadCancellationController = mockk(relaxed = true)
+    private val progress = MutableSharedFlow<com.stash.data.download.model.DownloadProgress>()
+
+    @Before fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        every { manager.progress } returns progress
+        every { dao.observeActiveDownloadRows() } returns flowOf(emptyList())
+        every { dao.observeDownloadHistory(100) } returns flowOf(emptyList())
+    }
+
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    @Test fun `active rows are partitioned into downloading queued and waiting`() = runTest {
+        every { dao.observeActiveDownloadRows() } returns flowOf(
+            listOf(
+                row(1, DownloadStatus.IN_PROGRESS),
+                row(2, DownloadStatus.PENDING),
+                row(3, DownloadStatus.WAITING_FOR_LOSSLESS),
+            ),
+        )
+        val vm = DownloadManagementViewModel(dao, manager, enqueuer, cancellation)
+        val state = vm.uiState.first { !it.isLoading }
+        assertEquals(listOf(1L), state.downloading.map { it.queueId })
+        assertEquals(listOf(2L), state.queued.map { it.queueId })
+        assertEquals(listOf(3L), state.waiting.map { it.queueId })
+        assertEquals(null, state.downloading.single().progress)
+    }
+
+    @Test fun `retry enqueues only after atomic claim`() = runTest {
+        coEvery { dao.atomicallyClaimForRetry(9) } returns 1
+        val vm = DownloadManagementViewModel(dao, manager, enqueuer, cancellation)
+        vm.retry(9)
+        coVerify(exactly = 1) { enqueuer.enqueue(9) }
+    }
+
+    @Test fun `cancel delegates to cancellation controller`() = runTest {
+        coEvery { cancellation.cancel(7) } returns true
+        val vm = DownloadManagementViewModel(dao, manager, enqueuer, cancellation)
+        vm.cancel(7)
+        coVerify(exactly = 1) { cancellation.cancel(7) }
+    }
+
+    private fun row(id: Long, status: DownloadStatus) = DownloadManagementRow(
+        queueId = id,
+        trackId = id + 100,
+        title = "Title $id",
+        artist = "Artist",
+        album = "Album",
+        albumArtUrl = null,
+        status = status,
+        retryCount = 0,
+        errorMessage = null,
+        failureType = DownloadFailureType.NONE,
+        createdAt = id,
+        completedAt = null,
+    )
+}


### PR DESCRIPTION
## Summary
- add an always-visible Downloads entry from the Sync screen
- show durable active queue and recent download history with live per-track progress
- support retry and race-safe per-item cancellation for sync and discovery downloads
- add Room and ViewModel regression coverage for ordering, transitions, retries, and cancellation races

## Testing
- :core:data:testDebugUnitTest --tests com.stash.core.data.db.dao.DownloadQueueDaoManagementTest
- :feature:sync:testDebugUnitTest --tests com.stash.feature.sync.DownloadManagementViewModelTest
- compileDebugUnitTestKotlin
- :app:assembleDebug

## Scope
Manual Search/Artist/Album downloads currently use a separate in-memory pipeline and are intentionally left for a follow-up requiring durable origin tracking.

Closes rawnaldclark/Stash#224

Original PR by @JoshDui 