### PR TITLE
fix(sync): stop filing a user's Spotify playlists as mixes (#437)

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
@@ -658,6 +658,20 @@ interface PlaylistDao {
     @Query("UPDATE playlists SET is_active = 1 WHERE id = :playlistId AND is_active = 0")
     suspend fun reactivateById(playlistId: Long): Int
 
+    /**
+     * Re-file a playlist under the type today's snapshot reports.
+     *
+     * `type` used to be write-once — whichever fetch pass saw the `source_id`
+     * first owned it forever. A playlist the Spotify home-feed mix pass had
+     * filed as DAILY_MIX therefore never returned to the Library Playlists
+     * tab, no matter how many syncs saw it as the user's own (issue #437).
+     *
+     * [mixNumber] travels with the type: it only means anything for a mix, so
+     * a row leaving DAILY_MIX must not keep a stale ordinal.
+     */
+    @Query("UPDATE playlists SET type = :type, mix_number = :mixNumber WHERE id = :playlistId")
+    suspend fun updateType(playlistId: Long, type: PlaylistType, mixNumber: Int?)
+
     // ── Custom playlist management ──────────────────────────────────────
 
     /** Get the next available position for appending a track to a playlist. */

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
@@ -28,6 +28,7 @@ import com.stash.core.model.MusicSource
 import com.stash.core.model.PlaylistType
 import com.stash.core.model.SyncMode
 import com.stash.core.model.SyncState
+import com.stash.data.spotify.SpotifyApiClient
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.first
@@ -76,20 +77,50 @@ internal fun defaultSyncEnabled(type: PlaylistType, online: Boolean): Boolean = 
  * per-source singleton with a synthetic source id that no library walk should
  * ever re-type.
  *
- * Known limit: this only sees ids that reach a CUSTOM snapshot, and while
- * auto-mix discovery is on `keepAsLibraryPlaylist` withholds every id the home
- * feed claimed. A Spotify-OWNED playlist the user saved therefore stays
- * DAILY_MIX — which is what it is. A user's OWN playlist is not claimed by the
- * home feed (isSpotifyMix skips owner-less items as of v0.9.99), so it reaches
- * the library walk and heals here, which is the #437 case. Reuniting the two
- * would mean plumbing the library walk's id list into the diff pass; do that
- * only if a saved Made-For-You playlist ever needs to live under Playlists.
+ * Scoped to Spotify ids OUTSIDE Spotify's own namespace, because the type pair
+ * alone does not identify the #437 case and the filters that used to stand in
+ * for it are not load-bearing:
+ *
+ * - YouTube reaches the same pair with a real mix. A saved auto-mix tile is a
+ *   `VLRD…` browseId, and `parseSinglePlaylistFromTwoRowRenderer` accepts any
+ *   VL-prefixed id but `VLLM`/`VLSE` and strips the `VL` — yielding the very
+ *   `RD…` id the home-mix pass snapshotted as DAILY_MIX, now arriving again as
+ *   CUSTOM. `getPlaylistTracks` already documents that `getUserPlaylists()`
+ *   returns saved radios. Nothing on the YouTube path filters this.
+ * - On Spotify, `keepAsLibraryPlaylist` only withholds ids in `homeFeedMixIds`,
+ *   and that set is filled solely inside the home-feed `Success` branch. One
+ *   `Empty`, `Error`, thrown exception, or discovery-off run leaves it empty,
+ *   after which every saved mix whose name isn't literally "Daily Mix N" —
+ *   Discover Weekly, Release Radar, On Repeat, daylist, Blends, the yearly
+ *   recaps — is snapshotted CUSTOM.
+ *
+ * A wrong re-type is worse than the bug this fixes, and the rule is one-way so
+ * it never heals: the row leaves the Home mix rails, `mix_number` is gone,
+ * DiffWorker's syncEnabled gate exempts DAILY_MIX only so the row is skipped
+ * forever after, and `shouldEnqueueForDownload(CUSTOM, offline)` is true — so
+ * one "Enable all" queues an entire rotating mix, the #368 regression the
+ * surrounding code exists to prevent.
+ *
+ * [SPOTIFY_OWNED_ID_PREFIX] is the honest discriminator: Spotify generates
+ * every mix inside it, and the #437 playlists — the user's own — are never in
+ * it. So a Spotify-generated mix is protected whether or not the home-feed pass
+ * ran, and YouTube cannot reach the reconcile at all.
  */
 internal fun reconciledPlaylistType(
     existing: PlaylistType,
     snapshot: PlaylistType,
+    source: MusicSource,
+    sourceId: String,
 ): PlaylistType? =
-    if (existing == PlaylistType.DAILY_MIX && snapshot == PlaylistType.CUSTOM) snapshot else null
+    if (source == MusicSource.SPOTIFY &&
+        !sourceId.startsWith(SpotifyApiClient.SPOTIFY_OWNED_ID_PREFIX) &&
+        existing == PlaylistType.DAILY_MIX &&
+        snapshot == PlaylistType.CUSTOM
+    ) {
+        snapshot
+    } else {
+        null
+    }
 
 /**
  * Whether a playlist's tracks should be enqueued for download during this sync.
@@ -391,7 +422,12 @@ class DiffWorker @AssistedInject constructor(
             // [reconciledPlaylistType] for why this is one-way only. Resolved
             // BEFORE the art check so a row leaving DAILY_MIX stops rotating
             // its cover in the same pass.
-            val reconciledType = reconciledPlaylistType(existing.type, snapshot.playlistType)
+            val reconciledType = reconciledPlaylistType(
+                existing = existing.type,
+                snapshot = snapshot.playlistType,
+                source = snapshot.source,
+                sourceId = snapshot.sourcePlaylistId,
+            )
             if (reconciledType != null) {
                 playlistDao.updateType(existing.id, reconciledType, mixNumber = null)
                 Log.i(

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/DiffWorker.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import com.stash.core.model.PlaylistType
 import androidx.room.withTransaction
 import androidx.work.workDataOf
 import com.stash.core.data.db.StashDatabase
@@ -26,6 +25,7 @@ import com.stash.core.data.sync.SyncStateManager
 import com.stash.core.data.sync.TrackMatcher
 import com.stash.core.model.DownloadStatus
 import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
 import com.stash.core.model.SyncMode
 import com.stash.core.model.SyncState
 import dagger.assisted.Assisted
@@ -51,6 +51,45 @@ import kotlinx.coroutines.flow.first
  */
 @Suppress("UNUSED_PARAMETER")
 internal fun defaultSyncEnabled(type: PlaylistType, online: Boolean): Boolean = false
+
+/**
+ * The type to re-write onto an existing playlist row, or null to leave it.
+ *
+ * `playlists.type` used to be write-once, set by whichever fetch pass saw the
+ * `source_id` first. That made one combination permanent and wrong: the
+ * Spotify home-feed mix pass inserts DAILY_MIX, and the library
+ * walk reports the same id as a saved CUSTOM playlist — but nothing ever
+ * updated the row, so it stayed a "mix" and disappeared from every CUSTOM
+ * surface (the Sync tab's "n/n PLAYLISTS" count, the Library Playlists grid).
+ * Issue #437: five Spotify playlists fetched, one shown.
+ *
+ * Deliberately ONE-WAY. Reconciling both directions would flap the type every
+ * run for a Spotify-owned playlist the user has saved: with auto-mix discovery
+ * on, the home feed claims the id and snapshots it DAILY_MIX; with it off, the
+ * library walk claims it and snapshots it CUSTOM. A saved library playlist
+ * wins, so the row settles — and with it the row's download eligibility
+ * ([shouldEnqueueForDownload] excludes DAILY_MIX) and its Home-vs-Library
+ * placement, which would otherwise change under the user run to run.
+ *
+ * Every other pair is left alone. Local-only types (STASH_MIX, STASH_LIKED,
+ * DOWNLOADS_MIX) are owned by Stash and never by a snapshot; LIKED_SONGS is a
+ * per-source singleton with a synthetic source id that no library walk should
+ * ever re-type.
+ *
+ * Known limit: this only sees ids that reach a CUSTOM snapshot, and while
+ * auto-mix discovery is on `keepAsLibraryPlaylist` withholds every id the home
+ * feed claimed. A Spotify-OWNED playlist the user saved therefore stays
+ * DAILY_MIX — which is what it is. A user's OWN playlist is not claimed by the
+ * home feed (isSpotifyMix skips owner-less items as of v0.9.99), so it reaches
+ * the library walk and heals here, which is the #437 case. Reuniting the two
+ * would mean plumbing the library walk's id list into the diff pass; do that
+ * only if a saved Made-For-You playlist ever needs to live under Playlists.
+ */
+internal fun reconciledPlaylistType(
+    existing: PlaylistType,
+    snapshot: PlaylistType,
+): PlaylistType? =
+    if (existing == PlaylistType.DAILY_MIX && snapshot == PlaylistType.CUSTOM) snapshot else null
 
 /**
  * Whether a playlist's tracks should be enqueued for download during this sync.
@@ -347,13 +386,29 @@ class DiffWorker @AssistedInject constructor(
     ): PlaylistEntity {
         val existing = playlistDao.findBySourceId(snapshot.sourcePlaylistId)
         if (existing != null) {
+            // A playlist the home feed once called a mix, and the library walk
+            // now reports as one the user saved, is re-typed here — see
+            // [reconciledPlaylistType] for why this is one-way only. Resolved
+            // BEFORE the art check so a row leaving DAILY_MIX stops rotating
+            // its cover in the same pass.
+            val reconciledType = reconciledPlaylistType(existing.type, snapshot.playlistType)
+            if (reconciledType != null) {
+                playlistDao.updateType(existing.id, reconciledType, mixNumber = null)
+                Log.i(
+                    TAG,
+                    "Re-typed '${existing.name}' ${existing.type} -> $reconciledType " +
+                        "(source_id=${snapshot.sourcePlaylistId})",
+                )
+                syncLog.info("${existing.name} is your playlist, not a mix — moved to Playlists")
+            }
+            val effectiveType = reconciledType ?: existing.type
             // Art refresh: ONLY for DAILY_MIX. Daily Mixes (and Spotify's
             // weekly mixes — Discover Weekly, Release Radar, etc., which
             // share the DAILY_MIX type) rotate, so their cover should
             // follow the tracks. Other playlist types never rotate here;
             // LIKED_SONGS gets only a missing-art repair during metadata
             // finalization below.
-            val rotatesArt = existing.type == PlaylistType.DAILY_MIX
+            val rotatesArt = effectiveType == PlaylistType.DAILY_MIX
             if (rotatesArt && snapshot.artUrl != null && snapshot.artUrl != existing.artUrl) {
                 playlistDao.updateArtUrl(existing.id, snapshot.artUrl)
             }
@@ -373,6 +428,8 @@ class DiffWorker @AssistedInject constructor(
                 artUrl = if (rotatesArt) snapshot.artUrl ?: existing.artUrl else existing.artUrl,
                 name = snapshot.playlistName.ifBlank { existing.name },
                 isActive = true,
+                type = effectiveType,
+                mixNumber = if (reconciledType != null) null else existing.mixNumber,
             )
         }
 

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/PlaylistFetchWorker.kt
@@ -118,6 +118,37 @@ internal fun keepAsLibraryPlaylist(
 ): Boolean = id !in homeFeedMixIds && !DAILY_MIX_NAME.matches(name)
 
 /**
+ * The Spotify playlist ids this run can honestly say still exist — the set
+ * [com.stash.core.data.db.dao.PlaylistDao.deactivateMissingSpotifyCustomPlaylists]
+ * measures "missing" against.
+ *
+ * Every id the library walk LISTED, pre-filter. libraryV3 is the account's
+ * inventory, so it is the only authority on whether a saved playlist is still
+ * saved — deliberately NOT widened with `homeFeedMixIds`, or unsaving a
+ * playlist Spotify still features would leave its row active forever.
+ *
+ * Equally NOT the post-[keepAsLibraryPlaylist] list. That filter is
+ * classification routing — "the mix pass owns this id, don't snapshot it
+ * twice" — and says nothing about whether the playlist left the account.
+ * Feeding the filtered list in hid a playlist the moment it started matching
+ * the filter: appear on the home feed, or get renamed to "Daily Mix N", and
+ * the CUSTOM row the walk had just listed flipped to `is_active = 0`. The
+ * name-match case has no DAILY_MIX snapshot behind it to reactivate the row,
+ * so the playlist disappeared for good (#437).
+ *
+ * ponytail: a name-filtered id counted live here gets no snapshot this run, so
+ * its row keeps whatever tracks it already had. Deliberate — stale beats gone,
+ * and the only ids that reach it are "Daily Mix N"-named rotating mixes whose
+ * contents were never authoritative. The real repair is to snapshot such an
+ * item when the home-feed pass didn't claim it; that belongs with the name
+ * filter, which exists to keep the home feed the single source of Daily Mixes
+ * even when sp_dc fails, and which also keeps [reconciledPlaylistType] from
+ * re-filing a genuine Daily Mix as a playlist on a failed-sp_dc run.
+ */
+internal fun spotifyLivenessIds(observedLibraryIds: List<String>): List<String> =
+    observedLibraryIds.distinct()
+
+/**
  * First worker in the sync chain. Authenticates with configured music services,
  * fetches playlist and track metadata, and writes everything to the remote
  * snapshot tables for the subsequent [DiffWorker] to consume.
@@ -743,7 +774,8 @@ class PlaylistFetchWorker @AssistedInject constructor(
             }
 
             if (shouldDeactivateMissingPlaylists(syncPreferencesManager.spotifySyncMode.first(), inventoryComplete)) {
-                val currentIds = customPlaylists.map { it.id }
+                // Observed, not snapshotted — see [spotifyLivenessIds].
+                val currentIds = spotifyLivenessIds(userPlaylists.map { it.id })
                 val hidden = playlistDao.deactivateMissingSpotifyCustomPlaylists(
                     currentSourceIds = currentIds,
                     hasCurrentIds = currentIds.isNotEmpty(),

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/DiffWorkerTest.kt
@@ -903,6 +903,100 @@ class DiffWorkerTest {
         assertEquals("existing track kept AND the fetched addition merged", 2, activeTrackCount(playlistId))
     }
 
+    // ── Type reconcile: which pairs REACH it, not just what it returns ───────
+    // ReconciledPlaylistTypeTest is a truth table over the arguments; these
+    // drive a real diff so the guard is exercised where the arguments are
+    // actually assembled.
+
+    /** The #437 case: a user's own playlist mis-filed as a mix is re-filed. */
+    @Test
+    fun `diff re-types a user playlist that a mix pass had claimed`() = runBlocking {
+        val playlistId = db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Pagotaki", source = MusicSource.SPOTIFY,
+                sourceId = "0NIipN6vyz2yLYguJwbUC6", type = PlaylistType.DAILY_MIX,
+                mixNumber = 7, syncEnabled = true,
+            )
+        )
+
+        val snapshot = RemotePlaylistSnapshotEntity(
+            id = 40L, syncId = 1L, source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "0NIipN6vyz2yLYguJwbUC6",
+            playlistName = "Pagotaki", playlistType = PlaylistType.CUSTOM,
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(snapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(40L) } returns emptyList()
+
+        buildWorker().doWork()
+
+        val row = db.playlistDao().findBySourceId("0NIipN6vyz2yLYguJwbUC6")!!
+        assertEquals(PlaylistType.CUSTOM, row.type)
+        assertNull("mix_number is meaningless off a mix", row.mixNumber)
+    }
+
+    /**
+     * A Spotify-GENERATED mix must survive. keepAsLibraryPlaylist can't be
+     * relied on to keep it out: homeFeedMixIds is filled only in the home-feed
+     * Success branch, so one Empty/Error/exception/discovery-off run hands the
+     * library walk every saved mix that isn't literally named "Daily Mix N".
+     */
+    @Test
+    fun `diff does not re-type a spotify-generated mix arriving as CUSTOM`() = runBlocking {
+        db.playlistDao().insert(
+            PlaylistEntity(
+                name = "Discover Weekly", source = MusicSource.SPOTIFY,
+                sourceId = "37i9dQZEVXcQ9COmYvdajy", type = PlaylistType.DAILY_MIX,
+                mixNumber = 3, syncEnabled = true,
+            )
+        )
+
+        val snapshot = RemotePlaylistSnapshotEntity(
+            id = 41L, syncId = 1L, source = MusicSource.SPOTIFY,
+            sourcePlaylistId = "37i9dQZEVXcQ9COmYvdajy",
+            playlistName = "Discover Weekly", playlistType = PlaylistType.CUSTOM,
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(snapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(41L) } returns emptyList()
+
+        buildWorker().doWork()
+
+        val row = db.playlistDao().findBySourceId("37i9dQZEVXcQ9COmYvdajy")!!
+        assertEquals("a Spotify-generated mix must stay a mix", PlaylistType.DAILY_MIX, row.type)
+        assertEquals("mix_number must survive", 3, row.mixNumber)
+    }
+
+    /**
+     * YouTube reaches the same type pair with a real mix and no filter at all:
+     * a saved auto-mix tile is a `VLRD…` browseId, and the library parser
+     * accepts any VL-prefixed id but VLLM/VLSE and strips the `VL`, handing
+     * back the same `RD…` id the home-mix pass snapshotted as DAILY_MIX.
+     */
+    @Test
+    fun `diff does not re-type a saved youtube radio arriving as CUSTOM`() = runBlocking {
+        val radioId = "RDCLAK5uy_kmPRjHDECIcuVwnKzx3sZLoDEcnzclyVQ"
+        db.playlistDao().insert(
+            PlaylistEntity(
+                name = "My Supermix", source = MusicSource.YOUTUBE,
+                sourceId = radioId, type = PlaylistType.DAILY_MIX,
+                mixNumber = 1, syncEnabled = true,
+            )
+        )
+
+        val snapshot = RemotePlaylistSnapshotEntity(
+            id = 42L, syncId = 1L, source = MusicSource.YOUTUBE,
+            sourcePlaylistId = radioId,
+            playlistName = "My Supermix", playlistType = PlaylistType.CUSTOM,
+        )
+        coEvery { remoteSnapshotDao.getPlaylistSnapshotsBySyncId(1L) } returns listOf(snapshot)
+        coEvery { remoteSnapshotDao.getTrackSnapshotsByPlaylistId(42L) } returns emptyList()
+
+        buildWorker().doWork()
+
+        val row = db.playlistDao().findBySourceId(radioId)!!
+        assertEquals("a saved YouTube radio must stay a mix", PlaylistType.DAILY_MIX, row.type)
+        assertEquals("mix_number must survive", 1, row.mixNumber)
+    }
+
     private fun buildWorker(): DiffWorker = TestListenableWorkerBuilder<DiffWorker>(context)
         .setInputData(workDataOf(PlaylistFetchWorker.KEY_SYNC_ID to 1L))
         .setWorkerFactory(object : WorkerFactory() {

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/ReconciledPlaylistTypeTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/ReconciledPlaylistTypeTest.kt
@@ -1,6 +1,7 @@
 package com.stash.core.data.sync.workers
 
 import com.google.common.truth.Truth.assertThat
+import com.stash.core.model.MusicSource
 import com.stash.core.model.PlaylistType
 import org.junit.Test
 
@@ -11,38 +12,107 @@ import org.junit.Test
  * Issue #437: a Spotify playlist first seen by the home-feed mix pass was
  * inserted as DAILY_MIX, and `type` was never written again. Once the library
  * walk reported the same `source_id` as a saved CUSTOM playlist, the row
- * stayed DAILY_MIX forever — invisible on every CUSTOM
- * surface (the Sync tab's "n/n PLAYLISTS" count and the Library Playlists
- * grid both filter on `type`). Five playlists fetched, one shown.
+ * stayed DAILY_MIX forever — invisible on every CUSTOM surface (the Sync tab's
+ * "n/n PLAYLISTS" count and the Library Playlists grid both filter on `type`).
+ * Five playlists fetched, one shown.
  *
- * The rule is deliberately ONE-WAY. Reconciling in both directions would make
- * the type flap every run for a Spotify-owned playlist the user has saved:
- * with auto-mix discovery on, the home feed claims the id and snapshots it
- * DAILY_MIX; with it off, the library walk claims it and snapshots it CUSTOM.
- * A saved library playlist wins, so the row settles instead of oscillating —
- * and with it the row's download eligibility (shouldEnqueueForDownload
- * excludes DAILY_MIX) and its home-vs-library placement.
+ * The rule is ONE-WAY, so a wrong re-type never heals: the row leaves the Home
+ * mix rails, `mix_number` is gone, the syncEnabled gate exempts DAILY_MIX only
+ * so the row is skipped on every later run, and `shouldEnqueueForDownload` is
+ * true for CUSTOM — one "Enable all" would queue an entire rotating mix (#368).
+ * That is why the pair alone is NOT enough to authorise a re-type, and why the
+ * source and the id namespace are part of the decision.
  */
 class ReconciledPlaylistTypeTest {
 
-    @Test fun `a mix the user has saved becomes a playlist`() {
-        assertThat(reconciledPlaylistType(PlaylistType.DAILY_MIX, PlaylistType.CUSTOM))
+    private val userPlaylistId = "0NIipN6vyz2yLYguJwbUC6"
+
+    /** A Spotify-generated playlist always lives in Spotify's own namespace. */
+    private val spotifyMixId = "37i9dQZF1E38ZgHCGJDJmC"
+
+    private fun reconcile(
+        existing: PlaylistType,
+        snapshot: PlaylistType,
+        source: MusicSource = MusicSource.SPOTIFY,
+        sourceId: String = userPlaylistId,
+    ) = reconciledPlaylistType(existing, snapshot, source, sourceId)
+
+    // ── The #437 case ────────────────────────────────────────────────────────
+
+    @Test fun `a user playlist mis-filed as a mix becomes a playlist again`() {
+        assertThat(reconcile(PlaylistType.DAILY_MIX, PlaylistType.CUSTOM))
             .isEqualTo(PlaylistType.CUSTOM)
     }
 
-    @Test fun `a saved playlist is never demoted back to a mix`() {
-        assertThat(reconciledPlaylistType(PlaylistType.CUSTOM, PlaylistType.DAILY_MIX)).isNull()
+    @Test fun `a saved playlist is never demoted to a mix`() {
+        assertThat(reconcile(PlaylistType.CUSTOM, PlaylistType.DAILY_MIX)).isNull()
     }
 
     @Test fun `an unchanged type is not rewritten`() {
         for (type in PlaylistType.entries) {
-            assertThat(reconciledPlaylistType(type, type)).isNull()
+            assertThat(reconcile(type, type)).isNull()
         }
     }
 
-    // Local-only types are owned by Stash, never by a remote snapshot. A
-    // sourceId collision must not turn the user's own liked songs or their
-    // one-off downloads holder into a synced playlist.
+    // ── Spotify-generated mixes must survive the reconcile ───────────────────
+    // keepAsLibraryPlaylist cannot be relied on to keep these away: it only
+    // withholds ids in homeFeedMixIds, and that set is populated solely inside
+    // the home-feed Success branch. One Empty/Error/exception/discovery-off run
+    // leaves it empty, after which every saved mix whose name isn't literally
+    // "Daily Mix N" arrives as a CUSTOM snapshot.
+
+    @Test fun `a spotify-generated mix is never re-typed`() {
+        assertThat(
+            reconcile(
+                PlaylistType.DAILY_MIX,
+                PlaylistType.CUSTOM,
+                sourceId = spotifyMixId,
+            ),
+        ).isNull()
+    }
+
+    /** Discover Weekly / Release Radar sit in a different sub-namespace. */
+    @Test fun `discover weekly is never re-typed`() {
+        assertThat(
+            reconcile(
+                PlaylistType.DAILY_MIX,
+                PlaylistType.CUSTOM,
+                sourceId = "37i9dQZEVXcQ9COmYvdajy",
+            ),
+        ).isNull()
+    }
+
+    // ── YouTube cannot reach the reconcile at all ────────────────────────────
+    // A saved auto-mix tile is a VLRD… browseId, and the library parser accepts
+    // any VL-prefixed id but VLLM/VLSE and strips the VL — handing back the
+    // same RD… id the home-mix pass already snapshotted as DAILY_MIX.
+
+    @Test fun `a saved youtube radio is never re-typed`() {
+        assertThat(
+            reconcile(
+                PlaylistType.DAILY_MIX,
+                PlaylistType.CUSTOM,
+                source = MusicSource.YOUTUBE,
+                sourceId = "RDCLAK5uy_kmPRjHDECIcuVwnKzx3sZLoDEcnzclyVQ",
+            ),
+        ).isNull()
+    }
+
+    @Test fun `no youtube id can be re-typed`() {
+        for (id in listOf("PLabc123", "RDabc123", "OLAK5uy_abc", userPlaylistId)) {
+            assertThat(
+                reconcile(
+                    PlaylistType.DAILY_MIX,
+                    PlaylistType.CUSTOM,
+                    source = MusicSource.YOUTUBE,
+                    sourceId = id,
+                ),
+            ).isNull()
+        }
+    }
+
+    // ── Everything else is left alone ────────────────────────────────────────
+
     @Test fun `local-only types are never reconciled`() {
         val localOnly = listOf(
             PlaylistType.STASH_MIX,
@@ -50,19 +120,17 @@ class ReconciledPlaylistTypeTest {
             PlaylistType.DOWNLOADS_MIX,
         )
         for (type in localOnly) {
-            assertThat(reconciledPlaylistType(type, PlaylistType.CUSTOM)).isNull()
-            assertThat(reconciledPlaylistType(type, PlaylistType.DAILY_MIX)).isNull()
-            assertThat(reconciledPlaylistType(PlaylistType.DAILY_MIX, type)).isNull()
-            assertThat(reconciledPlaylistType(PlaylistType.CUSTOM, type)).isNull()
+            assertThat(reconcile(type, PlaylistType.CUSTOM)).isNull()
+            assertThat(reconcile(type, PlaylistType.DAILY_MIX)).isNull()
+            assertThat(reconcile(PlaylistType.DAILY_MIX, type)).isNull()
+            assertThat(reconcile(PlaylistType.CUSTOM, type)).isNull()
         }
     }
 
-    // LIKED_SONGS is a per-source singleton with a synthetic sourceId; nothing
-    // in a library walk should ever re-type it, in either direction.
     @Test fun `liked songs is left alone`() {
-        assertThat(reconciledPlaylistType(PlaylistType.LIKED_SONGS, PlaylistType.CUSTOM)).isNull()
-        assertThat(reconciledPlaylistType(PlaylistType.LIKED_SONGS, PlaylistType.DAILY_MIX)).isNull()
-        assertThat(reconciledPlaylistType(PlaylistType.DAILY_MIX, PlaylistType.LIKED_SONGS)).isNull()
-        assertThat(reconciledPlaylistType(PlaylistType.CUSTOM, PlaylistType.LIKED_SONGS)).isNull()
+        assertThat(reconcile(PlaylistType.LIKED_SONGS, PlaylistType.CUSTOM)).isNull()
+        assertThat(reconcile(PlaylistType.LIKED_SONGS, PlaylistType.DAILY_MIX)).isNull()
+        assertThat(reconcile(PlaylistType.DAILY_MIX, PlaylistType.LIKED_SONGS)).isNull()
+        assertThat(reconcile(PlaylistType.CUSTOM, PlaylistType.LIKED_SONGS)).isNull()
     }
 }

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/ReconciledPlaylistTypeTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/ReconciledPlaylistTypeTest.kt
@@ -1,0 +1,68 @@
+package com.stash.core.data.sync.workers
+
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.model.PlaylistType
+import org.junit.Test
+
+/**
+ * Unit test for [reconciledPlaylistType] — the write-once-no-more rule for
+ * `playlists.type`.
+ *
+ * Issue #437: a Spotify playlist first seen by the home-feed mix pass was
+ * inserted as DAILY_MIX, and `type` was never written again. Once the library
+ * walk reported the same `source_id` as a saved CUSTOM playlist, the row
+ * stayed DAILY_MIX forever — invisible on every CUSTOM
+ * surface (the Sync tab's "n/n PLAYLISTS" count and the Library Playlists
+ * grid both filter on `type`). Five playlists fetched, one shown.
+ *
+ * The rule is deliberately ONE-WAY. Reconciling in both directions would make
+ * the type flap every run for a Spotify-owned playlist the user has saved:
+ * with auto-mix discovery on, the home feed claims the id and snapshots it
+ * DAILY_MIX; with it off, the library walk claims it and snapshots it CUSTOM.
+ * A saved library playlist wins, so the row settles instead of oscillating —
+ * and with it the row's download eligibility (shouldEnqueueForDownload
+ * excludes DAILY_MIX) and its home-vs-library placement.
+ */
+class ReconciledPlaylistTypeTest {
+
+    @Test fun `a mix the user has saved becomes a playlist`() {
+        assertThat(reconciledPlaylistType(PlaylistType.DAILY_MIX, PlaylistType.CUSTOM))
+            .isEqualTo(PlaylistType.CUSTOM)
+    }
+
+    @Test fun `a saved playlist is never demoted back to a mix`() {
+        assertThat(reconciledPlaylistType(PlaylistType.CUSTOM, PlaylistType.DAILY_MIX)).isNull()
+    }
+
+    @Test fun `an unchanged type is not rewritten`() {
+        for (type in PlaylistType.entries) {
+            assertThat(reconciledPlaylistType(type, type)).isNull()
+        }
+    }
+
+    // Local-only types are owned by Stash, never by a remote snapshot. A
+    // sourceId collision must not turn the user's own liked songs or their
+    // one-off downloads holder into a synced playlist.
+    @Test fun `local-only types are never reconciled`() {
+        val localOnly = listOf(
+            PlaylistType.STASH_MIX,
+            PlaylistType.STASH_LIKED,
+            PlaylistType.DOWNLOADS_MIX,
+        )
+        for (type in localOnly) {
+            assertThat(reconciledPlaylistType(type, PlaylistType.CUSTOM)).isNull()
+            assertThat(reconciledPlaylistType(type, PlaylistType.DAILY_MIX)).isNull()
+            assertThat(reconciledPlaylistType(PlaylistType.DAILY_MIX, type)).isNull()
+            assertThat(reconciledPlaylistType(PlaylistType.CUSTOM, type)).isNull()
+        }
+    }
+
+    // LIKED_SONGS is a per-source singleton with a synthetic sourceId; nothing
+    // in a library walk should ever re-type it, in either direction.
+    @Test fun `liked songs is left alone`() {
+        assertThat(reconciledPlaylistType(PlaylistType.LIKED_SONGS, PlaylistType.CUSTOM)).isNull()
+        assertThat(reconciledPlaylistType(PlaylistType.LIKED_SONGS, PlaylistType.DAILY_MIX)).isNull()
+        assertThat(reconciledPlaylistType(PlaylistType.DAILY_MIX, PlaylistType.LIKED_SONGS)).isNull()
+        assertThat(reconciledPlaylistType(PlaylistType.CUSTOM, PlaylistType.LIKED_SONGS)).isNull()
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/SpotifyLivenessIdsTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/SpotifyLivenessIdsTest.kt
@@ -1,0 +1,43 @@
+package com.stash.core.data.sync.workers
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit test for [spotifyLivenessIds] — the "these still exist" set that
+ * `deactivateMissingSpotifyCustomPlaylists` measures absence against.
+ *
+ * The bug it pins: the caller used to pass the POST-[keepAsLibraryPlaylist]
+ * list. That filter only decides which pass snapshots an id, so a playlist
+ * was hidden the moment it started matching it — appearing on the home feed,
+ * or being renamed to "Daily Mix N" — even though the library walk had just
+ * listed it. The name-match case has no DAILY_MIX snapshot behind it to
+ * reactivate the row, so the playlist vanished for good.
+ */
+class SpotifyLivenessIdsTest {
+
+    @Test fun `an observed playlist the library filter drops still counts as live`() {
+        val observed = listOf("keep_me", "daily_mix_named", "on_home_feed")
+        // Both of the ids keepAsLibraryPlaylist would reject.
+        assertThat(keepAsLibraryPlaylist("daily_mix_named", "Daily Mix 3", emptySet())).isFalse()
+        assertThat(keepAsLibraryPlaylist("on_home_feed", "Late Night", setOf("on_home_feed")))
+            .isFalse()
+
+        assertThat(spotifyLivenessIds(observed))
+            .containsExactly("keep_me", "daily_mix_named", "on_home_feed")
+    }
+
+    // The library walk is the only authority on what is still saved. Widening
+    // this with homeFeedMixIds would keep an unsaved playlist that Spotify
+    // still features alive forever, so home-feed ids must not leak in here.
+    @Test fun `only what the library walk listed counts`() {
+        assertThat(spotifyLivenessIds(emptyList())).isEmpty()
+        assertThat(spotifyLivenessIds(listOf("p1"))).containsExactly("p1")
+    }
+
+    // An id listed at the library root AND inside a folder must not produce a
+    // duplicate — the list goes straight into a SQL `NOT IN (...)`.
+    @Test fun `duplicates collapse`() {
+        assertThat(spotifyLivenessIds(listOf("p1", "p1", "p2"))).containsExactly("p1", "p2")
+    }
+}

--- a/data/spotify/src/main/kotlin/com/stash/data/spotify/SpotifyApiClient.kt
+++ b/data/spotify/src/main/kotlin/com/stash/data/spotify/SpotifyApiClient.kt
@@ -143,7 +143,13 @@ class SpotifyApiClient @Inject constructor(
         private const val EDITORIAL_ID_PREFIX = "37i9dQZF1D"
 
         /** Spotify's own playlist-id namespace; anything else is a user's copy. */
-        private const val SPOTIFY_OWNED_ID_PREFIX = "37i9dQ"
+        /**
+         * Spotify's own playlist-id namespace. Every algorithmic/editorial
+         * playlist Spotify generates lives here; a playlist a user made never
+         * does. Public so the sync diff can reuse THIS distinction instead of
+         * keeping a second copy of the prefix.
+         */
+        const val SPOTIFY_OWNED_ID_PREFIX = "37i9dQ"
 
         /**
          * Search terms that surface the recaps. "Your Top Songs" alone returns the


### PR DESCRIPTION
Fixes #437 — "5 playlists found, 1 shown".

## Root cause

Three defects stacked up:

**1. A fabricated owner.** `parseHomeFeedForSpotifyMixes` defaulted `ownerId` to `"spotify"` when a home-feed item carried no `ownerV2` block. Spotify's home feed surfaces the user's OWN playlists under "Recently played" / "Jump back in", and those cards often omit `ownerV2` — so they took `isSpotifyMix`'s owner catch-all and were snapshotted as `DAILY_MIX`. Unknown owner is now fail-closed: no owner data means we can't confirm it's a real mix, so the item is skipped rather than mislabelled.

**2. `playlists.type` was write-once.** Whichever fetch pass saw a `source_id` first owned its type forever. A row misfiled as `DAILY_MIX` never returned to the Library Playlists tab or the Sync tab's "n/n PLAYLISTS" count — both filter on `type`. `findOrCreatePlaylist` now re-types a `DAILY_MIX` row that the library walk reports as `CUSTOM`. Deliberately one-way, so the type can't flap with the auto-mix-discovery toggle; `mix_number` is cleared alongside it.

**3. Deactivation measured the wrong list.** `deactivateMissingSpotifyCustomPlaylists` compared against the post-`keepAsLibraryPlaylist` list. That filter is classification routing, not evidence a playlist left the account — an id landing in `homeFeedMixIds`, or a name turning into "Daily Mix N", hid the `CUSTOM` row the walk had just listed. It now measures against everything the run observed.

## Verification

Unit: `ReconciledPlaylistTypeTest` (one-way rule, local-only types and `LIKED_SONGS` left alone), `SpotifyLivenessIdsTest`.

On-device, Samsung Galaxy Tab Active3 (SM-T570, Android 13):

- One real sync skipped 17 owner-less home-feed items that would previously have become bogus mixes (`calm vibes`, `digital detox✌️`, `sad instrumentals`, `Peaceful Piano`, …).
- Reproduced #437 by flipping a real playlist row to `type='DAILY_MIX', mix_number=7`. The Spotify card then read **1 MIXES · 0/1 PLAYLISTS** with two playlists in the account — the reported shape.
- One Sync Now healed it: `DiffWorker: Re-typed 'Stash' DAILY_MIX -> CUSTOM (source_id=0NIipN6vyz2yLYguJwbUC6)`. Card went to **0/2 PLAYLISTS**, MIXES cell gone, `mix_number` cleared. A second, untouched playlist row stayed `CUSTOM` as a control.
- Sync log surfaces it to the user: `Stash is your playlist, not a mix — moved to Playlists`.
- No crash; Room opened at schema v42 (the change adds a `@Query` only, no schema change, no migration).

Defect 3 is unit-covered only — reaching it on-device needs a playlist to disappear from the account mid-run.

## Known limit

While auto-mix discovery is on, `keepAsLibraryPlaylist` withholds every id the home feed claimed, so a Spotify-OWNED playlist the user saved stays `DAILY_MIX` — which is what it is. A user's own playlist is not claimed by the home feed any more (defect 1), so it reaches the library walk and heals, which is the #437 case. Documented in `reconciledPlaylistType`'s KDoc.