### PR TITLE
fix(sync): make the Synced/Off chips filter every synced row (#373)

### DIFF
--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/ManagePlaylistsScreen.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/ManagePlaylistsScreen.kt
@@ -93,18 +93,20 @@ fun ManagePlaylistsScreen(
         if (rows.isNotEmpty()) listState.scrollToItem(0)
     }
 
-    val bySegment = when (segment) {
-        ManageSegment.ALL -> customAll
-        ManageSegment.SYNCED -> customAll.filter { it.syncEnabled }
-        ManageSegment.OFF -> customAll.filter { !it.syncEnabled }
-    }
+    val bySegment = customAll.filter { matchesSegment(segment, it.syncEnabled) }
     // The query filters every section, not just "Your playlists": accounts can
     // have 100+ auto mixes, and an unfiltered Liked/Mixes block pushes the
     // filtered custom results off-screen - making search look broken (#310).
+    //
+    // The SEGMENT reaches every section whose switch is sync state, for the same
+    // reason: it used to filter the custom list alone, so "Off" left the Liked
+    // row and every mix on screen wearing an ON switch and read as broken
+    // (#373). Mix rows are excluded rather than filtered — their switch is a
+    // different axis (see showMixRows).
     val q = query.trim()
     fun matchesQuery(row: ManageRow) = q.isBlank() || row.name.contains(q, ignoreCase = true)
-    val visibleLiked = liked?.takeIf { matchesQuery(it) }
-    val visibleMixes = mixes.filter { matchesQuery(it) }
+    val visibleLiked = liked?.takeIf { matchesQuery(it) && matchesSegment(segment, it.syncEnabled) }
+    val visibleMixes = if (showMixRows(segment)) mixes.filter { matchesQuery(it) } else emptyList()
     val visibleCustom = bySegment.filter { matchesQuery(it) }
 
     Scaffold(
@@ -277,11 +279,40 @@ private data class ManageRow(
 )
 
 /** Segment filter over the custom "Your playlists" list. */
-private enum class ManageSegment(val label: String) {
+internal enum class ManageSegment(val label: String) {
     ALL("All"),
     SYNCED("Synced"),
     OFF("Off"),
 }
+
+/**
+ * Whether a row belongs in [segment]. Only meaningful for rows whose switch IS
+ * the sync state — the Liked row and the user's own playlists.
+ *
+ * One predicate, both call sites: the segment used to be applied inline to the
+ * custom list only, so the Liked row silently fell through and an enabled
+ * playlist survived the "Off" chip (#373).
+ */
+internal fun matchesSegment(segment: ManageSegment, syncEnabled: Boolean): Boolean =
+    when (segment) {
+        ManageSegment.ALL -> true
+        ManageSegment.SYNCED -> syncEnabled
+        ManageSegment.OFF -> !syncEnabled
+    }
+
+/**
+ * Whether mix ROWS belong under [segment].
+ *
+ * A mix row's switch is `hideFromHome` ("shown on Home"), not sync state, so a
+ * sync-state chip has nothing honest to say about it — filtering mixes by
+ * `syncEnabled` would land every one of them under "Off" still wearing an
+ * ON-looking switch, which is the same confusion #373 reported. They show
+ * under "All" only.
+ *
+ * The section's HEADER and discovery switch are deliberately NOT gated on this
+ * — see the mixes-label item for why they must stay reachable (#335/#344).
+ */
+internal fun showMixRows(segment: ManageSegment): Boolean = segment == ManageSegment.ALL
 
 @Composable
 private fun ManageSectionLabel(text: String) {

--- a/feature/sync/src/test/kotlin/com/stash/feature/sync/ManageSegmentFilterTest.kt
+++ b/feature/sync/src/test/kotlin/com/stash/feature/sync/ManageSegmentFilterTest.kt
@@ -1,0 +1,58 @@
+package com.stash.feature.sync
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Contract tests for the Manage-playlists segment chips (All / Synced / Off).
+ *
+ * Issue #373: the chips filtered ONLY the "Your playlists" section. The Liked
+ * row and every mix row got the text query but never the segment, so tapping
+ * "Off" left rows with an ON switch on screen and the filter read as broken.
+ *
+ * The chips name a SYNC state, so they apply to exactly the rows whose switch
+ * IS sync state — Liked and custom playlists. A mix row's switch is
+ * `hideFromHome` ("shown on Home"), a different axis entirely, so a sync-state
+ * segment can only honestly show mix rows under All.
+ */
+class ManageSegmentFilterTest {
+
+    @Test fun allKeepsBothStates() {
+        assertTrue(matchesSegment(ManageSegment.ALL, syncEnabled = true))
+        assertTrue(matchesSegment(ManageSegment.ALL, syncEnabled = false))
+    }
+
+    @Test fun syncedKeepsOnlyEnabled() {
+        assertTrue(matchesSegment(ManageSegment.SYNCED, syncEnabled = true))
+        assertFalse(matchesSegment(ManageSegment.SYNCED, syncEnabled = false))
+    }
+
+    /** The reported bug: an enabled row must NOT survive the Off chip. */
+    @Test fun offKeepsOnlyDisabled() {
+        assertTrue(matchesSegment(ManageSegment.OFF, syncEnabled = false))
+        assertFalse(matchesSegment(ManageSegment.OFF, syncEnabled = true))
+    }
+
+    // ── Mix rows: sync state is the wrong axis ────────────────────────────────
+
+    @Test fun mixRowsShowOnlyUnderAll() {
+        assertTrue(showMixRows(ManageSegment.ALL))
+        assertFalse(showMixRows(ManageSegment.SYNCED))
+        assertFalse(showMixRows(ManageSegment.OFF))
+    }
+
+    /**
+     * Every segment must be decidable — a chip that falls through to "show
+     * everything" is how #373 looked to the reporter in the first place.
+     */
+    @Test fun everySegmentIsDecided() {
+        for (segment in ManageSegment.entries) {
+            val enabled = matchesSegment(segment, syncEnabled = true)
+            val disabled = matchesSegment(segment, syncEnabled = false)
+            if (segment != ManageSegment.ALL) {
+                assertFalse("$segment must exclude one of the two states", enabled && disabled)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #373.

## Root cause

`ManagePlaylistsScreen` applied the segment chip to the "Your playlists" list only:

```kotlin
val bySegment = when (segment) { ... customAll.filter { ... } }
val visibleLiked = liked?.takeIf { matchesQuery(it) }     // no segment
val visibleMixes = mixes.filter { matchesQuery(it) }      // no segment
val visibleCustom = bySegment.filter { matchesQuery(it) }
```

The Liked row and every mix row got the text query but never the segment, so tapping **Off** left rows with an ON switch on screen and the filter read as broken — which is what the reporter described ("both active and disabled playlists remain visible").

## Fix

The chips name a sync state, so they now reach every row whose switch **is** sync state — Liked included — through one shared predicate rather than an inline `when` duplicated per call site.

Mix rows are **excluded** rather than filtered. A mix row's switch is `hideFromHome` ("shown on Home"), a different axis; filtering mixes by `syncEnabled` would land every one of them under "Off" still wearing an ON-looking switch, i.e. the same confusion one level down. The section's header and its discovery switch render regardless of segment, so the "reachable before the first sync pulls any mixes in" guarantee added by #335/#344 is preserved.

## Verification

`ManageSegmentFilterTest` — the Off/Synced/All contract, mix rows under All only, and a guard that no chip except All can keep both states.

Not device-verified: showing the difference needs an account with a Liked row and at least one mix, and my test account has neither. The change is a pure-function extraction plus three call sites, and `:app:compileDebugKotlin` is green.