### PR TITLE
fix(update): tell the user what the update check found (#377)

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/UpdateCheckWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/UpdateCheckWorker.kt
@@ -18,6 +18,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import androidx.work.workDataOf
 import com.stash.core.data.sync.SyncNotificationManager
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -46,7 +47,32 @@ class UpdateCheckWorker(
     companion object {
         private const val TAG = "UpdateCheckWorker"
         private const val UNIQUE_WORK_NAME = "stash_update_check"
-        private const val UNIQUE_ONE_SHOT_NAME = "stash_update_check_oneshot"
+        /**
+         * Unique name for the manual/cold-start check. Public so the Settings
+         * screen can observe THIS work and report its outcome — before, every
+         * terminal path returned a bare `Result.success()` and a user on the
+         * latest release saw "Checking for updates…" and then nothing (#377).
+         */
+        const val UNIQUE_ONE_SHOT_NAME = "stash_update_check_oneshot"
+
+        /** Output key naming what the check concluded. */
+        const val KEY_OUTCOME = "outcome"
+
+        /** Output key carrying the remote tag, when one was read. */
+        const val KEY_LATEST_TAG = "latest_tag"
+
+        const val OUTCOME_UP_TO_DATE = "up_to_date"
+        const val OUTCOME_UPDATE_AVAILABLE = "update_available"
+        const val OUTCOME_FAILED = "failed"
+
+        /**
+         * Input flag marking a user-initiated check. A manual check must reach a
+         * TERMINAL state so the UI can speak: a network failure becomes
+         * `Result.failure` instead of `Result.retry`, which would otherwise
+         * leave the observer waiting on work that never completes.
+         */
+        const val KEY_MANUAL = "manual"
+
         private const val PREFS_NAME = "update_check_prefs"
         private const val KEY_LAST_NOTIFIED_VERSION = "last_notified_version"
         private const val RELEASES_URL =
@@ -56,6 +82,10 @@ class UpdateCheckWorker(
 
         /** Lenient JSON parser that ignores unknown keys from the GitHub API. */
         private val json = Json { ignoreUnknownKeys = true }
+
+        /** The outcome a completed check reports when the remote [isNewer]. */
+        internal fun outcomeFor(isNewer: Boolean): String =
+            if (isNewer) OUTCOME_UPDATE_AVAILABLE else OUTCOME_UP_TO_DATE
 
         /**
          * Enqueues a periodic update-check job that runs every 24 hours.
@@ -86,12 +116,27 @@ class UpdateCheckWorker(
          * [ExistingWorkPolicy.REPLACE] ensures a stale queued check doesn't
          * starve a fresh request; multiple rapid calls collapse to one.
          */
-        fun enqueueOneTimeCheck(context: Context) {
-            val constraints = Constraints.Builder()
-                .setRequiredNetworkType(NetworkType.CONNECTED)
-                .build()
+        fun enqueueOneTimeCheck(context: Context, manual: Boolean = false) {
             val request = OneTimeWorkRequestBuilder<UpdateCheckWorker>()
-                .setConstraints(constraints)
+                // A manual check runs UNCONSTRAINED on purpose. With
+                // NetworkType.CONNECTED an offline tap leaves the work ENQUEUED
+                // forever — the worker never starts, never reaches the manual
+                // failure path, and the button that's waiting on a finished
+                // WorkInfo stays stuck on "Checking…". Someone who asked has a
+                // right to a fast "couldn't check", so let the request run and
+                // let the HTTP call fail. Background checks keep the constraint:
+                // nobody is waiting, and deferring until there's a network is
+                // exactly right for them.
+                .apply {
+                    if (!manual) {
+                        setConstraints(
+                            Constraints.Builder()
+                                .setRequiredNetworkType(NetworkType.CONNECTED)
+                                .build(),
+                        )
+                    }
+                }
+                .setInputData(workDataOf(KEY_MANUAL to manual))
                 .build()
             WorkManager.getInstance(context).enqueueUniqueWork(
                 UNIQUE_ONE_SHOT_NAME,
@@ -111,7 +156,10 @@ class UpdateCheckWorker(
          */
         internal fun isNewerVersion(remote: String, local: String): Boolean {
             val clean = { v: String ->
-                v.removePrefix("v")
+                // Case-insensitive: an uppercase "V" used to survive the strip,
+                // so "V1.0.0" parsed as [0,0,0] and every remote tag looked
+                // newer than it.
+                v.removePrefix("v").removePrefix("V")
                     .replace(Regex("-.*"), "") // strip -beta, -rc.1, etc.
                     .split(".")
                     .map { it.toIntOrNull() ?: 0 }
@@ -132,8 +180,15 @@ class UpdateCheckWorker(
     }
 
     override suspend fun doWork(): Result {
+        val manual = inputData.getBoolean(KEY_MANUAL, false)
         return try {
-            val installedVersion = getInstalledVersion() ?: return Result.success()
+            // An unreadable package manager won't fix itself on a retry, so the
+            // background path still gives up quietly; a manual check says so.
+            val installedVersion = getInstalledVersion() ?: return if (manual) {
+                Result.failure(workDataOf(KEY_OUTCOME to OUTCOME_FAILED))
+            } else {
+                Result.success()
+            }
             val client = OkHttpClient()
             val request = Request.Builder()
                 .url(RELEASES_URL)
@@ -144,25 +199,32 @@ class UpdateCheckWorker(
             val response = client.newCall(request).execute()
             if (!response.isSuccessful) {
                 Log.w(TAG, "GitHub API returned ${response.code}")
-                return Result.retry()
+                return giveUpOrRetry(manual)
             }
 
-            val body = response.body?.string() ?: return Result.retry()
+            val body = response.body?.string() ?: return giveUpOrRetry(manual)
             val root = json.parseToJsonElement(body).jsonObject
-            val tagName = root["tag_name"]?.jsonPrimitive?.content ?: return Result.success()
+            val tagName = root["tag_name"]?.jsonPrimitive?.content
+                ?: return giveUpOrRetry(manual)
             val releaseName = root["name"]?.jsonPrimitive?.content ?: tagName
 
-            if (!isNewerVersion(tagName, installedVersion)) {
+            val outcome = outcomeFor(isNewerVersion(tagName, installedVersion))
+            val outcomeData = workDataOf(KEY_OUTCOME to outcome, KEY_LATEST_TAG to tagName)
+
+            if (outcome == OUTCOME_UP_TO_DATE) {
                 Log.d(TAG, "Already on latest ($installedVersion), remote is $tagName")
-                return Result.success()
+                return Result.success(outcomeData)
             }
 
             // Check if we already notified for this exact version.
             val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             val lastNotified = prefs.getString(KEY_LAST_NOTIFIED_VERSION, null)
             if (lastNotified == tagName) {
-                Log.d(TAG, "Already notified for $tagName, skipping")
-                return Result.success()
+                // Suppresses a DUPLICATE NOTIFICATION, never the answer: a user
+                // who dismissed the notice once and then asks again still gets
+                // told an update exists (#377).
+                Log.d(TAG, "Already notified for $tagName, skipping notification")
+                return Result.success(outcomeData)
             }
 
             val notified = showUpdateNotification(tagName, releaseName)
@@ -177,14 +239,29 @@ class UpdateCheckWorker(
                 Log.w(TAG, "notify() suppressed for $tagName; will retry on next run")
             }
 
-            Result.success()
+            Result.success(outcomeData)
         } catch (e: Exception) {
             // Don't turn a cancelled worker into a retry — rethrow the CE.
             if (e is kotlinx.coroutines.CancellationException) throw e
             Log.e(TAG, "Update check failed", e)
-            Result.retry()
+            giveUpOrRetry(manual)
         }
     }
+
+    /**
+     * A failed check's terminal state.
+     *
+     * A background check retries — it has no one waiting. A MANUAL check must
+     * fail loudly instead: `Result.retry()` leaves the work RUNNING/ENQUEUED
+     * forever from an observer's point of view, which is the silence #377
+     * reported. [Result.failure] is terminal, so the UI can say so.
+     */
+    private fun giveUpOrRetry(manual: Boolean): Result =
+        if (manual) {
+            Result.failure(workDataOf(KEY_OUTCOME to OUTCOME_FAILED))
+        } else {
+            Result.retry()
+        }
 
     /**
      * Reads the installed app version from the package manager.

--- a/core/data/src/test/kotlin/com/stash/core/data/sync/workers/UpdateCheckWorkerTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/sync/workers/UpdateCheckWorkerTest.kt
@@ -1,0 +1,73 @@
+package com.stash.core.data.sync.workers
+
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.data.sync.workers.UpdateCheckWorker.Companion.OUTCOME_UPDATE_AVAILABLE
+import com.stash.core.data.sync.workers.UpdateCheckWorker.Companion.OUTCOME_UP_TO_DATE
+import com.stash.core.data.sync.workers.UpdateCheckWorker.Companion.isNewerVersion
+import com.stash.core.data.sync.workers.UpdateCheckWorker.Companion.outcomeFor
+import org.junit.Test
+
+/**
+ * Contract tests for the update check's two pure decisions.
+ *
+ * Issue #377: three users on the latest release tapped "Check for updates",
+ * saw "Checking for updates…" and then nothing. Every no-update exit returned
+ * `Result.success()` with no output, so the UI had nothing to report — the
+ * check worked and stayed invisible. Each terminal path now names its outcome.
+ */
+class UpdateCheckWorkerTest {
+
+    // ── Outcome reporting: no terminal state may be silent ───────────────────
+
+    @Test fun `up to date is reported, not swallowed`() {
+        assertThat(outcomeFor(isNewer = false)).isEqualTo(OUTCOME_UP_TO_DATE)
+    }
+
+    @Test fun `a newer release is reported`() {
+        assertThat(outcomeFor(isNewer = true)).isEqualTo(OUTCOME_UPDATE_AVAILABLE)
+    }
+
+    /** The two outcomes must be distinguishable — that IS the fix. */
+    @Test fun `outcomes are distinct`() {
+        assertThat(OUTCOME_UP_TO_DATE).isNotEqualTo(OUTCOME_UPDATE_AVAILABLE)
+    }
+
+    // ── Version comparison ───────────────────────────────────────────────────
+
+    @Test fun `newer patch wins`() {
+        assertThat(isNewerVersion("v0.9.99", "0.9.84")).isTrue()
+    }
+
+    @Test fun `same version is not newer`() {
+        assertThat(isNewerVersion("v0.9.99", "0.9.99")).isFalse()
+    }
+
+    @Test fun `older remote is not newer`() {
+        assertThat(isNewerVersion("v0.9.84", "0.9.99")).isFalse()
+    }
+
+    /** Segments compare as integers, so 10 beats 2 despite sorting lower as text. */
+    @Test fun `segments compare numerically`() {
+        assertThat(isNewerVersion("v0.10.0", "0.2.0")).isTrue()
+        assertThat(isNewerVersion("v0.9.9", "0.9.84")).isFalse()
+    }
+
+    @Test fun `prerelease suffix is stripped`() {
+        assertThat(isNewerVersion("v1.0.0-beta.2", "1.0.0")).isFalse()
+        assertThat(isNewerVersion("v1.0.1-rc.1", "1.0.0")).isTrue()
+    }
+
+    @Test fun `missing components count as zero`() {
+        assertThat(isNewerVersion("v1.1", "1.0.9")).isTrue()
+        assertThat(isNewerVersion("v1.0", "1.0.0")).isFalse()
+    }
+
+    /**
+     * An UPPERCASE "V" used to survive the prefix strip, so "V1.0.0" parsed as
+     * [0, 0, 0] and any remote tag looked newer than it.
+     */
+    @Test fun `uppercase V prefix is stripped too`() {
+        assertThat(isNewerVersion("v0.9.99", "V1.0.0")).isFalse()
+        assertThat(isNewerVersion("V0.9.99", "0.9.84")).isTrue()
+    }
+}

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAboutScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsAboutScreen.kt
@@ -12,12 +12,15 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.work.WorkManager
 import com.stash.core.data.sync.workers.UpdateCheckWorker
 import com.stash.core.ui.components.GlassCard
 import com.stash.feature.settings.components.SettingsScaffold
@@ -135,6 +138,34 @@ fun SettingsAboutScreen(
             }.getOrNull() ?: "0.3.5-beta.1"
         }
 
+        // The check runs in a worker, so the tap alone can't report anything.
+        // Every no-update path used to return a bare success and the user was
+        // left with "Checking for updates…" and silence (#377) — so watch the
+        // work and say what it concluded.
+        var checking by remember { mutableStateOf(false) }
+        LaunchedEffect(context) {
+            WorkManager.getInstance(context)
+                .getWorkInfosForUniqueWorkFlow(UpdateCheckWorker.UNIQUE_ONE_SHOT_NAME)
+                .collect { infos ->
+                    val info = infos.lastOrNull() ?: return@collect
+                    if (!info.state.isFinished) return@collect
+                    // Only speak for a check this screen started. A cold-start
+                    // check finishing in the background must stay quiet.
+                    if (!checking) return@collect
+                    checking = false
+                    val outcome = info.outputData.getString(UpdateCheckWorker.KEY_OUTCOME)
+                    val tag = info.outputData.getString(UpdateCheckWorker.KEY_LATEST_TAG)
+                    val message = when (outcome) {
+                        UpdateCheckWorker.OUTCOME_UP_TO_DATE ->
+                            "You're on the latest version ($installedVersion)"
+                        UpdateCheckWorker.OUTCOME_UPDATE_AVAILABLE ->
+                            "Update available: ${tag ?: "see Releases"}"
+                        else -> "Couldn't check for updates — try again later"
+                    }
+                    Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+                }
+        }
+
         GlassCard {
             Column(modifier = Modifier.fillMaxWidth()) {
                 SettingsValueRow(label = "Version", value = installedVersion)
@@ -143,15 +174,17 @@ fun SettingsAboutScreen(
                 Spacer(modifier = Modifier.height(12.dp))
                 OutlinedButton(
                     onClick = {
-                        UpdateCheckWorker.enqueueOneTimeCheck(context)
+                        checking = true
+                        UpdateCheckWorker.enqueueOneTimeCheck(context, manual = true)
                         Toast.makeText(context, "Checking for updates…", Toast.LENGTH_SHORT).show()
                     },
+                    enabled = !checking,
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.outlinedButtonColors(
                         contentColor = MaterialTheme.colorScheme.primary,
                     ),
                 ) {
-                    Text("Check for updates")
+                    Text(if (checking) "Checking…" else "Check for updates")
                 }
             }
         }


### PR DESCRIPTION
Fixes #377.

## Root cause

"Check for updates" enqueued `UpdateCheckWorker`, toasted "Checking for updates…", and then never spoke again. Every no-update exit returned a bare `Result.success()`, so there was nothing for the UI to observe — the check ran fine and stayed invisible. The three reporters were all **on the latest release**, which is exactly the branch that hits `Result.success()` with only a `Log.d`.

## Fix

Each terminal path names its outcome in `outputData`, and the About screen watches the one-shot unique work and reports what it concluded: on the latest version, an update with its tag, or a failure.

Two more bugs fall out of the same change:

- **"Already notified for this tag" suppressed the answer, not just the duplicate notification.** Someone who dismissed the notice once and asked again got nothing back, even though an update existed. It now suppresses only the notification.

- **A manual check runs unconstrained.** With `NetworkType.CONNECTED`, an offline tap left the work ENQUEUED forever — never started, never terminal — so a UI waiting on a finished `WorkInfo` would wait for good. Someone who asked gets a fast "couldn't check"; background checks keep the constraint, because deferring until there's a network is right when nobody is waiting. (Caught by review before this shipped.)

Also strips an uppercase `V` in `isNewerVersion`: only lowercase was removed, so `V1.0.0` parsed as `[0, 0, 0]` and any remote tag looked newer than it.

## Verification

`UpdateCheckWorkerTest` — outcome mapping, and `isNewerVersion` across numeric-vs-text ordering (`0.10.0` > `0.2.0`, `0.9.9` < `0.9.84`), prerelease suffixes, missing components, and both `v`/`V` prefixes. This function had no tests before.

On-device, Samsung Galaxy Tab Active3 (SM-T570, Android 13), app at **0.9.99** — the reporters' exact state:

- **Online:** tap → `UpdateCheckWorker: Already on latest (0.9.99), remote is v0.9.99` → toast **"You're on the latest version (0.9.99)"**. Before this change that path produced the log line and nothing else.
- **Offline** (Wi-Fi and data off): tap → `UpdateCheckWorker: Update check failed` → toast **"Couldn't check for updates — try again later"**, and the button returns to its enabled state rather than sticking on "Checking…".