### PR TITLE
fix(sync): preserve playlist download consent

### DIFF
--- a/app/src/main/kotlin/com/stash/app/StashApplication.kt
+++ b/app/src/main/kotlin/com/stash/app/StashApplication.kt
@@ -407,7 +407,7 @@ class StashApplication : Application(), Configuration.Provider {
         // waiting up to 48 hours when Android Doze defers the fire.
         UpdateCheckWorker.enqueueOneTimeCheck(this)
         applicationScope.launch { maybeInvalidateArtistCache() }
-        applicationScope.launch { maybeEnableYouTubePlaylistSync() }
+        applicationScope.launch { enforceDailyMixSyncDisabled() }
         applicationScope.launch { maybeHideEmptyYouTubePlaylists() }
         applicationScope.launch { maybeBackfillCodecsFromExtension() }
         applicationScope.launch { maybeBackfillTrackAlbums() }
@@ -776,25 +776,24 @@ class StashApplication : Application(), Configuration.Provider {
     }
 
     /**
-     * Retroactively enables `sync_enabled = 1` on every YouTube playlist in
-     * the local DB exactly once. Fixes the parity gap where YouTube
-     * playlists discovered before the Sync-preferences UI was extended to
-     * YouTube got stuck at `sync_enabled = 0` and were silently skipped by
-     * DiffWorker. Gated by [YOUTUBE_SYNC_ENABLE_VERSION] so it runs at most
-     * once per install, no matter how many times the app restarts.
+     * Clears stale download consent from algorithmic mixes on every cold start.
+     *
+     * Older releases auto-enabled YouTube playlists and newly discovered
+     * online mixes. Mix visibility now has its own `hide_from_home` setting,
+     * while every playlist starts sync-disabled, so retaining those legacy
+     * flags makes mixes appear selected without the user choosing them.
+     * Custom and liked playlists are deliberately untouched because their
+     * enabled state may reflect an explicit user choice. This is intentionally
+     * idempotent rather than preference-gated: restoring an older database can
+     * reintroduce stale mix flags while SharedPreferences survives the restore.
      */
-    private suspend fun maybeEnableYouTubePlaylistSync() {
-        val prefs = getSharedPreferences("stash_migrations", MODE_PRIVATE)
-        val stored = prefs.getInt("youtube_sync_enable_version", 0)
-        if (stored < YOUTUBE_SYNC_ENABLE_VERSION) {
-            val updated = playlistDao.enableAllYouTubePlaylistSync()
+    private suspend fun enforceDailyMixSyncDisabled() {
+        val updated = playlistDao.disableLegacyDailyMixSync()
+        if (updated > 0) {
             Log.i(
                 "StashMigration",
-                "maybeEnableYouTubePlaylistSync: flipped $updated rows to sync_enabled=1",
+                "enforceDailyMixSyncDisabled: cleared sync_enabled on $updated mix row(s)",
             )
-            prefs.edit()
-                .putInt("youtube_sync_enable_version", YOUTUBE_SYNC_ENABLE_VERSION)
-                .apply()
         }
     }
 
@@ -883,15 +882,6 @@ class StashApplication : Application(), Configuration.Provider {
 
         /** Bump to re-run [maybePurgeAntraArtifacts] (one-shot antra cleanup). */
         private const val ANTRA_PURGE_VERSION = 1
-
-        /**
-         * Bump when [maybeEnableYouTubePlaylistSync] needs to run again.
-         * Current bump (v1) is the initial rollout that flips every
-         * pre-existing YouTube playlist to `sync_enabled = 1` so the Option
-         * A auto-download default takes effect for users whose playlists
-         * already live in the DB.
-         */
-        private const val YOUTUBE_SYNC_ENABLE_VERSION = 1
 
         /**
          * Bump when [maybeHideEmptyYouTubePlaylists] needs to run again.

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
@@ -582,16 +582,15 @@ interface PlaylistDao {
     fun getYouTubePlaylistsForPreferences(): Flow<List<PlaylistEntity>>
 
     /**
-     * One-shot data migration: flip sync_enabled on every YouTube playlist
-     * that's still false. Fixes the Option A gap where playlists discovered
-     * before the Sync-preference UI was extended to YouTube got stuck at
-     * sync_enabled = 0 and silently skipped by DiffWorker. Called once per
-     * install from [com.stash.app.StashApplication].
+     * Idempotent cleanup for mixes auto-enabled by older releases or restored
+     * from an older backup. Mix Home
+     * visibility is controlled independently, so no algorithmic mix should
+     * retain implicit download consent. Other playlist types are untouched.
      *
      * @return the number of rows updated.
      */
-    @Query("UPDATE playlists SET sync_enabled = 1 WHERE source = 'YOUTUBE' AND sync_enabled = 0")
-    suspend fun enableAllYouTubePlaylistSync(): Int
+    @Query("UPDATE playlists SET sync_enabled = 0 WHERE type = 'DAILY_MIX' AND sync_enabled = 1")
+    suspend fun disableLegacyDailyMixSync(): Int
 
     /**
      * One-shot data migration: hide every YouTube playlist that currently

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoLegacyMixConsentTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/PlaylistDaoLegacyMixConsentTest.kt
@@ -1,0 +1,68 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PlaylistDaoLegacyMixConsentTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var dao: PlaylistDao
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.playlistDao()
+    }
+
+    @After fun tearDown() { db.close() }
+
+    @Test fun `legacy cleanup disables only daily mixes`() = runTest {
+        val spotifyMix = insert("Spotify Mix", MusicSource.SPOTIFY, PlaylistType.DAILY_MIX, true)
+        val youtubeMix = insert("YouTube Mix", MusicSource.YOUTUBE, PlaylistType.DAILY_MIX, true)
+        val custom = insert("Road Trip", MusicSource.YOUTUBE, PlaylistType.CUSTOM, true)
+        val liked = insert("Liked Songs", MusicSource.YOUTUBE, PlaylistType.LIKED_SONGS, true)
+        val alreadyOff = insert("Mix already off", MusicSource.YOUTUBE, PlaylistType.DAILY_MIX, false)
+
+        assertThat(dao.disableLegacyDailyMixSync()).isEqualTo(2)
+
+        assertThat(dao.getById(spotifyMix)!!.syncEnabled).isFalse()
+        assertThat(dao.getById(youtubeMix)!!.syncEnabled).isFalse()
+        assertThat(dao.getById(custom)!!.syncEnabled).isTrue()
+        assertThat(dao.getById(liked)!!.syncEnabled).isTrue()
+        assertThat(dao.getById(alreadyOff)!!.syncEnabled).isFalse()
+        assertThat(dao.disableLegacyDailyMixSync()).isEqualTo(0)
+    }
+
+    private suspend fun insert(
+        name: String,
+        source: MusicSource,
+        type: PlaylistType,
+        syncEnabled: Boolean,
+    ): Long = dao.insert(
+        PlaylistEntity(
+            name = name,
+            source = source,
+            sourceId = "$source:$name",
+            type = type,
+            syncEnabled = syncEnabled,
+        )
+    )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
@@ -11,6 +11,7 @@ import com.stash.core.data.blocklist.BlocklistGuard
 import com.stash.core.data.db.StashDatabase
 import com.stash.core.data.db.dao.DownloadQueueDao
 import com.stash.core.data.db.dao.SyncHistoryDao
+import com.stash.core.data.db.entity.DownloadQueueEntity
 import com.stash.core.data.db.entity.PlaylistEntity
 import com.stash.core.data.db.entity.PlaylistTrackCrossRef
 import com.stash.core.data.db.entity.RemotePlaylistSnapshotEntity
@@ -179,6 +180,105 @@ class DiffWorkerTest {
         val crossRef = db.playlistDao().getCrossRef(playlistId, trackId)
         assertEquals(originalAddedAt, crossRef?.addedAt)
     }
+
+    @Test
+    fun `ACCUMULATE does not requeue an already downloaded track`() = runBlocking {
+        val trackId = db.trackDao().insert(downloadedTrack("Track A", "spotify:track:a", "/music/a.flac"))
+        val playlistId = seedAccumulatePlaylist()
+        db.playlistDao().insertCrossRef(
+            PlaylistTrackCrossRef(playlistId, trackId, 0, Instant.parse("2026-07-01T00:00:00Z"))
+        )
+        stubGrowingSnapshot(remoteTrack("Track A", "spotify:track:a", 0))
+
+        val result = buildWorker().doWork()
+
+        assertTrue(result is androidx.work.ListenableWorker.Result.Success)
+        assertEquals(trackId, db.playlistDao().getCrossRefsForPlaylist(playlistId).single().trackId)
+        assertEquals("/music/a.flac", db.trackDao().getById(trackId)?.filePath)
+        coVerify(exactly = 0) { downloadQueueDao.insertAll(any()) }
+    }
+
+    @Test
+    fun `consecutive ACCUMULATE snapshots queue only newly added undownloaded tracks`() = runBlocking {
+        val playlistId = seedAccumulatePlaylist()
+        val trackA = db.trackDao().insert(downloadedTrack("Track A", "spotify:track:a", "/music/a.flac"))
+        db.playlistDao().insertCrossRef(
+            PlaylistTrackCrossRef(playlistId, trackA, 0, Instant.parse("2026-07-01T00:00:00Z"))
+        )
+        val queuedTrackIds = mutableListOf<Long>()
+        coEvery { downloadQueueDao.insertAll(any()) } answers {
+            queuedTrackIds += firstArg<List<DownloadQueueEntity>>().map { it.trackId }
+            emptyList()
+        }
+
+        stubGrowingSnapshot(
+            remoteTrack("Track A", "spotify:track:a", 0),
+            remoteTrack("Track B", "spotify:track:b", 1),
+        )
+        assertTrue(buildWorker().doWork() is androidx.work.ListenableWorker.Result.Success)
+        val trackB = db.trackDao().getAllForIntegrityScan().single { it.spotifyUri == "spotify:track:b" }
+        db.trackDao().markAsDownloaded(trackB.id, "/music/b.flac", 1_000L)
+
+        stubGrowingSnapshot(
+            remoteTrack("Track B", "spotify:track:b", 0),
+            remoteTrack("Track C", "spotify:track:c", 1),
+        )
+        assertTrue(buildWorker().doWork() is androidx.work.ListenableWorker.Result.Success)
+
+        val tracksByUri = db.trackDao().getAllForIntegrityScan().associateBy { it.spotifyUri }
+        val trackC = tracksByUri.getValue("spotify:track:c").id
+        assertEquals(setOf("spotify:track:a", "spotify:track:b", "spotify:track:c"), tracksByUri.keys)
+        assertEquals(
+            setOf(trackA, trackB.id, trackC),
+            db.playlistDao().getCrossRefsForPlaylist(playlistId).map { it.trackId }.toSet(),
+        )
+        assertEquals(listOf(trackB.id, trackC), queuedTrackIds)
+    }
+
+    private suspend fun seedAccumulatePlaylist(): Long {
+        every { syncPreferencesManager.spotifySyncMode } returns flowOf(SyncMode.ACCUMULATE)
+        return db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Growing Playlist",
+                source = MusicSource.SPOTIFY,
+                sourceId = "spotify:playlist:growing",
+                type = PlaylistType.CUSTOM,
+                syncEnabled = true,
+            )
+        )
+    }
+
+    private fun stubGrowingSnapshot(vararg tracks: RemoteTrackSnapshotEntity) {
+        val snapshot = RemotePlaylistSnapshotEntity(
+            id = 21L,
+            syncId = 1L,
+            source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "spotify:playlist:growing",
+            playlistName = "Growing Playlist",
+            playlistType = PlaylistType.CUSTOM,
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(snapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(21L) } returns tracks.toList()
+    }
+
+    private fun downloadedTrack(title: String, spotifyUri: String, path: String) = TrackEntity(
+        title = title,
+        artist = "Artist",
+        canonicalTitle = title.lowercase(),
+        canonicalArtist = "artist",
+        spotifyUri = spotifyUri,
+        isDownloaded = true,
+        filePath = path,
+    )
+
+    private fun remoteTrack(title: String, spotifyUri: String, position: Int) = RemoteTrackSnapshotEntity(
+        syncId = 1L,
+        snapshotPlaylistId = 21L,
+        title = title,
+        artist = "Artist",
+        spotifyUri = spotifyUri,
+        position = position,
+    )
 
     // ── Batch identity match priority: spotifyUri > youtubeId > canonical ─
 


### PR DESCRIPTION
# Summary

- retire the obsolete startup migration that automatically enabled every existing YouTube playlist
- clear legacy `DAILY_MIX` sync-selection flags idempotently on cold start, including after database restore
- preserve Custom and Liked Songs selections because their provenance cannot safely be inferred
- add ACCUMULATE regressions proving downloaded tracks are not requeued and only new tracks are queued

# Root cause

Older releases used a one-shot migration that set `sync_enabled = 1` for every YouTube playlist. Later releases switched playlist discovery to explicit opt-in and made algorithmic mixes download-ineligible, but the obsolete migration remained reachable when an existing database had no matching SharedPreferences marker. That left mixes visibly selected without user consent and could make Custom YouTube playlists download-eligible.

The existing #368 fixes already prevent mix-only queue leakage. This patch closes the remaining consent/UI and restore edge case without deleting playlists, memberships, queue history, tracks, or audio files.

# Verification

- focused `DiffWorkerTest` and `PlaylistDaoLegacyMixConsentTest` passed
- existing mix exclusion, queue partition, default-selection, and enqueue-policy suites passed
- `:app:assembleDebug` passed
- `git diff --check` passed

Closes rawnaldclark/Stash#381

Original PR by @JoshDui 