### PR TITLE
feat(backup): choose what an Import Backup restores (#235)

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
@@ -580,9 +580,24 @@ class DatabaseBackupManager @Inject constructor(
                         continue
                     }
 
-                    // id = 0 → fresh autoincrement PK; every other column —
-                    // including like timestamps and play stats — travels as-is.
-                    val newId = trackDao.insert(track.copy(id = 0))
+                    // id = 0 → fresh autoincrement PK. Like timestamps, play
+                    // stats and match metadata all travel as-is; the LOCAL
+                    // FILE columns must not. A backup ZIP carries no audio,
+                    // and merge deliberately skips the restart that would run
+                    // the disk-truth sweep, so an inherited is_downloaded
+                    // would leave rows pointing playback, storage totals and
+                    // the library-move flow at files that aren't there.
+                    // Landing as not-downloaded is the recoverable direction:
+                    // if the audio IS present, adoption re-claims it on the
+                    // next reconcile.
+                    val newId = trackDao.insert(
+                        track.copy(
+                            id = 0,
+                            isDownloaded = false,
+                            filePath = null,
+                            fileSizeBytes = 0,
+                        )
+                    )
                     track.spotifyUri?.let { liveBySpotifyUri.putIfAbsent(it, newId) }
                     track.youtubeId?.let { liveByYoutubeId.putIfAbsent(it, newId) }
                     if (hasCanonicalIdentity(track.canonicalTitle, track.canonicalArtist)) {

--- a/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
@@ -2,13 +2,18 @@ package com.stash.core.data.db
 
 import android.content.Context
 import android.net.Uri
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.withTransaction
 import androidx.sqlite.db.SimpleSQLiteQuery
+import com.stash.core.data.db.entity.PlaylistTrackCrossRef
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.io.FileInputStream
+import java.time.Instant
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
@@ -30,12 +35,97 @@ import kotlinx.serialization.json.Json
 private val SQLITE_MAGIC: ByteArray = "SQLite format 3".toByteArray(Charsets.US_ASCII) + 0
 
 /**
+ * What the user chose to restore from a backup ZIP (issue #235). The classic
+ * full overwrite is [EVERYTHING_REPLACE]; the three new scopes exist so users
+ * can take just their library or just their settings from a backup, and so a
+ * library restore can MERGE instead of replace.
+ *
+ * @property consumesLibraryDatabase  True when the import stages and reads
+ *   the backup's `stash.db` (either to swap it in or to copy rows out of it).
+ * @property swapsDatabaseFile        True when the live database FILE is
+ *   replaced — implies [consumesLibraryDatabase]. Merge never swaps; it
+ *   writes through the still-open live Room instance instead.
+ * @property restoresSettingsFiles    True when DataStore files are restored.
+ */
+enum class BackupImportScope(
+    val consumesLibraryDatabase: Boolean,
+    val swapsDatabaseFile: Boolean,
+    val restoresSettingsFiles: Boolean,
+) {
+    /**
+     * Adds the backup's missing songs/playlists/memberships INTO the current
+     * library. Nothing is deleted, nothing is overwritten, settings files are
+     * untouched, and — because the live Room instance stays open — NO restart
+     * is required.
+     */
+    LIBRARY_MERGE(
+        consumesLibraryDatabase = true,
+        swapsDatabaseFile = false,
+        restoresSettingsFiles = false,
+    ),
+
+    /** Swaps in the backup's database but keeps the current settings. */
+    LIBRARY_REPLACE(
+        consumesLibraryDatabase = true,
+        swapsDatabaseFile = true,
+        restoresSettingsFiles = false,
+    ),
+
+    /** Restores settings/preferences but keeps the current library. */
+    SETTINGS_REPLACE(
+        consumesLibraryDatabase = false,
+        swapsDatabaseFile = false,
+        restoresSettingsFiles = true,
+    ),
+
+    /** The historical behavior: replace both the database and the settings. */
+    EVERYTHING_REPLACE(
+        consumesLibraryDatabase = true,
+        swapsDatabaseFile = true,
+        restoresSettingsFiles = true,
+    ),
+}
+
+/**
+ * Outcome of a successful [DatabaseBackupManager.importDatabase].
+ *
+ * @property restoredTreeUri  External storage tree URI found in restored
+ *   preferences, when the scope restored settings files and one was present.
+ *   Null otherwise (including for library-only scopes — settings were never
+ *   touched, so there is nothing to re-grant).
+ * @property requiresRestart  True when files behind live singletons (Room /
+ *   DataStore) were swapped and the process must be killed to reload them.
+ *   False for [BackupImportScope.LIBRARY_MERGE], which writes through the
+ *   still-open live database.
+ * @property addedTracks      New track rows inserted (merge scope only).
+ * @property addedPlaylists   New playlist rows inserted (merge scope only).
+ * @property mergedMemberships Playlist memberships appended/reactivated
+ *   (merge scope only).
+ */
+data class BackupImportResult(
+    val restoredTreeUri: Uri?,
+    val requiresRestart: Boolean,
+    val addedTracks: Int = 0,
+    val addedPlaylists: Int = 0,
+    val mergedMemberships: Int = 0,
+)
+
+/** Internal tally of what one merge pass inserted. */
+private data class MergeCounts(
+    val addedTracks: Int,
+    val addedPlaylists: Int,
+    val mergedMemberships: Int,
+)
+
+/**
  * Handles exporting and importing the internal Room database, DataStore settings,
  * and encrypted tokens. Bundles everything into a single ZIP archive.
  *
  * Exporting uses a checkpoint-then-zip approach to ensure WAL-mode
- * consistency. Importing replaces the database and preferences files on disk
- * and requires an app restart to take effect.
+ * consistency. Importing replaces the database and/or preferences files on disk
+ * (per [BackupImportScope]) and normally requires an app restart to take
+ * effect — except the library-MERGE scope, which copies rows into the live
+ * database transactionally and needs no restart.
  */
 @Singleton
 class DatabaseBackupManager @Inject constructor(
@@ -174,12 +264,30 @@ class DatabaseBackupManager @Inject constructor(
     }
 
     /**
-     * Imports a ZIP backup from [sourceUri], replacing the current DB and settings.
-     * Returns the restored external storage URI if found in the preferences.
+     * Imports a ZIP backup from [sourceUri], honoring the chosen [scope]:
+     *
+     *  - [BackupImportScope.EVERYTHING_REPLACE] — the historical behavior;
+     *    replaces the current DB AND settings files. Restart required.
+     *  - [BackupImportScope.LIBRARY_REPLACE] — swaps only the DB file, keeping
+     *    the current settings. Restart required.
+     *  - [BackupImportScope.SETTINGS_REPLACE] — swaps only the DataStore
+     *    files, keeping the current library. Restart required.
+     *  - [BackupImportScope.LIBRARY_MERGE] — adds the backup's missing tracks,
+     *    playlists, and playlist memberships into the CURRENT library without
+     *    deleting or overwriting anything (issue #235). Settings untouched.
+     *    No restart: the merge writes through the still-open live Room
+     *    instance inside one atomic transaction.
+     *
+     * Returns a [BackupImportResult]; for scopes that restore settings files
+     * this includes the restored external-storage tree URI if one was found in
+     * the preferences (so callers can re-grant SAF permission before restart).
      */
-    suspend fun importDatabase(sourceUri: Uri): Result<Uri?> = withContext(Dispatchers.IO) {
+    suspend fun importDatabase(
+        sourceUri: Uri,
+        scope: BackupImportScope = BackupImportScope.EVERYTHING_REPLACE,
+    ): Result<BackupImportResult> = withContext(Dispatchers.IO) {
         runCatching {
-            android.util.Log.i("BackupManager", "Starting import from $sourceUri")
+            android.util.Log.i("BackupManager", "Starting $scope import from $sourceUri")
 
             val currentDbVersion = database.openHelper.readableDatabase.version
             val dbFile = context.getDatabasePath(StashDatabase.DATABASE_NAME)
@@ -210,15 +318,15 @@ class DatabaseBackupManager @Inject constructor(
                 }
             } ?: throw IllegalStateException("Could not open input stream for validation")
 
+            // 2. Extract ONLY the entries this scope consumes to STAGING temp
+            //    files first — never write over live files straight from the
+            //    zip stream. The manifest sits early in the archive, so a
+            //    truncated/corrupt backup validates fine (step 1) and only
+            //    fails partway through the copy; writing directly would
+            //    half-overwrite stash.db and then the old WAL is deleted
+            //    below, destroying the user's only library with no rollback.
             val walFile = File(dbFile.path + "-wal")
             val shmFile = File(dbFile.path + "-shm")
-
-            // 2. Extract everything to STAGING temp files first — never write
-            // over the live database straight from the zip stream. The manifest
-            // sits early in the archive, so a truncated/corrupt backup validates
-            // fine (step 1) and only fails partway through the copy; writing
-            // directly would half-overwrite stash.db and then the old WAL is
-            // deleted below, destroying the user's only library with no rollback.
             val stagedDb = File(dbFile.parentFile, StashDatabase.DATABASE_NAME + ".import-tmp")
             stagedDb.delete()
             val stagedDatastore = mutableListOf<Pair<File, File>>() // tmp -> final
@@ -233,8 +341,8 @@ class DatabaseBackupManager @Inject constructor(
                         }
 
                         val target: File? = when {
-                            entry.name == "stash.db" -> stagedDb
-                            entry.name.startsWith("datastore/") -> {
+                            entry.name == "stash.db" && scope.consumesLibraryDatabase -> stagedDb
+                            entry.name.startsWith("datastore/") && scope.restoresSettingsFiles -> {
                                 val relativeName = entry.name.substringAfter("datastore/")
                                 if (relativeName.isBlank() || File(relativeName).isAbsolute) {
                                     throw SecurityException("Invalid datastore entry path: ${entry.name}")
@@ -267,65 +375,324 @@ class DatabaseBackupManager @Inject constructor(
             } ?: throw IllegalStateException("Could not open input stream for URI: $sourceUri")
 
             // 3. Verify the staged database opens and passes integrity_check
-            // BEFORE we touch the live one. If it doesn't, bail — the live
-            // library is completely untouched.
-            try {
-                if (!stagedDb.exists()) {
-                    throw IllegalStateException("The selected backup contains no database.")
+            //    BEFORE we touch anything live. Every scope that reads the
+            //    backup DB — swap AND merge — goes through this gate; if it
+            //    doesn't pass, bail and the live library is untouched.
+            //    Scopes that don't consume the DB simply skip it (a
+            //    settings-only import from a standard full backup is
+            //    legitimate).
+            if (scope.consumesLibraryDatabase) {
+                try {
+                    if (!stagedDb.exists()) {
+                        throw IllegalStateException("The selected backup contains no database.")
+                    }
+                    verifyDatabaseIntegrity(stagedDb)
+                } catch (e: Exception) {
+                    cleanupStaging(stagedDb, stagedDatastore)
+                    throw e
                 }
-                verifyDatabaseIntegrity(stagedDb)
-            } catch (e: Exception) {
-                cleanupStaging(stagedDb, stagedDatastore)
-                throw e
             }
 
-            // 4. Commit. Close the live DB, keep a rollback copy, then swap the
-            // verified staged files into place. A failure mid-swap restores the
+            // 4. Commit.
+            if (scope == BackupImportScope.LIBRARY_MERGE) {
+                // Merge path: copy rows into the LIVE database. No file is
+                // swapped, the singleton Room instance stays open, flows emit
+                // the new data immediately, and NO restart is needed.
+                try {
+                    val counts = mergeLibraryFrom(stagedDb)
+                    android.util.Log.i(
+                        "BackupManager",
+                        "Merge completed: +${counts.addedTracks} tracks, " +
+                            "+${counts.addedPlaylists} playlists, " +
+                            "${counts.mergedMemberships} memberships",
+                    )
+                    cleanupStaging(stagedDb, stagedDatastore)
+                    return@runCatching BackupImportResult(
+                        restoredTreeUri = null,
+                        requiresRestart = false,
+                        addedTracks = counts.addedTracks,
+                        addedPlaylists = counts.addedPlaylists,
+                        mergedMemberships = counts.mergedMemberships,
+                    )
+                } catch (e: Exception) {
+                    // The merge itself is one transaction — on any failure it
+                    // rolled back internally, leaving the live library intact.
+                    cleanupStaging(stagedDb, stagedDatastore)
+                    throw e
+                }
+            }
+
+            // File-swap path. Close the live DB (only being swapped when the
+            // scope includes it), keep a rollback copy, then swap the verified
+            // staged files into place. A failure mid-swap restores the
             // pre-import database, so a restore can never lose data.
-            database.close()
+            if (scope.swapsDatabaseFile) database.close()
             val rollback = File(dbFile.path + ".rollback")
-            if (dbFile.exists()) dbFile.copyTo(rollback, overwrite = true) else rollback.delete()
+            if (scope.swapsDatabaseFile) {
+                if (dbFile.exists()) dbFile.copyTo(rollback, overwrite = true) else rollback.delete()
+            }
             try {
-                moveInto(stagedDb, dbFile)
-                // Drop the old WAL/SHM so they don't conflict with the new DB.
-                if (walFile.exists()) walFile.delete()
-                if (shmFile.exists()) shmFile.delete()
-                stagedDatastore.forEach { (tmp, finalFile) ->
-                    finalFile.parentFile?.mkdirs()
-                    moveInto(tmp, finalFile)
+                if (scope.swapsDatabaseFile) {
+                    moveInto(stagedDb, dbFile)
+                    // Drop the old WAL/SHM so they don't conflict with the new DB.
+                    if (walFile.exists()) walFile.delete()
+                    if (shmFile.exists()) shmFile.delete()
+                }
+                if (scope.restoresSettingsFiles) {
+                    stagedDatastore.forEach { (tmp, finalFile) ->
+                        finalFile.parentFile?.mkdirs()
+                        moveInto(tmp, finalFile)
+                    }
                 }
                 rollback.delete()
             } catch (e: Exception) {
                 android.util.Log.e("BackupManager", "Restore swap failed — rolling back", e)
-                if (rollback.exists()) rollback.copyTo(dbFile, overwrite = true)
+                if (scope.swapsDatabaseFile && rollback.exists()) rollback.copyTo(dbFile, overwrite = true)
                 cleanupStaging(stagedDb, stagedDatastore)
                 throw e
             }
 
-            // 4. Read the restored Tree URI from DataStore.
-            // We use a fresh DataStore instance to bypass the singleton's cache
-            // and read the actual protobuf-serialized state we just restored.
-            val externalTreeUriKey = stringPreferencesKey("external_tree_uri")
-            val restoredTreeUri = try {
-                val restoredFile = File(datastoreDir, "storage_preferences.preferences_pb")
-                if (restoredFile.exists()) {
-                    // Create a temporary copy to avoid "multiple datastores" error on the main file
-                    val tmpFile = File(context.cacheDir, "restored_prefs_peek.preferences_pb")
-                    restoredFile.copyTo(tmpFile, overwrite = true)
-                    
-                    val uri = PreferenceDataStoreFactory.create { tmpFile }
-                        .data.firstOrNull()?.get(externalTreeUriKey)?.toUri()
-                    
-                    tmpFile.delete()
-                    uri
-                } else null
-            } catch (e: Exception) {
-                android.util.Log.e("BackupManager", "Failed to peek restored URI", e)
-                null
-            }
+            // 5. Read the restored Tree URI from DataStore — only meaningful
+            //    when this scope actually restored settings files. We use a
+            //    fresh DataStore instance to bypass the singleton's cache and
+            //    read the actual protobuf-serialized state we just restored.
+            val restoredTreeUri = if (scope.restoresSettingsFiles) {
+                peekRestoredTreeUri(datastoreDir)
+            } else null
 
             android.util.Log.i("BackupManager", "Import completed successfully. Restored URI: $restoredTreeUri")
-            restoredTreeUri
+            BackupImportResult(
+                restoredTreeUri = restoredTreeUri,
+                requiresRestart = true,
+            )
         }
     }
+
+    /**
+     * Peeks `external_tree_uri` out of a freshly-restored
+     * `storage_preferences.preferences_pb`, bypassing the cached DataStore
+     * singleton by reading a throwaway copy in cacheDir.
+     */
+    private suspend fun peekRestoredTreeUri(datastoreDir: File): Uri? = try {
+        val restoredFile = File(datastoreDir, "storage_preferences.preferences_pb")
+        if (restoredFile.exists()) {
+            // Create a temporary copy to avoid "multiple datastores" error on the main file
+            val tmpFile = File(context.cacheDir, "restored_prefs_peek.preferences_pb")
+            restoredFile.copyTo(tmpFile, overwrite = true)
+
+            val uri = PreferenceDataStoreFactory.create { tmpFile }
+                .data.firstOrNull()?.get(stringPreferencesKey("external_tree_uri"))?.toUri()
+
+            tmpFile.delete()
+            uri
+        } else null
+    } catch (e: Exception) {
+        android.util.Log.e("BackupManager", "Failed to peek restored URI", e)
+        null
+    }
+
+    /**
+     * The library-merge engine (issue #235): opens the staged backup with a
+     * THROWAWAY Room instance sharing the production migration chain
+     * ([StashDatabase.ALL_MIGRATIONS]), rolling an older-schema backup forward
+     * to the live schema, then copies its rows into the live database inside
+     * ONE transaction:
+     *
+     *  1. **Tracks** are matched by identity — Spotify URI first, then YouTube
+     *     id, then canonical (title, artist), mirroring
+     *     TrackDao.findByAnyIdentity's priority — and only MISSING rows are
+     *     inserted. An existing song is never modified or duplicated.
+     *  2. **Playlists** are matched by `source_id` (unique index). Existing
+     *     playlists keep ALL their current metadata; only genuinely new
+     *     playlists are inserted. Imported-new playlists arrive with sync OFF
+     *     so a restore can never silently opt the user into mass downloads.
+     *  3. **Memberships** are UNIONED: each backup membership whose track and
+     *     playlist resolve to the live library is appended (in backup order)
+     *     unless that track is already an active member. Soft-deleted
+     *     memberships are reactivated — the backup's content is being added,
+     *     which is exactly the requested semantics. All imported memberships
+     *     are marked `locally_added` so REFRESH-mode syncs won't wipe them,
+     *     and cached `track_count`s of touched playlists are recomputed.
+     *
+     * Any exception anywhere rolls the entire transaction back, leaving the
+     * live library byte-for-byte untouched.
+     */
+    private suspend fun mergeLibraryFrom(stagedDb: File): MergeCounts {
+        if (!stagedDb.exists()) {
+            throw IllegalStateException("The selected backup contains no database.")
+        }
+        val backupDb = Room.databaseBuilder(
+            context, StashDatabase::class.java, stagedDb.absolutePath,
+        )
+            .addMigrations(*StashDatabase.ALL_MIGRATIONS)
+            // TRUNCATE, not the WAL default: this is a throwaway single-
+            // connection copy read once and closed — WAL's sidecar files
+            // (-wal/-shm) buy nothing next to a `.import-tmp` staging name,
+            // and Robolectric's legacy SQLite chokes on WAL for file-backed
+            // databases, which keeps the import path unit-testable.
+            .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
+            .build()
+        try {
+            // Touching the helper forces Room to run the full migration chain
+            // on the staged file and validate the result — a backup that
+            // cannot be rolled forward fails HERE, before anything is copied.
+            backupDb.openHelper.writableDatabase
+
+            val backupTracks = backupDb.trackDao().getAllForIntegrityScan()
+            val backupPlaylists = backupDb.playlistDao().getAllForBackupMerge()
+            val backupRefs = backupDb.playlistDao().getAllCrossRefsForBackupMerge()
+
+            var addedTracks = 0
+            var addedPlaylists = 0
+            var mergedMemberships = 0
+
+            database.withTransaction {
+                val trackDao = database.trackDao()
+                val playlistDao = database.playlistDao()
+
+                // ── 1. Tracks ────────────────────────────────────────────
+                // Identity indexes over the live library, built once so N
+                // backup tracks cost zero extra queries. First row wins on
+                // canonical collisions (uri/yt are unique-indexed anyway).
+                val liveBySpotifyUri = HashMap<String, Long>()
+                val liveByYoutubeId = HashMap<String, Long>()
+                val liveByCanonical = HashMap<String, Long>()
+                for (t in trackDao.getAllForIntegrityScan()) {
+                    t.spotifyUri?.let { liveBySpotifyUri.putIfAbsent(it, t.id) }
+                    t.youtubeId?.let { liveByYoutubeId.putIfAbsent(it, t.id) }
+                    if (hasCanonicalIdentity(t.canonicalTitle, t.canonicalArtist)) {
+                        liveByCanonical.putIfAbsent(
+                            canonicalKey(t.canonicalTitle, t.canonicalArtist), t.id,
+                        )
+                    }
+                }
+
+                /** Backup track id → live track id (inserted or matched). */
+                val trackIdMap = HashMap<Long, Long>(backupTracks.size)
+                for (track in backupTracks.sortedBy { it.id }) {
+                    val existing = track.spotifyUri?.let { liveBySpotifyUri[it] }
+                        ?: track.youtubeId?.let { liveByYoutubeId[it] }
+                        ?: if (hasCanonicalIdentity(track.canonicalTitle, track.canonicalArtist)) {
+                            liveByCanonical[canonicalKey(track.canonicalTitle, track.canonicalArtist)]
+                        } else null
+                    if (existing != null) {
+                        trackIdMap[track.id] = existing
+                        continue
+                    }
+
+                    // id = 0 → fresh autoincrement PK; every other column —
+                    // including like timestamps and play stats — travels as-is.
+                    val newId = trackDao.insert(track.copy(id = 0))
+                    track.spotifyUri?.let { liveBySpotifyUri.putIfAbsent(it, newId) }
+                    track.youtubeId?.let { liveByYoutubeId.putIfAbsent(it, newId) }
+                    if (hasCanonicalIdentity(track.canonicalTitle, track.canonicalArtist)) {
+                        liveByCanonical.putIfAbsent(
+                            canonicalKey(track.canonicalTitle, track.canonicalArtist), newId,
+                        )
+                    }
+                    trackIdMap[track.id] = newId
+                    addedTracks++
+                }
+
+                // ── 2. Playlists ─────────────────────────────────────────
+                val liveBySourceId = HashMap<String, Long>()
+                for (p in playlistDao.getAllForBackupMerge()) {
+                    liveBySourceId.putIfAbsent(p.sourceId, p.id)
+                }
+
+                /** Backup playlist id → live playlist id. */
+                val playlistIdMap = HashMap<Long, Long>(backupPlaylists.size)
+                for (playlist in backupPlaylists.sortedBy { it.id }) {
+                    val existingId = liveBySourceId[playlist.sourceId]
+                    if (existingId != null) {
+                        // Exists here already — keep the live metadata
+                        // (name, art, pinning, activation…) exactly as-is.
+                        playlistIdMap[playlist.id] = existingId
+                        continue
+                    }
+
+                    val newId = playlistDao.insert(
+                        playlist.copy(
+                            id = 0,
+                            // Never inherit download consent from a backup —
+                            // see PlaylistEntity.syncEnabled's KDoc.
+                            syncEnabled = false,
+                            dateAdded = if (playlist.dateAdded.toEpochMilli() > 0) {
+                                playlist.dateAdded
+                            } else Instant.now(),
+                        )
+                    )
+                    liveBySourceId.putIfAbsent(playlist.sourceId, newId)
+                    playlistIdMap[playlist.id] = newId
+                    addedPlaylists++
+                }
+
+                // ── 3. Memberships (union) ───────────────────────────────
+                val targetIds = playlistIdMap.values.distinct()
+                val nextPosition = HashMap<Long, Int>(targetIds.size * 2)
+                val refByKey = HashMap<Pair<Long, Long>, PlaylistTrackCrossRef>()
+                targetIds.chunkedForBind { ids ->
+                    playlistDao.getCrossRefsForPlaylists(ids)
+                }.forEach { ref ->
+                    refByKey[ref.playlistId to ref.trackId] = ref
+                    if (ref.removedAt == null) {
+                        nextPosition.merge(ref.playlistId, ref.position + 1, ::maxOf)
+                    }
+                }
+
+                val touchedPlaylists = sortedSetOf<Long>()
+                for ((backupPlaylistId, refs) in backupRefs.groupBy { it.playlistId }) {
+                    val livePlaylistId = playlistIdMap[backupPlaylistId] ?: continue
+                    for (ref in refs.sortedBy { it.position }) {
+                        val liveTrackId = trackIdMap[ref.trackId] ?: continue
+                        val key = livePlaylistId to liveTrackId
+                        val existing = refByKey[key]
+                        if (existing != null && existing.removedAt == null) {
+                            continue // already an active member — leave it alone
+                        }
+
+                        // Append (or reactivate) at the end of the live
+                        // ordering, preserving the backup's addedAt stamp.
+                        val position = nextPosition.getOrDefault(livePlaylistId, 0)
+                            .also { nextPosition[livePlaylistId] = it + 1 }
+                        playlistDao.insertCrossRef(
+                            existing?.copy(
+                                removedAt = null,
+                                position = position,
+                                addedAt = ref.addedAt,
+                                locallyAdded = true,
+                            ) ?: PlaylistTrackCrossRef(
+                                playlistId = livePlaylistId,
+                                trackId = liveTrackId,
+                                position = position,
+                                addedAt = ref.addedAt,
+                                locallyAdded = true,
+                            )
+                        )
+                        mergedMemberships++
+                        touchedPlaylists.add(livePlaylistId)
+                    }
+                }
+
+                // Recompute the cached count of every playlist we changed so
+                // Library/Home badges don't drift from reality.
+                for (playlistId in touchedPlaylists) {
+                    playlistDao.updateTrackCount(
+                        playlistId,
+                        playlistDao.getOrderedTrackIdsForPlaylist(playlistId).size,
+                    )
+                }
+            }
+
+            return MergeCounts(addedTracks, addedPlaylists, mergedMemberships)
+        } finally {
+            backupDb.close()
+        }
+    }
+
+    private fun hasCanonicalIdentity(title: String, artist: String): Boolean =
+        title.isNotBlank() && artist.isNotBlank()
+
+    /** Stable composite key for canonical-identity matching. */
+    private fun canonicalKey(title: String, artist: String): String = "$title\u0001$artist"
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
@@ -644,6 +644,11 @@ class DatabaseBackupManager @Inject constructor(
                 for ((backupPlaylistId, refs) in backupRefs.groupBy { it.playlistId }) {
                     val livePlaylistId = playlistIdMap[backupPlaylistId] ?: continue
                     for (ref in refs.sortedBy { it.position }) {
+                        // A membership the user REMOVED in the backup carries
+                        // removedAt — restoring it would ADD a track the
+                        // backup itself no longer holds. Merge copies what the
+                        // backup still has; a soft-deleted row has nothing.
+                        if (ref.removedAt != null) continue
                         val liveTrackId = trackIdMap[ref.trackId] ?: continue
                         val key = livePlaylistId to liveTrackId
                         val existing = refByKey[key]

--- a/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
@@ -621,6 +621,12 @@ class DatabaseBackupManager @Inject constructor(
                             isDownloaded = false,
                             filePath = null,
                             albumArtPath = null,
+                            // getTracksNeedingEmbed and the Home banner count
+                            // both gate on `metadata_embedded_at IS NULL`, so a
+                            // stamp carried in from the backup would exclude the
+                            // file adoption creates later from the tag pass for
+                            // good — no stale-stamp sweep heals this one.
+                            metadataEmbeddedAt = null,
                             fileSizeBytes = 0,
                             qualityKbps = 0,
                             sampleRateHz = null,

--- a/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
@@ -524,7 +524,8 @@ class DatabaseBackupManager @Inject constructor(
      *     memberships are reactivated — the backup's content is being added,
      *     which is exactly the requested semantics. All imported memberships
      *     keep the backup's own `locally_added` answer when a sync actually
-     *     mirrors the playlist (`last_synced != null`) — forcing it to 1
+     *     mirrors the playlist (`last_synced != null` on EITHER the live or
+     *     the backup row) — forcing it to 1
      *     cleanup that exists to drop what a remote no longer has. Where no
      *     sync has ever run, a 0 is a state no live write path can produce,
      *     so it is read as user-added instead; reactivation ORs with the
@@ -643,11 +644,11 @@ class DatabaseBackupManager @Inject constructor(
                 // ONLY writer of last_synced (PlaylistDao.updateLastSynced has
                 // one call site), so non-null means this playlist's membership
                 // can legitimately be sync-owned. Null means no sync has ever
-                // touched it, and there a locally_added = 0 row is a state
-                // nothing else in the schema produces — every live add path
-                // stamps 1. Absence resolves to "user-added", which is the
-                // safe direction: a wrongly-kept membership is one the user
-                // can delete by hand, a wrongly-dropped one is gone.
+                // touched it on EITHER side, and there a locally_added = 0 row
+                // is a state nothing else in the schema produces — every live
+                // add path stamps 1. Absence resolves to "user-added", the safe
+                // direction: a wrongly-kept membership is one the user can
+                // delete by hand, a wrongly-dropped one is gone.
                 val syncMirrored = HashSet<Long>()
                 for (p in playlistDao.getAllForBackupMerge()) {
                     liveBySourceId.putIfAbsent(p.sourceId, p.id)
@@ -677,9 +678,18 @@ class DatabaseBackupManager @Inject constructor(
                         )
                     )
                     liveBySourceId.putIfAbsent(playlist.sourceId, newId)
-                    if (playlist.lastSynced != null) syncMirrored += newId
                     playlistIdMap[playlist.id] = newId
                     addedPlaylists++
+                }
+
+                // The BACKUP's history counts too: a playlist can be synced
+                // there and never yet here (sync enabled, not run), and it is
+                // that sync which wrote the backup's locally_added = 0 rows.
+                // One pass over the mapping so matched and newly-created
+                // playlists answer the question the same way.
+                for (playlist in backupPlaylists) {
+                    if (playlist.lastSynced == null) continue
+                    playlistIdMap[playlist.id]?.let { syncMirrored += it }
                 }
 
                 // ── 3. Memberships (union) ───────────────────────────────

--- a/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
@@ -393,11 +393,14 @@ class DatabaseBackupManager @Inject constructor(
                 }
             }
 
-            // Mirror of the check above for the settings-only scope: a
-            // library-only export carries no `datastore/` entries, and
-            // committing zero files would report a successful settings
-            // restore that wrote nothing.
-            if (scope.restoresSettingsFiles && stagedDatastore.isEmpty()) {
+            // Mirror of the check above, SETTINGS_REPLACE only: a library-only
+            // export carries no `datastore/` entries, and committing zero files
+            // would report a successful settings restore that wrote nothing.
+            // Deliberately NOT scope.restoresSettingsFiles — that would also
+            // fail EVERYTHING_REPLACE on an archive whose database is fine but
+            // whose export predated any preference write (the exporter emits
+            // datastore entries only `if (datastoreDir.exists())`).
+            if (scope == BackupImportScope.SETTINGS_REPLACE && stagedDatastore.isEmpty()) {
                 cleanupStaging(stagedDb, stagedDatastore)
                 throw IllegalStateException("The selected backup contains no settings.")
             }
@@ -520,9 +523,12 @@ class DatabaseBackupManager @Inject constructor(
      *     unless that track is already an active member. Soft-deleted
      *     memberships are reactivated — the backup's content is being added,
      *     which is exactly the requested semantics. All imported memberships
-     *     keep the backup's own `locally_added` answer — forcing it to 1
-     *     would make every restored membership immune to the REFRESH
-     *     cleanup that exists to drop what a remote no longer has —
+     *     keep the backup's own `locally_added` answer when a sync actually
+     *     mirrors the playlist (`last_synced != null`) — forcing it to 1
+     *     cleanup that exists to drop what a remote no longer has. Where no
+     *     sync has ever run, a 0 is a state no live write path can produce,
+     *     so it is read as user-added instead; reactivation ORs with the
+     *     live row so provenance is never downgraded —
      *     and cached `track_count`s of touched playlists are recomputed.
      *
      * **Known limit.** A backup predating the canonical-identity columns
@@ -613,6 +619,7 @@ class DatabaseBackupManager @Inject constructor(
                             id = 0,
                             isDownloaded = false,
                             filePath = null,
+                            albumArtPath = null,
                             fileSizeBytes = 0,
                             qualityKbps = 0,
                             sampleRateHz = null,
@@ -632,8 +639,19 @@ class DatabaseBackupManager @Inject constructor(
 
                 // ── 2. Playlists ─────────────────────────────────────────
                 val liveBySourceId = HashMap<String, Long>()
+                // Live playlist ids a sync run has mirrored. DiffWorker is the
+                // ONLY writer of last_synced (PlaylistDao.updateLastSynced has
+                // one call site), so non-null means this playlist's membership
+                // can legitimately be sync-owned. Null means no sync has ever
+                // touched it, and there a locally_added = 0 row is a state
+                // nothing else in the schema produces — every live add path
+                // stamps 1. Absence resolves to "user-added", which is the
+                // safe direction: a wrongly-kept membership is one the user
+                // can delete by hand, a wrongly-dropped one is gone.
+                val syncMirrored = HashSet<Long>()
                 for (p in playlistDao.getAllForBackupMerge()) {
                     liveBySourceId.putIfAbsent(p.sourceId, p.id)
+                    if (p.lastSynced != null) syncMirrored += p.id
                 }
 
                 /** Backup playlist id → live playlist id. */
@@ -659,6 +677,7 @@ class DatabaseBackupManager @Inject constructor(
                         )
                     )
                     liveBySourceId.putIfAbsent(playlist.sourceId, newId)
+                    if (playlist.lastSynced != null) syncMirrored += newId
                     playlistIdMap[playlist.id] = newId
                     addedPlaylists++
                 }
@@ -679,6 +698,7 @@ class DatabaseBackupManager @Inject constructor(
                 val touchedPlaylists = sortedSetOf<Long>()
                 for ((backupPlaylistId, refs) in backupRefs.groupBy { it.playlistId }) {
                     val livePlaylistId = playlistIdMap[backupPlaylistId] ?: continue
+                    val syncOwnsMembership = livePlaylistId in syncMirrored
                     for (ref in refs.sortedBy { it.position }) {
                         // A membership the user REMOVED in the backup carries
                         // removedAt — restoring it would ADD a track the
@@ -701,13 +721,16 @@ class DatabaseBackupManager @Inject constructor(
                                 removedAt = null,
                                 position = position,
                                 addedAt = ref.addedAt,
-                                locallyAdded = ref.locallyAdded,
+                                // Reactivation overwrites a LIVE row: OR so the
+                                // user's own provenance is never downgraded.
+                                locallyAdded = existing.locallyAdded ||
+                                    ref.locallyAdded || !syncOwnsMembership,
                             ) ?: PlaylistTrackCrossRef(
                                 playlistId = livePlaylistId,
                                 trackId = liveTrackId,
                                 position = position,
                                 addedAt = ref.addedAt,
-                                locallyAdded = ref.locallyAdded,
+                                locallyAdded = ref.locallyAdded || !syncOwnsMembership,
                             )
                         )
                         mergedMemberships++

--- a/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/DatabaseBackupManager.kt
@@ -393,6 +393,15 @@ class DatabaseBackupManager @Inject constructor(
                 }
             }
 
+            // Mirror of the check above for the settings-only scope: a
+            // library-only export carries no `datastore/` entries, and
+            // committing zero files would report a successful settings
+            // restore that wrote nothing.
+            if (scope.restoresSettingsFiles && stagedDatastore.isEmpty()) {
+                cleanupStaging(stagedDb, stagedDatastore)
+                throw IllegalStateException("The selected backup contains no settings.")
+            }
+
             // 4. Commit.
             if (scope == BackupImportScope.LIBRARY_MERGE) {
                 // Merge path: copy rows into the LIVE database. No file is
@@ -511,8 +520,17 @@ class DatabaseBackupManager @Inject constructor(
      *     unless that track is already an active member. Soft-deleted
      *     memberships are reactivated — the backup's content is being added,
      *     which is exactly the requested semantics. All imported memberships
-     *     are marked `locally_added` so REFRESH-mode syncs won't wipe them,
+     *     keep the backup's own `locally_added` answer — forcing it to 1
+     *     would make every restored membership immune to the REFRESH
+     *     cleanup that exists to drop what a remote no longer has —
      *     and cached `track_count`s of touched playlists are recomputed.
+     *
+     * **Known limit.** A backup predating the canonical-identity columns
+     * gets them from the migration chain, which adds the columns but does
+     * not run the app-side backfill, so they can arrive blank. Identity
+     * then rests on the Spotify URI / YouTube id alone, and a track with
+     * neither (a local-file import) can land as a duplicate of one the
+     * library already holds.
      *
      * Any exception anywhere rolls the entire transaction back, leaving the
      * live library byte-for-byte untouched.
@@ -596,6 +614,9 @@ class DatabaseBackupManager @Inject constructor(
                             isDownloaded = false,
                             filePath = null,
                             fileSizeBytes = 0,
+                            qualityKbps = 0,
+                            sampleRateHz = null,
+                            bitsPerSample = null,
                         )
                     )
                     track.spotifyUri?.let { liveBySpotifyUri.putIfAbsent(it, newId) }
@@ -680,13 +701,13 @@ class DatabaseBackupManager @Inject constructor(
                                 removedAt = null,
                                 position = position,
                                 addedAt = ref.addedAt,
-                                locallyAdded = true,
+                                locallyAdded = ref.locallyAdded,
                             ) ?: PlaylistTrackCrossRef(
                                 playlistId = livePlaylistId,
                                 trackId = liveTrackId,
                                 position = position,
                                 addedAt = ref.addedAt,
-                                locallyAdded = true,
+                                locallyAdded = ref.locallyAdded,
                             )
                         )
                         mergedMemberships++

--- a/core/data/src/main/kotlin/com/stash/core/data/db/StashDatabase.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/StashDatabase.kt
@@ -1140,5 +1140,64 @@ abstract class StashDatabase : RoomDatabase() {
                 )
             }
         }
+
+        /**
+         * The complete migration chain, shared by every builder of a
+         * [StashDatabase]: the DI singleton in
+         * [com.stash.core.data.di.DatabaseModule] AND the throwaway instance
+         * DatabaseBackupManager opens over a staged backup file to roll it
+         * forward before a library-merge import (#235).
+         *
+         * Declared `by lazy` so declaration order in this companion stops
+         * mattering: the array captures every `MIGRATION_*` on first use,
+         * not while the companion is still initializing. When adding
+         * `MIGRATION_N_N+1` above, append it here too; DatabaseModule spreads
+         * this array, so there is exactly ONE place to forget — and
+         * AllMigrationsChainTest fails the build when it falls behind.
+         */
+        val ALL_MIGRATIONS: Array<Migration> by lazy {
+            arrayOf(
+                MIGRATION_3_4,
+                MIGRATION_4_5,
+                MIGRATION_5_6,
+                MIGRATION_6_7,
+                MIGRATION_7_8,
+                MIGRATION_8_9,
+                MIGRATION_9_10,
+                MIGRATION_10_11,
+                MIGRATION_11_12,
+                MIGRATION_12_13,
+                MIGRATION_13_14,
+                MIGRATION_14_15,
+                MIGRATION_15_16,
+                MIGRATION_16_17,
+                MIGRATION_17_18,
+                MIGRATION_18_19,
+                MIGRATION_19_20,
+                MIGRATION_20_21,
+                MIGRATION_21_22,
+                MIGRATION_22_23,
+                MIGRATION_23_24,
+                MIGRATION_24_25,
+                MIGRATION_25_26,
+                MIGRATION_26_27,
+                MIGRATION_27_28,
+                MIGRATION_28_29,
+                MIGRATION_29_30,
+                MIGRATION_30_31,
+                MIGRATION_31_32,
+                MIGRATION_32_33,
+                MIGRATION_33_34,
+                MIGRATION_34_35,
+                MIGRATION_35_36,
+                MIGRATION_36_37,
+                MIGRATION_37_38,
+                MIGRATION_38_39,
+                MIGRATION_39_40,
+                MIGRATION_40_41,
+                MIGRATION_41_42,
+                MIGRATION_42_43,
+            )
+        }
     }
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
@@ -209,6 +209,32 @@ interface PlaylistDao {
     @Query("SELECT * FROM playlist_tracks WHERE playlist_id = :playlistId")
     suspend fun getCrossRefsForPlaylist(playlistId: Long): List<PlaylistTrackCrossRef>
 
+    /**
+     * Chunked bulk counterpart to [getCrossRefsForPlaylist] — every cross-ref
+     * row (active AND soft-deleted) for the given playlists in one pass.
+     * Route through [com.stash.core.data.db.chunkedForBind]; a library-sized
+     * playlist id list overflows SQLite's bind cap unchunked.
+     */
+    @Query("SELECT * FROM playlist_tracks WHERE playlist_id IN (:playlistIds)")
+    suspend fun getCrossRefsForPlaylists(playlistIds: List<Long>): List<PlaylistTrackCrossRef>
+
+    // ── Backup merge snapshots (#235) ───────────────────────────────────
+
+    /**
+     * One-shot read of EVERY playlist row regardless of visibility or
+     * sync state. Used by DatabaseBackupManager's library-merge import,
+     * which must see hidden/inactive playlists too: a backup's mix may be
+     * currently rotated off in the live library, but its memberships still
+     * need somewhere to land. Not for UI consumers.
+     */
+    @Query("SELECT * FROM playlists")
+    suspend fun getAllForBackupMerge(): List<PlaylistEntity>
+
+    /** One-shot read of every cross-ref row, soft-deleted included.
+     *  Merge-import counterpart to [getAllForBackupMerge]. */
+    @Query("SELECT * FROM playlist_tracks")
+    suspend fun getAllCrossRefsForBackupMerge(): List<PlaylistTrackCrossRef>
+
     // ── Update / Delete ─────────────────────────────────────────────────
 
     /** Update an existing playlist entity. */

--- a/core/data/src/main/kotlin/com/stash/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/di/DatabaseModule.kt
@@ -33,48 +33,11 @@ object DatabaseModule {
             StashDatabase::class.java,
             StashDatabase.DATABASE_NAME,
         )
-            .addMigrations(
-                StashDatabase.MIGRATION_3_4,
-                StashDatabase.MIGRATION_4_5,
-                StashDatabase.MIGRATION_5_6,
-                StashDatabase.MIGRATION_6_7,
-                StashDatabase.MIGRATION_7_8,
-                StashDatabase.MIGRATION_8_9,
-                StashDatabase.MIGRATION_9_10,
-                StashDatabase.MIGRATION_10_11,
-                StashDatabase.MIGRATION_11_12,
-                StashDatabase.MIGRATION_12_13,
-                StashDatabase.MIGRATION_13_14,
-                StashDatabase.MIGRATION_14_15,
-                StashDatabase.MIGRATION_15_16,
-                StashDatabase.MIGRATION_16_17,
-                StashDatabase.MIGRATION_17_18,
-                StashDatabase.MIGRATION_18_19,
-                StashDatabase.MIGRATION_19_20,
-                StashDatabase.MIGRATION_20_21,
-                StashDatabase.MIGRATION_21_22,
-                StashDatabase.MIGRATION_22_23,
-                StashDatabase.MIGRATION_23_24,
-                StashDatabase.MIGRATION_24_25,
-                StashDatabase.MIGRATION_25_26,
-                StashDatabase.MIGRATION_26_27,
-                StashDatabase.MIGRATION_27_28,
-                StashDatabase.MIGRATION_28_29,
-                StashDatabase.MIGRATION_29_30,
-                StashDatabase.MIGRATION_30_31,
-                StashDatabase.MIGRATION_31_32,
-                StashDatabase.MIGRATION_32_33,
-                StashDatabase.MIGRATION_33_34,
-                StashDatabase.MIGRATION_34_35,
-                StashDatabase.MIGRATION_35_36,
-                StashDatabase.MIGRATION_36_37,
-                StashDatabase.MIGRATION_37_38,
-                StashDatabase.MIGRATION_38_39,
-                StashDatabase.MIGRATION_39_40,
-                StashDatabase.MIGRATION_40_41,
-                StashDatabase.MIGRATION_41_42,
-                StashDatabase.MIGRATION_42_43,
-            )
+            // Single source of truth for the chain — DatabaseBackupManager's
+            // merge-import opens a second Room instance over a staged backup
+            // file with this same array, so an older backup can be rolled
+            // forward to the live schema before rows are copied out of it.
+            .addMigrations(*StashDatabase.ALL_MIGRATIONS)
             // No fallbackToDestructiveMigration() — if a migration is missing,
             // the app will crash on startup instead of silently wiping the
             // user's entire library. This forces us to write proper migrations

--- a/core/data/src/test/kotlin/com/stash/core/data/db/AllMigrationsChainTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/AllMigrationsChainTest.kt
@@ -1,0 +1,71 @@
+package com.stash.core.data.db
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Guards [StashDatabase.ALL_MIGRATIONS] against the one mistake its KDoc can
+ * only ask for in prose: adding `MIGRATION_N_N+1` and bumping `version` but
+ * forgetting to append the val to the array.
+ *
+ * That omission has no compile-time symptom. It surfaces at runtime as
+ * "A migration from N to N+1 was required but not found" — on the DI
+ * singleton for anyone upgrading, and on the throwaway instance
+ * DatabaseBackupManager opens over a staged backup to roll it forward before
+ * a library-merge import (#235), where it takes the import down with it.
+ *
+ * The current version is read back from a real Room-built database rather
+ * than restated here, so there is still exactly ONE place to declare it.
+ *
+ * Note the array captures its entries by reference in declaration order: a
+ * `MIGRATION_*` val declared *below* `ALL_MIGRATIONS` enters it as null and
+ * fails this test with an NPE rather than an assertion. That is still a red
+ * test, which is the point — the array must stay the companion's last member.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class AllMigrationsChainTest {
+
+    private fun currentSchemaVersion(): Int {
+        val db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        return try {
+            db.openHelper.readableDatabase.version
+        } finally {
+            db.close()
+        }
+    }
+
+    @Test
+    fun `ALL_MIGRATIONS is an unbroken chain ending at the current schema version`() {
+        val edges = StashDatabase.ALL_MIGRATIONS
+            .map { it.startVersion to it.endVersion }
+            .sortedBy { it.first }
+
+        // Every migration advances exactly one version, and each one picks up
+        // where the previous left off — a gap here is a version no upgrading
+        // install can cross.
+        edges.forEach { (start, end) ->
+            assertEquals("migration $start -> $end must advance exactly one version", start + 1, end)
+        }
+        edges.zipWithNext { (_, end), (nextStart, _) ->
+            assertEquals("gap in the migration chain at version $end", end, nextStart)
+        }
+
+        // The one that catches the forgotten append: the chain must reach the
+        // version the @Database annotation actually declares.
+        assertEquals(
+            "ALL_MIGRATIONS stops short of the current schema version — " +
+                "a MIGRATION_* val was added without being appended to the array",
+            currentSchemaVersion(),
+            edges.last().second,
+        )
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
@@ -315,4 +315,29 @@ class DatabaseBackupMergeTest {
         assertEquals(0, summary.mergedMemberships)
         assertEquals(listOf(a), live.playlistDao().getOrderedTrackIdsForPlaylist(pid))
     }
+
+    @Test
+    fun `merged tracks never inherit the backup's downloaded state`() = runTest {
+        // A backup ZIP carries metadata, never audio — and merge skips the
+        // restart that would run the disk-truth sweep. Inheriting
+        // is_downloaded would leave a row pointing at a file that isn't here.
+        val uri = buildBackupZip { backup ->
+            backup.trackDao().insert(
+                track("Elsewhere", spotifyUri = "spotify:track:e").copy(
+                    isDownloaded = true,
+                    filePath = "/data/user/0/other.install/files/music/elsewhere.flac",
+                    fileSizeBytes = 40_000_000,
+                )
+            )
+        }
+
+        val result = manager.importDatabase(uri, BackupImportScope.LIBRARY_MERGE)
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, result.getOrThrow().addedTracks)
+        val merged = live.trackDao().getAllForIntegrityScan().single()
+        assertFalse(merged.isDownloaded)
+        assertNull(merged.filePath)
+        assertEquals(0L, merged.fileSizeBytes)
+    }
 }

--- a/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
@@ -288,4 +288,31 @@ class DatabaseBackupMergeTest {
             File(dbPath, "${StashDatabase.DATABASE_NAME}.import-tmp").exists().not(),
         )
     }
+
+    @Test
+    fun `merge ignores a membership the backup itself soft-removed`() = runTest {
+        val a = live.trackDao().insert(track("A", spotifyUri = "spotify:track:a"))
+        val pid = live.playlistDao().insert(playlist("List", "list-1"))
+        addMember(pid, a, position = 0)
+
+        // The backup holds A and B, but B was REMOVED from the playlist there.
+        val uri = buildBackupZip { backup ->
+            val bA = backup.trackDao().insert(track("A", spotifyUri = "spotify:track:a"))
+            val bB = backup.trackDao().insert(track("B", spotifyUri = "spotify:track:b"))
+            val bPid = backup.playlistDao().insert(playlist("List", "list-1"))
+            backup.playlistDao().insertCrossRef(PlaylistTrackCrossRef(bPid, bA, 0))
+            backup.playlistDao().insertCrossRef(PlaylistTrackCrossRef(bPid, bB, 1))
+            backup.playlistDao().softDeleteTrackFromPlaylist(bPid, bB)
+        }
+
+        val result = manager.importDatabase(uri, BackupImportScope.LIBRARY_MERGE)
+
+        assertTrue(result.isSuccess)
+        val summary = result.getOrThrow()
+        // B's library row still arrives — merge adds tracks — but a membership
+        // the backup no longer holds must not be resurrected as an active one.
+        assertEquals(1, summary.addedTracks)
+        assertEquals(0, summary.mergedMemberships)
+        assertEquals(listOf(a), live.playlistDao().getOrderedTrackIdsForPlaylist(pid))
+    }
 }

--- a/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
@@ -1,0 +1,291 @@
+package com.stash.core.data.db
+
+import android.content.Context
+import android.net.Uri
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.db.entity.PlaylistTrackCrossRef
+import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.model.MusicSource
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Tests for [DatabaseBackupManager.importDatabase]'s LIBRARY_MERGE scope —
+ * the issue #235 feature that adds a backup's songs/playlists INTO the
+ * current library without deleting or replacing anything.
+ *
+ * Uses a REAL in-memory Room DB as the live library and a real on-disk Room
+ * DB zipped into a backup archive, so the whole pipeline (manifest gate →
+ * staging → integrity check → throwaway migrated instance → transactional
+ * copy) executes exactly as it will on device.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class DatabaseBackupMergeTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var tmpDir: File
+    private lateinit var live: StashDatabase
+    private lateinit var manager: DatabaseBackupManager
+
+    @Before fun setUp() {
+        tmpDir = File(context.cacheDir, "backup-merge-test-${System.nanoTime()}").apply { mkdirs() }
+        live = Room.inMemoryDatabaseBuilder(context, StashDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        manager = DatabaseBackupManager(context, live)
+    }
+
+    @After fun tearDown() {
+        live.close()
+        tmpDir.deleteRecursively()
+    }
+
+    // ── Fixtures ─────────────────────────────────────────────────────────
+
+    private fun track(
+        title: String,
+        artist: String = "Artist",
+        spotifyUri: String? = null,
+        youtubeId: String? = null,
+    ) = TrackEntity(
+        title = title,
+        artist = artist,
+        spotifyUri = spotifyUri,
+        youtubeId = youtubeId,
+        canonicalTitle = title.lowercase(),
+        canonicalArtist = artist.lowercase(),
+    )
+
+    private fun playlist(name: String, sourceId: String) = PlaylistEntity(
+        name = name,
+        source = MusicSource.SPOTIFY,
+        sourceId = sourceId,
+    )
+
+    private suspend fun addMember(playlistId: Long, trackId: Long, position: Int) {
+        live.playlistDao().insertCrossRef(
+            PlaylistTrackCrossRef(
+                playlistId = playlistId,
+                trackId = trackId,
+                position = position,
+            )
+        )
+    }
+
+    /** Populates an on-disk Room DB through [populate], closes it, and zips
+     *  it up as a valid Stash backup (manifest + stash.db). */
+    private suspend fun buildBackupZip(
+        populate: suspend (StashDatabase) -> Unit,
+    ): Uri {
+        val dbFile = File(tmpDir, "backup-source.db")
+        val backupDb = Room.databaseBuilder(context, StashDatabase::class.java, dbFile.absolutePath)
+            // TRUNCATE — Robolectric's legacy SQLite cannot open file-backed
+            // databases in WAL mode (see DatabaseBackupManager.mergeLibraryFrom).
+            .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
+            .allowMainThreadQueries()
+            .build()
+        backupDb.openHelper.writableDatabase // force schema creation
+        populate(backupDb)
+        val schemaVersion = backupDb.openHelper.readableDatabase.version
+        backupDb.close()
+
+        val zipFile = File(tmpDir, "backup.zip")
+        ZipOutputStream(FileOutputStream(zipFile)).use { zip ->
+            zip.putNextEntry(ZipEntry("manifest.json"))
+            zip.write(
+                """{"dbSchemaVersion":$schemaVersion,"exportTimestamp":1,"appVersionName":"test"}"""
+                    .toByteArray(),
+            )
+            zip.closeEntry()
+
+            zip.putNextEntry(ZipEntry("stash.db"))
+            FileInputStream(dbFile).use { it.copyTo(zip) }
+            zip.closeEntry()
+        }
+        return Uri.fromFile(zipFile)
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `merge adds only missing tracks and unions memberships without touching settings`() =
+        runTest {
+            // Live: shared song S + live-only song X; playlist P1 holding S.
+            val liveShared = live.trackDao().insert(track("Same Song", spotifyUri = "spotify:track:same"))
+            live.trackDao().insert(track("Only Live", youtubeId = "yt-live"))
+            val p1Live = live.playlistDao().insert(playlist("Road Trip", "sp-p1"))
+            addMember(p1Live, liveShared, position = 0)
+
+            // Backup: same S, backup-only song Y; P1 (renamed remotely!) now
+            // holds [S, Y]; brand-new playlist P2 holding Y.
+            val uri = buildBackupZip { backup ->
+                val bShared = backup.trackDao().insert(track("Same Song", spotifyUri = "spotify:track:same"))
+                val bY = backup.trackDao().insert(track("Only Backup", spotifyUri = "spotify:track:y"))
+                val bP1 = backup.playlistDao().insert(playlist("Road Trip Renamed", "sp-p1"))
+                backup.playlistDao().insertCrossRef(
+                    PlaylistTrackCrossRef(playlistId = bP1, trackId = bShared, position = 0)
+                )
+                backup.playlistDao().insertCrossRef(
+                    PlaylistTrackCrossRef(playlistId = bP1, trackId = bY, position = 1)
+                )
+                val bP2 = backup.playlistDao().insert(playlist("Fresh Finds", "custom-123"))
+                backup.playlistDao().insertCrossRef(
+                    PlaylistTrackCrossRef(playlistId = bP2, trackId = bY, position = 0)
+                )
+            }
+
+            val result = manager.importDatabase(uri, BackupImportScope.LIBRARY_MERGE)
+
+            assertTrue("merge failed: ${result.exceptionOrNull()}", result.isSuccess)
+            val summary = result.getOrThrow()
+            assertFalse("merge must not require a restart", summary.requiresRestart)
+            assertNull(summary.restoredTreeUri)
+            assertEquals(1, summary.addedTracks)
+            assertEquals(1, summary.addedPlaylists)
+            assertEquals(2, summary.mergedMemberships)
+
+            // Library union: X + S + Y, with S NOT duplicated.
+            val allTracks = live.trackDao().getAllForIntegrityScan()
+            assertEquals(3, allTracks.size)
+            assertEquals(
+                listOf("Same Song"),
+                allTracks.filter { it.spotifyUri == "spotify:track:same" }.map { it.title },
+            )
+
+            // Existing playlist keeps its live name; gains only Y, appended after S.
+            val p1After = live.playlistDao().getById(p1Live)!!
+            assertEquals("Road Trip", p1After.name)
+            val ordered = live.playlistDao().getOrderedTrackIdsForPlaylist(p1Live)
+            assertEquals(2, ordered.size)
+            assertEquals(liveShared, ordered.first())
+            assertEquals(
+                "spotify:track:y",
+                live.trackDao().getById(ordered.last())!!.spotifyUri,
+            )
+            assertEquals(2, p1After.trackCount)
+
+            // New playlist arrives with its member and an accurate count…
+            val p2After = live.playlistDao().findBySourceId("custom-123")!!
+            val p2Members = live.playlistDao().getOrderedTrackIdsForPlaylist(p2After.id)
+            assertEquals(listOf<String>("spotify:track:y"), p2Members.map {
+                live.trackDao().getById(it)!!.spotifyUri
+            })
+            assertEquals(1, p2After.trackCount)
+            // …but NEVER inherits download consent from a backup.
+            assertFalse(p2After.syncEnabled)
+        }
+
+    @Test
+    fun `merge never duplicates active members and preserves their order`() = runTest {
+        val a = live.trackDao().insert(track("A", spotifyUri = "spotify:track:a"))
+        val b = live.trackDao().insert(track("B", spotifyUri = "spotify:track:b"))
+        val pid = live.playlistDao().insert(playlist("Mix", "mix-1"))
+        addMember(pid, a, position = 0)
+        addMember(pid, b, position = 1)
+
+        // Backup has the SAME playlist but reversed order plus one new track.
+        val uri = buildBackupZip { backup ->
+            val bA = backup.trackDao().insert(track("A", spotifyUri = "spotify:track:a"))
+            val bB = backup.trackDao().insert(track("B", spotifyUri = "spotify:track:b"))
+            val bC = backup.trackDao().insert(track("C", spotifyUri = "spotify:track:c"))
+            val bPid = backup.playlistDao().insert(playlist("Mix", "mix-1"))
+            backup.playlistDao().insertCrossRef(PlaylistTrackCrossRef(bPid, bB, 0))
+            backup.playlistDao().insertCrossRef(PlaylistTrackCrossRef(bPid, bA, 1))
+            backup.playlistDao().insertCrossRef(PlaylistTrackCrossRef(bPid, bC, 2))
+        }
+
+        val result = manager.importDatabase(uri, BackupImportScope.LIBRARY_MERGE)
+
+        assertTrue(result.isSuccess)
+        val summary = result.getOrThrow()
+        // Only C is new; A and B are already active members and must not be
+        // re-added or reordered.
+        assertEquals(1, summary.addedTracks)
+        assertEquals(0, summary.addedPlaylists)
+        assertEquals(1, summary.mergedMemberships)
+
+        val tracks = live.trackDao().getAllForIntegrityScan()
+        assertEquals(3, tracks.size)
+        val ordered = live.playlistDao().getOrderedTrackIdsForPlaylist(pid)
+        assertEquals(listOf(a, b), ordered.dropLast(1))
+        assertEquals(
+            "spotify:track:c",
+            live.trackDao().getById(ordered.last())!!.spotifyUri,
+        )
+    }
+
+    @Test
+    fun `merge reactivates a soft-removed membership instead of duplicating`() = runTest {
+        val a = live.trackDao().insert(track("A", spotifyUri = "spotify:track:a"))
+        val b = live.trackDao().insert(track("B", spotifyUri = "spotify:track:b"))
+        val pid = live.playlistDao().insert(playlist("List", "list-1"))
+        addMember(pid, a, position = 0)
+        addMember(pid, b, position = 1)
+        live.playlistDao().softDeleteTrackFromPlaylist(pid, b) // user removed B here
+
+        val uri = buildBackupZip { backup ->
+            val bB = backup.trackDao().insert(track("B", spotifyUri = "spotify:track:b"))
+            val bPid = backup.playlistDao().insert(playlist("List", "list-1"))
+            backup.playlistDao().insertCrossRef(PlaylistTrackCrossRef(bPid, bB, 0))
+        }
+
+        val result = manager.importDatabase(uri, BackupImportScope.LIBRARY_MERGE)
+
+        assertTrue(result.isSuccess)
+        assertEquals(0, result.getOrThrow().addedTracks)
+        assertEquals(1, result.getOrThrow().mergedMemberships)
+
+        // B is back — the backup's content was added, per #235 semantics.
+        val ordered = live.playlistDao().getOrderedTrackIdsForPlaylist(pid)
+        assertEquals(listOf(a, b), ordered)
+        assertEquals(2, live.playlistDao().getById(pid)!!.trackCount)
+    }
+
+    @Test
+    fun `a corrupt backup fails the merge and leaves the live library untouched`() = runTest {
+        val a = live.trackDao().insert(track("Precious", spotifyUri = "spotify:track:p"))
+
+        val zipFile = File(tmpDir, "corrupt.zip")
+        ZipOutputStream(FileOutputStream(zipFile)).use { zip ->
+            zip.putNextEntry(ZipEntry("manifest.json"))
+            zip.write("""{"dbSchemaVersion":42,"exportTimestamp":1}""".toByteArray())
+            zip.closeEntry()
+            zip.putNextEntry(ZipEntry("stash.db"))
+            // Valid-looking header followed by junk — the shape the integrity
+            // gate exists to reject deterministically.
+            zip.write(byteArrayOf(0x53, 0x51, 0x4C, 0x69, 0x74, 0x65, 0x00, 0x01) + ByteArray(64))
+            zip.closeEntry()
+        }
+
+        val result = manager.importDatabase(Uri.fromFile(zipFile), BackupImportScope.LIBRARY_MERGE)
+
+        assertTrue(result.isFailure)
+        // Live library byte-for-byte intact.
+        val tracks = live.trackDao().getAllForIntegrityScan()
+        assertEquals(listOf("Precious"), tracks.map { it.title })
+        assertEquals(a, tracks.single().id)
+        // No staging residue left behind.
+        val dbPath = context.getDatabasePath(StashDatabase.DATABASE_NAME).parentFile
+        assertTrue(
+            File(dbPath, "${StashDatabase.DATABASE_NAME}.import-tmp").exists().not(),
+        )
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
@@ -23,6 +23,7 @@ import org.robolectric.annotation.Config
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.time.Instant
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
@@ -74,11 +75,26 @@ class DatabaseBackupMergeTest {
         canonicalArtist = artist.lowercase(),
     )
 
-    private fun playlist(name: String, sourceId: String) = PlaylistEntity(
+    /**
+     * [lastSynced] is the discriminator the merge uses for membership
+     * ownership: DiffWorker is its only writer, so non-null means a sync
+     * run has mirrored this playlist and its `locally_added = 0` rows are
+     * genuinely sync-owned.
+     */
+    private fun playlist(name: String, sourceId: String, lastSynced: Instant? = null) = PlaylistEntity(
         name = name,
         source = MusicSource.SPOTIFY,
         sourceId = sourceId,
+        lastSynced = lastSynced,
     )
+
+    /** `locally_added` of the membership joining [playlistId] to [title]. */
+    private suspend fun flagFor(playlistId: Long, title: String): Boolean {
+        val trackId = live.trackDao().getAllForIntegrityScan().first { it.title == title }.id
+        return live.playlistDao().getCrossRefsForPlaylist(playlistId)
+            .first { it.trackId == trackId }
+            .locallyAdded
+    }
 
     private suspend fun addMember(playlistId: Long, trackId: Long, position: Int) {
         live.playlistDao().insertCrossRef(
@@ -356,6 +372,7 @@ class DatabaseBackupMergeTest {
                     qualityKbps = 1411,
                     sampleRateHz = 96_000,
                     bitsPerSample = 24,
+                    albumArtPath = "/data/user/0/other.install/files/art/elsewhere.jpg",
                 )
             )
         }
@@ -367,16 +384,17 @@ class DatabaseBackupMergeTest {
         assertEquals(0, merged.qualityKbps)
         assertNull(merged.sampleRateHz)
         assertNull(merged.bitsPerSample)
+        assertNull(merged.albumArtPath)
     }
 
     @Test
-    fun `merged memberships keep the backup's locally-added flag`() = runTest {
-        // locally_added decides whether a REFRESH sync may clean a membership
-        // up (PlaylistDao.clearSyncedPlaylistTracks deletes locally_added = 0
-        // only). Forcing every merged row to 1 would pin a stale backup's
-        // tracks into a synced playlist forever, so the backup's own answer
-        // travels with the row.
-        val pid = live.playlistDao().insert(playlist("List", "list-1"))
+    fun `a sync-owned membership stays sync-owned so REFRESH can still drop it`() = runTest {
+        // locally_added = 1 makes a membership immune to
+        // PlaylistDao.clearSyncedPlaylistTracks AND to
+        // SyncUndoDao.clearSyncedMembershipForRestore. Forcing it on every
+        // merged row pinned a stale backup's tracks into a synced playlist
+        // forever, so a sync-owned row keeps the backup's honest 0.
+        val pid = live.playlistDao().insert(playlist("List", "list-1", lastSynced = Instant.now()))
         val uri = buildBackupZip { backup ->
             val synced = backup.trackDao().insert(track("Synced", spotifyUri = "spotify:track:s"))
             val byHand = backup.trackDao().insert(track("ByHand", spotifyUri = "spotify:track:h"))
@@ -393,11 +411,60 @@ class DatabaseBackupMergeTest {
 
         assertTrue(result.isSuccess)
         assertEquals(2, result.getOrThrow().mergedMemberships)
-        val titleById = live.trackDao().getAllForIntegrityScan().associate { it.id to it.title }
-        val flagByTitle = live.playlistDao().getCrossRefsForPlaylist(pid)
-            .associate { titleById.getValue(it.trackId) to it.locallyAdded }
-        assertFalse(flagByTitle.getValue("Synced"))
-        assertTrue(flagByTitle.getValue("ByHand"))
+        assertFalse(flagFor(pid, "Synced"))
+        assertTrue(flagFor(pid, "ByHand"))
+    }
+
+    @Test
+    fun `a playlist no sync has mirrored takes every membership as user-added`() = runTest {
+        // No sync writes memberships into a playlist it does not mirror, so
+        // every live add path stamps locally_added = 1 there and a 0 is a
+        // state nothing else in the schema can produce. A backup predating
+        // the column (MIGRATION_22_23 added it DEFAULT 0) reads 0 even for
+        // rows the user added by hand, and importing that verbatim would
+        // expose them to SyncUndoDao.clearSyncedMembershipForRestore, whose
+        // DELETE is playlist-type-blind. last_synced is the discriminator:
+        // DiffWorker is its only writer, so null means no sync has ever
+        // touched this playlist.
+        val pid = live.playlistDao().insert(playlist("Mine", "custom_abc", lastSynced = null))
+        val uri = buildBackupZip { backup ->
+            val t = backup.trackDao().insert(track("Mine", spotifyUri = "spotify:track:m"))
+            val bPid = backup.playlistDao().insert(playlist("Mine", "custom_abc"))
+            backup.playlistDao().insertCrossRef(
+                PlaylistTrackCrossRef(bPid, t, position = 0, locallyAdded = false),
+            )
+        }
+
+        val result = manager.importDatabase(uri, BackupImportScope.LIBRARY_MERGE)
+
+        assertTrue(result.isSuccess)
+        assertTrue(flagFor(pid, "Mine"))
+    }
+
+    @Test
+    fun `reactivating a membership never downgrades the live row's provenance`() = runTest {
+        // The live row is the user's own hand-add, soft-deleted. The backup
+        // holds the same membership as sync-added. Reactivation must not let
+        // the backup's 0 overwrite the live 1 — that would hand a row the
+        // user created to the next REFRESH or sync-undo.
+        val pid = live.playlistDao().insert(playlist("List", "list-1", lastSynced = Instant.now()))
+        val tid = live.trackDao().insert(track("Song", spotifyUri = "spotify:track:x"))
+        live.playlistDao().insertCrossRef(
+            PlaylistTrackCrossRef(pid, tid, position = 0, locallyAdded = true),
+        )
+        live.playlistDao().softDeleteTrackFromPlaylist(pid, tid)
+        val uri = buildBackupZip { backup ->
+            val bt = backup.trackDao().insert(track("Song", spotifyUri = "spotify:track:x"))
+            val bPid = backup.playlistDao().insert(playlist("List", "list-1"))
+            backup.playlistDao().insertCrossRef(
+                PlaylistTrackCrossRef(bPid, bt, position = 0, locallyAdded = false),
+            )
+        }
+
+        val result = manager.importDatabase(uri, BackupImportScope.LIBRARY_MERGE)
+
+        assertTrue(result.isSuccess)
+        assertTrue(flagFor(pid, "Song"))
     }
 
     @Test

--- a/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
@@ -416,6 +416,30 @@ class DatabaseBackupMergeTest {
     }
 
     @Test
+    fun `the backup's own sync history settles ownership when the live row has none`() = runTest {
+        // Sync enabled here but never run, while the backup's copy of the
+        // same playlist HAS synced. The backup's 0 rows were written by that
+        // sync, so they are genuinely sync-owned — forcing them to 1 because
+        // the LIVE row has no last_synced yet would pin them past the next
+        // REFRESH, which is the bug this whole thread started on.
+        val pid = live.playlistDao().insert(playlist("List", "list-1", lastSynced = null))
+        val uri = buildBackupZip { backup ->
+            val t = backup.trackDao().insert(track("Remote", spotifyUri = "spotify:track:r"))
+            val bPid = backup.playlistDao().insert(
+                playlist("List", "list-1", lastSynced = Instant.now()),
+            )
+            backup.playlistDao().insertCrossRef(
+                PlaylistTrackCrossRef(bPid, t, position = 0, locallyAdded = false),
+            )
+        }
+
+        val result = manager.importDatabase(uri, BackupImportScope.LIBRARY_MERGE)
+
+        assertTrue(result.isSuccess)
+        assertFalse(flagFor(pid, "Remote"))
+    }
+
+    @Test
     fun `a playlist no sync has mirrored takes every membership as user-added`() = runTest {
         // No sync writes memberships into a playlist it does not mirror, so
         // every live add path stamps locally_added = 1 there and a 0 is a

--- a/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
@@ -340,4 +340,78 @@ class DatabaseBackupMergeTest {
         assertNull(merged.filePath)
         assertEquals(0L, merged.fileSizeBytes)
     }
+
+    @Test
+    fun `merged tracks do not keep quality read off a file they no longer have`() = runTest {
+        // qualityKbps / sampleRateHz / bitsPerSample are read OFF THE FILE,
+        // not from the source catalog. A merged row lands not-downloaded, so
+        // keeping them lets a quality badge describe audio that isn't there
+        // until adoption re-stamps the row.
+        val uri = buildBackupZip { backup ->
+            backup.trackDao().insert(
+                track("Elsewhere", spotifyUri = "spotify:track:e").copy(
+                    isDownloaded = true,
+                    filePath = "/data/user/0/other.install/files/music/elsewhere.flac",
+                    fileSizeBytes = 40_000_000,
+                    qualityKbps = 1411,
+                    sampleRateHz = 96_000,
+                    bitsPerSample = 24,
+                )
+            )
+        }
+
+        val result = manager.importDatabase(uri, BackupImportScope.LIBRARY_MERGE)
+
+        assertTrue(result.isSuccess)
+        val merged = live.trackDao().getAllForIntegrityScan().single()
+        assertEquals(0, merged.qualityKbps)
+        assertNull(merged.sampleRateHz)
+        assertNull(merged.bitsPerSample)
+    }
+
+    @Test
+    fun `merged memberships keep the backup's locally-added flag`() = runTest {
+        // locally_added decides whether a REFRESH sync may clean a membership
+        // up (PlaylistDao.clearSyncedPlaylistTracks deletes locally_added = 0
+        // only). Forcing every merged row to 1 would pin a stale backup's
+        // tracks into a synced playlist forever, so the backup's own answer
+        // travels with the row.
+        val pid = live.playlistDao().insert(playlist("List", "list-1"))
+        val uri = buildBackupZip { backup ->
+            val synced = backup.trackDao().insert(track("Synced", spotifyUri = "spotify:track:s"))
+            val byHand = backup.trackDao().insert(track("ByHand", spotifyUri = "spotify:track:h"))
+            val bPid = backup.playlistDao().insert(playlist("List", "list-1"))
+            backup.playlistDao().insertCrossRef(
+                PlaylistTrackCrossRef(bPid, synced, position = 0, locallyAdded = false),
+            )
+            backup.playlistDao().insertCrossRef(
+                PlaylistTrackCrossRef(bPid, byHand, position = 1, locallyAdded = true),
+            )
+        }
+
+        val result = manager.importDatabase(uri, BackupImportScope.LIBRARY_MERGE)
+
+        assertTrue(result.isSuccess)
+        assertEquals(2, result.getOrThrow().mergedMemberships)
+        val titleById = live.trackDao().getAllForIntegrityScan().associate { it.id to it.title }
+        val flagByTitle = live.playlistDao().getCrossRefsForPlaylist(pid)
+            .associate { titleById.getValue(it.trackId) to it.locallyAdded }
+        assertFalse(flagByTitle.getValue("Synced"))
+        assertTrue(flagByTitle.getValue("ByHand"))
+    }
+
+    @Test
+    fun `a settings-only import of a backup that carries no settings fails`() = runTest {
+        // buildBackupZip writes manifest.json + stash.db and no datastore/
+        // entries at all. Reporting success here would tell the user their
+        // preferences were restored when nothing was written — the DB path
+        // already refuses the mirror case ("contains no database").
+        live.trackDao().insert(track("Keep me", spotifyUri = "spotify:track:k"))
+        val uri = buildBackupZip { backup -> backup.trackDao().insert(track("A")) }
+
+        val result = manager.importDatabase(uri, BackupImportScope.SETTINGS_REPLACE)
+
+        assertTrue(result.isFailure)
+        assertEquals(1, live.trackDao().getAllForIntegrityScan().size)
+    }
 }

--- a/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/db/DatabaseBackupMergeTest.kt
@@ -358,8 +358,9 @@ class DatabaseBackupMergeTest {
     }
 
     @Test
-    fun `merged tracks do not keep quality read off a file they no longer have`() = runTest {
-        // qualityKbps / sampleRateHz / bitsPerSample are read OFF THE FILE,
+    fun `merged tracks keep no state describing a file they no longer have`() = runTest {
+        // These columns all describe the audio FILE, not the catalog entry:
+        // qualityKbps / sampleRateHz / bitsPerSample are read off it,
         // not from the source catalog. A merged row lands not-downloaded, so
         // keeping them lets a quality badge describe audio that isn't there
         // until adoption re-stamps the row.
@@ -373,6 +374,7 @@ class DatabaseBackupMergeTest {
                     sampleRateHz = 96_000,
                     bitsPerSample = 24,
                     albumArtPath = "/data/user/0/other.install/files/art/elsewhere.jpg",
+                    metadataEmbeddedAt = 1_700_000_000_000L,
                 )
             )
         }
@@ -385,6 +387,11 @@ class DatabaseBackupMergeTest {
         assertNull(merged.sampleRateHz)
         assertNull(merged.bitsPerSample)
         assertNull(merged.albumArtPath)
+        // Not just untidy: getTracksNeedingEmbed and the Home banner count
+        // both gate on `metadata_embedded_at IS NULL`, so a stamp carried in
+        // from the backup means the file adoption creates later NEVER gets
+        // the v0.9.35 tag set — and there is no stale-stamp sweep to heal it.
+        assertNull(merged.metadataEmbeddedAt)
     }
 
     @Test

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsLibraryStorageScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsLibraryStorageScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.stash.core.data.db.BackupImportScope
 import com.stash.core.model.DownloadNetworkMode
 import com.stash.core.ui.components.GlassCard
 import com.stash.core.ui.theme.StashTheme
@@ -44,6 +45,57 @@ import com.stash.feature.settings.components.SettingsScaffold
 import com.stash.feature.settings.components.SettingsSectionLabel
 import com.stash.feature.settings.components.SettingsToggleRow
 import com.stash.feature.settings.components.SettingsValueRow
+
+/**
+ * One radio choice of the import dialog (issue #235).
+ *
+ * @property scope        What the backup restores — passed straight to the VM.
+ * @property label        Short option title.
+ * @property description  One-line consequence summary shown under the label.
+ * @property confirmLabel Verb on the confirm button ("Merge", "Overwrite All"…).
+ * @property destructive  True when the action REPLACES existing data; renders
+ *                        the row and the confirm button in the error color.
+ */
+private data class ImportScopeOption(
+    val scope: BackupImportScope,
+    val label: String,
+    val description: String,
+    val confirmLabel: String,
+    val destructive: Boolean,
+)
+
+private val importScopeOptions = listOf(
+    ImportScopeOption(
+        scope = BackupImportScope.LIBRARY_MERGE,
+        label = "Merge into library",
+        description = "Adds missing songs and playlists from the backup. " +
+            "Nothing is deleted or replaced; settings stay untouched.",
+        confirmLabel = "Merge",
+        destructive = false,
+    ),
+    ImportScopeOption(
+        scope = BackupImportScope.LIBRARY_REPLACE,
+        label = "Replace library only",
+        description = "Restores the backup's library. Your current settings are kept.",
+        confirmLabel = "Replace Library",
+        destructive = true,
+    ),
+    ImportScopeOption(
+        scope = BackupImportScope.SETTINGS_REPLACE,
+        label = "Restore settings only",
+        description = "Restores settings from the backup. Your current library is kept.",
+        confirmLabel = "Restore Settings",
+        destructive = true,
+    ),
+    ImportScopeOption(
+        scope = BackupImportScope.EVERYTHING_REPLACE,
+        label = "Replace everything",
+        description = "Full restore exactly as backed up — replaces your entire " +
+            "library AND all settings.",
+        confirmLabel = "Overwrite All",
+        destructive = true,
+    ),
+)
 
 /**
  * The Library & Storage spoke of the hub-and-spoke Settings redesign.
@@ -255,7 +307,7 @@ fun SettingsLibraryStorageScreen(
                     Text(
                         text = when (databaseBackupState) {
                             DatabaseBackupState.Exporting -> "Exporting Database"
-                            DatabaseBackupState.Importing -> "Importing Database"
+                            DatabaseBackupState.Importing -> "Importing Backup"
                             is DatabaseBackupState.Success -> "Success"
                             is DatabaseBackupState.Error -> "Error"
                         },
@@ -302,35 +354,94 @@ fun SettingsLibraryStorageScreen(
         }
 
         if (uiState.showImportConfirmation) {
+            // Issue #235: importing is no longer all-or-nothing. The user picks
+            // WHAT the backup restores — merge-into-library is the default
+            // because it can't destroy anything. Selection lives in composition
+            // on purpose: dismissing/reopening the dialog resets to Merge.
+            var selectedScope by remember { mutableStateOf(BackupImportScope.LIBRARY_MERGE) }
+            val option = importScopeOptions.first { it.scope == selectedScope }
+
             AlertDialog(
                 onDismissRequest = viewModel::onCancelImportDatabase,
                 containerColor = MaterialTheme.colorScheme.surface,
                 shape = MaterialTheme.shapes.large,
                 title = {
                     Text(
-                        text = "Overwrite Library & Settings?",
+                        text = "Import Backup",
                         style = MaterialTheme.typography.titleLarge,
-                        color = MaterialTheme.colorScheme.error,
                     )
                 },
                 text = {
-                    Text(
-                        text = "This will completely replace your existing library metadata, playlists, settings, and account connections. This action cannot be undone.",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    Column {
+                        Text(
+                            text = "Choose what this backup should restore:",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Column(modifier = Modifier.selectableGroup()) {
+                            importScopeOptions.forEach { option ->
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .selectable(
+                                            selected = selectedScope == option.scope,
+                                            role = Role.RadioButton,
+                                            onClick = { selectedScope = option.scope },
+                                        )
+                                        .padding(vertical = 6.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    RadioButton(
+                                        selected = selectedScope == option.scope,
+                                        onClick = null,
+                                    )
+                                    Column(modifier = Modifier.padding(start = 8.dp)) {
+                                        Text(
+                                            text = option.label,
+                                            style = MaterialTheme.typography.bodyLarge,
+                                            color = if (option.destructive) {
+                                                MaterialTheme.colorScheme.error
+                                            } else {
+                                                MaterialTheme.colorScheme.onSurface
+                                            },
+                                        )
+                                        Text(
+                                            text = option.description,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                        if (option.destructive) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = "This cannot be undone.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    }
                 },
                 confirmButton = {
                     TextButton(
                         onClick = {
-                            viewModel.onConfirmImportDatabase { restoredUri ->
+                            viewModel.onConfirmImportDatabase(selectedScope) { restoredUri ->
                                 pendingLibStoragePickerIntent = LibStoragePickerIntent.SetAndRestart
                                 treePicker.launch(restoredUri)
                             }
                         },
-                        colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = if (option.destructive) {
+                                MaterialTheme.colorScheme.error
+                            } else {
+                                MaterialTheme.colorScheme.primary
+                            },
+                        ),
                     ) {
-                        Text("Overwrite")
+                        Text(option.confirmLabel)
                     }
                 },
                 dismissButton = {

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -29,6 +29,8 @@ import com.stash.core.data.lastfm.LastFmCredentials
 import com.stash.core.data.lastfm.LastFmScrobbler
 import com.stash.core.data.lastfm.LastFmSession
 import com.stash.core.data.lastfm.LastFmSessionPreference
+import com.stash.core.data.db.BackupImportResult
+import com.stash.core.data.db.BackupImportScope
 import com.stash.core.data.db.DatabaseBackupManager
 import com.stash.core.data.db.dao.ListeningEventDao
 import com.stash.data.download.files.LibrarySizeBreakdown
@@ -772,29 +774,49 @@ class SettingsViewModel @Inject constructor(
     }
 
     /**
-     * Triggers a database import from the chosen URI. Closes the current
-     * database and overwrites it. Success triggers an app process kill
-     * to force a clean re-init.
+     * Triggers a database import from the chosen URI. The user picks a
+     * [BackupImportScope] in the confirmation dialog; scopes that swap files
+     * behind live singletons end with an app process kill to force a clean
+     * re-init, while LIBRARY_MERGE writes through the live database and just
+     * reports its tally.
      */
     fun onImportDatabase(uri: Uri) {
         _localState.update { it.copy(showImportConfirmation = true, pendingImportUri = uri) }
     }
 
     /**
-     * Confirms the pending database import.
+     * Confirms the pending database import with the user-chosen [scope].
      */
-    fun onConfirmImportDatabase(onExternalPermissionNeeded: (Uri) -> Unit) {
+    fun onConfirmImportDatabase(
+        scope: BackupImportScope,
+        onExternalPermissionNeeded: (Uri) -> Unit,
+    ) {
         val uri = _localState.value.pendingImportUri ?: return
         _localState.update { it.copy(showImportConfirmation = false, pendingImportUri = null) }
 
         viewModelScope.launch {
             _localState.update { it.copy(databaseBackupState = DatabaseBackupState.Importing) }
-            val result = databaseBackupManager.importDatabase(uri)
+            val result = databaseBackupManager.importDatabase(uri, scope)
 
             if (result.isSuccess) {
-                // v0.9.15: The import manager peeks at the restored preferences
+                val summary = result.getOrThrow()
+
+                // v0.9.x (#235): a library MERGE never swaps files — the data
+                // is already visible through the live Room instance — so we
+                // simply report what was added instead of restarting.
+                if (!summary.requiresRestart) {
+                    _localState.update {
+                        it.copy(
+                            databaseBackupState =
+                            DatabaseBackupState.Success(mergeSuccessMessage(summary)),
+                        )
+                    }
+                    return@launch
+                }
+
+                // The import manager peeks at the restored preferences
                 // to detect if an external storage folder was configured.
-                val restoredTreeUri = result.getOrNull()
+                val restoredTreeUri = summary.restoredTreeUri
 
                 if (restoredTreeUri != null) {
                     // Check if we ALREADY have the permission (maybe it's a restore over same install)
@@ -822,6 +844,21 @@ class SettingsViewModel @Inject constructor(
                     )
                 }
             }
+        }
+    }
+
+    /** Human-readable tally for a completed [BackupImportScope.LIBRARY_MERGE]. */
+    private fun mergeSuccessMessage(summary: BackupImportResult): String {
+        val pluralTracks = if (summary.addedTracks == 1) "track" else "tracks"
+        val pluralPlaylists = if (summary.addedPlaylists == 1) "playlist" else "playlists"
+        val pluralEntries = if (summary.mergedMemberships == 1) "entry" else "entries"
+        return when {
+            summary.addedTracks == 0 && summary.addedPlaylists == 0 &&
+                summary.mergedMemberships == 0 ->
+                "Nothing new to import — your library already contains everything from this backup."
+            else -> "Merge complete — added ${summary.addedTracks} new $pluralTracks, " +
+                "${summary.addedPlaylists} new $pluralPlaylists, and " +
+                "${summary.mergedMemberships} playlist $pluralEntries. Settings were left untouched."
         }
     }
 


### PR DESCRIPTION
Closes #235, Closes https://github.com/ParaliyzedEvo/Stash/issues/46.

Import Backup was all-or-nothing: it replaced the library **and** settings. This adds a scope picker so a backup can be merged instead of replacing, and so library and settings can be restored independently.

## Scopes

`BackupImportScope` covers both halves of what the issue asked for:

| Scope | Effect |
|---|---|
| `LIBRARY_MERGE` (default) | Adds the backup's missing songs/playlists/memberships. Nothing deleted, settings untouched, **no restart** — it writes through the live Room instance. |
| `LIBRARY_REPLACE` | Swaps in the backup's database, keeps current settings. |
| `SETTINGS_REPLACE` | Restores settings, keeps the current library. |
| `EVERYTHING_REPLACE` | The historical behavior. |

Merge identity is `spotifyUri → youtubeId → canonical(title, artist)`. Playlists match on `sourceId` and never inherit `syncEnabled` from a backup (keeps the #438 download-consent rule).

## Verified on device

Samsung Tab (SM-T570), debug build:

- Dialog shows 4 options, Merge preselected, the three destructive ones in red; the confirm button relabels `Merge` → `Overwrite All` and adds a "This cannot be undone." warning.
- **The issue's exact scenario:** library held song X, merged a backup containing song Y, ended with **both**. Tally read *"added 1 new track, 1 new playlist, and 1 playlist entry. Settings were left untouched."* and the process id was unchanged — no restart.
- Replace-everything left only the backup's track and did restart.

## Review fixes

Two defects found in review and fixed here, each with a regression test and a negative-control run:

- The membership merge guarded only the live side and never `ref.removedAt`, so a membership the user had **removed** in the backup was re-inserted as active — the mirror image of what merge promises.
- Merged tracks inherited `is_downloaded`/`file_path`/`file_size`. A backup ZIP carries no audio and merge skips the restart that runs the disk-truth sweep, so rows pointed playback and storage totals at files that aren't on this install. They now land not-downloaded; adoption re-claims them if the audio is really there.

## Tests

`core:data` 715 and `feature:settings` 38, 0 failures; `:app:compileDebugKotlin` clean.
