### PR TITLE
feat(library): official artist photos

### DIFF
--- a/app/src/main/kotlin/com/stash/app/StashApplication.kt
+++ b/app/src/main/kotlin/com/stash/app/StashApplication.kt
@@ -28,6 +28,7 @@ import com.stash.core.data.sync.SyncNotificationManager
 import com.stash.data.download.backfill.MetadataBackfillScheduler
 import com.stash.data.download.ytdlp.YtDlpManager
 import com.stash.core.data.sync.workers.ArtBackfillWorker
+import com.stash.core.data.sync.workers.ArtistImageBackfillWorker
 import com.stash.core.data.sync.workers.AutoSaveScrobbler
 import com.stash.core.data.sync.workers.DiscoveryDownloadWorker
 import com.stash.core.data.sync.workers.QualityInfoBackfillWorker
@@ -442,6 +443,11 @@ class StashApplication : Application(), Configuration.Provider {
         // no thumbnail (see ArtBackfillWorker KDoc). KEEP policy means the
         // worker is a no-op on every subsequent launch once it completes.
         ArtBackfillWorker.enqueueOneTime(this)
+        // First-launch artist-photo backfill: resolves the official avatar
+        // for every artist on the Library Artists tab (see ArtistImageBackfillWorker
+        // KDoc). KEEP policy means a re-launch before the worker completes
+        // doesn't re-enqueue; re-arms after each sync via SyncFinalizeWorker.
+        ArtistImageBackfillWorker.enqueueOneTime(this)
         // v0.9.11: kick a background sweep that fills in bit-depth +
         // sample-rate for tracks downloaded before the columns existed.
         // The flag is set immediately on enqueue (not after success) so

--- a/core/data/schemas/com.stash.core.data.db.StashDatabase/44.json
+++ b/core/data/schemas/com.stash.core.data.db.StashDatabase/44.json
@@ -1,0 +1,2168 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 44,
+    "identityHash": "b97f8e7a010533ebaa7367e4272f4e2a",
+    "entities": [
+      {
+        "tableName": "tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_artist` TEXT NOT NULL DEFAULT '', `duration_ms` INTEGER NOT NULL, `file_path` TEXT, `file_format` TEXT NOT NULL, `quality_kbps` INTEGER NOT NULL, `file_size_bytes` INTEGER NOT NULL, `source` TEXT NOT NULL, `spotify_uri` TEXT, `youtube_id` TEXT, `album_art_url` TEXT, `album_art_path` TEXT, `date_added` INTEGER NOT NULL, `last_played` INTEGER, `play_count` INTEGER NOT NULL, `is_downloaded` INTEGER NOT NULL, `canonical_title` TEXT NOT NULL, `canonical_artist` TEXT NOT NULL, `match_confidence` REAL NOT NULL, `match_dismissed` INTEGER NOT NULL, `match_flagged` INTEGER NOT NULL DEFAULT 0, `isrc` TEXT, `explicit` INTEGER, `music_video_type` TEXT, `yt_canonical_video_id` TEXT, `bits_per_sample` INTEGER, `sample_rate_hz` INTEGER, `spotify_saved_at` INTEGER, `ytmusic_saved_at` INTEGER, `lastfm_loved_at` INTEGER, `stash_liked_at` INTEGER, `mbid` TEXT, `lastfm_user_playcount` INTEGER, `lastfm_listeners` INTEGER, `lastfm_user_loved` INTEGER NOT NULL DEFAULT 0, `loudness_lufs` REAL, `true_peak_dbfs` REAL, `loudness_measured_at` INTEGER, `is_streamable` INTEGER NOT NULL DEFAULT 0, `is_streamable_checked_at` INTEGER, `metadata_embedded_at` INTEGER, `lyrics_fetched_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileFormat",
+            "columnName": "file_format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "qualityKbps",
+            "columnName": "quality_kbps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSizeBytes",
+            "columnName": "file_size_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotify_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeId",
+            "columnName": "youtube_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtUrl",
+            "columnName": "album_art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtPath",
+            "columnName": "album_art_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayed",
+            "columnName": "last_played",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDownloaded",
+            "columnName": "is_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalTitle",
+            "columnName": "canonical_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalArtist",
+            "columnName": "canonical_artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchConfidence",
+            "columnName": "match_confidence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchDismissed",
+            "columnName": "match_dismissed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "matchFlagged",
+            "columnName": "match_flagged",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "musicVideoType",
+            "columnName": "music_video_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ytCanonicalVideoId",
+            "columnName": "yt_canonical_video_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitsPerSample",
+            "columnName": "bits_per_sample",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRateHz",
+            "columnName": "sample_rate_hz",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "spotifySavedAt",
+            "columnName": "spotify_saved_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "ytMusicSavedAt",
+            "columnName": "ytmusic_saved_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastFmLovedAt",
+            "columnName": "lastfm_loved_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "stashLikedAt",
+            "columnName": "stash_liked_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mbid",
+            "columnName": "mbid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastfmUserPlaycount",
+            "columnName": "lastfm_user_playcount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastfmListeners",
+            "columnName": "lastfm_listeners",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastfmUserLoved",
+            "columnName": "lastfm_user_loved",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "loudnessLufs",
+            "columnName": "loudness_lufs",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "truePeakDbfs",
+            "columnName": "true_peak_dbfs",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "loudnessMeasuredAt",
+            "columnName": "loudness_measured_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isStreamable",
+            "columnName": "is_streamable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isStreamableCheckedAt",
+            "columnName": "is_streamable_checked_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "metadataEmbeddedAt",
+            "columnName": "metadata_embedded_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lyricsFetchedAt",
+            "columnName": "lyrics_fetched_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tracks_spotify_uri",
+            "unique": true,
+            "columnNames": [
+              "spotify_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tracks_spotify_uri` ON `${TABLE_NAME}` (`spotify_uri`)"
+          },
+          {
+            "name": "index_tracks_youtube_id",
+            "unique": true,
+            "columnNames": [
+              "youtube_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tracks_youtube_id` ON `${TABLE_NAME}` (`youtube_id`)"
+          },
+          {
+            "name": "index_tracks_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_artist` ON `${TABLE_NAME}` (`artist`)"
+          },
+          {
+            "name": "index_tracks_album",
+            "unique": false,
+            "columnNames": [
+              "album"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_album` ON `${TABLE_NAME}` (`album`)"
+          },
+          {
+            "name": "index_tracks_date_added",
+            "unique": false,
+            "columnNames": [
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_date_added` ON `${TABLE_NAME}` (`date_added`)"
+          },
+          {
+            "name": "index_tracks_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_last_played` ON `${TABLE_NAME}` (`last_played`)"
+          },
+          {
+            "name": "index_tracks_play_count",
+            "unique": false,
+            "columnNames": [
+              "play_count"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_play_count` ON `${TABLE_NAME}` (`play_count`)"
+          },
+          {
+            "name": "index_tracks_title_artist",
+            "unique": false,
+            "columnNames": [
+              "title",
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tracks_title_artist` ON `${TABLE_NAME}` (`title`, `artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `source` TEXT NOT NULL, `source_id` TEXT NOT NULL, `type` TEXT NOT NULL, `mix_number` INTEGER, `last_synced` INTEGER, `track_count` INTEGER NOT NULL, `is_active` INTEGER NOT NULL, `art_url` TEXT, `snapshot_id` TEXT, `sync_enabled` INTEGER NOT NULL DEFAULT 1, `date_added` INTEGER NOT NULL DEFAULT 0, `hide_from_home` INTEGER NOT NULL DEFAULT 0, `pinned` INTEGER NOT NULL DEFAULT 0, `pinned_to_home_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mixNumber",
+            "columnName": "mix_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastSynced",
+            "columnName": "last_synced",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artUrl",
+            "columnName": "art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "snapshotId",
+            "columnName": "snapshot_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncEnabled",
+            "columnName": "sync_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hideFromHome",
+            "columnName": "hide_from_home",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "pinnedToHomeAt",
+            "columnName": "pinned_to_home_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_source_id",
+            "unique": true,
+            "columnNames": [
+              "source_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playlists_source_id` ON `${TABLE_NAME}` (`source_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `track_id` INTEGER NOT NULL, `position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `removed_at` INTEGER, `locally_added` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`playlist_id`, `track_id`), FOREIGN KEY(`playlist_id`) REFERENCES `playlists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "removedAt",
+            "columnName": "removed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "locallyAdded",
+            "columnName": "locally_added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "track_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_tracks_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_tracks_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `started_at` INTEGER NOT NULL, `completed_at` INTEGER, `status` TEXT NOT NULL, `playlists_checked` INTEGER NOT NULL, `new_tracks_found` INTEGER NOT NULL, `tracks_downloaded` INTEGER NOT NULL, `tracks_failed` INTEGER NOT NULL, `bytes_downloaded` INTEGER NOT NULL, `error_message` TEXT, `diagnostics` TEXT, `trigger` TEXT NOT NULL, `streaming_mode` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistsChecked",
+            "columnName": "playlists_checked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newTracksFound",
+            "columnName": "new_tracks_found",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tracksDownloaded",
+            "columnName": "tracks_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tracksFailed",
+            "columnName": "tracks_failed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bytesDownloaded",
+            "columnName": "bytes_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "diagnostics",
+            "columnName": "diagnostics",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trigger",
+            "columnName": "trigger",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamingMode",
+            "columnName": "streaming_mode",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "download_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `track_id` INTEGER NOT NULL, `sync_id` INTEGER, `status` TEXT NOT NULL, `search_query` TEXT NOT NULL, `youtube_url` TEXT, `retry_count` INTEGER NOT NULL, `error_message` TEXT, `failure_type` TEXT NOT NULL, `rejected_video_id` TEXT, `created_at` INTEGER NOT NULL, `completed_at` INTEGER, FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`sync_id`) REFERENCES `sync_history`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchQuery",
+            "columnName": "search_query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeUrl",
+            "columnName": "youtube_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "retryCount",
+            "columnName": "retry_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "failureType",
+            "columnName": "failure_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rejectedVideoId",
+            "columnName": "rejected_video_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_queue_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          },
+          {
+            "name": "index_download_queue_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          },
+          {
+            "name": "index_download_queue_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_queue_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sync_history",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sync_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "source_accounts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `source` TEXT NOT NULL, `display_name` TEXT NOT NULL, `email` TEXT NOT NULL, `avatar_url` TEXT, `is_connected` INTEGER NOT NULL, `connected_at` INTEGER, `last_sync_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatar_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isConnected",
+            "columnName": "is_connected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connectedAt",
+            "columnName": "connected_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastSyncAt",
+            "columnName": "last_sync_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_source_accounts_source",
+            "unique": true,
+            "columnNames": [
+              "source"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_source_accounts_source` ON `${TABLE_NAME}` (`source`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tracks_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, tokenize=unicode61, content=`tracks`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "tracks",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_BEFORE_UPDATE BEFORE UPDATE ON `tracks` BEGIN DELETE FROM `tracks_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_BEFORE_DELETE BEFORE DELETE ON `tracks` BEGIN DELETE FROM `tracks_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_AFTER_UPDATE AFTER UPDATE ON `tracks` BEGIN INSERT INTO `tracks_fts`(`docid`, `title`, `artist`, `album`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`artist`, NEW.`album`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_tracks_fts_AFTER_INSERT AFTER INSERT ON `tracks` BEGIN INSERT INTO `tracks_fts`(`docid`, `title`, `artist`, `album`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`artist`, NEW.`album`); END"
+        ]
+      },
+      {
+        "tableName": "remote_playlist_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `source_playlist_id` TEXT NOT NULL, `playlist_name` TEXT NOT NULL, `playlist_type` TEXT NOT NULL, `mix_number` INTEGER, `snapshot_id` TEXT, `track_count` INTEGER NOT NULL, `art_url` TEXT, `fetched_at` INTEGER NOT NULL, `partial` INTEGER NOT NULL, `expected_count` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePlaylistId",
+            "columnName": "source_playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistName",
+            "columnName": "playlist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistType",
+            "columnName": "playlist_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mixNumber",
+            "columnName": "mix_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "snapshotId",
+            "columnName": "snapshot_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artUrl",
+            "columnName": "art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partial",
+            "columnName": "partial",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedCount",
+            "columnName": "expected_count",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_playlist_snapshots_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_playlist_snapshots_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          },
+          {
+            "name": "index_remote_playlist_snapshots_sync_id_source_playlist_id",
+            "unique": true,
+            "columnNames": [
+              "sync_id",
+              "source_playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_remote_playlist_snapshots_sync_id_source_playlist_id` ON `${TABLE_NAME}` (`sync_id`, `source_playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "remote_track_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sync_id` INTEGER NOT NULL, `snapshot_playlist_id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT, `duration_ms` INTEGER NOT NULL, `spotify_uri` TEXT, `youtube_id` TEXT, `album_art_url` TEXT, `position` INTEGER NOT NULL, `isrc` TEXT, `explicit` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snapshotPlaylistId",
+            "columnName": "snapshot_playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotify_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeId",
+            "columnName": "youtube_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtUrl",
+            "columnName": "album_art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_track_snapshots_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_track_snapshots_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          },
+          {
+            "name": "index_remote_track_snapshots_snapshot_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "snapshot_playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_remote_track_snapshots_snapshot_playlist_id` ON `${TABLE_NAME}` (`snapshot_playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist_profile_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artist_id` TEXT NOT NULL, `json` TEXT NOT NULL, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`artist_id`))",
+        "fields": [
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artist_id"
+          ]
+        }
+      },
+      {
+        "tableName": "listening_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `track_id` INTEGER NOT NULL, `started_at` INTEGER NOT NULL, `scrobbled` INTEGER NOT NULL, `yt_scrobbled` INTEGER NOT NULL DEFAULT 0, `completed_at` INTEGER, FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scrobbled",
+            "columnName": "scrobbled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ytScrobbled",
+            "columnName": "yt_scrobbled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_listening_events_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          },
+          {
+            "name": "index_listening_events_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          },
+          {
+            "name": "index_listening_events_scrobbled",
+            "unique": false,
+            "columnNames": [
+              "scrobbled"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_scrobbled` ON `${TABLE_NAME}` (`scrobbled`)"
+          },
+          {
+            "name": "index_listening_events_yt_scrobbled",
+            "unique": false,
+            "columnNames": [
+              "yt_scrobbled"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listening_events_yt_scrobbled` ON `${TABLE_NAME}` (`yt_scrobbled`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "track_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`track_id` INTEGER NOT NULL, `tag` TEXT NOT NULL, `weight` REAL NOT NULL, `source` TEXT NOT NULL, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`track_id`, `tag`), FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "track_id",
+            "tag"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_tags_tag",
+            "unique": false,
+            "columnNames": [
+              "tag"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_tags_tag` ON `${TABLE_NAME}` (`tag`)"
+          },
+          {
+            "name": "index_track_tags_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_tags_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stash_mix_recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT, `include_tags_csv` TEXT NOT NULL, `exclude_tags_csv` TEXT NOT NULL, `era_start_year` INTEGER, `era_end_year` INTEGER, `affinity_bias` REAL NOT NULL, `discovery_ratio` REAL NOT NULL, `freshness_window_days` INTEGER NOT NULL, `target_length` INTEGER NOT NULL, `is_builtin` INTEGER NOT NULL, `is_active` INTEGER NOT NULL, `playlist_id` INTEGER, `created_at` INTEGER NOT NULL, `last_refreshed_at` INTEGER, `seed_strategy` TEXT NOT NULL DEFAULT 'ARTIST_SIMILAR', `mood_keys_csv` TEXT NOT NULL DEFAULT '', `tag_sample_depth` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`playlist_id`) REFERENCES `playlists`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "includeTagsCsv",
+            "columnName": "include_tags_csv",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeTagsCsv",
+            "columnName": "exclude_tags_csv",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eraStartYear",
+            "columnName": "era_start_year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "eraEndYear",
+            "columnName": "era_end_year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "affinityBias",
+            "columnName": "affinity_bias",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discoveryRatio",
+            "columnName": "discovery_ratio",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "freshnessWindowDays",
+            "columnName": "freshness_window_days",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetLength",
+            "columnName": "target_length",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBuiltin",
+            "columnName": "is_builtin",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastRefreshedAt",
+            "columnName": "last_refreshed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seedStrategy",
+            "columnName": "seed_strategy",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ARTIST_SIMILAR'"
+          },
+          {
+            "fieldPath": "moodKeysCsv",
+            "columnName": "mood_keys_csv",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "tagSampleDepth",
+            "columnName": "tag_sample_depth",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stash_mix_recipes_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stash_mix_recipes_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          },
+          {
+            "name": "index_stash_mix_recipes_is_active",
+            "unique": false,
+            "columnNames": [
+              "is_active"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stash_mix_recipes_is_active` ON `${TABLE_NAME}` (`is_active`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "discovery_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `recipe_id` INTEGER NOT NULL, `artist` TEXT NOT NULL, `title` TEXT NOT NULL, `seed_artist` TEXT NOT NULL, `status` TEXT NOT NULL, `track_id` INTEGER, `queued_at` INTEGER NOT NULL, `completed_at` INTEGER, `error_message` TEXT, FOREIGN KEY(`recipe_id`) REFERENCES `stash_mix_recipes`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipe_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seedArtist",
+            "columnName": "seed_artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queued_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_discovery_queue_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_queue_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_discovery_queue_recipe_id",
+            "unique": false,
+            "columnNames": [
+              "recipe_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_queue_recipe_id` ON `${TABLE_NAME}` (`recipe_id`)"
+          },
+          {
+            "name": "index_discovery_queue_queued_at",
+            "unique": false,
+            "columnNames": [
+              "queued_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_queue_queued_at` ON `${TABLE_NAME}` (`queued_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "stash_mix_recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipe_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "track_blocklist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`canonical_key` TEXT NOT NULL, `artist` TEXT NOT NULL, `title` TEXT NOT NULL, `spotify_uri` TEXT, `youtube_id` TEXT, `blocked_at` INTEGER NOT NULL, `blocked_from` TEXT NOT NULL, PRIMARY KEY(`canonical_key`))",
+        "fields": [
+          {
+            "fieldPath": "canonicalKey",
+            "columnName": "canonical_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotify_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeId",
+            "columnName": "youtube_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "blockedAt",
+            "columnName": "blocked_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockedFrom",
+            "columnName": "blocked_from",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "canonical_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_blocklist_spotify_uri",
+            "unique": false,
+            "columnNames": [
+              "spotify_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_blocklist_spotify_uri` ON `${TABLE_NAME}` (`spotify_uri`)"
+          },
+          {
+            "name": "index_track_blocklist_youtube_id",
+            "unique": false,
+            "columnNames": [
+              "youtube_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_blocklist_youtube_id` ON `${TABLE_NAME}` (`youtube_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "track_skip_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `track_id` INTEGER NOT NULL, `skipped_at` INTEGER NOT NULL, `position_ms` INTEGER NOT NULL, FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skippedAt",
+            "columnName": "skipped_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_skip_events_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_skip_events_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          },
+          {
+            "name": "index_track_skip_events_skipped_at",
+            "unique": false,
+            "columnNames": [
+              "skipped_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_skip_events_skipped_at` ON `${TABLE_NAME}` (`skipped_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lyrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`track_id` INTEGER NOT NULL, `plain_text` TEXT, `synced_lrc` TEXT, `instrumental` INTEGER NOT NULL, `language` TEXT, `source` TEXT NOT NULL, `source_lyrics_id` TEXT, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`track_id`), FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plainText",
+            "columnName": "plain_text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedLrc",
+            "columnName": "synced_lrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "instrumental",
+            "columnName": "instrumental",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceLyricsId",
+            "columnName": "source_lyrics_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "track_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lyrics_track_id",
+            "unique": false,
+            "columnNames": [
+              "track_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lyrics_track_id` ON `${TABLE_NAME}` (`track_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lastfm_response_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cache_key` TEXT NOT NULL, `json` TEXT NOT NULL, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`cache_key`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cache_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cache_key"
+          ]
+        }
+      },
+      {
+        "tableName": "spotify_resolution",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`trackId` INTEGER NOT NULL, `status` TEXT NOT NULL, `spotifyUri` TEXT, `matchedIsrc` TEXT, `titleSim` REAL, `durDeltaSec` INTEGER, `resolvedAtMs` INTEGER NOT NULL, `expiresAtMs` INTEGER NOT NULL, `attempts` INTEGER NOT NULL, PRIMARY KEY(`trackId`))",
+        "fields": [
+          {
+            "fieldPath": "trackId",
+            "columnName": "trackId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spotifyUri",
+            "columnName": "spotifyUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedIsrc",
+            "columnName": "matchedIsrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "titleSim",
+            "columnName": "titleSim",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "durDeltaSec",
+            "columnName": "durDeltaSec",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "resolvedAtMs",
+            "columnName": "resolvedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAtMs",
+            "columnName": "expiresAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "trackId"
+          ]
+        }
+      },
+      {
+        "tableName": "flac_upgrade_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`track_id` INTEGER NOT NULL, `status` TEXT NOT NULL, `enqueued_at` INTEGER NOT NULL, PRIMARY KEY(`track_id`), FOREIGN KEY(`track_id`) REFERENCES `tracks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enqueuedAt",
+            "columnName": "enqueued_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "track_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_flac_upgrade_queue_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_flac_upgrade_queue_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tracks",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "track_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "listen_submissions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`event_id` INTEGER NOT NULL, `target` TEXT NOT NULL, `state` TEXT NOT NULL, `attempts` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`event_id`, `target`), FOREIGN KEY(`event_id`) REFERENCES `listening_events`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "eventId",
+            "columnName": "event_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target",
+            "columnName": "target",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "event_id",
+            "target"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_listen_submissions_target_state",
+            "unique": false,
+            "columnNames": [
+              "target",
+              "state"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listen_submissions_target_state` ON `${TABLE_NAME}` (`target`, `state`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "listening_events",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "event_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_undo_points",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sync_id` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `playlist_count` INTEGER NOT NULL, `membership_count` INTEGER NOT NULL, PRIMARY KEY(`sync_id`))",
+        "fields": [
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtEpochMs",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistCount",
+            "columnName": "playlist_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "membershipCount",
+            "columnName": "membership_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sync_id"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_undo_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sync_id` INTEGER NOT NULL, `playlist_id` INTEGER NOT NULL, `is_active` INTEGER NOT NULL, `sync_enabled` INTEGER NOT NULL, PRIMARY KEY(`sync_id`, `playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncEnabled",
+            "columnName": "sync_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sync_id",
+            "playlist_id"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_undo_memberships",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sync_id` INTEGER NOT NULL, `playlist_id` INTEGER NOT NULL, `track_id` INTEGER NOT NULL, `position` INTEGER NOT NULL, `added_at` INTEGER, `removed_at` INTEGER, `locally_added` INTEGER NOT NULL, PRIMARY KEY(`sync_id`, `playlist_id`, `track_id`))",
+        "fields": [
+          {
+            "fieldPath": "syncId",
+            "columnName": "sync_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "track_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "removedAt",
+            "columnName": "removed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "locallyAdded",
+            "columnName": "locally_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sync_id",
+            "playlist_id",
+            "track_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_undo_memberships_sync_id",
+            "unique": false,
+            "columnNames": [
+              "sync_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_undo_memberships_sync_id` ON `${TABLE_NAME}` (`sync_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artist_name` TEXT NOT NULL COLLATE NOCASE, `image_url` TEXT, `attempted_at` INTEGER NOT NULL, PRIMARY KEY(`artist_name`))",
+        "fields": [
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attemptedAt",
+            "columnName": "attempted_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artist_name"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b97f8e7a010533ebaa7367e4272f4e2a')"
+    ]
+  }
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/db/StashDatabase.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/StashDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.stash.core.data.db.converter.Converters
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.db.dao.ArtistProfileCacheDao
 import com.stash.core.data.db.dao.DiscoveryQueueDao
 import com.stash.core.data.db.dao.DownloadQueueDao
@@ -25,6 +26,7 @@ import com.stash.core.data.db.dao.TrackBlocklistDao
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.db.dao.TrackSkipEventDao
 import com.stash.core.data.db.dao.TrackTagDao
+import com.stash.core.data.db.entity.ArtistImageEntity
 import com.stash.core.data.db.entity.ArtistProfileCacheEntity
 import com.stash.core.data.db.entity.DiscoveryQueueEntity
 import com.stash.core.data.db.entity.DownloadQueueEntity
@@ -91,8 +93,9 @@ import com.stash.core.data.db.entity.TrackTagEntity
         SyncUndoPointEntity::class,
         SyncUndoPlaylistEntity::class,
         SyncUndoMembershipEntity::class,
+        ArtistImageEntity::class,
     ],
-    version = 43,
+    version = 44,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -111,6 +114,8 @@ abstract class StashDatabase : RoomDatabase() {
     abstract fun remoteSnapshotDao(): RemoteSnapshotDao
 
     abstract fun artistProfileCacheDao(): ArtistProfileCacheDao
+
+    abstract fun artistImageDao(): ArtistImageDao
 
     abstract fun listeningEventDao(): ListeningEventDao
 
@@ -1035,6 +1040,33 @@ abstract class StashDatabase : RoomDatabase() {
                 db.execSQL(
                     "UPDATE playlists SET art_url = REPLACE(art_url, '/sddefault.', '/hqdefault.') " +
                         "WHERE art_url LIKE '%i.ytimg.com/%/sddefault.%'",
+                )
+            }
+        }
+
+        /**
+         * v43 → v44: `artist_images` cache table for the Library Artists tab.
+         *
+         * `ArtistImageBackfillWorker` resolves each displayed artist's official
+         * photo via the YT Music artists search and stores it here, keyed by
+         * the primary artist name ([ArtistImageEntity]). A row with a NULL
+         * `image_url` and a non-NULL `attempted_at` is a permanent
+         * "unresolvable" sentinel so the worker never re-polls local-only rips.
+         *
+         * The primary key is COLLATE NOCASE so a case-variant credit collapses
+         * onto the same row (one photo per artist, not one per spelling).
+         */
+        val MIGRATION_43_44 = object : Migration(43, 44) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `artist_images` (
+                        `artist_name` TEXT NOT NULL COLLATE NOCASE,
+                        `image_url` TEXT,
+                        `attempted_at` INTEGER NOT NULL,
+                        PRIMARY KEY(`artist_name`)
+                    )
+                    """.trimIndent(),
                 )
             }
         }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/StashDatabase.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/StashDatabase.kt
@@ -1229,6 +1229,7 @@ abstract class StashDatabase : RoomDatabase() {
                 MIGRATION_40_41,
                 MIGRATION_41_42,
                 MIGRATION_42_43,
+                MIGRATION_43_44,
             )
         }
     }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/ArtistImageDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/ArtistImageDao.kt
@@ -1,0 +1,66 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.stash.core.data.db.entity.ArtistImageEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Storage for the cached artist photos backing the Library Artists tab.
+ *
+ * The write path is entirely worker-owned ([ArtistImageBackfillWorker]); the
+ * Library only ever reads. Reads are targeted per-artist ([observeByName],
+ * COLLATE NOCASE) so the detail screen subscribes to one row instead of the
+ * whole table, and writes are batched into a single transaction so a backfill
+ * pass re-emits the observable flow once instead of once per artist.
+ */
+@Dao
+interface ArtistImageDao {
+
+    /** All cached artist photos — keyed by primary artist name. */
+    @Query("SELECT * FROM artist_images")
+    fun observeAll(): Flow<List<ArtistImageEntity>>
+
+    /**
+     * The photo row for one primary-artist name, or null when that name has
+     * never been attempted. COLLATE NOCASE — a case variant of the stored key
+     * ("aarne" vs "Aarne") still resolves, matching the worker's case-
+     * insensitive collapse.
+     */
+    @Query("SELECT * FROM artist_images WHERE artist_name = :name COLLATE NOCASE")
+    fun observeByName(name: String): Flow<ArtistImageEntity?>
+
+    /** Every artist name that has already been attempted (photo or sentinel). */
+    @Query("SELECT artist_name FROM artist_images")
+    suspend fun observedNames(): List<String>
+
+    /**
+     * Every distinct track artist credit the Library Artists tab shows, in
+     * the same scope as `TrackDao.getAllArtists` (downloads only — the tab
+     * is the offline-first surface).
+     */
+    @Query(
+        """
+        SELECT DISTINCT artist FROM tracks
+        WHERE artist != ''
+          AND is_downloaded = 1
+        """,
+    )
+    suspend fun distinctArtistNames(): List<String>
+
+    /**
+     * Insert or replace photo rows in ONE transaction ([ArtistImageEntity.artistName]
+     * is the key). Batching the whole pass into a single write keeps
+     * [observeAll]/[observeByName] from re-emitting the flow per upsert.
+     */
+    @Transaction
+    suspend fun upsertAll(entities: List<ArtistImageEntity>) {
+        upsertRows(entities)
+    }
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertRows(entities: List<ArtistImageEntity>)
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/ArtistImageDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/ArtistImageDao.kt
@@ -38,15 +38,30 @@ interface ArtistImageDao {
     suspend fun observedNames(): List<String>
 
     /**
-     * Every distinct track artist credit the Library Artists tab shows, in
-     * the same scope as `TrackDao.getAllArtists` (downloads only — the tab
-     * is the offline-first surface).
+     * Every distinct track artist credit the Library Artists tab can show, in
+     * the same scope as `TrackDao.getAllArtists`: downloads in every mode, plus
+     * stream-only rows when streaming is on. The playlist-membership arm also
+     * keeps still-unchecked streamable stubs (`is_streamable_checked_at` null)
+     * in the set — a freshly-synced playlist's artists get photos before the
+     * availability worker has probed them, matching how the tab renders
+     * playlists in Online mode (membership is the source of truth).
      */
     @Query(
         """
         SELECT DISTINCT artist FROM tracks
         WHERE artist != ''
-          AND is_downloaded = 1
+          AND (
+              is_downloaded = 1
+              OR is_streamable = 1
+              OR EXISTS (
+                  SELECT 1
+                  FROM playlist_tracks pt
+                  JOIN playlists p ON p.id = pt.playlist_id
+                  WHERE pt.track_id = tracks.id
+                    AND pt.removed_at IS NULL
+                    AND p.is_active = 1
+              )
+          )
         """,
     )
     suspend fun distinctArtistNames(): List<String>

--- a/core/data/src/main/kotlin/com/stash/core/data/db/entity/ArtistImageEntity.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/entity/ArtistImageEntity.kt
@@ -1,0 +1,38 @@
+package com.stash.core.data.db.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Cached artist photo for the Library Artists tab.
+ *
+ * Keyed by the *display* artist name — the primary artist after
+ * [com.stash.core.common.primaryArtist] collapses collaboration credits
+ * ("Aarne, Toxi$, Big Baby Tape" → "Aarne"), so the backfill resolves and
+ * stores one row per card the tab actually renders.
+ *
+ * - [imageUrl] is the artist's official avatar from the YT Music artists
+ *   search, run through `ArtUrlUpgrader` for a high-res URL. Null when the
+ *   name could not be resolved (local-only rips, obscure acts) — the UI then
+ *   falls back to the album-art proxy / gradient initial.
+ * - [attemptedAt] marks that a resolution was TRIED. A null [imageUrl] with a
+ *   non-null [attemptedAt] is a permanent "no photo" sentinel, so the worker
+ *   never re-polls unresolvable names on every run.
+ *
+ * The primary key is COLLATE NOCASE so a case variant of an attempted name
+ * ("Aarne" vs "aarne") resolves to the same row instead of two API calls.
+ *
+ * Not part of any foreign-key graph — artist names are free-text tags on
+ * `tracks`, and the table is a small pure cache (one row per artist, a few
+ * hundred max). Stale rows are harmless: the Library only looks names up, and
+ * orphaned entries simply never match.
+ */
+@Entity(tableName = "artist_images")
+data class ArtistImageEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "artist_name", collate = ColumnInfo.NOCASE)
+    val artistName: String,
+    @ColumnInfo(name = "image_url") val imageUrl: String? = null,
+    @ColumnInfo(name = "attempted_at") val attemptedAt: Long = 0L,
+)

--- a/core/data/src/main/kotlin/com/stash/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/di/DatabaseModule.kt
@@ -33,7 +33,7 @@ object DatabaseModule {
             StashDatabase::class.java,
             StashDatabase.DATABASE_NAME,
         )
-            // Single source of truth for the chain — DatabaseBackupManager's
+// Single source of truth for the chain — DatabaseBackupManager's
             // merge-import opens a second Room instance over a staged backup
             // file with this same array, so an older backup can be rolled
             // forward to the live schema before rows are copied out of it.
@@ -66,6 +66,10 @@ object DatabaseModule {
     @Provides
     fun provideArtistProfileCacheDao(db: StashDatabase): ArtistProfileCacheDao =
         db.artistProfileCacheDao()
+
+    @Provides
+    fun provideArtistImageDao(db: StashDatabase): com.stash.core.data.db.dao.ArtistImageDao =
+        db.artistImageDao()
 
     @Provides
     fun provideListeningEventDao(db: StashDatabase): com.stash.core.data.db.dao.ListeningEventDao =

--- a/core/data/src/main/kotlin/com/stash/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/di/DatabaseModule.kt
@@ -33,7 +33,7 @@ object DatabaseModule {
             StashDatabase::class.java,
             StashDatabase.DATABASE_NAME,
         )
-// Single source of truth for the chain — DatabaseBackupManager's
+            // Single source of truth for the chain — DatabaseBackupManager's
             // merge-import opens a second Room instance over a staged backup
             // file with this same array, so an older backup can be rolled
             // forward to the live schema before rows are copied out of it.

--- a/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
@@ -287,8 +287,18 @@ class MusicRepositoryImpl @Inject constructor(
             trackDao.getByPlaylist(playlistId, includeStreamable = enabled)
         }.map { entities -> entities.map { it.toDomain() } }
 
+    /**
+     * Artists for the Library Artists tab. Mirrors the other library-wide
+     * surfaces (`getTracksByPlaylist`, `getAllAlbums`): Offline mode lists
+     * downloaded tracks only, Online/streaming mode also surfaces stream-only
+     * rows so a mostly-streamed library still gets real artist cards — and,
+     * by extension, photos ([ArtistImageBackfillWorker] keys on this same set).
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun getAllArtists(): Flow<List<ArtistSummary>> =
-        trackDao.getAllArtists(includeStreamable = false)
+        streamingPreference.enabled.flatMapLatest { enabled ->
+            trackDao.getAllArtists(includeStreamable = enabled)
+        }
 
     override fun getAllAlbums(): Flow<List<AlbumSummary>> =
         trackDao.getAllAlbums(includeStreamable = false)

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorker.kt
@@ -11,6 +11,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.stash.core.common.ArtUrlUpgrader
 import com.stash.core.common.primaryArtist
 import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.db.entity.ArtistImageEntity
@@ -149,7 +150,7 @@ class ArtistImageBackfillWorker @AssistedInject constructor(
                 is ArtistPhotoResolution.Resolved -> {
                     batch += ArtistImageEntity(
                         artistName = name,
-                        imageUrl = resolution.avatarUrl?.takeIf { it.isNotBlank() },
+                        imageUrl = ArtUrlUpgrader.upgrade(resolution.avatarUrl?.takeIf { it.isNotBlank() }),
                         attemptedAt = System.currentTimeMillis(),
                     )
                     if (resolution.avatarUrl.isNullOrBlank()) unresolved++ else filled++

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorker.kt
@@ -1,0 +1,187 @@
+package com.stash.core.data.sync.workers
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.stash.core.common.primaryArtist
+import com.stash.core.data.db.dao.ArtistImageDao
+import com.stash.core.data.db.entity.ArtistImageEntity
+import com.stash.data.ytmusic.YTMusicApiClient
+import com.stash.data.ytmusic.model.ArtistPhotoResolution
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import java.util.concurrent.TimeUnit
+
+/**
+ * Background backfill that resolves the official artist photo for every
+ * artist shown on the Library Artists tab.
+ *
+ * ## Why
+ * Before this worker, the Artists tab rendered album art (or a gradient
+ * initial) for every artist — there was no source of *artist* images. YT
+ * Music's artists search returns the official avatar, so this worker walks
+ * the distinct artist credits in `tracks`, collapses them to their primary
+ * act ([primaryArtist], matching the Library regroup), and stores each
+ * resolved avatar in the `artist_images` table. The Library then renders
+ * photo → album-art proxy → gradient initial, in that order.
+ *
+ * ## Idempotency / sentinel
+ * Only a GENUINE "no avatar" answer stamps the permanent sentinel: a row with
+ * NULL `image_url` + a stamp means the API answered and had no photo, so that
+ * name is never re-polled. Transient failures (rate limit, DNS blip, InnerTube
+ * 5xx) write NOTHING — the name stays in the candidate set and is re-picked
+ * on the next pass, mirroring `ArtBackfillWorker`'s still-blank retry guard.
+ *
+ * ## Scheduling & throttling
+ * Enqueued once per install from [StashApplication] (`KEEP`) and re-fired
+ * after each sync (`REPLACE`), so newly-synced artists are picked up. Each
+ * run handles [BATCH_SIZE] names at ~[REQUEST_INTERVAL_MS]ms apart to stay
+ * well under InnerTube's rate limits; a fresh sync (or app relaunch) drains
+ * the remainder. Network is gated to UNMETERED so a full library walk
+ * (~hundreds of small searches) never burns cellular data.
+ */
+@HiltWorker
+class ArtistImageBackfillWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val artistImageDao: ArtistImageDao,
+    private val ytMusicApiClient: YTMusicApiClient,
+) : CoroutineWorker(appContext, params) {
+
+    companion object {
+        private const val TAG = "ArtistImgBackfill"
+        private const val WORK_NAME = "stash_artist_image_backfill"
+        private const val BATCH_SIZE = 150
+        private const val REQUEST_INTERVAL_MS = 400L
+
+        /**
+         * Schedule the artist-photo backfill. `KEEP`: a queued or running pass
+         * is left alone, so a re-launch before the worker completes is a no-op.
+         */
+        fun enqueueOneTime(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.UNMETERED)
+                .build()
+            val work = OneTimeWorkRequestBuilder<ArtistImageBackfillWorker>()
+                .setConstraints(constraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                WORK_NAME,
+                ExistingWorkPolicy.KEEP,
+                work,
+            )
+        }
+
+        /**
+         * Post-sync re-fire. `REPLACE` so a freshly-finished sync immediately
+         * re-runs the backfill for any artists the sync just added, instead of
+         * waiting for the next app launch's `KEEP` request to be a no-op.
+         */
+        fun enqueueAfterSync(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.UNMETERED)
+                .build()
+            val work = OneTimeWorkRequestBuilder<ArtistImageBackfillWorker>()
+                .setConstraints(constraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                WORK_NAME,
+                ExistingWorkPolicy.REPLACE,
+                work,
+            )
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        // Names already resolved OR marked unresolvable (NULL image + stamp).
+        // Case-insensitive: the PK is COLLATE NOCASE, so the lowercase set
+        // dedupes a case-variant credit against an already-attempted name.
+        val observed = artistImageDao.observedNames()
+            .map { it.lowercase() }
+            .toHashSet()
+
+        // Distinct raw track credits → primary acts, matching exactly what the
+        // Artists tab groups by — a photo keyed on the displayed name is a
+        // clean 1:1 lookup for the UI.
+        val missing = artistImageDao.distinctArtistNames()
+            .asSequence()
+            .map { it.primaryArtist() }
+            .filter { it.isNotBlank() && it.lowercase() !in observed }
+            .distinct()
+            .toList()
+
+        if (missing.isEmpty()) {
+            Log.d(TAG, "no artists need a photo")
+            return Result.success()
+        }
+
+        var filled = 0
+        var unresolved = 0
+        var failed = 0
+        var processed = 0
+        val batch = mutableListOf<ArtistImageEntity>()
+
+        for (name in missing.take(BATCH_SIZE)) {
+            if (isStopped) break
+            val resolution = try {
+                ytMusicApiClient.resolveArtistPhoto(name)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.w(TAG, "resolveArtistPhoto($name) failed: ${e.message}")
+                failed++
+                continue
+            }
+            processed++
+            when (resolution) {
+                is ArtistPhotoResolution.Resolved -> {
+                    batch += ArtistImageEntity(
+                        artistName = name,
+                        imageUrl = resolution.avatarUrl?.takeIf { it.isNotBlank() },
+                        attemptedAt = System.currentTimeMillis(),
+                    )
+                    if (resolution.avatarUrl.isNullOrBlank()) unresolved++ else filled++
+                }
+                ArtistPhotoResolution.NoAvatar -> {
+                    // API answered and had no artist — a genuine no-photo,
+                    // stamped so it is never re-polled.
+                    batch += ArtistImageEntity(
+                        artistName = name,
+                        imageUrl = null,
+                        attemptedAt = System.currentTimeMillis(),
+                    )
+                    unresolved++
+                }
+                ArtistPhotoResolution.Failed -> {
+                    // API did not answer (network / 5xx / rate limit). Write
+                    // nothing — the name stays missing and is retried next pass.
+                    failed++
+                }
+            }
+            // Rate limit — one YT Music search per candidate.
+            delay(REQUEST_INTERVAL_MS)
+        }
+
+        // One transactional write for the whole pass so observers re-emit once.
+        if (batch.isNotEmpty()) artistImageDao.upsertAll(batch)
+
+        Log.i(
+            TAG,
+            "artist-photo backfill: processed=$processed filled=$filled " +
+                "unresolved=$unresolved failed=$failed remaining=${(missing.size - processed).coerceAtLeast(0)}",
+        )
+        return Result.success()
+    }
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorker.kt
@@ -120,7 +120,7 @@ class ArtistImageBackfillWorker @AssistedInject constructor(
             .asSequence()
             .map { it.primaryArtist() }
             .filter { it.isNotBlank() && it.lowercase() !in observed }
-            .distinct()
+            .distinctBy { it.lowercase() }
             .toList()
 
         if (missing.isEmpty()) {
@@ -183,6 +183,14 @@ class ArtistImageBackfillWorker @AssistedInject constructor(
             "artist-photo backfill: processed=$processed filled=$filled " +
                 "unresolved=$unresolved failed=$failed remaining=${(missing.size - processed).coerceAtLeast(0)}",
         )
+
+        // Every candidate in this pass failed to get any response from the API
+        // — the whole batch was a transient failure (rate limit, DNS blip,
+        // InnerTube 5xx). Retry with WorkManager's exponential backoff
+        // (set in the request builders above) instead of waiting for the next
+        // app-launches / post-sync re-fire.
+        if (batch.isEmpty() && failed > 0) return Result.retry()
+
         return Result.success()
     }
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorker.kt
@@ -45,11 +45,15 @@ import java.util.concurrent.TimeUnit
  *
  * ## Scheduling & throttling
  * Enqueued once per install from [StashApplication] (`KEEP`) and re-fired
- * after each sync (`REPLACE`), so newly-synced artists are picked up. Each
- * run handles [BATCH_SIZE] names at ~[REQUEST_INTERVAL_MS]ms apart to stay
- * well under InnerTube's rate limits; a fresh sync (or app relaunch) drains
- * the remainder. Network is gated to UNMETERED so a full library walk
- * (~hundreds of small searches) never burns cellular data.
+ * after each sync (`KEEP`), so newly-synced artists are picked up. A `KEEP`
+ * re-fire never pre-empts a running pass: a sync that finishes mid-backfill
+ * lets the current pass drain instead of restarting from the top. Each run
+ * handles [BATCH_SIZE] names at ~[REQUEST_INTERVAL_MS]ms apart to stay well
+ * under InnerTube's rate limits. A large library fills over several syncs —
+ * at 150 artists per pass an 860-artist library takes ~6 runs — so a
+ * half-filled grid on first launch is expected, not a bug. Network is gated
+ * to UNMETERED so a full library walk (~hundreds of small searches) never
+ * burns cellular data.
  */
 @HiltWorker
 class ArtistImageBackfillWorker @AssistedInject constructor(
@@ -85,9 +89,10 @@ class ArtistImageBackfillWorker @AssistedInject constructor(
         }
 
         /**
-         * Post-sync re-fire. `REPLACE` so a freshly-finished sync immediately
-         * re-runs the backfill for any artists the sync just added, instead of
-         * waiting for the next app launch's `KEEP` request to be a no-op.
+         * Post-sync re-fire. `KEEP` so a sync finishing mid-backfill lets the
+         * running pass complete instead of restarting it from the top; newly-
+         * synced artists are drained by this and later passes. (Same policy as
+         * [enqueueOneTime] — the two share [WORK_NAME].)
          */
         fun enqueueAfterSync(context: Context) {
             val constraints = Constraints.Builder()
@@ -99,7 +104,7 @@ class ArtistImageBackfillWorker @AssistedInject constructor(
                 .build()
             WorkManager.getInstance(context).enqueueUniqueWork(
                 WORK_NAME,
-                ExistingWorkPolicy.REPLACE,
+                ExistingWorkPolicy.KEEP,
                 work,
             )
         }

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/SyncFinalizeWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/SyncFinalizeWorker.kt
@@ -79,6 +79,12 @@ class SyncFinalizeWorker @AssistedInject constructor(
             // Transition to completed state.
             syncStateManager.onCompleted()
 
+            // A finished sync may have added artists to the library — re-run
+            // the artist-photo backfill so new acts get a photo. REPLACE policy
+            // lets this supersede any queued first-run pass; it is a cheap
+            // dedupe (observed-names set) when nothing is new.
+            ArtistImageBackfillWorker.enqueueAfterSync(applicationContext)
+
             Log.i(
                 TAG,
                 "Sync $syncId complete: $playlistsChecked playlists, " +

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/SyncFinalizeWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/SyncFinalizeWorker.kt
@@ -80,9 +80,10 @@ class SyncFinalizeWorker @AssistedInject constructor(
             syncStateManager.onCompleted()
 
             // A finished sync may have added artists to the library — re-run
-            // the artist-photo backfill so new acts get a photo. REPLACE policy
-            // lets this supersede any queued first-run pass; it is a cheap
-            // dedupe (observed-names set) when nothing is new.
+            // the artist-photo backfill so new acts get a photo. KEEP policy
+            // lets a pass that was already running finish instead of being
+            // restarted from the top; it is a cheap dedupe (observed-names
+            // set) when nothing is new.
             ArtistImageBackfillWorker.enqueueAfterSync(applicationContext)
 
             Log.i(

--- a/core/data/src/test/kotlin/com/stash/core/data/db/MigrationV43V44Test.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/MigrationV43V44Test.kt
@@ -1,0 +1,81 @@
+package com.stash.core.data.db
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Verifies migration v43 -> v44: the `artist_images` cache table is created
+ * with its COLLATE NOCASE primary key, existing tables survive, and the
+ * sentinel semantics hold (NULL `image_url` = resolvable-but-no-photo stamp).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class MigrationV43V44Test {
+
+    private val DB_NAME = "migration-v43v44-test"
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        StashDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    @Test
+    fun `artist_images table is created with NOCASE primary key and stores photos`() {
+        helper.createDatabase(DB_NAME, 43).use { db ->
+            db.execSQL(
+                """
+                INSERT INTO playlists (id, name, source, source_id, type, track_count, is_active)
+                VALUES (1, 'Gym', 'SPOTIFY', 'sp1', 'CUSTOM', 10, 1)
+                """.trimIndent(),
+            )
+        }
+
+        val migrated = helper.runMigrationsAndValidate(
+            DB_NAME, 44, true, StashDatabase.MIGRATION_43_44,
+        )
+
+        // Existing data survives the migration.
+        migrated.query("SELECT name FROM playlists WHERE id = 1").use { c ->
+            assertTrue(c.moveToNext())
+            assertEquals("Gym", c.getString(0))
+        }
+
+        // A resolved photo stores round-trip.
+        migrated.execSQL(
+            "INSERT INTO artist_images (artist_name, image_url, attempted_at) " +
+                "VALUES ('Aarne', 'https://yt3.example/aarne.jpg', 1723900000000)",
+        )
+        // A no-photo sentinel (NULL image_url) also round-trips.
+        migrated.execSQL(
+            "INSERT INTO artist_images (artist_name, image_url, attempted_at) " +
+                "VALUES ('Local Rip', NULL, 1723900000001)",
+        )
+        migrated.query("SELECT artist_name, image_url FROM artist_images").use { c ->
+            assertTrue(c.moveToNext())
+            assertEquals("Aarne", c.getString(0))
+            assertEquals("https://yt3.example/aarne.jpg", c.getString(1))
+            assertTrue(c.moveToNext())
+            assertEquals("Local Rip", c.getString(0))
+            assertTrue("unresolvable name is a NULL-image sentinel", c.isNull(1))
+        }
+
+        // COLLATE NOCASE: a case-variant key resolves to the SAME row.
+        migrated.query(
+            "SELECT image_url FROM artist_images WHERE artist_name = 'aarne' COLLATE NOCASE",
+        ).use { c ->
+            assertTrue(c.moveToNext())
+            assertEquals("https://yt3.example/aarne.jpg", c.getString(0))
+        }
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/db/dao/ArtistImageDaoTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/dao/ArtistImageDaoTest.kt
@@ -1,0 +1,209 @@
+package com.stash.core.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.PlaylistTrackCrossRef
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import java.time.Instant
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Verifies `ArtistImageDao.distinctArtistNames()` — the candidate set the
+ * [com.stash.core.data.sync.workers.ArtistImageBackfillWorker] walks. It must
+ * mirror what the Library Artists tab can list:
+ *  - downloaded tracks (every mode);
+ *  - streamable-only tracks (`is_streamable = 1`);
+ *  - still-unchecked stubs (`is_streamable_checked_at IS NULL`) that belong to
+ *    a live playlist — membership is the source of truth for Online-mode
+ *    playlists, so their artists get photos before the availability worker
+ *    has probed them;
+ *  - and it must exclude checked-but-unavailable rows and stubs with no live
+ *    playlist membership, so nobody pays an InnerTube search for artists the
+ *    tab never shows.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ArtistImageDaoTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var trackDao: TrackDao
+    private lateinit var playlistDao: PlaylistDao
+    private lateinit var artistImageDao: ArtistImageDao
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        trackDao = db.trackDao()
+        playlistDao = db.playlistDao()
+        artistImageDao = db.artistImageDao()
+    }
+
+    @After fun tearDown() = db.close()
+
+    @Test fun `includes downloaded artists`() = runTest {
+        insertDownloaded(id = 1L, artist = "Drake")
+
+        assertEquals(listOf("Drake"), artistImageDao.distinctArtistNames())
+    }
+
+    @Test fun `includes streamable-only artists`() = runTest {
+        insertStreamableOnly(id = 1L, artist = "Future")
+
+        assertEquals(listOf("Future"), artistImageDao.distinctArtistNames())
+    }
+
+    @Test fun `includes unchecked stubs that belong to a live playlist`() = runTest {
+        val unchecked = insertUnchecked(id = 1L, artist = "Aarne")
+        val playlistId = playlistDao.insert(activePlaylist())
+        playlistDao.insertCrossRef(crossRef(playlistId, unchecked, position = 0))
+
+        assertEquals(listOf("Aarne"), artistImageDao.distinctArtistNames())
+    }
+
+    @Test fun `excludes unavailable artists`() = runTest {
+        insertUnavailable(id = 1L, artist = "Travis")
+
+        assertTrue(artistImageDao.distinctArtistNames().isEmpty())
+    }
+
+    @Test fun `excludes unchecked stubs with no live playlist membership`() = runTest {
+        insertUnchecked(id = 1L, artist = "Mystery Band")
+
+        assertTrue(artistImageDao.distinctArtistNames().isEmpty())
+    }
+
+    @Test fun `excludes membership in an inactive playlist`() = runTest {
+        val unchecked = insertUnchecked(id = 1L, artist = "Aarne")
+        val playlistId = playlistDao.insert(activePlaylist(isActive = false))
+        playlistDao.insertCrossRef(crossRef(playlistId, unchecked, position = 0))
+
+        assertTrue(artistImageDao.distinctArtistNames().isEmpty())
+    }
+
+    @Test fun `excludes soft-removed membership`() = runTest {
+        val unchecked = insertUnchecked(id = 1L, artist = "Aarne")
+        val playlistId = playlistDao.insert(activePlaylist())
+        playlistDao.insertCrossRef(crossRef(playlistId, unchecked, position = 0, removed = true))
+
+        assertTrue(artistImageDao.distinctArtistNames().isEmpty())
+    }
+
+    @Test fun `dedupes repeated credits`() = runTest {
+        insertDownloaded(id = 1L, artist = "Drake")
+        insertStreamableOnly(id = 2L, artist = "Drake")
+
+        assertEquals(listOf("Drake"), artistImageDao.distinctArtistNames())
+    }
+
+    @Test fun `excludes empty artist credits`() = runTest {
+        insertDownloaded(id = 1L, artist = "")
+
+        assertFalse("blank credit must not be resolved", artistImageDao.distinctArtistNames().isNotEmpty())
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private suspend fun insertDownloaded(id: Long, artist: String): Long {
+        trackDao.insert(
+            TrackEntity(
+                id = id,
+                title = "Title $id",
+                artist = artist,
+                album = "Album $id",
+                canonicalTitle = "title $id",
+                canonicalArtist = artist.lowercase(),
+                isDownloaded = true,
+                isStreamable = false,
+                isStreamableCheckedAt = null,
+            )
+        )
+        return id
+    }
+
+    private suspend fun insertStreamableOnly(id: Long, artist: String): Long {
+        trackDao.insert(
+            TrackEntity(
+                id = id,
+                title = "Title $id",
+                artist = artist,
+                album = "Album $id",
+                canonicalTitle = "title $id",
+                canonicalArtist = artist.lowercase(),
+                isDownloaded = false,
+                isStreamable = true,
+                isStreamableCheckedAt = 1_000_000L,
+            )
+        )
+        return id
+    }
+
+    private suspend fun insertUnavailable(id: Long, artist: String): Long {
+        trackDao.insert(
+            TrackEntity(
+                id = id,
+                title = "Title $id",
+                artist = artist,
+                album = "Album $id",
+                canonicalTitle = "title $id",
+                canonicalArtist = artist.lowercase(),
+                isDownloaded = false,
+                isStreamable = false,
+                isStreamableCheckedAt = 1_000_000L,
+            )
+        )
+        return id
+    }
+
+    private suspend fun insertUnchecked(id: Long, artist: String): Long {
+        trackDao.insert(
+            TrackEntity(
+                id = id,
+                title = "Title $id",
+                artist = artist,
+                album = "Album $id",
+                canonicalTitle = "title $id",
+                canonicalArtist = artist.lowercase(),
+                isDownloaded = false,
+                isStreamable = false,
+                isStreamableCheckedAt = null,
+            )
+        )
+        return id
+    }
+
+    private fun activePlaylist(isActive: Boolean = true) = PlaylistEntity(
+        name = "Test Playlist",
+        source = MusicSource.BOTH,
+        sourceId = "test_playlist_${System.nanoTime()}",
+        type = PlaylistType.CUSTOM,
+        trackCount = 0,
+        syncEnabled = true,
+        isActive = isActive,
+    )
+
+    private fun crossRef(playlistId: Long, trackId: Long, position: Int, removed: Boolean = false) =
+        PlaylistTrackCrossRef(
+            playlistId = playlistId,
+            trackId = trackId,
+            position = position,
+            addedAt = Instant.EPOCH,
+            removedAt = if (removed) Instant.now() else null,
+        )
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorkerTest.kt
@@ -195,4 +195,32 @@ class ArtistImageBackfillWorkerTest {
             )
         }
     }
+
+    @Test fun `case variant primary artists are deduped to a single search`() = runTest {
+        // "Aarne" and "AARNE" both collapse to themselves (single-artist credits);
+        // the case-insensitive dedup must keep only one instead of issuing two
+        // YT Music searches for the same act.
+        coEvery { artistImageDao.distinctArtistNames() } returns
+            listOf("Aarne", "AARNE")
+        coEvery { ytMusicApiClient.resolveArtistPhoto(any()) } returns
+            ArtistPhotoResolution.Resolved("https://photo/aarne.jpg")
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) { ytMusicApiClient.resolveArtistPhoto(any()) }
+    }
+
+    @Test fun `all-transient-failure batch returns Result_retry to engage backoff`() = runTest {
+        // Every candidate gets no response (API errors). No row is written,
+        // and the worker signals WorkManager to retry with the configured
+        // exponential backoff instead of silently succeeding.
+        coEvery { artistImageDao.distinctArtistNames() } returns listOf("Down Act", "Mystery Band")
+        coEvery { ytMusicApiClient.resolveArtistPhoto(any()) } throws
+            RuntimeException("rate limited")
+
+        val result = newWorker().doWork()
+
+        assertTrue(result is ListenableWorker.Result.Retry)
+        coVerify(exactly = 0) { artistImageDao.upsertAll(any()) }
+    }
 }

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/ArtistImageBackfillWorkerTest.kt
@@ -1,0 +1,198 @@
+package com.stash.core.data.sync.workers
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import com.stash.core.data.db.dao.ArtistImageDao
+import com.stash.data.ytmusic.YTMusicApiClient
+import com.stash.data.ytmusic.model.ArtistPhotoResolution
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * MockK tests for [ArtistImageBackfillWorker] — the worker that resolves the
+ * official artist photo for every artist shown on the Library Artists tab.
+ *
+ * Mirrors [LoudnessBackfillWorkerTest]'s constructor-injection + mocked
+ * WorkerParameters pattern. The assertions focus on the contracts that keep
+ * the backfill safe to re-run: candidate collapse via
+ * [com.stash.core.common.primaryArtist], the case-insensitive observed-set
+ * guard, and the tri-state [ArtistPhotoResolution] semantics — only a GENUINE
+ * no-avatar answer (NoAvatar) stamps the permanent sentinel, while a Failed
+ * request writes NOTHING so the name is retried on the next pass.
+ */
+class ArtistImageBackfillWorkerTest {
+
+    private val appContext: Context = mockk(relaxed = true)
+    private val workerParams: WorkerParameters = mockk(relaxed = true)
+    private val artistImageDao: ArtistImageDao = mockk(relaxed = true)
+    private val ytMusicApiClient: YTMusicApiClient = mockk(relaxed = true)
+
+    private fun newWorker() =
+        ArtistImageBackfillWorker(appContext, workerParams, artistImageDao, ytMusicApiClient)
+
+    @Test fun `empty candidate set returns success without any resolution or write`() = runTest {
+        coEvery { artistImageDao.distinctArtistNames() } returns emptyList()
+
+        val result = newWorker().doWork()
+
+        assertTrue(result is ListenableWorker.Result.Success)
+        coVerify(exactly = 0) { ytMusicApiClient.resolveArtistPhoto(any()) }
+        coVerify(exactly = 0) { artistImageDao.upsertAll(any()) }
+    }
+
+    @Test fun `collapses raw credits to primary acts and stores photos keyed by display name`() =
+        runTest {
+            coEvery { artistImageDao.distinctArtistNames() } returns
+                listOf("Aarne, Toxi$", "Kozak System")
+            coEvery { ytMusicApiClient.resolveArtistPhoto("Aarne") } returns
+                ArtistPhotoResolution.Resolved("https://photo/aarne.jpg")
+            coEvery { ytMusicApiClient.resolveArtistPhoto("Kozak System") } returns
+                ArtistPhotoResolution.Resolved("https://photo/kozak.jpg")
+
+            val result = newWorker().doWork()
+
+            assertTrue(result is ListenableWorker.Result.Success)
+            // One transactional batched write for the whole pass.
+            coVerify(exactly = 1) {
+                artistImageDao.upsertAll(
+                    match { list ->
+                        list.any {
+                            it.artistName == "Aarne" &&
+                                it.imageUrl == "https://photo/aarne.jpg" &&
+                                it.attemptedAt > 0L
+                        } && list.any {
+                            it.artistName == "Kozak System" &&
+                                it.imageUrl == "https://photo/kozak.jpg" &&
+                                it.attemptedAt > 0L
+                        }
+                    },
+                )
+            }
+        }
+
+    @Test fun `NoAvatar stamps a permanent sentinel but Failed writes nothing`() = runTest {
+        coEvery { artistImageDao.distinctArtistNames() } returns
+            listOf("Mystery Band", "Aarne", "Down Act")
+        coEvery { ytMusicApiClient.resolveArtistPhoto("Mystery Band") } returns
+            ArtistPhotoResolution.NoAvatar
+        coEvery { ytMusicApiClient.resolveArtistPhoto("Aarne") } returns
+            ArtistPhotoResolution.Resolved("https://photo/aarne.jpg")
+        coEvery { ytMusicApiClient.resolveArtistPhoto("Down Act") } returns
+            ArtistPhotoResolution.Failed
+
+        val result = newWorker().doWork()
+
+        assertTrue(result is ListenableWorker.Result.Success)
+        // The failed request must not stop the Aarne photo from being written.
+        coVerify(exactly = 1) {
+            artistImageDao.upsertAll(
+                match { list -> list.any { it.artistName == "Aarne" && it.imageUrl == "https://photo/aarne.jpg" } },
+            )
+        }
+        // NoAvatar + stamp = permanent sentinel, so "Mystery Band" is never
+        // re-polled on a later run.
+        coVerify(exactly = 1) {
+            artistImageDao.upsertAll(
+                match { list -> list.any { it.artistName == "Mystery Band" && it.imageUrl == null && it.attemptedAt > 0L } },
+            )
+        }
+        // Failed = the API did not answer. NO sentinel row may be written for
+        // "Down Act" — it stays in the candidate set and is retried next pass.
+        coVerify(exactly = 0) {
+            artistImageDao.upsertAll(
+                match { list -> list.any { it.artistName == "Down Act" } },
+            )
+        }
+    }
+
+    @Test fun `a throwing resolution is treated as failed and never aborts the batch`() = runTest {
+        coEvery { artistImageDao.distinctArtistNames() } returns
+            listOf("Down Act", "Aarne")
+        coEvery { ytMusicApiClient.resolveArtistPhoto("Down Act") } throws
+            RuntimeException("rate limited")
+        coEvery { ytMusicApiClient.resolveArtistPhoto("Aarne") } returns
+            ArtistPhotoResolution.Resolved("https://photo/aarne.jpg")
+
+        val result = newWorker().doWork()
+
+        assertTrue(result is ListenableWorker.Result.Success)
+        coVerify(exactly = 1) {
+            artistImageDao.upsertAll(
+                match { list -> list.any { it.artistName == "Aarne" && it.imageUrl == "https://photo/aarne.jpg" } },
+            )
+        }
+        coVerify(exactly = 0) {
+            artistImageDao.upsertAll(
+                match { list -> list.any { it.artistName == "Down Act" } },
+            )
+        }
+    }
+
+    @Test fun `skips names already attempted so they are never re-polled`() = runTest {
+        coEvery { artistImageDao.observedNames() } returns listOf("Aarne", "Mystery Band")
+        coEvery { artistImageDao.distinctArtistNames() } returns
+            listOf("Aarne, Toxi$", "Mystery Band", "Kozak System")
+        coEvery { ytMusicApiClient.resolveArtistPhoto("Kozak System") } returns
+            ArtistPhotoResolution.Resolved("https://photo/kozak.jpg")
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) { ytMusicApiClient.resolveArtistPhoto("Kozak System") }
+        coVerify(exactly = 0) { ytMusicApiClient.resolveArtistPhoto("Aarne") }
+        coVerify(exactly = 0) { ytMusicApiClient.resolveArtistPhoto("Mystery Band") }
+        coVerify(exactly = 1) { artistImageDao.upsertAll(any()) }
+    }
+
+    @Test fun `case variants of an attempted name are also skipped`() = runTest {
+        // The PK is COLLATE NOCASE and the observed set is lowercased — a
+        // case-variant credit must not trigger a second resolution.
+        coEvery { artistImageDao.observedNames() } returns listOf("Aarne")
+        coEvery { artistImageDao.distinctArtistNames() } returns listOf("AARNE")
+
+        newWorker().doWork()
+
+        coVerify(exactly = 0) { ytMusicApiClient.resolveArtistPhoto(any()) }
+        coVerify(exactly = 0) { artistImageDao.upsertAll(any()) }
+    }
+
+    @Test fun `caps each run at BATCH_SIZE names leaving the remainder for a later run`() = runTest {
+        val manyNames = (1..200).map { "Artist $it" }
+        coEvery { artistImageDao.distinctArtistNames() } returns manyNames
+        coEvery { ytMusicApiClient.resolveArtistPhoto(any()) } returns
+            ArtistPhotoResolution.NoAvatar
+
+        val result = newWorker().doWork()
+
+        assertTrue(result is ListenableWorker.Result.Success)
+        // Only the first 150 candidates are resolved per pass.
+        coVerify(exactly = 150) { ytMusicApiClient.resolveArtistPhoto(any()) }
+        coVerify(exactly = 1) { artistImageDao.upsertAll(any()) }
+    }
+
+    @Test fun `primary-artist collapse dedupes collab credits into a single row`() = runTest {
+        // Two different raw credits that both collapse to the same primary
+        // act must produce a single deduplicated photo row.
+        coEvery { artistImageDao.distinctArtistNames() } returns
+            listOf("Aarne, Toxi$", "Aarne, Big Baby Tape")
+        coEvery { ytMusicApiClient.resolveArtistPhoto("Aarne") } returns
+            ArtistPhotoResolution.Resolved("https://photo/aarne.jpg")
+
+        newWorker().doWork()
+
+        coVerify(exactly = 1) { ytMusicApiClient.resolveArtistPhoto("Aarne") }
+        coVerify(exactly = 1) {
+            artistImageDao.upsertAll(
+                match { list ->
+                    list.size == 1 &&
+                        list.first().artistName == "Aarne" &&
+                        list.first().imageUrl == "https://photo/aarne.jpg"
+                },
+            )
+        }
+    }
+}

--- a/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/InnerTubeClient.kt
+++ b/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/InnerTubeClient.kt
@@ -412,6 +412,28 @@ class InnerTubeClient @Inject constructor(
         executeRequest("$BASE_URL/search", body, cookie, variant)
     }
 
+    /**
+     * Calls the InnerTube `search` action, preserving the HTTP outcome.
+     *
+     * Unlike [search], which discards the status code and collapses every
+     * failure into `null`, this returns the [RequestOutcome] so a caller can
+     * tell "the API answered but found nothing" apart from "the API did not
+     * answer" (network failure, 4xx/5xx, rate limit) — the distinction the
+     * artist-photo backfill needs to decide between a permanent "no photo"
+     * sentinel and a transient retry.
+     */
+    internal suspend fun searchWithStatus(query: String, params: String? = null): RequestOutcome =
+        withContext(Dispatchers.IO) {
+            val cookie = tokenManager.getYouTubeCookie()
+            val variant = InnerTubeVariant.WEB_REMIX
+            val body = buildJsonObject {
+                put("context", buildContext(variant))
+                put("query", query)
+                if (params != null) put("params", params)
+            }
+            executeRequestWithStatus("$BASE_URL/search", body, cookie, variant)
+        }
+
     /** ytmusicapi-derived filter selector that constrains search results to the
      *  "Songs" shelf only. With this set, the response reverts to the legacy
      *  `musicShelfRenderer` shape that downstream parsers expect. */

--- a/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/YTMusicApiClient.kt
+++ b/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/YTMusicApiClient.kt
@@ -5,6 +5,7 @@ import com.stash.core.model.SyncResult
 import com.stash.data.ytmusic.model.AlbumDetail
 import com.stash.data.ytmusic.model.AlbumSource
 import com.stash.data.ytmusic.model.AlbumSummary
+import com.stash.data.ytmusic.model.ArtistPhotoResolution
 import com.stash.data.ytmusic.model.ArtistProfile
 import com.stash.data.ytmusic.model.PagedAlbums
 import com.stash.data.ytmusic.model.ArtistSummary
@@ -626,6 +627,30 @@ class YTMusicApiClient @Inject constructor(
     suspend fun resolveArtist(name: String): ArtistSummary? {
         if (name.isBlank()) return null
         val response = innerTubeClient.search(name, params = ARTISTS_FILTER) ?: return null
+        return firstArtistOnShelf(response)
+    }
+
+    /**
+     * Resolve an artist name to its official photo for the artist-photo
+     * backfill. Same artists-filtered search as [resolveArtist], but returns a
+     * tri-state [ArtistPhotoResolution] so the worker can distinguish a
+     * GENUINE "no avatar" answer (stamp the permanent sentinel) from a request
+     * that never got an answer (retry on the next pass, like `ArtBackfillWorker`).
+     */
+    suspend fun resolveArtistPhoto(name: String): ArtistPhotoResolution {
+        if (name.isBlank()) return ArtistPhotoResolution.NoAvatar
+        val outcome = innerTubeClient.searchWithStatus(name, params = ARTISTS_FILTER)
+        if (outcome.body == null) return ArtistPhotoResolution.Failed
+        val artist = firstArtistOnShelf(outcome.body)
+        return if (artist != null) {
+            ArtistPhotoResolution.Resolved(avatarUrl = artist.avatarUrl)
+        } else {
+            ArtistPhotoResolution.NoAvatar
+        }
+    }
+
+    /** Top [ArtistSummary] from an artists-filtered search response, or null. */
+    private fun firstArtistOnShelf(response: JsonObject): ArtistSummary? {
         val shelves = response.navigatePath(
             "contents", "tabbedSearchResultsRenderer", "tabs",
         )?.firstArray()?.firstOrNull()?.asObject()

--- a/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/model/ArtistPhotoResolution.kt
+++ b/data/ytmusic/src/main/kotlin/com/stash/data/ytmusic/model/ArtistPhotoResolution.kt
@@ -1,0 +1,25 @@
+package com.stash.data.ytmusic.model
+
+/**
+ * Outcome of an artist-photo resolution ([com.stash.data.ytmusic.YTMusicApiClient.resolveArtistPhoto]).
+ *
+ * Tri-state on purpose, so the backfill worker can tell a genuine "no photo"
+ * answer apart from a failed request:
+ *
+ * - [Resolved] — the API answered and found the artist; [avatarUrl] may still
+ *   be null when the artist channel has no avatar.
+ * - [NoAvatar] — the API answered but had no matching artist — a permanent
+ *   "no photo", safe to stamp as a sentinel.
+ * - [Failed] — the API did not answer (network failure, 4xx/5xx, rate limit).
+ *   NOT a "no photo"; the caller should retry later, not give up.
+ */
+sealed interface ArtistPhotoResolution {
+    /** The API answered and found the artist. */
+    data class Resolved(val avatarUrl: String?) : ArtistPhotoResolution
+
+    /** The API answered but had no matching artist — a genuine no-photo. */
+    data object NoAvatar : ArtistPhotoResolution
+
+    /** The API did not answer (network / HTTP failure / rate limit). */
+    data object Failed : ArtistPhotoResolution
+}

--- a/data/ytmusic/src/test/kotlin/com/stash/data/ytmusic/ResolveArtistTest.kt
+++ b/data/ytmusic/src/test/kotlin/com/stash/data/ytmusic/ResolveArtistTest.kt
@@ -1,5 +1,6 @@
 package com.stash.data.ytmusic
 
+import com.stash.data.ytmusic.model.ArtistPhotoResolution
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -7,6 +8,7 @@ import kotlinx.serialization.json.jsonObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -22,7 +24,15 @@ class ResolveArtistTest {
     private fun fakeInner(responseJson: String?): InnerTubeClient {
         val inner = mock<InnerTubeClient>()
         val parsed = responseJson?.let { Json.parseToJsonElement(it).jsonObject }
-        runBlocking { whenever(inner.search(any(), any())).thenReturn(parsed) }
+        runBlocking {
+            whenever(inner.search(any(), any())).thenReturn(parsed)
+            whenever(inner.searchWithStatus(any(), any())).thenReturn(
+                InnerTubeClient.RequestOutcome(
+                    body = parsed,
+                    statusCode = if (parsed != null) 200 else InnerTubeClient.RequestOutcome.STATUS_NETWORK_ERROR,
+                ),
+            )
+        }
         return inner
     }
 
@@ -55,5 +65,29 @@ class ResolveArtistTest {
         val client = YTMusicApiClient(inner)
         assertNull(client.resolveArtist("   "))
         verifyBlocking(inner, never()) { search(any(), any()) }
+    }
+
+    @Test fun `resolveArtistPhoto resolves an avatar when an artist shelf exists`() = runTest {
+        val client = fakeClient(loadFixture("search_artists_filter.json"))
+        val result = client.resolveArtistPhoto("my bloody valentine")
+        assertTrue(result is ArtistPhotoResolution.Resolved)
+        assertNotNull((result as ArtistPhotoResolution.Resolved).avatarUrl)
+    }
+
+    @Test fun `resolveArtistPhoto is NoAvatar when the API answered without an artist`() = runTest {
+        val client = fakeClient("""{"contents":{}}""")
+        assertEquals(ArtistPhotoResolution.NoAvatar, client.resolveArtistPhoto("nobody"))
+    }
+
+    @Test fun `resolveArtistPhoto is Failed when the API did not answer`() = runTest {
+        val client = fakeClient(null)
+        assertEquals(ArtistPhotoResolution.Failed, client.resolveArtistPhoto("nobody"))
+    }
+
+    @Test fun `resolveArtistPhoto is NoAvatar for a blank name without hitting the network`() = runTest {
+        val inner = fakeInner(loadFixture("search_artists_filter.json"))
+        val client = YTMusicApiClient(inner)
+        assertEquals(ArtistPhotoResolution.NoAvatar, client.resolveArtistPhoto("   "))
+        verifyBlocking(inner, never()) { searchWithStatus(any(), any()) }
     }
 }

--- a/feature/library/build.gradle.kts
+++ b/feature/library/build.gradle.kts
@@ -15,6 +15,7 @@ android {
 }
 dependencies {
     implementation(project(":core:auth"))
+    implementation(project(":core:common"))
     implementation(project(":core:data"))
     implementation(project(":core:media"))
     // Artist-credit parsing: album-card display (String.primaryArtist) and

--- a/feature/library/src/main/kotlin/com/stash/feature/library/ArtistDetailScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/ArtistDetailScreen.kt
@@ -2,6 +2,7 @@ package com.stash.feature.library
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -47,6 +48,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -55,11 +57,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImagePainter
+import coil3.compose.rememberAsyncImagePainter
 import com.stash.core.media.BulkPlayAction
 import com.stash.core.model.Track
 import com.stash.core.ui.components.DetailTrackRow
@@ -395,7 +400,12 @@ private fun ArtistDetailHeader(
                 .padding(horizontal = 20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // Circular artist icon placeholder
+            // Circular artist icon — real photo from the artist_images cache
+            // (ArtistImageBackfillWorker output), else the gradient placeholder.
+            // The painter state is collected in composition so the circle
+            // upgrades to the photo the moment the request succeeds and never
+            // renders blank when the URL fails (Coil draws nothing outside a
+            // Success state, so everything else keeps the placeholder).
             Box(
                 modifier = Modifier
                     .size(96.dp)
@@ -410,12 +420,23 @@ private fun ArtistDetailHeader(
                     ),
                 contentAlignment = Alignment.Center,
             ) {
-                Icon(
-                    imageVector = Icons.Default.Person,
-                    contentDescription = null,
-                    modifier = Modifier.size(48.dp),
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
-                )
+                val photoUrl = state.photoUrl
+                if (photoUrl != null) {
+                    val painter = rememberAsyncImagePainter(model = photoUrl)
+                    val painterState by painter.state.collectAsState()
+                    if (painterState is AsyncImagePainter.State.Success) {
+                        Image(
+                            painter = painter,
+                            contentDescription = state.artistName,
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop,
+                        )
+                    } else {
+                        ArtistHeaderPlaceholder()
+                    }
+                } else {
+                    ArtistHeaderPlaceholder()
+                }
             }
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -506,4 +527,15 @@ private fun ArtistDetailHeader(
 
         Spacer(modifier = Modifier.height(16.dp))
     }
+}
+
+/** The no-photo fallback for the artist header — a soft Person icon. */
+@Composable
+private fun ArtistHeaderPlaceholder() {
+    Icon(
+        imageVector = Icons.Default.Person,
+        contentDescription = null,
+        modifier = Modifier.size(48.dp),
+        tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+    )
 }

--- a/feature/library/src/main/kotlin/com/stash/feature/library/ArtistDetailViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/ArtistDetailViewModel.kt
@@ -3,6 +3,8 @@ package com.stash.feature.library
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.stash.core.common.primaryArtist
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.BulkPlayAction
 import com.stash.core.media.PlayerRepository
@@ -32,6 +34,9 @@ import javax.inject.Inject
  *                                   to highlight the active row.
  * @property searchQuery            The active search/filter string.
  * @property showSearch             Whether the search bar is currently visible.
+ * @property photoUrl               The artist's cached official photo
+ *                                  (`artist_images`), or null to fall back to
+ *                                  the gradient initial header.
  */
 data class ArtistDetailUiState(
     val artistName: String = "",
@@ -40,6 +45,7 @@ data class ArtistDetailUiState(
     val currentlyPlayingTrackId: Long? = null,
     val searchQuery: String = "",
     val showSearch: Boolean = false,
+    val photoUrl: String? = null,
 )
 
 /**
@@ -57,6 +63,7 @@ class ArtistDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val musicRepository: MusicRepository,
     private val playerRepository: PlayerRepository,
+    private val artistImageDao: ArtistImageDao,
 ) : ViewModel() {
 
     /** The artist name extracted from the navigation route arguments. */
@@ -100,7 +107,8 @@ class ArtistDetailViewModel @Inject constructor(
         playerRepository.playerState,
         _searchQuery,
         _showSearch,
-    ) { tracks, playerState, query, showSearch ->
+        artistImageDao.observeByName(artistName.primaryArtist()),
+    ) { tracks, playerState, query, showSearch, photo ->
         ArtistDetailUiState(
             artistName = artistName,
             tracks = tracks,
@@ -108,6 +116,11 @@ class ArtistDetailViewModel @Inject constructor(
             currentlyPlayingTrackId = playerState.currentTrack?.id,
             searchQuery = query,
             showSearch = showSearch,
+            // Photo cache is keyed by the SAME primary-artist name the Library
+            // Artists tab groups by, and the lookup is COLLATE NOCASE — a case
+            // variant of the name still lines up, whichever entry point (grid,
+            // album hero, Now Playing) navigated here.
+            photoUrl = photo?.imageUrl,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
@@ -92,6 +92,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.Image
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -99,6 +100,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -1669,36 +1671,12 @@ private fun ArtistsGrid(
                             onLongClick = { selectedArtist = artist },
                         ),
                 ) {
-                    // Album art proxy or gradient circle fallback
-                    if (artist.artUrl != null) {
-                        coil3.compose.AsyncImage(
-                            model = artist.artUrl,
-                            contentDescription = null,
-                            modifier = Modifier
-                                .size(72.dp)
-                                .clip(CircleShape),
-                            contentScale = androidx.compose.ui.layout.ContentScale.Crop,
-                        )
-                    } else {
-                        val gradientColors = remember(artist.name) {
-                            artistGradient(artist.name)
-                        }
-                        Box(
-                            modifier = Modifier
-                                .size(72.dp)
-                                .clip(CircleShape)
-                                .background(Brush.linearGradient(gradientColors)),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Text(
-                                text = artist.name.firstOrNull()
-                                    ?.uppercaseChar()?.toString() ?: "?",
-                                style = MaterialTheme.typography.headlineMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = Color.White,
-                            )
-                        }
-                    }
+                    ArtistAvatar(
+                        name = artist.name,
+                        photoUrl = artist.photoUrl,
+                        artUrl = artist.artUrl,
+                        size = 72.dp,
+                    )
                     Text(
                         text = artist.name,
                         style = MaterialTheme.typography.bodyMedium,
@@ -2114,6 +2092,66 @@ private val artistGradientPalette = listOf(
 private fun artistGradient(name: String): List<Color> {
     val index = name.hashCode().absoluteValue % artistGradientPalette.size
     return artistGradientPalette[index]
+}
+
+/**
+ * Artist circular avatar for the Artists grid: the cached official photo
+ * ([ArtistInfo.photoUrl]) when available, else the album-art proxy
+ * ([ArtistInfo.artUrl]), else a gradient-initial circle. Coil draws the photo;
+ * while it loads (or if it errors) the gradient initial is shown so a failed
+ * fetch never leaves an empty ring.
+ */
+@Composable
+private fun ArtistAvatar(
+    name: String,
+    photoUrl: String?,
+    artUrl: String?,
+    size: Dp,
+) {
+    val model = photoUrl ?: artUrl
+    if (model != null) {
+        val painter = rememberAsyncImagePainter(model = model)
+        val state by painter.state.collectAsState()
+        Box(
+            modifier = Modifier
+                .size(size)
+                .clip(CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (state is AsyncImagePainter.State.Success) {
+                Image(
+                    painter = painter,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                )
+            } else {
+                ArtistInitialFallback(name, size)
+            }
+        }
+    } else {
+        ArtistInitialFallback(name, size)
+    }
+}
+
+/** Gradient circle with the artist's first letter — the no-photo fallback. */
+@Composable
+private fun ArtistInitialFallback(name: String, size: Dp) {
+    val gradientColors = remember(name) { artistGradient(name) }
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(Brush.linearGradient(gradientColors)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = name.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+    }
 }
 
 // ── Empty state placeholder ──────────────────────────────────────────────────

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryUiState.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryUiState.kt
@@ -70,6 +70,7 @@ data class ArtistInfo(
     val trackCount: Int,
     val totalDurationMs: Long,
     val artUrl: String? = null,
+    val photoUrl: String? = null,
 )
 
 /**

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryViewModel.kt
@@ -6,6 +6,7 @@ import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
 import com.stash.core.common.matchesArtistCredits
 import com.stash.core.common.primaryArtist
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.prefs.StreamingPreference
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.data.sync.FlacUpgradeEnqueuer
@@ -100,6 +101,7 @@ class LibraryViewModel @Inject constructor(
     private val flacUpgradeEnqueuer: FlacUpgradeEnqueuer,
     private val libraryPreferencesStore: LibraryPreferencesStore,
     private val libraryDeepLinkController: com.stash.core.data.navigation.LibraryDeepLinkController,
+    private val artistImageDao: ArtistImageDao,
 ) : ViewModel() {
 
     /** Live progress for "Import from device". Observed by LibraryScreen. */
@@ -220,7 +222,24 @@ class LibraryViewModel @Inject constructor(
         val query = controls.searchQuery.trim().lowercase()
 
         // -- Map DAO projections to UI models --
-        val artists = allArtists.map { ArtistInfo(it.artist, it.trackCount, it.totalDurationMs, it.artUrl) }
+        // Artists are regrouped by PRIMARY act so a track credit like
+        // "Aarne, Toxi$, Big Baby Tape" lands under a single "Aarne" card
+        // instead of fragmenting the artist across a wall of "Aarne …" rows.
+        val artists = allArtists
+            .map { ArtistInfo(it.artist, it.trackCount, it.totalDurationMs, it.artUrl) }
+            .groupBy { it.name.primaryArtist() }
+            .map { (primary, group) ->
+                ArtistInfo(
+                    name = primary,
+                    trackCount = group.sumOf { it.trackCount },
+                    totalDurationMs = group.sumOf { it.totalDurationMs },
+                    // Prefer art from a release credited to the primary act
+                    // alone (their own album), falling back to any collab art —
+                    // "Aarne" shows his own cover, not SLAANG's.
+                    artUrl = group.firstOrNull { it.name == primary }?.artUrl
+                        ?: group.firstNotNullOfOrNull { it.artUrl },
+                )
+            }
         val albums = mergeDuplicateAlbums(
             // Album card shows the lead act of a collaboration credit
             // ("Metro Boomin" for "Metro Boomin, Travis Scott"), so the card
@@ -327,6 +346,16 @@ class LibraryViewModel @Inject constructor(
         // Overlay the currently-playing track ID so the UI can highlight it.
         libraryState.copy(
             currentlyPlayingTrackId = playerState.currentTrack?.id,
+        )
+    }.combine(artistImageDao.observeAll()) { libraryState, images ->
+        // Overlay real artist photos (ArtistImageBackfillWorker output) keyed
+        // by the SAME primary-artist name the Artists tab groups by. Artists
+        // without a photo keep photoUrl = null → UI falls back to artUrl.
+        val photoByName = images.associate { it.artistName to it.imageUrl }
+        libraryState.copy(
+            artists = libraryState.artists.map { it.copy(photoUrl = photoByName[it.name]) },
+            singleTrackArtists = libraryState.singleTrackArtists
+                .map { it.copy(photoUrl = photoByName[it.name]) },
         )
     }
         // The whole filter+sort+lowercase pipeline above re-runs on every

--- a/feature/library/src/test/kotlin/com/stash/feature/library/ArtistDetailViewModelTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/ArtistDetailViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.stash.feature.library
 
 import androidx.lifecycle.SavedStateHandle
+import com.stash.core.data.db.dao.ArtistImageDao
+import com.stash.core.data.db.entity.ArtistImageEntity
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.PlayerRepository
 import com.stash.core.model.PlayerState
@@ -8,6 +10,8 @@ import com.stash.core.model.Track
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -17,6 +21,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -122,6 +127,33 @@ class ArtistDetailViewModelTest {
     }
 
     @Test
+    fun uiState_exposes_photoUrl_from_artist_image_cache() = runTest {
+        val artistImageDao = mock<ArtistImageDao> {
+            on { observeByName(any()) } doReturn flowOf(
+                ArtistImageEntity(
+                    artistName = "Artist",
+                    imageUrl = "https://yt3.example/photo.jpg",
+                    attemptedAt = 1L,
+                ),
+            )
+        }
+        val vm = buildVm(artistImageDao = artistImageDao)
+        // drop(1): skip the WhileSubscribed initialValue (photoUrl = null)
+        // and grab the first state the combine actually computes.
+        val state = vm.uiState.drop(1).first()
+
+        assertEquals("https://yt3.example/photo.jpg", state.photoUrl)
+    }
+
+    @Test
+    fun uiState_photoUrl_is_null_when_no_cache_row_exists() = runTest {
+        val vm = buildVm()
+        val state = vm.uiState.drop(1).first()
+
+        assertNull(state.photoUrl)
+    }
+
+    @Test
     fun downloadSelected_isolates_per_item_failure() = runTest {
         val musicRepo = musicRepoMock()
         // Second item throws; first and third must still be attempted.
@@ -194,6 +226,9 @@ class ArtistDetailViewModelTest {
             on { getTracksByArtist(any()) } doReturn flowOf(emptyList())
             on { getUserCreatedPlaylists() } doReturn flowOf(emptyList())
         },
+        artistImageDao: ArtistImageDao = mock {
+            on { observeByName(any()) } doReturn flowOf(null)
+        },
         savedStateHandle: SavedStateHandle = SavedStateHandle(
             mapOf("artistName" to "Artist"),
         ),
@@ -201,5 +236,6 @@ class ArtistDetailViewModelTest {
         savedStateHandle = savedStateHandle,
         musicRepository = musicRepository,
         playerRepository = playerRepository,
+        artistImageDao = artistImageDao,
     )
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibrarySearchFieldQueryTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibrarySearchFieldQueryTest.kt
@@ -3,6 +3,7 @@ package com.stash.feature.library
 import com.google.common.truth.Truth.assertThat
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.model.PlayerState
 import com.stash.core.model.PlaylistType
@@ -107,6 +108,7 @@ class LibrarySearchFieldQueryTest {
                 onBlocking { getSourceFilter() } doReturn SourceFilter.ALL
             },
             libraryDeepLinkController = com.stash.core.data.navigation.LibraryDeepLinkController(),
+            artistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
         )
     }
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelLikedOrderTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelLikedOrderTest.kt
@@ -110,6 +110,7 @@ class LibraryViewModelLikedOrderTest {
                 onBlocking { getSourceFilter() } doReturn SourceFilter.ALL
             },
             libraryDeepLinkController = com.stash.core.data.navigation.LibraryDeepLinkController(),
+            artistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
         )
     }
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelLikedSearchTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelLikedSearchTest.kt
@@ -3,6 +3,7 @@ package com.stash.feature.library
 import com.google.common.truth.Truth.assertThat
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.model.MusicSource
 import com.stash.core.model.PlayerState
@@ -106,6 +107,7 @@ class LibraryViewModelLikedSearchTest {
                 onBlocking { getSourceFilter() } doReturn SourceFilter.ALL
             },
             libraryDeepLinkController = com.stash.core.data.navigation.LibraryDeepLinkController(),
+            artistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
         )
     }
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelMixTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelMixTest.kt
@@ -3,6 +3,7 @@ package com.stash.feature.library
 import com.google.common.truth.Truth.assertThat
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.prefs.StreamingPreference
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.PlayerRepository
@@ -140,6 +141,7 @@ class LibraryViewModelMixTest {
         },
         streamingPreference: StreamingPreference = mock { on { enabled } doReturn flowOf(false) },
         libraryPreferencesStore: LibraryPreferencesStore = libraryPreferencesStoreMock(),
+        artistImageDao: ArtistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
     ): LibraryViewModel = LibraryViewModel(
         musicRepository = musicRepository,
         playerRepository = playerRepository,
@@ -151,5 +153,6 @@ class LibraryViewModelMixTest {
         ytMusicApiClient = org.mockito.kotlin.mock(),
         libraryPreferencesStore = libraryPreferencesStore,
         libraryDeepLinkController = com.stash.core.data.navigation.LibraryDeepLinkController(),
+        artistImageDao = artistImageDao,
     )
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelPinToHomeTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelPinToHomeTest.kt
@@ -2,6 +2,7 @@ package com.stash.feature.library
 
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.PlayerRepository
 import com.stash.core.model.MusicSource
@@ -102,6 +103,7 @@ class LibraryViewModelPinToHomeTest {
                 onBlocking { getSourceFilter() } doReturn SourceFilter.ALL
             },
             libraryDeepLinkController = com.stash.core.data.navigation.LibraryDeepLinkController(),
+            artistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
         )
     }
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelShuffleLikedTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelShuffleLikedTest.kt
@@ -3,6 +3,7 @@ package com.stash.feature.library
 import com.google.common.truth.Truth.assertThat
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.PlayerRepository
 import com.stash.core.model.MusicSource
@@ -145,6 +146,7 @@ class LibraryViewModelShuffleLikedTest {
                 onBlocking { getSourceFilter() } doReturn SourceFilter.ALL
             },
             libraryDeepLinkController = com.stash.core.data.navigation.LibraryDeepLinkController(),
+            artistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
         )
     }
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelSortTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelSortTest.kt
@@ -3,6 +3,7 @@ package com.stash.feature.library
 import com.google.common.truth.Truth.assertThat
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.prefs.StreamingPreference
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.PlayerRepository
@@ -98,5 +99,6 @@ class LibraryViewModelSortTest {
             onBlocking { getSourceFilter() } doReturn SourceFilter.ALL
         },
         libraryDeepLinkController = com.stash.core.data.navigation.LibraryDeepLinkController(),
+        artistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
     )
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelSourceFilterTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelSourceFilterTest.kt
@@ -3,6 +3,7 @@ package com.stash.feature.library
 import com.google.common.truth.Truth.assertThat
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.model.PlayerState
 import com.stash.core.model.Track
@@ -74,5 +75,6 @@ class LibraryViewModelSourceFilterTest {
             onBlocking { getSourceFilter() } doReturn SourceFilter.ALL
         },
         libraryDeepLinkController = com.stash.core.data.navigation.LibraryDeepLinkController(),
+        artistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
     )
 }

--- a/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/kotlin/com/stash/feature/library/LibraryViewModelTest.kt
@@ -2,6 +2,7 @@ package com.stash.feature.library
 
 import com.stash.core.auth.TokenManager
 import com.stash.core.auth.model.AuthState
+import com.stash.core.data.db.dao.ArtistImageDao
 import com.stash.core.data.prefs.StreamingPreference
 import com.stash.core.data.repository.MusicRepository
 import com.stash.core.media.PlayerRepository
@@ -307,6 +308,7 @@ class LibraryViewModelTest {
         },
         streamingPreference: StreamingPreference = mock { on { enabled } doReturn flowOf(false) },
         libraryPreferencesStore: LibraryPreferencesStore = libraryPreferencesStoreMock(),
+        artistImageDao: ArtistImageDao = mock { on { observeAll() } doReturn flowOf(emptyList()) },
     ): LibraryViewModel = LibraryViewModel(
         musicRepository = musicRepository,
         playerRepository = playerRepository,
@@ -318,5 +320,6 @@ class LibraryViewModelTest {
         ytMusicApiClient = org.mockito.kotlin.mock(),
         libraryPreferencesStore = libraryPreferencesStore,
         libraryDeepLinkController = com.stash.core.data.navigation.LibraryDeepLinkController(),
+        artistImageDao = artistImageDao,
     )
 }


### PR DESCRIPTION
## What

Gives the Library Artists tab real artist photos instead of album-art proxies / gradient initials, and the Artist Detail header the same official avatar.

- **Backfill worker** (`ArtistImageBackfillWorker`) walks the distinct artist credits in the library, collapses them to their primary act, resolves each via a new tri-state `resolveArtistPhoto` API, and caches the result in a new `artist_images` table (DB v43, migration 42 -> 43).
- **Sentinel semantics**: only a genuine "no avatar" answer stamps the permanent sentinel; transient failures (network / rate limit) write nothing and are retried on the next pass — mirrors `ArtBackfillWorker`.
- **Parser**: `core:common` gains `String.primaryArtist()` (comma-only split + allowlist) so collaboration credits like "Aarne, Toxi$, Big Baby Tape" display as "Aarne" without shredding band names that merely contain separators.
- **UI**: `ArtistAvatar` in the Artists grid (photo -> album-art proxy -> gradient initial), `LibraryViewModel` regroups by primary artist and overlays photos, `ArtistDetailScreen` header shows the cached photo with the `Person`-icon placeholder fallback.
- **Batch & case fixes** per review: single transactional upsert per pass, targeted `observeByName` query, COLLATE NOCASE key, `CancellationException` rethrown, `remaining=` clamped to 0.

This PR is the artist-photos slice of the feature. The album-hero FlowRow wrap (#385, PR #441), the album-card tap navigation (#386, PR #442), and the display/match credit-parsing work (PR #440) live in their own PRs. Does **not** fix #388 (the artist-text list-scroll shuffle is a separate `.animateItem()` drag-reorder follow-up).