### PR TITLE
feat(downloads): selectable folder layouts + reorganize pass (#198, #104)

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -332,6 +332,22 @@ interface TrackDao {
     @Query("UPDATE tracks SET file_path = :filePath WHERE id = :trackId")
     suspend fun healFilePath(trackId: Long, filePath: String)
 
+    /**
+     * Name of the playlist a track is filed under for the PLAYLIST library
+     * layout (issue #198): the first sync-enabled playlist containing the
+     * track, lowest playlist row id as tie-break — the exact rule the
+     * Failed Downloads viewer's scalar subquery uses so both surfaces agree
+     * on "which playlist owns this track". Null when the track belongs to
+     * no playlist; callers fall back to the Artist/Album location.
+     */
+    @Query("""
+        SELECT p.name FROM playlists p
+        INNER JOIN playlist_tracks pt ON pt.playlist_id = p.id
+        WHERE pt.track_id = :trackId AND pt.removed_at IS NULL
+        ORDER BY p.sync_enabled DESC, p.id ASC LIMIT 1
+    """)
+    suspend fun getFirstPlaylistNameForTrack(trackId: Long): String?
+
     /** Reverts tracks whose file no longer exists on disk back to
     *  "needs download" — clears is_downloaded, file_path, and the stale
     *  size so LibrarySizeHolder's next walk doesn't count phantom bytes. */

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -334,17 +334,25 @@ interface TrackDao {
 
     /**
      * Name of the playlist a track is filed under for the PLAYLIST library
-     * layout (issue #198): the first sync-enabled playlist containing the
-     * track, lowest playlist row id as tie-break — the exact rule the
-     * Failed Downloads viewer's scalar subquery uses so both surfaces agree
-     * on "which playlist owns this track". Null when the track belongs to
-     * no playlist; callers fall back to the Artist/Album location.
+     * layout (issue #198): the first SYNC-ENABLED playlist containing the
+     * track, lowest playlist row id as tie-break. Null when no sync-enabled
+     * playlist owns it — callers fall back to the Artist/Album location.
+     *
+     * Deliberately NOT the same rule as [DownloadQueueDao]'s "from
+     * <playlist>" subquery, which merely ORDERs by `sync_enabled` so it can
+     * still show *some* name for a track whose only memberships are
+     * disabled. That is right for a label and wrong for a directory: filing
+     * audio under a playlist the user has switched off contradicts the
+     * documented fallback and puts files where they are not expected. A
+     * display name and a storage location are different questions, so this
+     * FILTERS where the viewer only sorts.
      */
     @Query("""
         SELECT p.name FROM playlists p
         INNER JOIN playlist_tracks pt ON pt.playlist_id = p.id
         WHERE pt.track_id = :trackId AND pt.removed_at IS NULL
-        ORDER BY p.sync_enabled DESC, p.id ASC LIMIT 1
+          AND p.sync_enabled = 1
+        ORDER BY p.id ASC LIMIT 1
     """)
     suspend fun getFirstPlaylistNameForTrack(trackId: Long): String?
 

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/TrackDao.kt
@@ -346,6 +346,12 @@ interface TrackDao {
      * documented fallback and puts files where they are not expected. A
      * display name and a storage location are different questions, so this
      * FILTERS where the viewer only sorts.
+     *
+     * A track in several enabled playlists is filed under the LOWEST
+     * playlist id, i.e. the one it was added to first. Ids never change,
+     * so the answer is stable: do NOT "fix" this to alphabetical name
+     * order — that would reshuffle files on disk every time a playlist is
+     * renamed.
      */
     @Query("""
         SELECT p.name FROM playlists p

--- a/core/data/src/main/kotlin/com/stash/core/data/library/FileExistenceChecker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/library/FileExistenceChecker.kt
@@ -11,6 +11,9 @@ package com.stash.core.data.library
  * is present — the real implementation re-derives the file's location
  * from the current SAF tree grant using the same slug convention used
  * to write it, instead of trusting the old URI. See FileOrganizer.
+ * [FileExistenceChecker.exists]'s trackId lets the Per-playlist library
+ * layout (#198) re-derive the owning playlist exactly like the download
+ * path did.
  *
  * suspend because the SAF-tree lookup needs the current tree URI from
  * DataStore.
@@ -40,6 +43,7 @@ fun interface FileAdopter {
 
 fun interface FileExistenceChecker {
     suspend fun exists(
+        trackId: Long,
         artist: String,
         album: String?,
         title: String,

--- a/core/data/src/main/kotlin/com/stash/core/data/library/LibraryReconciliationUseCase.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/library/LibraryReconciliationUseCase.kt
@@ -68,8 +68,8 @@ class LibraryReconciliationUseCase @Inject constructor(
     suspend fun reconcile(
         syncId: Long? = null,
         onProgress: (step: Int, total: Int) -> Unit = { _, _ -> },
-        checkFileExists: suspend (artist: String, album: String?, title: String, filePath: String) -> com.stash.core.data.library.FileExistenceResult =
-            { _, _, _, _ -> com.stash.core.data.library.FileExistenceResult(exists = true) },
+        checkFileExists: suspend (trackId: Long, artist: String, album: String?, title: String, filePath: String) -> com.stash.core.data.library.FileExistenceResult =
+            { _, _, _, _, _ -> com.stash.core.data.library.FileExistenceResult(exists = true) },
         adoptExistingFiles: suspend () -> Int = { 0 },
     ): ReconciliationResult {
         onProgress(0, TOTAL_STEPS)
@@ -99,7 +99,7 @@ class LibraryReconciliationUseCase @Inject constructor(
         val downloadedTracks = trackDao.getDownloadedTrackRefs()
         val missingIds = mutableListOf<Long>()
         for (t in downloadedTracks) {
-            val result = checkFileExists(t.artist, t.album, t.title, t.filePath)
+            val result = checkFileExists(t.id, t.artist, t.album, t.title, t.filePath)
             when {
                 !result.exists -> missingIds.add(t.id)
                 result.resolvedFilePath != null -> trackDao.healFilePath(t.id, result.resolvedFilePath)

--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/LibraryLayout.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/LibraryLayout.kt
@@ -1,0 +1,64 @@
+package com.stash.core.data.prefs
+
+/**
+ * Folder structure used for downloaded tracks inside whichever storage
+ * destination is configured (internal `filesDir/music` or the user-picked
+ * SAF tree).
+ *
+ * Issue #198 ("Feature: Define folder structure for library", incl. storing
+ * songs per playlist) and issue #104 ("one folder" — every track directly
+ * inside the destination root).
+ *
+ * The layout only governs where files are WRITTEN and how existing files
+ * are LOOKED UP (reconciliation / adoption / lyrics sidecars). Changing the
+ * setting never moves files by itself; the Settings screen offers an
+ * explicit "Reorganize library" action for relocating already-downloaded
+ * tracks into the chosen structure.
+ */
+enum class LibraryLayout(
+    val key: String,
+    val label: String,
+    val description: String,
+) {
+    /**
+     * Classic nested layout: `<Artist>/<Album>/<title>.<ext>`, with blank
+     * albums filed under `singles/`. This is the historical default.
+     */
+    ARTIST_ALBUM(
+        key = "artist_album",
+        label = "Artist / Album",
+        description = "Nested folders — one per artist, one per album inside it.",
+    ),
+
+    /**
+     * Issue #104: every track lands directly in the destination root as
+     * `<artist>-<title>.<ext>` so the whole library is one flat folder
+     * that's trivial to move or copy elsewhere.
+     */
+    SINGLE_FOLDER(
+        key = "single_folder",
+        label = "Single folder",
+        description = "All tracks directly in one folder, named artist - title.",
+    ),
+
+    /**
+     * Issue #198: one folder per playlist (`<Playlist>/<artist>-<title>.<ext>`).
+     * A track in several playlists is filed under its first sync-enabled
+     * playlist (lowest row id tie-break — the same rule the Failed Downloads
+     * viewer uses). Tracks in no playlist fall back to Artist/Album so
+     * unfiled music stays grouped instead of landing in a junk folder.
+     */
+    PLAYLIST(
+        key = "playlist",
+        label = "Per playlist",
+        description = "One folder per playlist; tracks without a playlist use Artist / Album.",
+    ),
+    ;
+
+    companion object {
+        val DEFAULT: LibraryLayout = ARTIST_ALBUM
+
+        fun fromKey(key: String?): LibraryLayout =
+            entries.firstOrNull { it.key == key } ?: DEFAULT
+    }
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/StoragePreference.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/StoragePreference.kt
@@ -32,4 +32,14 @@ interface StoragePreference {
      * to internal storage.
      */
     suspend fun setExternalTreeUri(uri: Uri?)
+
+    /**
+     * Emits the folder structure new downloads are filed under inside
+     * whichever destination is active (issue #198 / #104). Defaults to
+     * [LibraryLayout.DEFAULT]; changing it does not move existing files.
+     */
+    val libraryLayout: Flow<LibraryLayout>
+
+    /** Persists the folder-structure choice for future downloads. */
+    suspend fun setLibraryLayout(layout: LibraryLayout)
 }

--- a/core/data/src/main/kotlin/com/stash/core/data/prefs/StoragePreferencesManager.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/prefs/StoragePreferencesManager.kt
@@ -32,6 +32,7 @@ class StoragePreferencesManager @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : StoragePreference {
     private val externalTreeUriKey = stringPreferencesKey("external_tree_uri")
+    private val libraryLayoutKey = stringPreferencesKey("library_layout")
 
     override val externalTreeUri: Flow<Uri?> = context.storageDataStore.data.map { prefs ->
         prefs[externalTreeUriKey]?.takeIf { it.isNotBlank() }?.let { Uri.parse(it) }
@@ -44,6 +45,16 @@ class StoragePreferencesManager @Inject constructor(
             } else {
                 prefs[externalTreeUriKey] = uri.toString()
             }
+        }
+    }
+
+    override val libraryLayout: Flow<LibraryLayout> = context.storageDataStore.data.map { prefs ->
+        LibraryLayout.fromKey(prefs[libraryLayoutKey])
+    }
+
+    override suspend fun setLibraryLayout(layout: LibraryLayout) {
+        context.storageDataStore.edit { prefs ->
+            prefs[libraryLayoutKey] = layout.key
         }
     }
 }

--- a/core/data/src/test/kotlin/com/stash/core/data/prefs/StoragePreferencesLayoutTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/prefs/StoragePreferencesLayoutTest.kt
@@ -1,0 +1,57 @@
+package com.stash.core.data.prefs
+
+import android.content.Context
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+/**
+ * Round-trip coverage for the folder-structure preference (#198/#104):
+ * defaults to Artist/Album, persists every layout key, and tolerates
+ * unknown/corrupt keys by falling back to the default instead of crashing.
+ */
+@RunWith(RobolectricTestRunner::class)
+class StoragePreferencesLayoutTest {
+    private lateinit var context: Context
+    private lateinit var manager: StoragePreferencesManager
+    private lateinit var file: File
+
+    @Before fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        file = context.preferencesDataStoreFile("storage_preferences")
+        if (file.exists()) file.delete()
+        manager = StoragePreferencesManager(context)
+    }
+
+    @After fun tearDown() {
+        if (file.exists()) file.delete()
+    }
+
+    @Test fun libraryLayout_defaultsToArtistAlbum() = runTest {
+        assertEquals(LibraryLayout.DEFAULT, manager.libraryLayout.first())
+    }
+
+    @Test fun libraryLayout_persistsEveryLayout() = runTest {
+        for (layout in LibraryLayout.entries) {
+            manager.setLibraryLayout(layout)
+            assertEquals(layout, manager.libraryLayout.first())
+        }
+    }
+
+    @Test fun fromKey_unknownOrNullFallsBackToDefault() {
+        assertEquals(LibraryLayout.DEFAULT, LibraryLayout.fromKey(null))
+        assertEquals(LibraryLayout.DEFAULT, LibraryLayout.fromKey("bogus_layout"))
+        // Every real key round-trips.
+        for (layout in LibraryLayout.entries) {
+            assertEquals(layout, LibraryLayout.fromKey(layout.key))
+        }
+    }
+}

--- a/data/download/src/main/kotlin/com/stash/data/download/DownloadManager.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/DownloadManager.kt
@@ -346,6 +346,7 @@ class DownloadManager @Inject constructor(
             album = effectiveTrack.album.ifEmpty { null },
             title = effectiveTrack.title,
             format = downloadedFile.extension,
+            trackId = track.id,
         )
 
         // Clean up the previous file if the canonicalizer renamed the

--- a/data/download/src/main/kotlin/com/stash/data/download/files/AdoptExistingFilesUseCase.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/AdoptExistingFilesUseCase.kt
@@ -76,11 +76,18 @@ class AdoptExistingFilesUseCase @Inject constructor(
 
     /** Resolves and adopts a single candidate. Returns true if it was adopted. */
     private suspend fun adoptOne(index: FileOrganizer.SafIndex, c: TrackAdoptionCandidate): Boolean {
+        // Layout-aware lookup (#198/#104): probe the current structure first,
+        // then legacy locations, so files downloaded under an earlier layout
+        // (or before the user reorganized) are still recognized instead of
+        // being queued for a redundant network download.
+        val playlistName = runCatching { trackDao.getFirstPlaylistNameForTrack(c.id) }.getOrNull()
         val match = fileOrganizer.resolveInIndex(
             index = index,
+            layout = fileOrganizer.currentLayout(),
             artist = c.artist,
             album = c.album,
             title = c.title,
+            playlistName = playlistName,
         ) ?: return false
 
         trackDao.markAsDownloaded(

--- a/data/download/src/main/kotlin/com/stash/data/download/files/FileOrganizer.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/FileOrganizer.kt
@@ -3,6 +3,8 @@ package com.stash.data.download.files
 import android.content.Context
 import android.net.Uri
 import androidx.documentfile.provider.DocumentFile
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.prefs.LibraryLayout
 import com.stash.core.data.prefs.StoragePreference
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
@@ -15,7 +17,7 @@ import javax.inject.Singleton
  * Manages file paths for downloaded music.
  *
  * Supports two storage destinations:
- *  - **Internal** (default): tracks live under `context.filesDir/music/<artist>/<album>/`.
+ *  - **Internal** (default): tracks live under `context.filesDir/music/…`.
  *    Pure `java.io.File` API. Tracks are deleted when the app is uninstalled
  *    and are not visible to other apps.
  *  - **External** (user-chosen via SAF): when the user picks an SD card or
@@ -23,6 +25,12 @@ import javax.inject.Singleton
  *    written to that location via `ContentResolver` / `DocumentFile`. These
  *    files survive app uninstall and are accessible to other apps + over
  *    USB/PC — users can take their library anywhere.
+ *
+ * Within either destination, the folder structure follows the user's
+ * [LibraryLayout] preference (#198/#104): Artist/Album (classic default),
+ * Single folder, or Per playlist. ALL path computation goes through
+ * [LibraryLayoutResolver]; this class never slugs artist/album by hand so
+ * writers and readers cannot drift.
  *
  * yt-dlp always writes to the internal cache (`getTempDir()`); the
  * destination switch happens in [commitDownload] after the download
@@ -32,31 +40,77 @@ import javax.inject.Singleton
 class FileOrganizer @Inject constructor(
     @ApplicationContext private val context: Context,
     private val storagePreference: StoragePreference,
+    private val trackDao: TrackDao,
 ) {
     /** Root directory for all internally-stored downloaded music files. */
     private val musicDir: File get() = File(context.filesDir, "music").also { it.mkdirs() }
 
     /**
-     * Returns the internal directory for a specific artist/album combination.
-     * Only used for internal-storage downloads; SAF downloads compute their
-     * own path inside [commitDownload].
+     * The absolute internal music root, exposed so bulk coordinators
+     * (reorganize / move-library gating) can classify stored paths as
+     * internal vs SAF without duplicating the `filesDir/music` convention.
      */
-    fun getTrackDir(artist: String, album: String?): File {
-        val artistSlug = FileOrganizerSlugs.slugify(artist)
-        val albumSlug = if (!album.isNullOrBlank()) FileOrganizerSlugs.slugify(album) else "singles"
-        return File(musicDir, "$artistSlug/$albumSlug").also { it.mkdirs() }
+    fun internalMusicRoot(): File = musicDir
+
+    /**
+     * The persisted library layout, defaulting safely when DataStore read
+     * fails. One-call convenience for bulk passes that want a consistent
+     * layout for their whole duration (adoption, reorganize).
+     */
+    suspend fun currentLayout(): LibraryLayout =
+        runCatching { storagePreference.libraryLayout.first() }.getOrDefault(LibraryLayout.DEFAULT)
+
+    /**
+     * Resolves a track's destination under the CURRENT library layout,
+     * including the owning-playlist lookup when the layout is
+     * [LibraryLayout.PLAYLIST] and a [trackId] is known. Every writer
+     * (downloads, moves, reorganize, sidecars) resolves through here.
+     */
+    suspend fun resolveLocation(
+        artist: String,
+        album: String?,
+        title: String,
+        trackId: Long? = null,
+        layout: LibraryLayout? = null,
+    ): LibraryLayoutResolver.ResolvedLocation {
+        val effectiveLayout = layout ?: currentLayout()
+        val playlistName = if (effectiveLayout == LibraryLayout.PLAYLIST && trackId != null) {
+            runCatching { trackDao.getFirstPlaylistNameForTrack(trackId) }.getOrNull()
+        } else {
+            null
+        }
+        return LibraryLayoutResolver.resolve(effectiveLayout, artist, album, title, playlistName)
     }
 
     /**
-     * Returns the internal file path for a downloaded track. Prefer
-     * [commitDownload] which automatically handles both internal and SAF
-     * destinations; this getter is retained for callers that only need the
-     * target path (e.g. existence checks before download).
+     * Returns the internal directory for a specific artist/album combination
+     * under [layout]. Only meaningful for internal-storage destinations;
+     * SAF downloads compute their own path inside [commitDownload].
+     * Defaults to the classic Artist/Album shape — live downloads should go
+     * through [commitDownload]/[resolveLocation], which honor the pref.
      */
-    fun getTrackFile(artist: String, album: String?, title: String, format: String = "opus"): File {
-        val dir = getTrackDir(artist, album)
-        val titleSlug = FileOrganizerSlugs.slugify(title)
-        return File(dir, "$titleSlug.$format")
+    fun getTrackDir(artist: String, album: String?, layout: LibraryLayout = LibraryLayout.DEFAULT): File {
+        val location = LibraryLayoutResolver.resolve(layout, artist, album, title = "", playlistName = null)
+        val dir = if (location.segments.isEmpty()) musicDir else File(musicDir, location.segments.joinToString("/"))
+        return dir.also { it.mkdirs() }
+    }
+
+    /**
+     * Returns the internal file path for a downloaded track under [layout].
+     * Prefer [commitDownload] which automatically handles both internal and
+     * SAF destinations plus the live layout preference; this getter is
+     * retained for callers that only need the classic target path.
+     */
+    fun getTrackFile(
+        artist: String,
+        album: String?,
+        title: String,
+        format: String = "opus",
+        layout: LibraryLayout = LibraryLayout.DEFAULT,
+    ): File {
+        val location =
+            LibraryLayoutResolver.resolve(layout, artist, album, title, playlistName = null)
+        return File(getTrackDir(artist, album, layout), "${location.baseName}.$format")
     }
 
     /** Temporary download directory inside the cache. Cleaned by the OS as needed. */
@@ -67,10 +121,10 @@ class FileOrganizer @Inject constructor(
      * (for SAF) a fresh URI to persist if the stored one was stale.
      * [FileExistenceChecker.exists]'s `filePath` is only consulted for the
      * internal-storage fast path; for SAF paths the location is re-derived
-     * from artist/album/title against a [buildSafIndex] built lazily ONCE
-     * per session — per-track findFile walks were the "stuck on Checking
-     * library" hang (#429). A missing tree grant fails SAFE (files reported
-     * present) so it can never mass-reset the library.
+     * via [LibraryLayoutResolver.lookupCandidates] against a [buildSafIndex]
+     * built lazily ONCE per session — per-track findFile walks were the
+     * "stuck on Checking library" hang (#429). A missing tree grant fails
+     * SAFE (files reported present) so it can never mass-reset the library.
      *
      * Used by library reconciliation (missing-file detection) via
      * [com.stash.core.data.library.FileExistenceSessionFactory]. Open a
@@ -80,9 +134,10 @@ class FileOrganizer @Inject constructor(
         object : com.stash.core.data.library.FileExistenceChecker {
             private val lock = kotlinx.coroutines.sync.Mutex()
             private var built = false
-            private var index: SafIndex? = null
+            private var snapshot: IndexSnapshot? = null
 
             override suspend fun exists(
+                trackId: Long,
                 artist: String,
                 album: String?,
                 title: String,
@@ -91,10 +146,11 @@ class FileOrganizer @Inject constructor(
                 if (!filePath.startsWith("content://")) {
                     return com.stash.core.data.library.FileExistenceResult(exists = File(filePath).exists())
                 }
-                val idx = lock.withLock {
+                val snap = lock.withLock {
                     if (!built) {
-                        index = buildSafIndex()
-                        built = true
+                        val layout = runCatching { storagePreference.libraryLayout.first() }
+                            .getOrNull() ?: LibraryLayout.DEFAULT
+                        val index = buildSafIndex()
                         if (index == null) {
                             android.util.Log.w(
                                 "FileOrganizer",
@@ -103,14 +159,28 @@ class FileOrganizer @Inject constructor(
                                     "would reset the whole library to undownloaded)",
                             )
                         }
+                        // Fail SAFE on a missing/revoked tree grant: report the file as
+                        // existing rather than triggering a library-wide reset + redownload
+                        // storm the first sync after a re-grant lapse.
+                        snapshot = index?.let { IndexSnapshot(it, layout) }
+                        built = true
                     }
-                    index
-                    // Fail SAFE on a missing/revoked tree grant: report the file as
-                    // existing rather than triggering a library-wide reset + redownload
-                    // storm the first sync after a re-grant lapse.
+                    snapshot
                 } ?: return com.stash.core.data.library.FileExistenceResult(exists = true)
-                val match = resolveInIndex(idx, artist, album, title)
-                    ?: return com.stash.core.data.library.FileExistenceResult(exists = false)
+
+                val playlistName = if (snap.layout == LibraryLayout.PLAYLIST) {
+                    runCatching { trackDao.getFirstPlaylistNameForTrack(trackId) }.getOrNull()
+                } else {
+                    null
+                }
+                val match = resolveInIndex(
+                    index = snap.index,
+                    layout = snap.layout,
+                    artist = artist,
+                    album = album,
+                    title = title,
+                    playlistName = playlistName,
+                ) ?: return com.stash.core.data.library.FileExistenceResult(exists = false)
                 val freshUri = match.uri.toString()
                 return com.stash.core.data.library.FileExistenceResult(
                     exists = true,
@@ -121,80 +191,116 @@ class FileOrganizer @Inject constructor(
             }
         }
 
+    /** Index + the layout it was built under, frozen for one bulk pass. */
+    private data class IndexSnapshot(val index: SafIndex, val layout: LibraryLayout)
+
     /**
     * Pre-built index of the current SAF tree, so a bulk pass (like
     * [com.stash.core.data.library.AdoptExistingFilesUseCase]) can look up
-    * album directories in O(1) instead of re-walking `root -> artist -> album`
-    * via [DocumentFile.findFile] for every single candidate.
+    * any track in O(1) instead of re-walking directories via
+    * [DocumentFile.findFile] for every single candidate.
     *
     * [DocumentFile.findFile] is not a direct lookup: internally it calls
     * `listFiles()` on the parent and linearly scans for a name match. Doing
     * that per-candidate against thousands of tracks means re-listing the same
-    * artist/album directories over and over via ContentResolver IPC — the
-    * actual cost that was making adoption slower than downloading the same
-    * tracks over the network. Building this index means the tree is walked
-    * exactly once regardless of candidate count.
+    * directories over and over via ContentResolver IPC — the actual cost that
+    * was making adoption slower than downloading the same tracks over the
+    * network. Building this index means the tree is walked exactly once
+    * regardless of candidate count.
     *
-    * Filenames are also pre-listed per album dir (see [AlbumIndex]) so a
-    * lookup for a specific title never has to hit the provider again.
+    * Since #198/#104 the tree is NOT guaranteed to be a strict two-level
+    * `<artist>/<album>` hierarchy anymore (flat single-folder libraries,
+    * per-playlist folders, mixed layouts mid-reorganize), so the walk is
+    * fully recursive and keyed by slash-joined relative directory paths
+    * ([SafIndex.byDirKey]). A whole-tree filename index ([SafIndex.byFileName])
+    * backs the last-resort unique-name match for locations whose owning
+    * playlist can't be re-derived.
     */
     suspend fun buildSafIndex(): SafIndex? {
         val treeUri = storagePreference.externalTreeUri.first() ?: return null
         val root = DocumentFile.fromTreeUri(context, treeUri) ?: return null
-    
-        val index = HashMap<Pair<String, String>, AlbumIndex>()
-        root.listFiles().forEach { artistDir ->
-            if (!artistDir.isDirectory) return@forEach
-            val artistName = artistDir.name ?: return@forEach
-            artistDir.listFiles().forEach { albumDir ->
-                if (!albumDir.isDirectory) return@forEach
-                val albumName = albumDir.name ?: return@forEach
-                // List each album dir's files exactly once, up front, and
-                // index by name for O(1) lookup instead of a per-candidate
-                // listFiles().firstOrNull { ... } scan.
-                val filesByName = albumDir.listFiles()
-                    .filter { it.isFile }
-                    .associateBy { it.name.orEmpty() }
-                index[artistName to albumName] = AlbumIndex(albumDir, filesByName)
+
+        val byDirKey = LinkedHashMap<String, AlbumIndex>(256)
+        val byFileName = HashMap<String, MutableList<DocumentFile>>(512)
+        indexTree(root, "", byDirKey, byFileName)
+        return SafIndex(byDirKey, byFileName)
+    }
+
+    /** Recursive worker behind [buildSafIndex]. Depth is directory nesting (≤4 in practice). */
+    private fun indexTree(
+        dir: DocumentFile,
+        dirKey: String,
+        byDirKey: MutableMap<String, AlbumIndex>,
+        byFileName: MutableMap<String, MutableList<DocumentFile>>,
+    ) {
+        val subDirs = ArrayList<DocumentFile>()
+        val filesByName = LinkedHashMap<String, DocumentFile>()
+        for (child in dir.listFiles()) {
+            if (child.isDirectory) {
+                subDirs += child
+            } else if (child.isFile) {
+                val name = child.name ?: continue
+                filesByName[name] = child
+                byFileName.getOrPut(name) { ArrayList(1) }.add(child)
             }
         }
-        return SafIndex(index)
+        byDirKey[dirKey] = AlbumIndex(dir, filesByName)
+        for (sub in subDirs) {
+            val subName = sub.name ?: continue
+            indexTree(sub, if (dirKey.isEmpty()) subName else "$dirKey/$subName", byDirKey, byFileName)
+        }
     }
-    
+
     /**
-    * O(1) lookup against a pre-built [SafIndex]. Same slug convention and
-    * extension-probing behaviour the per-track slug walk used to have, but with no
-    * SAF IPC calls at all once the index is built — everything after
-    * [buildSafIndex] is in-memory map lookups.
+    * O(1) lookup against a pre-built [SafIndex]. Probes every location
+    * [LibraryLayoutResolver.lookupCandidates] derives for the track — the
+    * current-layout spot first, then the legacy/nested and flat spots for
+    * files downloaded before a layout switch — with zero further SAF IPC
+    * once the index is built. A final whole-tree unique-filename match
+    * covers playlist-owned directories when the owning playlist couldn't be
+    * re-derived (deterministic: ambiguous duplicates match nothing rather
+    * than guessing wrong).
     */
     fun resolveInIndex(
         index: SafIndex,
+        layout: LibraryLayout,
         artist: String,
         album: String?,
         title: String,
+        playlistName: String? = null,
         knownFormat: String? = null,
     ): DocumentFile? {
-        val artistSlug = FileOrganizerSlugs.slugify(artist)
-        val albumSlug = if (!album.isNullOrBlank()) FileOrganizerSlugs.slugify(album) else "singles"
-        val titleSlug = FileOrganizerSlugs.slugify(title)
-    
-        val albumIndex = index.byArtistAlbum[artistSlug to albumSlug] ?: return null
-    
-        val candidateNames = if (knownFormat != null) {
-            setOf("$titleSlug.$knownFormat")
-        } else {
-            KNOWN_AUDIO_FORMATS.map { "$titleSlug.$it" }
+        val formats = knownFormat?.let { listOf(it) } ?: KNOWN_AUDIO_FORMATS
+        val candidates = LibraryLayoutResolver.lookupCandidates(
+            layout, artist, album, title, playlistName, formats,
+        )
+        for (candidate in candidates) {
+            val filesByName = index.byDirKey[candidate.dirKey]?.filesByName ?: continue
+            for (name in candidate.candidateFileNames) {
+                filesByName[name]?.let { return it }
+            }
         }
-        for (name in candidateNames) {
-            albumIndex.filesByName[name]?.let { return it }
+        // Last resort: exactly one file somewhere in the tree carries a
+        // candidate name. Unique ⇒ unambiguous; multiple hits stay unmatched
+        // (reporting "missing" for a genuinely ambiguous pair is safer than
+        // adopting the wrong song's file).
+        for (candidate in candidates) {
+            for (name in candidate.candidateFileNames) {
+                index.byFileName[name]?.singleOrNull()?.let { return it }
+            }
         }
         return null
     }
-    
+
     /** In-memory index built once per bulk pass by [buildSafIndex]. */
-    class SafIndex(val byArtistAlbum: Map<Pair<String, String>, AlbumIndex>)
-    
-    /** Pre-listed contents of a single album directory. */
+    class SafIndex(
+        /** Relative slash-joined dir key ("" = tree root) → its listing. */
+        val byDirKey: Map<String, AlbumIndex>,
+        /** Whole-tree filename → every document carrying it (usually 1). */
+        val byFileName: Map<String, List<DocumentFile>>,
+    )
+
+    /** Pre-listed contents of a single directory. */
     class AlbumIndex(val dir: DocumentFile, val filesByName: Map<String, DocumentFile>)
 
     /** Directory for cached album artwork files. */
@@ -305,6 +411,10 @@ class FileOrganizer @Inject constructor(
      * all accept content URIs natively so playback works without further
      * changes. Otherwise the file is moved into internal storage and the
      * returned path is the absolute File path (existing behaviour).
+     *
+     * The sub-destination inside the root follows the current [LibraryLayout]
+     * (#198/#104); when the layout is Per-playlist and [trackId] is known,
+     * the owning playlist is looked up so the file lands in its folder.
      */
     suspend fun commitDownload(
         tempFile: File,
@@ -312,47 +422,53 @@ class FileOrganizer @Inject constructor(
         album: String?,
         title: String,
         format: String,
+        trackId: Long? = null,
     ): CommittedTrack {
         val size = tempFile.length()
         val externalTree = storagePreference.externalTreeUri.first()
         return if (externalTree == null) {
-            val finalFile = getTrackFile(artist, album, title, format)
+            val location = resolveLocation(artist, album, title, trackId)
+            val dir = if (location.segments.isEmpty()) {
+                musicDir
+            } else {
+                File(musicDir, location.segments.joinToString("/")).also { it.mkdirs() }
+            }
+            val finalFile = File(dir, "${location.baseName}.$format")
             tempFile.copyTo(finalFile, overwrite = true)
             tempFile.delete()
             CommittedTrack(finalFile.absolutePath, size)
         } else {
-            val safUriString = writeToSafTree(tempFile, externalTree, artist, album, title, format)
+            val location = resolveLocation(artist, album, title, trackId)
+            val safUriString = writeToSafTree(tempFile, externalTree, location, format)
             tempFile.delete()
             CommittedTrack(safUriString, size)
         }
     }
 
     /**
-     * Writes [tempFile] to the user's SAF tree under `artist/album/title.ext`.
-     * Returns the created document's URI as a string. Throws if the tree
-     * URI is stale (permission revoked) or I/O fails — caller should log
-     * and leave the temp file in place for retry.
+     * Writes [tempFile] into the user's SAF tree at [location]'s relative
+     * path, creating intermediate directories on demand. Returns the created
+     * document's URI as a string. Throws if the tree URI is stale (permission
+     * revoked) or I/O fails — caller should log and leave the temp file in
+     * place for retry.
      */
     private fun writeToSafTree(
         tempFile: File,
         treeUri: Uri,
-        artist: String,
-        album: String?,
-        title: String,
+        location: LibraryLayoutResolver.ResolvedLocation,
         format: String,
     ): String {
         val root = DocumentFile.fromTreeUri(context, treeUri)
             ?: error("Could not open SAF tree; permission may have been revoked: $treeUri")
-        val artistSlug = FileOrganizerSlugs.slugify(artist)
-        val albumSlug = if (!album.isNullOrBlank()) FileOrganizerSlugs.slugify(album) else "singles"
-        val artistDir = root.findOrCreateDir(artistSlug)
-        val albumDir = artistDir.findOrCreateDir(albumSlug)
-        val titleSlug = FileOrganizerSlugs.slugify(title)
-        val filename = "$titleSlug.$format"
+        var cursor = root
+        for (segment in location.segments) {
+            cursor = cursor.findOrCreateDir(segment)
+        }
+        val filename = "${location.baseName}.$format"
         // Overwrite: delete any existing file with the same name before creating.
-        albumDir.findFile(filename)?.delete()
-        val target = albumDir.createFile(mimeTypeFor(format), filename)
-            ?: error("Could not create SAF file '$filename' under ${albumDir.uri}")
+        cursor.findFile(filename)?.delete()
+        val target = cursor.createFile(mimeTypeFor(format), filename)
+            ?: error("Could not create SAF file '$filename' under ${cursor.uri}")
         tempFile.inputStream().use { input ->
             context.contentResolver.openOutputStream(target.uri)?.use { output ->
                 input.copyTo(output)

--- a/data/download/src/main/kotlin/com/stash/data/download/files/FileOrganizer.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/FileOrganizer.kt
@@ -281,11 +281,20 @@ class FileOrganizer @Inject constructor(
             }
         }
         // Last resort: exactly one file somewhere in the tree carries a
-        // candidate name. Unique ⇒ unambiguous; multiple hits stay unmatched
+        // candidate name. Restricted to ARTIST-QUALIFIED names
+        // (`<artist>-<title>.<ext>`): the legacy Artist/Album candidate's
+        // filename is a bare `<title>.<ext>`, which is not an identity once
+        // it leaves its `<artist>/<album>` directory. A different artist's
+        // song that slugs to the same title would be matched here and have
+        // this track's file_path healed onto it. Uniqueness of a FILENAME is
+        // not uniqueness of a TRACK, so only names that still carry the
+        // artist may be matched tree-wide; multiple hits stay unmatched
         // (reporting "missing" for a genuinely ambiguous pair is safer than
         // adopting the wrong song's file).
+        val artistQualifiedPrefix = FileOrganizerSlugs.slugify(artist) + "-"
         for (candidate in candidates) {
             for (name in candidate.candidateFileNames) {
+                if (!name.startsWith(artistQualifiedPrefix)) continue
                 index.byFileName[name]?.singleOrNull()?.let { return it }
             }
         }

--- a/data/download/src/main/kotlin/com/stash/data/download/files/LibraryLayoutResolver.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/LibraryLayoutResolver.kt
@@ -1,0 +1,140 @@
+package com.stash.data.download.files
+
+import com.stash.core.data.prefs.LibraryLayout
+
+/**
+ * Single source of truth for where a downloaded track lives inside the
+ * configured library destination (internal `filesDir/music` root or the
+ * user-picked SAF tree root).
+ *
+ * Issue #198 / #104 introduced selectable folder structures. Before this
+ * object the `<artist>/<album>/<title>` layout was re-derived by hand in
+ * four places (internal commit, SAF commit, library move, lyrics sidecar)
+ * plus a fifth assumption baked into the reconciliation index — each one
+ * an opportunity for drift. Every writer and reader now goes through
+ * [resolve] (writes) or [lookupCandidates] (reads), so the on-disk shape
+ * cannot disagree with itself.
+ *
+ * Filename rules:
+ *  - [LibraryLayout.ARTIST_ALBUM] keeps the historical `<title>.<ext>`
+ *    (the directory pair already disambiguates same-titled tracks, and
+ *    changing it would rename every existing file).
+ *  - [LibraryLayout.SINGLE_FOLDER] and [LibraryLayout.PLAYLIST] prefix the
+ *    artist slug (`<artist>-<title>.<ext>`) because the directory no longer
+ *    separates artists — two different songs both titled "Intro" would
+ *    otherwise silently overwrite each other in one shared folder.
+ *
+ * Fallback rules (deliberate, tested):
+ *  - Blank album → `singles/` directory (unchanged historical behavior).
+ *  - PLAYLIST with no resolvable playlist name (track in no playlist, or
+ *    the name slugifies to nothing) → falls back to ARTIST_ALBUM segments,
+ *    so unfiled tracks stay grouped under their artist instead of piling
+ *    into a junk folder.
+ */
+object LibraryLayoutResolver {
+
+    /**
+     * A track's location relative to the library root: [segments] are the
+     * directory names in order (empty = directly in the root) and
+     * [baseName] is the filename without extension.
+     */
+    data class ResolvedLocation(
+        val segments: List<String>,
+        val baseName: String,
+    ) {
+        /** Slash-joined directory key ("artist/album"); "" = library root. */
+        val dirKey: String get() = segments.joinToString("/")
+    }
+
+    /**
+     * Computes where a track should be written under [layout].
+     *
+     * @param artist       Track artist as stored on the row (slugged here).
+     * @param album        Album name, or null/blank when unknown.
+     * @param title        Track title (slugged into the base name).
+     * @param playlistName Resolved owning playlist for [LibraryLayout.PLAYLIST];
+     *   ignored by the other layouts. Null when unknown/unresolvable.
+     */
+    fun resolve(
+        layout: LibraryLayout,
+        artist: String,
+        album: String?,
+        title: String,
+        playlistName: String?,
+    ): ResolvedLocation {
+        val artistSlug = FileOrganizerSlugs.slugify(artist)
+        val titleSlug = FileOrganizerSlugs.slugify(title)
+
+        if (layout == LibraryLayout.SINGLE_FOLDER) {
+            return ResolvedLocation(emptyList(), "$artistSlug-$titleSlug")
+        }
+
+        if (layout == LibraryLayout.PLAYLIST && !playlistName.isNullOrBlank()) {
+            val playlistSlug = FileOrganizerSlugs.slugify(playlistName)
+            if (playlistSlug.isNotBlank()) {
+                return ResolvedLocation(listOf(playlistSlug), "$artistSlug-$titleSlug")
+            }
+            // Playlist name slugified to nothing (emoji-only etc.) → fall through.
+        }
+
+        // ARTIST_ALBUM — and the PLAYLIST fallback when no playlist resolved.
+        val albumSlug = if (!album.isNullOrBlank()) FileOrganizerSlugs.slugify(album) else "singles"
+        return ResolvedLocation(listOf(artistSlug, albumSlug), titleSlug)
+    }
+
+    /**
+     * Candidate locations to probe when looking up whether a file already
+     * exists on disk (library reconciliation, adoption). Ordered most
+     * specific first:
+     *
+     *  1. The current-layout location.
+     *  2. The legacy `<artist>/<album>` location — tracks downloaded before
+     *     a layout switch stay there until the user runs Reorganize, and a
+     *     lookup that only tried the new location would report them missing
+     *     and reset/redownload them (the #429 failure shape).
+     *  3. For nested layouts, the flat `<artist>-<title>` name at the root —
+     *     covers files downloaded while SINGLE_FOLDER was active and not yet
+     *     reorganized.
+     *
+     * Each entry is `(dirKey, candidate full filenames)`. With
+     * [knownFormats] empty only the bare base name is probed; otherwise one
+     * candidate per known audio extension is generated (the extension-probe
+     * behavior of the old slug-walk).
+     */
+    fun lookupCandidates(
+        layout: LibraryLayout,
+        artist: String,
+        album: String?,
+        title: String,
+        playlistName: String?,
+        knownFormats: List<String>,
+    ): List<CandidateLocation> {
+        val artistSlug = FileOrganizerSlugs.slugify(artist)
+        val titleSlug = FileOrganizerSlugs.slugify(title)
+        val flatBase = "$artistSlug-$titleSlug"
+
+        fun namesFor(base: String): List<String> =
+            if (knownFormats.isEmpty()) listOf(base) else knownFormats.map { "$base.$it" }
+
+        val primary = resolve(layout, artist, album, title, playlistName)
+        val candidates = mutableListOf(
+            CandidateLocation(primary.dirKey, namesFor(primary.baseName)),
+        )
+
+        val albumSlug = if (!album.isNullOrBlank()) FileOrganizerSlugs.slugify(album) else "singles"
+        val legacyKey = "$artistSlug/$albumSlug"
+        if (candidates.none { it.dirKey == legacyKey }) {
+            candidates += CandidateLocation(legacyKey, namesFor(titleSlug))
+        }
+        if (primary.segments.isNotEmpty()) {
+            candidates += CandidateLocation("", namesFor(flatBase))
+        }
+        return candidates
+    }
+
+    /** One probe location from [lookupCandidates]. */
+    data class CandidateLocation(
+        val dirKey: String,
+        val candidateFileNames: List<String>,
+    )
+}

--- a/data/download/src/main/kotlin/com/stash/data/download/files/LibraryRewriteGate.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/LibraryRewriteGate.kt
@@ -1,0 +1,41 @@
+package com.stash.data.download.files
+
+import java.util.concurrent.atomic.AtomicReference
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Mutual exclusion between the bulk passes that rewrite `file_path` for
+ * every downloaded track: the library move ([MoveLibraryCoordinator]) and
+ * the folder-layout reorganize ([ReorganizeLibraryCoordinator], #198/#104).
+ *
+ * Run at the same time, the two heal the same rows and whichever
+ * `healFilePath` lands last wins — the other pass's file is left on disk
+ * with nothing pointing at it. The gate lives here rather than in either
+ * coordinator because the exclusion has to hold in BOTH start orders, and a
+ * coordinator that checks the other one's state can only cover one of them
+ * (and would need a dependency cycle to cover both).
+ *
+ * The loser is refused, not queued: both passes are manual, restartable
+ * actions, so telling the user to try again is honest and a queue is a
+ * surprise.
+ *
+ * ponytail: one global claim, not a per-track lock — these are
+ * whole-library sweeps, so there is nothing finer to contend over.
+ */
+@Singleton
+class LibraryRewriteGate @Inject constructor() {
+
+    private val holder = AtomicReference<String?>(null)
+
+    /** Human-readable name of the pass holding the gate, or null if free. */
+    val heldBy: String? get() = holder.get()
+
+    /** Claims the gate for [owner]; false when someone else already holds it. */
+    fun tryAcquire(owner: String): Boolean = holder.compareAndSet(null, owner)
+
+    /** Hands the gate back. A no-op unless [owner] is the current holder. */
+    fun release(owner: String) {
+        holder.compareAndSet(owner, null)
+    }
+}

--- a/data/download/src/main/kotlin/com/stash/data/download/files/MoveLibraryCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/MoveLibraryCoordinator.kt
@@ -6,6 +6,8 @@ import android.util.Log
 import androidx.documentfile.provider.DocumentFile
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.prefs.LibraryLayout
+import com.stash.core.data.prefs.StoragePreference
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -15,6 +17,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.io.File
 import javax.inject.Inject
@@ -36,10 +39,10 @@ sealed interface MoveLibraryState {
 
 /**
  * Moves every downloaded track currently stored under the app's internal
- * music directory into a user-picked SAF folder, preserving
- * `<artist>/<album>/<title>.ext` layout and updating `Track.filePath` in the
- * DB to the resulting content URI. Deletes the internal copy after each
- * successful SAF write.
+ * music directory into a user-picked SAF folder, preserving the folder
+ * structure selected by the user's [LibraryLayout] preference (#198/#104)
+ * and updating `Track.filePath` in the DB to the resulting content URI.
+ * Deletes the internal copy after each successful SAF write.
  *
  * Runs on a `@Singleton`-scoped [scope] so the move survives VM death (the
  * user can leave the Settings screen and come back to see progress). Work
@@ -61,6 +64,7 @@ sealed interface MoveLibraryState {
 class MoveLibraryCoordinator @Inject constructor(
     @ApplicationContext private val context: Context,
     private val trackDao: TrackDao,
+    private val storagePreference: StoragePreference,
 ) {
     private val _state = MutableStateFlow<MoveLibraryState>(MoveLibraryState.Idle)
     val state: StateFlow<MoveLibraryState> = _state.asStateFlow()
@@ -123,20 +127,26 @@ class MoveLibraryCoordinator @Inject constructor(
                 return
             }
 
+            // Freeze the layout for the whole move so a mid-flight pref
+            // change can't produce a half-artist/album, half-playlist tree.
+            val layout = runCatching { storagePreference.libraryLayout.first() }
+                .getOrDefault(LibraryLayout.DEFAULT)
+
             var moved = 0
             var failed = 0
             _state.value = MoveLibraryState.Running(current = 0, total = total)
 
             // Directory-lookup cache. DocumentFile.findFile() is O(children)
             // per SAF provider — on a moving target that fills up as we go,
-            // the library-move becomes O(n²). Caching by "<artistSlug>" and
-            // "<artistSlug>/<albumSlug>" collapses the N² to O(n+unique-dirs)
+            // the library-move becomes O(n²). Caching by cumulative relative
+            // dir key ("<artistSlug>" / "<playlistSlug>" /
+            // "<artistSlug>/<albumSlug>") collapses the N² to O(n+unique-dirs)
             // which is typically a 3-5× speedup on a 1000+ track library.
             val dirCache = HashMap<String, DocumentFile>(256)
 
             for ((index, track) in tracks.withIndex()) {
                 _state.value = MoveLibraryState.Running(current = index, total = total)
-                val ok = runCatching { moveOne(track, root, dirCache) }
+                val ok = runCatching { moveOne(track, root, layout, dirCache) }
                 if (ok.isSuccess) {
                     moved++
                 } else {
@@ -158,6 +168,7 @@ class MoveLibraryCoordinator @Inject constructor(
     private suspend fun moveOne(
         track: TrackEntity,
         root: DocumentFile,
+        layout: LibraryLayout,
         dirCache: MutableMap<String, DocumentFile>,
     ) {
         val path = track.filePath ?: return
@@ -166,27 +177,37 @@ class MoveLibraryCoordinator @Inject constructor(
             error("Internal file missing: $path")
         }
 
-        val artistSlug = FileOrganizerSlugs.slugify(track.artist)
-        val albumSlug = if (track.album.isNotBlank()) {
-            FileOrganizerSlugs.slugify(track.album)
-        } else {
-            "singles"
-        }
-        val titleSlug = FileOrganizerSlugs.slugify(track.title)
-        val format = localFile.extension.ifBlank { "m4a" }
-        val filename = "$titleSlug.$format"
+        // Same resolver the download path uses, so the moved library has
+        // exactly the structure new downloads will keep producing (#198/#104).
+        val playlistName =
+            if (layout == LibraryLayout.PLAYLIST) {
+                runCatching { trackDao.getFirstPlaylistNameForTrack(track.id) }.getOrNull()
+            } else {
+                null
+            }
+        val location = LibraryLayoutResolver.resolve(
+            layout,
+            artist = track.artist,
+            album = track.album.takeIf { it.isNotBlank() },
+            title = track.title,
+            playlistName = playlistName,
+        )
 
-        val artistDir = dirCache.getOrPut("a:$artistSlug") {
-            root.findOrCreateDir(artistSlug)
+        var cursor = root
+        var cumulativeKey = ""
+        for (segment in location.segments) {
+            cumulativeKey = if (cumulativeKey.isEmpty()) segment else "$cumulativeKey/$segment"
+            cursor = dirCache.getOrPut(cumulativeKey) { cursor.findOrCreateDir(segment) }
         }
-        val albumDir = dirCache.getOrPut("b:$artistSlug/$albumSlug") {
-            artistDir.findOrCreateDir(albumSlug)
-        }
+
+        val format = localFile.extension.ifBlank { "m4a" }
+        val filename = "${location.baseName}.$format"
+
         // Overwrite: still scan for an existing file since we can't cache
         // per-title dirs (they'd explode the map). This is the only O(m)
-        // lookup left per track where m = album size, usually <15.
-        albumDir.findFile(filename)?.delete()
-        val target = albumDir.createFile(mimeTypeFor(format), filename)
+        // lookup left per track where m = target dir size, usually <15.
+        cursor.findFile(filename)?.delete()
+        val target = cursor.createFile(mimeTypeFor(format), filename)
             ?: error("Could not create SAF file for '${track.title}'")
 
         localFile.inputStream().use { input ->

--- a/data/download/src/main/kotlin/com/stash/data/download/files/MoveLibraryCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/MoveLibraryCoordinator.kt
@@ -57,6 +57,9 @@ sealed interface MoveLibraryState {
  *    the two at worst leaves a duplicate file (harmless — DB points to SAF).
  *  - Concurrent invocations are collapsed: a second [start] while [Running]
  *    is a no-op.
+ *  - Only one whole-library `file_path` rewrite runs at a time: the move
+ *    and the reorganize exclude each other through [LibraryRewriteGate],
+ *    in either start order.
  *  - Cancellation mid-move leaves the DB consistent — each track is its own
  *    atomic unit, and a cancelled coroutine stops at track boundaries.
  */
@@ -65,6 +68,7 @@ class MoveLibraryCoordinator @Inject constructor(
     @ApplicationContext private val context: Context,
     private val trackDao: TrackDao,
     private val storagePreference: StoragePreference,
+    private val rewriteGate: LibraryRewriteGate,
 ) {
     private val _state = MutableStateFlow<MoveLibraryState>(MoveLibraryState.Idle)
     val state: StateFlow<MoveLibraryState> = _state.asStateFlow()
@@ -94,7 +98,22 @@ class MoveLibraryCoordinator @Inject constructor(
      */
     fun start(targetTreeUri: Uri) {
         if (_state.value is MoveLibraryState.Running) return
-        activeJob = scope.launch { runMove(targetTreeUri) }
+        // Only one whole-library file_path rewrite at a time — see
+        // LibraryRewriteGate. Released in the launch's finally, so a
+        // cancelled or failed move hands it straight back.
+        if (!rewriteGate.tryAcquire(GATE_OWNER)) {
+            _state.value = MoveLibraryState.Error(
+                "${rewriteGate.heldBy} is still running. Try again once it finishes.",
+            )
+            return
+        }
+        activeJob = scope.launch {
+            try {
+                runMove(targetTreeUri)
+            } finally {
+                rewriteGate.release(GATE_OWNER)
+            }
+        }
     }
 
     /** Cancel an in-progress move. Flips state back to [Idle]. */
@@ -237,6 +256,8 @@ class MoveLibraryCoordinator @Inject constructor(
     }
 
     companion object {
+        /** Name this pass claims [LibraryRewriteGate] under. */
+        const val GATE_OWNER = "A library move"
         private const val TAG = "MoveLibraryCoord"
     }
 }

--- a/data/download/src/main/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinator.kt
@@ -202,6 +202,12 @@ class ReorganizeLibraryCoordinator @Inject constructor(
                         moveWithinInternal(entry)
                     }
                 }
+                // runCatching swallows CancellationException too. Cancel works
+                // by cancelling activeJob, which surfaces here as a failed
+                // entry — the loop would carry on moving the REST of the
+                // library and then overwrite Idle with Done. Re-throw so the
+                // outer handler resets to Idle and the pass actually stops.
+                ok.exceptionOrNull()?.let { if (it is CancellationException) throw it }
                 if (ok.getOrDefault(false)) moved++ else {
                     failed++
                     Log.w(TAG, "Reorganize failed for track ${entry.trackId}", ok.exceptionOrNull())

--- a/data/download/src/main/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinator.kt
@@ -245,8 +245,42 @@ class ReorganizeLibraryCoordinator @Inject constructor(
         // the library move (crash ⇒ duplicate file, never dangling pointer).
         trackDao.healFilePath(entry.trackId, target.absolutePath)
         if (!renamed) source.delete()
+        moveInternalSidecar(source, target)
         return true
     }
+
+    /**
+     * Carry the `.lrc` lyrics sidecar along with its audio (#198/#104).
+     *
+     * [com.stash.data.lyrics.sidecar.LyricsSidecarWriter] writes
+     * `<basename>.lrc` NEXT TO the audio file, which is the contract external
+     * players rely on. Moving the audio without the sidecar silently breaks
+     * that pairing and strands the old file as litter, so the relocation is
+     * part of moving a track, not a separate concern.
+     *
+     * Best-effort by design: a missing sidecar is the normal case (most
+     * tracks have no lyrics) and a failed sidecar move must never fail the
+     * track's move — the audio and its DB row are already consistent by the
+     * time this runs.
+     */
+    private fun moveInternalSidecar(source: File, target: File) {
+        val from = File(source.parentFile, source.nameWithoutExtension + LRC_EXTENSION)
+        if (!from.exists()) return
+        val to = File(target.parentFile, target.nameWithoutExtension + LRC_EXTENSION)
+        if (from.absoluteFile == to.absoluteFile) return
+        try {
+            if (to.exists()) to.delete()
+            if (!from.renameTo(to)) {
+                from.inputStream().use { input ->
+                    to.outputStream().use { output -> input.copyTo(output) }
+                }
+                from.delete()
+            }
+        } catch (t: Throwable) {
+            Log.w(TAG, "Could not move lyrics sidecar for ${target.name}", t)
+        }
+    }
+
 
     /** SAF → SAF relocation within the granted tree via copy + delete. */
     private suspend fun moveWithinSaf(
@@ -254,7 +288,12 @@ class ReorganizeLibraryCoordinator @Inject constructor(
         root: DocumentFile,
         dirCache: MutableMap<String, DocumentFile>,
     ): Boolean {
-        val source = DocumentFile.fromTreeUri(context, Uri.parse(entry.sourcePath))
+        // sourcePath is the audio DOCUMENT uri healed in by a previous write
+        // (createFile().uri), not the picked TREE uri. fromTreeUri would
+        // rebuild the tree ROOT from it, so the copy+delete below would run
+        // against the wrong document and every SAF track would fail to
+        // reorganize. A document uri needs fromSingleUri.
+        val source = DocumentFile.fromSingleUri(context, Uri.parse(entry.sourcePath))
             ?: error("Source document unreadable: ${entry.sourcePath}")
 
         var cursor = root
@@ -332,6 +371,8 @@ class ReorganizeLibraryCoordinator @Inject constructor(
     }
 
     companion object {
+        /** Sidecar extension written by the lyrics module, moved alongside audio. */
+        private const val LRC_EXTENSION = ".lrc"
         private const val TAG = "ReorganizeCoord"
     }
 }

--- a/data/download/src/main/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinator.kt
@@ -336,7 +336,61 @@ class ReorganizeLibraryCoordinator @Inject constructor(
         if (!source.delete()) {
             Log.w(TAG, "Old SAF document could not be deleted: ${entry.sourcePath}")
         }
+        moveSafSidecar(entry, root, cursor)
         return true
+    }
+
+    /**
+     * SAF twin of [moveInternalSidecar]: carry `<basename>.lrc` from the
+     * audio's OLD directory into its new one.
+     *
+     * The old directory is recovered by decoding the source document id the
+     * same way [safAlreadyInPlace] does; providers whose ids don't follow
+     * `<volume>:<path>` simply leave the sidecar alone. Best-effort — the
+     * audio and its DB row are already consistent when this runs, so a
+     * sidecar problem must never fail the track.
+     */
+    private fun moveSafSidecar(entry: PlanEntry, root: DocumentFile, targetDir: DocumentFile) {
+        try {
+            val docRel = DocumentsContract
+                .getDocumentId(Uri.parse(entry.sourcePath))
+                .substringAfter(':', "")
+            val parts = docRel.split('/').filter { it.isNotBlank() }
+            if (parts.isEmpty()) return
+            val oldName = parts.last().substringBeforeLast('.') + LRC_EXTENSION
+            val newName = entry.targetName.substringBeforeLast('.') + LRC_EXTENSION
+
+            // Walk from the tree root to the audio's old directory. The
+            // decoded path is volume-relative, so it is PREFIXED by the
+            // picked tree's own base path — those leading segments do not
+            // exist under root and are skipped. Once we have descended even
+            // once we are inside the tree, and any further miss means the
+            // path doesn't match this tree: give up rather than guess.
+            var oldDir = root
+            var descended = false
+            for (segment in parts.dropLast(1)) {
+                val child = oldDir.findFile(segment)?.takeIf { it.isDirectory }
+                if (child == null) {
+                    if (descended) return
+                    continue
+                }
+                oldDir = child
+                descended = true
+            }
+            val sidecar = oldDir.findFile(oldName)?.takeIf { it.isFile } ?: return
+            if (sidecar.uri == targetDir.findFile(newName)?.uri) return
+
+            targetDir.findFile(newName)?.delete()
+            val moved = targetDir.createFile(LRC_MIME, newName) ?: return
+            context.contentResolver.openInputStream(sidecar.uri)?.use { input ->
+                context.contentResolver.openOutputStream(moved.uri)?.use { output ->
+                    input.copyTo(output)
+                }
+            }
+            sidecar.delete()
+        } catch (t: Throwable) {
+            Log.w(TAG, "Could not move SAF lyrics sidecar for ${entry.targetName}", t)
+        }
     }
 
     /**
@@ -379,6 +433,7 @@ class ReorganizeLibraryCoordinator @Inject constructor(
     companion object {
         /** Sidecar extension written by the lyrics module, moved alongside audio. */
         private const val LRC_EXTENSION = ".lrc"
+        private const val LRC_MIME = "application/x-lrc"
         private const val TAG = "ReorganizeCoord"
     }
 }

--- a/data/download/src/main/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinator.kt
@@ -1,0 +1,337 @@
+package com.stash.data.download.files
+
+import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
+import android.util.Log
+import androidx.documentfile.provider.DocumentFile
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.prefs.LibraryLayout
+import com.stash.core.data.prefs.StoragePreference
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * State for the one-shot "Reorganize library" operation (#198/#104).
+ *
+ * Observable via [ReorganizeLibraryCoordinator.state]. Stays in [Done] or
+ * [Error] until the Settings screen explicitly [ReorganizeLibraryCoordinator.dismiss]es
+ * it, which flips back to [Idle].
+ */
+sealed interface ReorganizeLibraryState {
+    data object Idle : ReorganizeLibraryState
+    data class Running(val current: Int, val total: Int) : ReorganizeLibraryState
+    data class Done(val moved: Int, val skipped: Int, val failed: Int) : ReorganizeLibraryState
+    data class Error(val message: String) : ReorganizeLibraryState
+}
+
+/**
+ * Relocates every downloaded track INTO the user's chosen folder structure
+ * ([LibraryLayout]) without changing its storage destination — internal
+ * tracks stay internal, SAF-tree tracks stay inside the granted tree. The
+ * destination switch itself remains the separate "Move library to SD" flow;
+ * this pass is purely about the on-disk SHAPE (#198 per-playlist, #104 flat).
+ *
+ * Runs on a `@Singleton`-scoped [scope] so the reorganize survives ViewModel
+ * death (the user can leave Settings and come back to progress), mirroring
+ * [MoveLibraryCoordinator]. Work does NOT survive process death — it's a
+ * manual, restartable action.
+ *
+ * Safety invariants (mirroring MoveLibraryCoordinator):
+ *  - A track is skipped, never double-copied, when its stored location is
+ *    already exactly what the current layout prescribes.
+ *  - The DB `file_path` is healed only AFTER the new copy exists; the old
+ *    file is deleted only AFTER the DB write succeeded. A crash between
+ *    steps at worst leaves a duplicate file, never a dangling pointer.
+ *  - Each track is an atomic unit; cancellation stops at track boundaries.
+ *  - Concurrent invocations are collapsed (a second [start] while running
+ *    is a no-op).
+ */
+@Singleton
+class ReorganizeLibraryCoordinator @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val trackDao: TrackDao,
+    private val storagePreference: StoragePreference,
+    private val fileOrganizer: FileOrganizer,
+) {
+    private val _state = MutableStateFlow<ReorganizeLibraryState>(ReorganizeLibraryState.Idle)
+    val state: StateFlow<ReorganizeLibraryState> = _state.asStateFlow()
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var activeJob: Job? = null
+
+    /** Kick off the reorganize. No-op if already running. */
+    fun start() {
+        if (_state.value is ReorganizeLibraryState.Running) return
+        activeJob = scope.launch { runPass() }
+    }
+
+    /** Cancel an in-progress pass. State reverts to Idle. */
+    fun cancel() {
+        activeJob?.cancel()
+        activeJob = null
+        _state.value = ReorganizeLibraryState.Idle
+    }
+
+    /** Dismiss a terminal state, returning to Idle. */
+    fun dismiss() {
+        if (_state.value is ReorganizeLibraryState.Done || _state.value is ReorganizeLibraryState.Error) {
+            _state.value = ReorganizeLibraryState.Idle
+        }
+    }
+
+    /**
+     * Cheap count of downloaded tracks whose stored location doesn't already
+     * match the current layout — used by Settings to gate/label the button.
+     * Internal paths are compared exactly; SAF URIs are decoded from their
+     * document ids and compared structurally (unparseable ⇒ counted as
+     * misplaced so the pass gets a chance to verify properly on disk).
+     */
+    suspend fun countMisplacedTracks(): Int {
+        val plan = buildPlan() ?: return 0
+        return plan.count { !it.alreadyInPlace }
+    }
+
+    private suspend fun buildPlan(): List<PlanEntry>? {
+        val refs = try {
+            trackDao.getDownloadedTrackRefs()
+        } catch (t: Throwable) {
+            Log.w(TAG, "Could not load downloaded tracks", t)
+            return null
+        }
+        if (refs.isEmpty()) return emptyList()
+        val layout = fileOrganizer.currentLayout()
+        val treeUri = if (refs.any { it.filePath.startsWith("content://") }) {
+            runCatching { storagePreference.externalTreeUri.first() }.getOrNull()
+        } else {
+            null
+        }
+        val musicRoot = fileOrganizer.internalMusicRoot().absolutePath.trimEnd('/')
+
+        return refs.mapNotNull { ref ->
+            val ext = ref.filePath.substringAfterLast('.', "").ifBlank { "m4a" }
+            val playlistName =
+                if (layout == LibraryLayout.PLAYLIST) {
+                    runCatching { trackDao.getFirstPlaylistNameForTrack(ref.id) }.getOrNull()
+                } else {
+                    null
+                }
+            val location = LibraryLayoutResolver.resolve(
+                layout,
+                artist = ref.artist,
+                album = ref.album.takeIf { it.isNotBlank() },
+                title = ref.title,
+                playlistName = playlistName,
+            )
+            val targetName = "${location.baseName}.$ext"
+            val isSaf = ref.filePath.startsWith("content://")
+
+            val alreadyInPlace = if (isSaf) {
+                treeUri?.let { safAlreadyInPlace(it, ref.filePath, location.dirKey, targetName) } ?: false
+            } else {
+                val expected = if (location.segments.isEmpty()) {
+                    File(musicRoot, targetName)
+                } else {
+                    File(File(musicRoot, location.dirKey), targetName)
+                }
+                File(ref.filePath).absoluteFile == expected.absoluteFile
+            }
+            PlanEntry(ref.id, ref.filePath, isSaf, location, targetName, alreadyInPlace)
+        }
+    }
+
+    private data class PlanEntry(
+        val trackId: Long,
+        val sourcePath: String,
+        val sourceIsSaf: Boolean,
+        val location: LibraryLayoutResolver.ResolvedLocation,
+        val targetName: String,
+        val alreadyInPlace: Boolean,
+    )
+
+    private suspend fun runPass() {
+        try {
+            val plan = buildPlan()
+            if (plan == null) {
+                _state.value = ReorganizeLibraryState.Error("Couldn't read the library database.")
+                return
+            }
+            val work = plan.filterNot { it.alreadyInPlace }
+            if (work.isEmpty()) {
+                _state.value = ReorganizeLibraryState.Done(0, plan.size, 0)
+                return
+            }
+
+            // Resolve the SAF root once when any SAF track needs work.
+            val safRoot = if (work.any { it.sourceIsSaf }) {
+                val uri = runCatching { storagePreference.externalTreeUri.first() }.getOrNull()
+                if (uri == null) null else DocumentFile.fromTreeUri(context, uri)
+            } else {
+                null
+            }
+            if (work.any { it.sourceIsSaf } && safRoot == null) {
+                _state.value = ReorganizeLibraryState.Error(
+                    "Couldn't open the external folder. Permission may have been revoked.",
+                )
+                return
+            }
+
+            val dirCache = HashMap<String, DocumentFile>(256)
+            var moved = 0
+            var failed = 0
+            _state.value = ReorganizeLibraryState.Running(current = 0, total = work.size)
+
+            for ((index, entry) in work.withIndex()) {
+                _state.value = ReorganizeLibraryState.Running(current = index, total = work.size)
+                val ok = runCatching {
+                    if (entry.sourceIsSaf) {
+                        moveWithinSaf(entry, safRoot!!, dirCache)
+                    } else {
+                        moveWithinInternal(entry)
+                    }
+                }
+                if (ok.getOrDefault(false)) moved++ else {
+                    failed++
+                    Log.w(TAG, "Reorganize failed for track ${entry.trackId}", ok.exceptionOrNull())
+                }
+            }
+
+            _state.value = ReorganizeLibraryState.Done(moved, plan.size - work.size, failed)
+        } catch (t: CancellationException) {
+            _state.value = ReorganizeLibraryState.Idle
+            throw t
+        } catch (t: Throwable) {
+            Log.e(TAG, "Reorganize failed", t)
+            _state.value = ReorganizeLibraryState.Error(t.message ?: "Unknown error")
+        }
+    }
+
+    /** Internal → internal relocation via rename (copy+delete fallback). */
+    private suspend fun moveWithinInternal(entry: PlanEntry): Boolean {
+        val musicRoot = fileOrganizer.internalMusicRoot()
+        val source = File(entry.sourcePath)
+        if (!source.exists()) error("Internal file missing: ${entry.sourcePath}")
+
+        val targetDir = if (entry.location.segments.isEmpty()) {
+            musicRoot
+        } else {
+            File(musicRoot, entry.location.dirKey).also { it.mkdirs() }
+        }
+        val target = File(targetDir, entry.targetName)
+        // Late re-check (races between plan and execution): nothing to do is
+        // a successful no-op, not a failure.
+        if (target.absoluteFile == source.absoluteFile) return true
+        if (target.exists()) target.delete()
+
+        val renamed = source.renameTo(target)
+        if (!renamed) {
+            source.inputStream().use { input ->
+                target.outputStream().use { output -> input.copyTo(output) }
+            }
+        }
+        // DB first, then remove the leftover copy — same ordering guarantee as
+        // the library move (crash ⇒ duplicate file, never dangling pointer).
+        trackDao.healFilePath(entry.trackId, target.absolutePath)
+        if (!renamed) source.delete()
+        return true
+    }
+
+    /** SAF → SAF relocation within the granted tree via copy + delete. */
+    private suspend fun moveWithinSaf(
+        entry: PlanEntry,
+        root: DocumentFile,
+        dirCache: MutableMap<String, DocumentFile>,
+    ): Boolean {
+        val source = DocumentFile.fromTreeUri(context, Uri.parse(entry.sourcePath))
+            ?: error("Source document unreadable: ${entry.sourcePath}")
+
+        var cursor = root
+        var cumulativeKey = ""
+        for (segment in entry.location.segments) {
+            cumulativeKey = if (cumulativeKey.isEmpty()) segment else "$cumulativeKey/$segment"
+            cursor = dirCache.getOrPut(cumulativeKey) {
+                cursor.findFile(segment)?.takeIf { it.isDirectory }
+                    ?: cursor.createDirectory(segment)
+                    ?: error("Could not create SAF directory '$segment'")
+            }
+        }
+
+        // Already exactly where the layout wants it → skip without touching
+        // (protects against delete-then-recreate of the only copy). Counted
+        // as a successful no-op.
+        val existing = cursor.findFile(entry.targetName)
+        if (existing != null && existing.uri == source.uri) return true
+
+        existing?.delete()
+        val format = entry.targetName.substringAfterLast('.', "m4a")
+        val target = cursor.createFile(mimeTypeFor(format), entry.targetName)
+            ?: error("Could not create SAF file '${entry.targetName}'")
+
+        context.contentResolver.openInputStream(source.uri)?.use { input ->
+            context.contentResolver.openOutputStream(target.uri)?.use { output ->
+                input.copyTo(output)
+            }
+        } ?: error("Could not copy '${entry.targetName}' within the SAF tree")
+
+        // DB write before deleting the source — a crash leaves a duplicate
+        // document (harmless orphan), never a dead pointer.
+        trackDao.healFilePath(entry.trackId, target.uri.toString())
+        if (!source.delete()) {
+            Log.w(TAG, "Old SAF document could not be deleted: ${entry.sourcePath}")
+        }
+        return true
+    }
+
+    /**
+     * Structural in-place check for a SAF-stored file: decode the document id
+     * (`<volume>:<path>`) and compare the volume-relative path against the
+     * picked tree's base plus the layout-derived relative path. Returns null
+     * when the provider's ids don't follow that convention (caller then
+     * treats the track as needing verification during the actual pass).
+     */
+    private fun safAlreadyInPlace(
+        treeUri: Uri,
+        docUriString: String,
+        dirKey: String,
+        fileName: String,
+    ): Boolean {
+        return try {
+            val docUri = Uri.parse(docUriString)
+            val treeDocId = DocumentsContract.getTreeDocumentId(treeUri)
+            val docDocId = DocumentsContract.getDocumentId(docUri)
+            val baseRel = treeDocId.substringAfter(':', "")
+            val docRel = docDocId.substringAfter(':', "")
+            val expectedRel = if (dirKey.isEmpty()) fileName else "$dirKey/$fileName"
+            val fullExpected = if (baseRel.isBlank()) expectedRel else "$baseRel/$expectedRel"
+            docRel.equals(fullExpected, ignoreCase = true)
+        } catch (t: Throwable) {
+            Log.d(TAG, "SAF in-place check unparseable ($docUriString): ${t.message}")
+            false
+        }
+    }
+
+    private fun mimeTypeFor(format: String): String = when (format.lowercase()) {
+        "m4a", "mp4", "aac" -> "audio/mp4"
+        "opus", "ogg" -> "audio/ogg"
+        "mp3" -> "audio/mpeg"
+        "flac" -> "audio/flac"
+        "wav" -> "audio/wav"
+        else -> "audio/*"
+    }
+
+    companion object {
+        private const val TAG = "ReorganizeCoord"
+    }
+}

--- a/data/download/src/main/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinator.kt
@@ -56,6 +56,11 @@ sealed interface ReorganizeLibraryState {
  *    file is deleted only AFTER the DB write succeeded. A crash between
  *    steps at worst leaves a duplicate file, never a dangling pointer.
  *  - Each track is an atomic unit; cancellation stops at track boundaries.
+ *  - Two rows that resolve to ONE target name never race for it: the
+ *    first claimant keeps the name and the rest are skipped, decided in
+ *    the plan so no delete runs for a loser.
+ *  - A reorganize refuses to start while [MoveLibraryCoordinator] is
+ *    running — both rewrite every `file_path` and would orphan files.
  *  - Concurrent invocations are collapsed (a second [start] while running
  *    is a no-op).
  */
@@ -65,6 +70,7 @@ class ReorganizeLibraryCoordinator @Inject constructor(
     private val trackDao: TrackDao,
     private val storagePreference: StoragePreference,
     private val fileOrganizer: FileOrganizer,
+    private val moveLibraryCoordinator: MoveLibraryCoordinator,
 ) {
     private val _state = MutableStateFlow<ReorganizeLibraryState>(ReorganizeLibraryState.Idle)
     val state: StateFlow<ReorganizeLibraryState> = _state.asStateFlow()
@@ -75,6 +81,15 @@ class ReorganizeLibraryCoordinator @Inject constructor(
     /** Kick off the reorganize. No-op if already running. */
     fun start() {
         if (_state.value is ReorganizeLibraryState.Running) return
+        // Both passes rewrite `file_path` for every downloaded track; run
+        // together, whichever healFilePath lands last wins and the other
+        // pass's file is orphaned. Second one to start yields.
+        if (moveLibraryCoordinator.state.value is MoveLibraryState.Running) {
+            _state.value = ReorganizeLibraryState.Error(
+                "The library is still being moved. Try again once that finishes.",
+            )
+            return
+        }
         activeJob = scope.launch { runPass() }
     }
 
@@ -101,7 +116,7 @@ class ReorganizeLibraryCoordinator @Inject constructor(
      */
     suspend fun countMisplacedTracks(): Int {
         val plan = buildPlan() ?: return 0
-        return plan.count { !it.alreadyInPlace }
+        return plan.count { !it.alreadyInPlace && !it.losesNameClash }
     }
 
     private suspend fun buildPlan(): List<PlanEntry>? {
@@ -120,7 +135,7 @@ class ReorganizeLibraryCoordinator @Inject constructor(
         }
         val musicRoot = fileOrganizer.internalMusicRoot().absolutePath.trimEnd('/')
 
-        return refs.mapNotNull { ref ->
+        val entries = refs.mapNotNull { ref ->
             val ext = ref.filePath.substringAfterLast('.', "").ifBlank { "m4a" }
             val playlistName =
                 if (layout == LibraryLayout.PLAYLIST) {
@@ -150,6 +165,25 @@ class ReorganizeLibraryCoordinator @Inject constructor(
             }
             PlanEntry(ref.id, ref.filePath, isSaf, location, targetName, alreadyInPlace)
         }
+
+        // Two rows can resolve to ONE target: SINGLE_FOLDER drops the album
+        // segment, so a studio and a live cut of the same song collide, and
+        // PLAYLIST does the same for a track filed under one playlist name.
+        // Both movers overwrite whatever occupies the target name, so an
+        // unguarded pass would delete the first claimant's audio and leave
+        // its row pointing at the second one's file. First claimant wins —
+        // a row already sitting on the name keeps it — and the rest are
+        // skipped, decided here so no delete ever runs for a loser.
+        val claimed = HashSet<String>()
+        entries.filter { it.alreadyInPlace }.forEach { claimed += it.targetKey }
+        return entries.map { entry ->
+            if (entry.alreadyInPlace || claimed.add(entry.targetKey)) {
+                entry
+            } else {
+                Log.w(TAG, "Skipping track ${entry.trackId}: '${entry.targetKey}' already claimed")
+                entry.copy(losesNameClash = true)
+            }
+        }
     }
 
     private data class PlanEntry(
@@ -159,7 +193,17 @@ class ReorganizeLibraryCoordinator @Inject constructor(
         val location: LibraryLayoutResolver.ResolvedLocation,
         val targetName: String,
         val alreadyInPlace: Boolean,
-    )
+        /** Lost the race for [targetName]; skipped so the winner's file survives. */
+        val losesNameClash: Boolean = false,
+    ) {
+        /** Case-insensitive target identity — SD cards are case-insensitive. */
+        val targetKey: String
+            get() = if (location.dirKey.isEmpty()) {
+                targetName.lowercase()
+            } else {
+                "${location.dirKey}/$targetName".lowercase()
+            }
+    }
 
     private suspend fun runPass() {
         try {
@@ -168,7 +212,7 @@ class ReorganizeLibraryCoordinator @Inject constructor(
                 _state.value = ReorganizeLibraryState.Error("Couldn't read the library database.")
                 return
             }
-            val work = plan.filterNot { it.alreadyInPlace }
+            val work = plan.filterNot { it.alreadyInPlace || it.losesNameClash }
             if (work.isEmpty()) {
                 _state.value = ReorganizeLibraryState.Done(0, plan.size, 0)
                 return

--- a/data/download/src/main/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinator.kt
@@ -59,8 +59,9 @@ sealed interface ReorganizeLibraryState {
  *  - Two rows that resolve to ONE target name never race for it: the
  *    first claimant keeps the name and the rest are skipped, decided in
  *    the plan so no delete runs for a loser.
- *  - A reorganize refuses to start while [MoveLibraryCoordinator] is
- *    running — both rewrite every `file_path` and would orphan files.
+ *  - Only one whole-library `file_path` rewrite runs at a time: the
+ *    reorganize and the library move exclude each other through
+ *    [LibraryRewriteGate], in either start order.
  *  - Concurrent invocations are collapsed (a second [start] while running
  *    is a no-op).
  */
@@ -70,7 +71,7 @@ class ReorganizeLibraryCoordinator @Inject constructor(
     private val trackDao: TrackDao,
     private val storagePreference: StoragePreference,
     private val fileOrganizer: FileOrganizer,
-    private val moveLibraryCoordinator: MoveLibraryCoordinator,
+    private val rewriteGate: LibraryRewriteGate,
 ) {
     private val _state = MutableStateFlow<ReorganizeLibraryState>(ReorganizeLibraryState.Idle)
     val state: StateFlow<ReorganizeLibraryState> = _state.asStateFlow()
@@ -81,16 +82,22 @@ class ReorganizeLibraryCoordinator @Inject constructor(
     /** Kick off the reorganize. No-op if already running. */
     fun start() {
         if (_state.value is ReorganizeLibraryState.Running) return
-        // Both passes rewrite `file_path` for every downloaded track; run
-        // together, whichever healFilePath lands last wins and the other
-        // pass's file is orphaned. Second one to start yields.
-        if (moveLibraryCoordinator.state.value is MoveLibraryState.Running) {
+        // Only one whole-library file_path rewrite at a time — see
+        // LibraryRewriteGate. Released in the launch's finally, so a
+        // cancelled or failed pass hands it straight back.
+        if (!rewriteGate.tryAcquire(GATE_OWNER)) {
             _state.value = ReorganizeLibraryState.Error(
-                "The library is still being moved. Try again once that finishes.",
+                "${rewriteGate.heldBy} is still running. Try again once it finishes.",
             )
             return
         }
-        activeJob = scope.launch { runPass() }
+        activeJob = scope.launch {
+            try {
+                runPass()
+            } finally {
+                rewriteGate.release(GATE_OWNER)
+            }
+        }
     }
 
     /** Cancel an in-progress pass. State reverts to Idle. */
@@ -196,9 +203,14 @@ class ReorganizeLibraryCoordinator @Inject constructor(
         /** Lost the race for [targetName]; skipped so the winner's file survives. */
         val losesNameClash: Boolean = false,
     ) {
-        /** Case-insensitive target identity — SD cards are case-insensitive. */
+        /**
+         * Target identity for clash detection. Scoped to the storage root:
+         * an internal and a SAF-tree track that resolve to the same
+         * layout-relative name are written to different roots and cannot
+         * overwrite each other. Case-insensitive because SD cards are.
+         */
         val targetKey: String
-            get() = if (location.dirKey.isEmpty()) {
+            get() = (if (sourceIsSaf) "saf:" else "internal:") + if (location.dirKey.isEmpty()) {
                 targetName.lowercase()
             } else {
                 "${location.dirKey}/$targetName".lowercase()
@@ -478,6 +490,8 @@ class ReorganizeLibraryCoordinator @Inject constructor(
         /** Sidecar extension written by the lyrics module, moved alongside audio. */
         private const val LRC_EXTENSION = ".lrc"
         private const val LRC_MIME = "application/x-lrc"
+        /** Name this pass claims [LibraryRewriteGate] under. */
+        const val GATE_OWNER = "A library reorganize"
         private const val TAG = "ReorganizeCoord"
     }
 }

--- a/data/download/src/main/kotlin/com/stash/data/download/files/SwapCoordinator.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/files/SwapCoordinator.kt
@@ -137,6 +137,7 @@ class SwapCoordinator @Inject constructor(
                     album = null,
                     title = title,
                     format = result.file.extension,
+                    trackId = trackId,
                 )
                 // Validate before committing the swap: a "successful" yt-dlp run
                 // can still produce a tiny error body. If so, discard it and

--- a/data/download/src/main/kotlin/com/stash/data/download/shared/TrackFinalizer.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/shared/TrackFinalizer.kt
@@ -77,6 +77,9 @@ class TrackFinalizer @Inject constructor(
             album = track.album.takeIf { it.isNotBlank() },
             title = track.title,
             format = format.fileExtension.ifBlank { format.codec.ifBlank { "flac" } },
+            // Lets the Per-playlist layout (#198) file the track under its
+            // playlist folder; null/unknown ids fall back gracefully.
+            trackId = track.id.takeIf { it > 0 },
         )
         val meta: AudioMetadata? = audioExtractor.extract(committed.filePath)
         FinalizeResult.Success(committed, meta)

--- a/data/download/src/test/kotlin/com/stash/data/download/files/FileOrganizerExistenceSessionTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/files/FileOrganizerExistenceSessionTest.kt
@@ -59,4 +59,53 @@ class FileOrganizerExistenceSessionTest {
         }
         coVerify(exactly = 1) { spied.buildSafIndex() }
     }
+
+    /**
+     * The tree-wide filename fallback must not match a BARE `<title>.<ext>`.
+     * That name is only an identity inside its own `<artist>/<album>`
+     * directory; loose in the tree it belongs to whichever artist got there
+     * first, and matching it would heal this track's file_path onto a
+     * different song's audio.
+     */
+    @Test
+    fun `tree-wide fallback ignores a bare title owned by another artist`() {
+        val otherArtistsFile: androidx.documentfile.provider.DocumentFile = mockk(relaxed = true)
+        val index = FileOrganizer.SafIndex(
+            byDirKey = emptyMap(),
+            // "Intro" by SOMEONE ELSE, sitting somewhere in the tree.
+            byFileName = mapOf("intro.opus" to listOf(otherArtistsFile)),
+        )
+
+        val hit = organizer().resolveInIndex(
+            index = index,
+            layout = com.stash.core.data.prefs.LibraryLayout.ARTIST_ALBUM,
+            artist = "Our Artist",
+            album = "Our Album",
+            title = "Intro",
+            knownFormat = "opus",
+        )
+
+        assertThat(hit).isNull()
+    }
+
+    /** The artist-qualified flat name stays matchable tree-wide. */
+    @Test
+    fun `tree-wide fallback still matches an artist qualified name`() {
+        val ourFile: androidx.documentfile.provider.DocumentFile = mockk(relaxed = true)
+        val index = FileOrganizer.SafIndex(
+            byDirKey = emptyMap(),
+            byFileName = mapOf("our-artist-intro.opus" to listOf(ourFile)),
+        )
+
+        val hit = organizer().resolveInIndex(
+            index = index,
+            layout = com.stash.core.data.prefs.LibraryLayout.ARTIST_ALBUM,
+            artist = "Our Artist",
+            album = "Our Album",
+            title = "Intro",
+            knownFormat = "opus",
+        )
+
+        assertThat(hit).isSameInstanceAs(ourFile)
+    }
 }

--- a/data/download/src/test/kotlin/com/stash/data/download/files/FileOrganizerExistenceSessionTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/files/FileOrganizerExistenceSessionTest.kt
@@ -2,6 +2,7 @@ package com.stash.data.download.files
 
 import android.content.Context
 import com.google.common.truth.Truth.assertThat
+import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.prefs.StoragePreference
 import io.mockk.every
 import io.mockk.mockk
@@ -15,12 +16,13 @@ import java.io.File
 class FileOrganizerExistenceSessionTest {
 
     private val context: Context = mockk(relaxed = true)
+    private val trackDao: TrackDao = mockk(relaxed = true)
 
     private fun organizer(treeUri: android.net.Uri? = null): FileOrganizer {
         val prefs: StoragePreference = mockk {
             every { externalTreeUri } returns flowOf(treeUri)
         }
-        return FileOrganizer(context, prefs)
+        return FileOrganizer(context, prefs, trackDao)
     }
 
     @Test
@@ -28,8 +30,8 @@ class FileOrganizerExistenceSessionTest {
         val real = File.createTempFile("existing", ".opus")
         try {
             val session = organizer().existenceSession()
-            assertThat(session.exists("a", "b", "t", real.absolutePath).exists).isTrue()
-            assertThat(session.exists("a", "b", "t", real.absolutePath + ".gone").exists).isFalse()
+            assertThat(session.exists(1L, "a", "b", "t", real.absolutePath).exists).isTrue()
+            assertThat(session.exists(1L, "a", "b", "t", real.absolutePath + ".gone").exists).isFalse()
         } finally {
             real.delete()
         }
@@ -43,7 +45,7 @@ class FileOrganizerExistenceSessionTest {
     @Test
     fun `content path with no tree grant is reported as existing`() = runTest {
         val session = organizer(treeUri = null).existenceSession()
-        val result = session.exists("Artist", "Album", "Title", "content://com.android.externalstorage/tree/x")
+        val result = session.exists(1L, "Artist", "Album", "Title", "content://com.android.externalstorage/tree/x")
         assertThat(result.exists).isTrue()
         assertThat(result.resolvedFilePath).isNull()
     }
@@ -53,7 +55,7 @@ class FileOrganizerExistenceSessionTest {
         val spied = spyk(organizer(treeUri = null))
         val session = spied.existenceSession()
         repeat(5) {
-            session.exists("Artist", "Album", "Title $it", "content://tree/doc$it")
+            session.exists(1L, "Artist", "Album", "Title $it", "content://tree/doc$it")
         }
         coVerify(exactly = 1) { spied.buildSafIndex() }
     }

--- a/data/download/src/test/kotlin/com/stash/data/download/files/LibraryLayoutResolverTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/files/LibraryLayoutResolverTest.kt
@@ -1,0 +1,160 @@
+package com.stash.data.download.files
+
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.data.prefs.LibraryLayout
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of the folder-structure resolver behind #198/#104.
+ * Every path-writer (downloads, library move, reorganize, lyrics sidecars)
+ * and every path-reader (SAF index lookups) shares these semantics, so the
+ * assertions here pin down the exact on-disk contract.
+ */
+class LibraryLayoutResolverTest {
+
+    // ── ARTIST_ALBUM (historical default) ────────────────────────────────
+
+    @Test fun `artist album keeps historical nested layout`() {
+        val loc = LibraryLayoutResolver.resolve(
+            LibraryLayout.ARTIST_ALBUM, "Nina Simone", "Pastel Blues", "Sinnerman", null,
+        )
+        assertThat(loc.segments).containsExactly("nina-simone", "pastel-blues").inOrder()
+        assertThat(loc.baseName).isEqualTo("sinnerman")
+        assertThat(loc.dirKey).isEqualTo("nina-simone/pastel-blues")
+    }
+
+    @Test fun `artist album blank album falls back to singles`() {
+        val loc = LibraryLayoutResolver.resolve(
+            LibraryLayout.ARTIST_ALBUM, "Drake", "", "Hotline Bling", null,
+        )
+        assertThat(loc.segments).containsExactly("drake", "singles").inOrder()
+    }
+
+    @Test fun `artist album filename has no artist prefix`() {
+        val loc = LibraryLayoutResolver.resolve(
+            LibraryLayout.ARTIST_ALBUM, "Artist", "Album", "Title", null,
+        )
+        assertThat(loc.baseName).isEqualTo("title")
+    }
+
+    // ── SINGLE_FOLDER (#104) ─────────────────────────────────────────────
+
+    @Test fun `single folder puts track directly in root with artist prefix`() {
+        val loc = LibraryLayoutResolver.resolve(
+            LibraryLayout.SINGLE_FOLDER, "Kanye West", "DONDA", "Off The Grid", null,
+        )
+        assertThat(loc.segments).isEmpty()
+        assertThat(loc.dirKey).isEmpty()
+        assertThat(loc.baseName).isEqualTo("kanye-west-off-the-grid")
+    }
+
+    @Test fun `single folder artist prefix prevents same-title collisions`() {
+        val a = LibraryLayoutResolver.resolve(LibraryLayout.SINGLE_FOLDER, "Artist A", "X", "Intro", null)
+        val b = LibraryLayoutResolver.resolve(LibraryLayout.SINGLE_FOLDER, "Artist B", "Y", "Intro", null)
+        assertThat(a.baseName).isNotEqualTo(b.baseName)
+    }
+
+    @Test fun `playlist name is ignored in single folder mode`() {
+        val loc = LibraryLayoutResolver.resolve(
+            LibraryLayout.SINGLE_FOLDER, "A", "B", "C", "Road Trip",
+        )
+        assertThat(loc.segments).isEmpty()
+        assertThat(loc.baseName).isEqualTo("a-c")
+    }
+
+    // ── PLAYLIST (#198) ──────────────────────────────────────────────────
+
+    @Test fun `playlist files under playlist folder with artist prefix`() {
+        val loc = LibraryLayoutResolver.resolve(
+            LibraryLayout.PLAYLIST, "Daft Punk", "Discovery", "Aerodynamic", "Road Trip 2026",
+        )
+        assertThat(loc.segments).containsExactly("road-trip-2026")
+        assertThat(loc.baseName).isEqualTo("daft-punk-aerodynamic")
+    }
+
+    @Test fun `playlist without playlist name falls back to artist album`() {
+        val loc = LibraryLayoutResolver.resolve(
+            LibraryLayout.PLAYLIST, "Drake", "Views", "Weston Road Flows", null,
+        )
+        assertThat(loc.segments).containsExactly("drake", "views").inOrder()
+        // Fallback keeps the historical bare-title filename so pre-existing
+        // nested downloads stay addressable without a rename.
+        assertThat(loc.baseName).isEqualTo("weston-road-flows")
+    }
+
+    @Test fun `playlist with emoji-only name falls back to artist album`() {
+        val loc = LibraryLayoutResolver.resolve(
+            LibraryLayout.PLAYLIST, "A", "B", "C", "♪♪♪",
+        )
+        assertThat(loc.segments).containsExactly("a", "b").inOrder()
+        assertThat(loc.baseName).isEqualTo("c")
+    }
+
+    @Test fun `playlist with blank name falls back to artist album`() {
+        val loc = LibraryLayoutResolver.resolve(
+            LibraryLayout.PLAYLIST, "A", "B", "C", "   ",
+        )
+        assertThat(loc.segments).containsExactly("a", "b").inOrder()
+    }
+
+    // ── Slug parity with FileOrganizerSlugs ──────────────────────────────
+
+    @Test fun `unicode names slug consistently across layouts`() {
+        val nested = LibraryLayoutResolver.resolve(
+            LibraryLayout.ARTIST_ALBUM, "Кино — Группа крови", "Альбом", "Песня", null,
+        )
+        val flat = LibraryLayoutResolver.resolve(
+            LibraryLayout.SINGLE_FOLDER, "Кино — Группа крови", "Альбом", "Песня", null,
+        )
+        assertThat(nested.segments.first())
+            .isEqualTo(FileOrganizerSlugs.slugify("Кино — Группа крови"))
+        assertThat(flat.baseName).startsWith(nested.segments.first())
+    }
+
+    @Test fun `long inputs are truncated by the shared slug rules`() {
+        val longTitle = "x".repeat(200)
+        val loc = LibraryLayoutResolver.resolve(
+            LibraryLayout.ARTIST_ALBUM, "a", "b", longTitle, null,
+        )
+        assertThat(loc.baseName.length).isAtMost(60)
+    }
+
+    // ── lookupCandidates (reconciliation / adoption probing) ─────────────
+
+    @Test fun `candidates probe current layout first then legacy then flat`() {
+        val candidates = LibraryLayoutResolver.lookupCandidates(
+            LibraryLayout.PLAYLIST, "Artist", "Album", "Title", "My Playlist",
+            knownFormats = listOf("flac"),
+        )
+        assertThat(candidates.map { it.dirKey }).containsExactly(
+            "my-playlist",      // current PLAYLIST location
+            "artist/album",     // legacy nested location
+            "",                 // flat root
+        ).inOrder()
+        assertThat(candidates[0].candidateFileNames).containsExactly("artist-title.flac")
+        assertThat(candidates[1].candidateFileNames).containsExactly("title.flac")
+        assertThat(candidates[2].candidateFileNames).containsExactly("artist-title.flac")
+    }
+
+    @Test fun `candidates for artist album skip duplicate legacy entry but keep flat fallback`() {
+        val candidates = LibraryLayoutResolver.lookupCandidates(
+            LibraryLayout.ARTIST_ALBUM, "Artist", "Album", "Title", null,
+            knownFormats = emptyList(),
+        )
+        assertThat(candidates.map { it.dirKey }).containsExactly("artist/album", "").inOrder()
+        // Empty knownFormats probes the bare base names only.
+        assertThat(candidates[0].candidateFileNames).containsExactly("title")
+    }
+
+    @Test fun `candidates generate one filename per known format when format unknown`() {
+        val candidates = LibraryLayoutResolver.lookupCandidates(
+            LibraryLayout.SINGLE_FOLDER, "A", "B", "T", null,
+            knownFormats = listOf("opus", "m4a"),
+        )
+        // Primary (flat root) comes first; the legacy nested entry follows.
+        assertThat(candidates.first().dirKey).isEmpty()
+        assertThat(candidates.first().candidateFileNames)
+            .containsExactly("a-t.opus", "a-t.m4a")
+            .inOrder()
+    }
+}

--- a/data/download/src/test/kotlin/com/stash/data/download/files/MoveLibraryCoordinatorTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/files/MoveLibraryCoordinatorTest.kt
@@ -1,0 +1,37 @@
+package com.stash.data.download.files
+
+import android.content.Context
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.prefs.StoragePreference
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+/**
+ * The move is exercised end to end on a device (it needs a real SAF
+ * provider). What is unit-testable — and what a review asked for — is that
+ * it cannot run alongside the reorganize pass in EITHER start order.
+ */
+class MoveLibraryCoordinatorTest {
+
+    private val context = mockk<Context>(relaxed = true)
+    private val trackDao = mockk<TrackDao>(relaxed = true)
+    private val storagePreference = mockk<StoragePreference>(relaxed = true)
+    private val gate = LibraryRewriteGate()
+
+    private val coordinator = MoveLibraryCoordinator(context, trackDao, storagePreference, gate)
+
+    @Test fun `refuses to start while another pass holds the gate`() = runBlocking {
+        assertThat(gate.tryAcquire("reorganize")).isTrue()
+
+        // A mock Uri: the gate is checked before the destination is touched.
+        coordinator.start(mockk())
+        delay(300)
+
+        assertThat(coordinator.state.value).isInstanceOf(MoveLibraryState.Error::class.java)
+        coVerify(exactly = 0) { trackDao.healFilePath(any(), any()) }
+    }
+}

--- a/data/download/src/test/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinatorTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinatorTest.kt
@@ -1,0 +1,204 @@
+package com.stash.data.download.files
+
+import android.content.Context
+import com.google.common.truth.Truth.assertThat
+import com.stash.core.data.db.dao.TrackDao
+import com.stash.core.data.db.dao.TrackExistenceRef
+import com.stash.core.data.prefs.LibraryLayout
+import com.stash.core.data.prefs.StoragePreference
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Internal-storage coverage of the reorganize pass (#198/#104). The SAF
+ * branch needs a real provider and is exercised on-device; everything
+ * asserted here is layout/plan behavior shared by both movers.
+ */
+class ReorganizeLibraryCoordinatorTest {
+
+    @get:Rule val tmp = TemporaryFolder()
+
+    private val context = mockk<Context>(relaxed = true)
+    private val trackDao = mockk<TrackDao>(relaxed = true)
+    private val storagePreference = mockk<StoragePreference>()
+    private val fileOrganizer = mockk<FileOrganizer>()
+    private val moveState = MutableStateFlow<MoveLibraryState>(MoveLibraryState.Idle)
+    private val moveLibrary = mockk<MoveLibraryCoordinator>()
+
+    private lateinit var musicRoot: File
+    private lateinit var coordinator: ReorganizeLibraryCoordinator
+
+    @Before
+    fun setUp() {
+        musicRoot = tmp.newFolder("music")
+        every { storagePreference.externalTreeUri } returns flowOf(null)
+        every { fileOrganizer.internalMusicRoot() } returns musicRoot
+        coEvery { fileOrganizer.currentLayout() } returns LibraryLayout.SINGLE_FOLDER
+        every { moveLibrary.state } returns moveState
+        coordinator =
+            ReorganizeLibraryCoordinator(context, trackDao, storagePreference, fileOrganizer, moveLibrary)
+    }
+
+    private fun seed(relativePath: String, content: String): File =
+        File(musicRoot, relativePath).apply {
+            parentFile!!.mkdirs()
+            writeText(content)
+        }
+
+    private fun ref(id: Long, file: File, artist: String, album: String, title: String) =
+        TrackExistenceRef(id, artist, album, title, file.absolutePath)
+
+    private suspend fun awaitDone(): ReorganizeLibraryState.Done =
+        withTimeout(10_000) {
+            coordinator.state.first { it is ReorganizeLibraryState.Done }
+        } as ReorganizeLibraryState.Done
+
+    /**
+     * Two rows, one target name — SINGLE_FOLDER drops the album segment, so
+     * a studio and a live cut of the same song collide. The mover overwrites
+     * whatever occupies the target, so without a plan-level guard the second
+     * claimant deletes the first one's audio and the first row is left
+     * pointing at the second one's file.
+     */
+    @Test fun `a second row claiming an occupied target name is skipped, not overwritten`() = runBlocking {
+        val studio = seed("nirvana/nevermind/something-in-the-way.m4a", "STUDIO")
+        val live = seed("nirvana/unplugged/something-in-the-way.m4a", "LIVE")
+        coEvery { trackDao.getDownloadedTrackRefs() } returns listOf(
+            ref(1L, studio, "Nirvana", "Nevermind", "Something In The Way"),
+            ref(2L, live, "Nirvana", "Unplugged", "Something In The Way"),
+        )
+
+        coordinator.start()
+        val done = awaitDone()
+
+        val target = File(musicRoot, "nirvana-something-in-the-way.m4a")
+        assertThat(target.readText()).isEqualTo("STUDIO")
+        assertThat(live.exists()).isTrue()
+        assertThat(live.readText()).isEqualTo("LIVE")
+        coVerify(exactly = 1) { trackDao.healFilePath(1L, target.absolutePath) }
+        coVerify(exactly = 0) { trackDao.healFilePath(2L, any()) }
+        assertThat(done.moved).isEqualTo(1)
+        assertThat(done.skipped).isEqualTo(1)
+        assertThat(done.failed).isEqualTo(0)
+    }
+
+    /** A clash never counts as work the button promises to do. */
+    @Test fun `misplaced count excludes rows that would lose a name clash`() = runBlocking {
+        val studio = seed("nirvana/nevermind/something-in-the-way.m4a", "STUDIO")
+        val live = seed("nirvana/unplugged/something-in-the-way.m4a", "LIVE")
+        coEvery { trackDao.getDownloadedTrackRefs() } returns listOf(
+            ref(1L, studio, "Nirvana", "Nevermind", "Something In The Way"),
+            ref(2L, live, "Nirvana", "Unplugged", "Something In The Way"),
+        )
+
+        assertThat(coordinator.countMisplacedTracks()).isEqualTo(1)
+    }
+
+    /** The row already sitting on the target keeps it; the other one yields. */
+    @Test fun `a row already in place wins the target name over a later claimant`() = runBlocking {
+        val inPlace = seed("nirvana-something-in-the-way.m4a", "IN_PLACE")
+        val other = seed("nirvana/unplugged/something-in-the-way.m4a", "OTHER")
+        coEvery { trackDao.getDownloadedTrackRefs() } returns listOf(
+            ref(1L, inPlace, "Nirvana", "Nevermind", "Something In The Way"),
+            ref(2L, other, "Nirvana", "Unplugged", "Something In The Way"),
+        )
+
+        coordinator.start()
+        val done = awaitDone()
+
+        assertThat(inPlace.readText()).isEqualTo("IN_PLACE")
+        assertThat(other.exists()).isTrue()
+        coVerify(exactly = 0) { trackDao.healFilePath(any(), any()) }
+        assertThat(done.moved).isEqualTo(0)
+        assertThat(done.skipped).isEqualTo(2)
+    }
+
+    /** One unmovable track is counted and does not stop the rest of the pass. */
+    @Test fun `a missing source file fails only its own track`() = runBlocking {
+        val present = seed("a/x/one.m4a", "ONE")
+        val vanished = File(musicRoot, "b/y/two.m4a")
+        coEvery { trackDao.getDownloadedTrackRefs() } returns listOf(
+            ref(1L, vanished, "Artist B", "Y", "Two"),
+            ref(2L, present, "Artist A", "X", "One"),
+        )
+
+        coordinator.start()
+        val done = awaitDone()
+
+        assertThat(done.failed).isEqualTo(1)
+        assertThat(done.moved).isEqualTo(1)
+        assertThat(File(musicRoot, "artist-a-one.m4a").readText()).isEqualTo("ONE")
+    }
+
+    /**
+     * Cancel mid-pass must stop the pass, not merely flip the state: the
+     * loop re-throws the CancellationException it would otherwise swallow,
+     * so the run ends at Idle instead of overwriting it with a Done that
+     * reports a library-wide sweep the user cancelled.
+     */
+    @Test fun `cancel mid-pass ends at idle instead of reporting done`() = runBlocking {
+        val first = seed("a/x/one.m4a", "ONE")
+        val second = seed("b/y/two.m4a", "TWO")
+        coEvery { trackDao.getDownloadedTrackRefs() } returns listOf(
+            ref(1L, first, "Artist A", "X", "One"),
+            ref(2L, second, "Artist B", "Y", "Two"),
+        )
+        val reachedFirstHeal = CountDownLatch(1)
+        val releaseFirstHeal = CountDownLatch(1)
+        var heals = 0
+        coEvery { trackDao.healFilePath(any(), any()) } coAnswers {
+            if (heals++ == 0) {
+                reachedFirstHeal.countDown()
+                releaseFirstHeal.await(10, TimeUnit.SECONDS)
+            } else {
+                // A real suspension point, so the cancelled job actually
+                // observes the cancellation while on the second track.
+                delay(10_000)
+            }
+        }
+
+        coordinator.start()
+        assertThat(reachedFirstHeal.await(10, TimeUnit.SECONDS)).isTrue()
+        coordinator.cancel()
+        releaseFirstHeal.countDown()
+
+        delay(500)
+        assertThat(coordinator.state.value).isEqualTo(ReorganizeLibraryState.Idle)
+    }
+
+    /**
+     * Both passes rewrite `file_path` for every downloaded track. Run at the
+     * same time, whichever [TrackDao.healFilePath] lands last wins and the
+     * other pass's file is orphaned, so the second one to start refuses.
+     */
+    @Test fun `refuses to start while the library move is running`() = runBlocking {
+        val file = seed("a/x/one.m4a", "ONE")
+        coEvery { trackDao.getDownloadedTrackRefs() } returns listOf(
+            ref(1L, file, "Artist A", "X", "One"),
+        )
+        moveState.value = MoveLibraryState.Running(current = 0, total = 3)
+
+        coordinator.start()
+        delay(300)
+
+        assertThat(coordinator.state.value).isInstanceOf(ReorganizeLibraryState.Error::class.java)
+        assertThat(file.readText()).isEqualTo("ONE")
+        assertThat(File(musicRoot, "artist-a-one.m4a").exists()).isFalse()
+        coVerify(exactly = 0) { trackDao.healFilePath(any(), any()) }
+    }
+}

--- a/data/download/src/test/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinatorTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/files/ReorganizeLibraryCoordinatorTest.kt
@@ -11,7 +11,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
@@ -37,8 +36,7 @@ class ReorganizeLibraryCoordinatorTest {
     private val trackDao = mockk<TrackDao>(relaxed = true)
     private val storagePreference = mockk<StoragePreference>()
     private val fileOrganizer = mockk<FileOrganizer>()
-    private val moveState = MutableStateFlow<MoveLibraryState>(MoveLibraryState.Idle)
-    private val moveLibrary = mockk<MoveLibraryCoordinator>()
+    private val gate = LibraryRewriteGate()
 
     private lateinit var musicRoot: File
     private lateinit var coordinator: ReorganizeLibraryCoordinator
@@ -49,9 +47,8 @@ class ReorganizeLibraryCoordinatorTest {
         every { storagePreference.externalTreeUri } returns flowOf(null)
         every { fileOrganizer.internalMusicRoot() } returns musicRoot
         coEvery { fileOrganizer.currentLayout() } returns LibraryLayout.SINGLE_FOLDER
-        every { moveLibrary.state } returns moveState
         coordinator =
-            ReorganizeLibraryCoordinator(context, trackDao, storagePreference, fileOrganizer, moveLibrary)
+            ReorganizeLibraryCoordinator(context, trackDao, storagePreference, fileOrganizer, gate)
     }
 
     private fun seed(relativePath: String, content: String): File =
@@ -182,16 +179,37 @@ class ReorganizeLibraryCoordinatorTest {
     }
 
     /**
-     * Both passes rewrite `file_path` for every downloaded track. Run at the
-     * same time, whichever [TrackDao.healFilePath] lands last wins and the
-     * other pass's file is orphaned, so the second one to start refuses.
+     * A name clash can only destroy a file when both rows land in the SAME
+     * storage root. An internal track and a SAF-tree track that resolve to
+     * one layout-relative name are written to different roots and cannot
+     * overwrite each other, so neither may be skipped.
      */
-    @Test fun `refuses to start while the library move is running`() = runBlocking {
+    @Test fun `an internal and an external row may share one target name`() = runBlocking {
+        val studio = seed("nirvana/nevermind/something-in-the-way.m4a", "STUDIO")
+        coEvery { trackDao.getDownloadedTrackRefs() } returns listOf(
+            ref(1L, studio, "Nirvana", "Nevermind", "Something In The Way"),
+            TrackExistenceRef(
+                2L, "Nirvana", "Unplugged", "Something In The Way",
+                "content://com.android.externalstorage.documents/document/1A2B%3AMusic%2Fold.m4a",
+            ),
+        )
+
+        assertThat(coordinator.countMisplacedTracks()).isEqualTo(2)
+    }
+
+    /**
+     * Both bulk passes rewrite `file_path` for every downloaded track. Run at
+     * once, whichever [TrackDao.healFilePath] lands last wins and the other
+     * pass's file is orphaned, so the second to start is refused — in EITHER
+     * order, which is why the exclusion lives in a shared gate rather than in
+     * one coordinator looking at the other.
+     */
+    @Test fun `refuses to start while another pass holds the gate`() = runBlocking {
         val file = seed("a/x/one.m4a", "ONE")
         coEvery { trackDao.getDownloadedTrackRefs() } returns listOf(
             ref(1L, file, "Artist A", "X", "One"),
         )
-        moveState.value = MoveLibraryState.Running(current = 0, total = 3)
+        assertThat(gate.tryAcquire("library move")).isTrue()
 
         coordinator.start()
         delay(300)
@@ -200,5 +218,40 @@ class ReorganizeLibraryCoordinatorTest {
         assertThat(file.readText()).isEqualTo("ONE")
         assertThat(File(musicRoot, "artist-a-one.m4a").exists()).isFalse()
         coVerify(exactly = 0) { trackDao.healFilePath(any(), any()) }
+    }
+
+    /** A finished pass hands the gate back, so the next one can run. */
+    @Test fun `the gate is released when the pass finishes`() = runBlocking {
+        val file = seed("a/x/one.m4a", "ONE")
+        coEvery { trackDao.getDownloadedTrackRefs() } returns listOf(
+            ref(1L, file, "Artist A", "X", "One"),
+        )
+
+        coordinator.start()
+        awaitDone()
+
+        assertThat(gate.heldBy).isNull()
+    }
+
+    /** Cancel hands the gate back too, or the button stays dead forever. */
+    @Test fun `the gate is released when the pass is cancelled`() = runBlocking {
+        val first = seed("a/x/one.m4a", "ONE")
+        coEvery { trackDao.getDownloadedTrackRefs() } returns listOf(
+            ref(1L, first, "Artist A", "X", "One"),
+        )
+        val reached = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        coEvery { trackDao.healFilePath(any(), any()) } coAnswers {
+            reached.countDown()
+            release.await(10, TimeUnit.SECONDS)
+        }
+
+        coordinator.start()
+        assertThat(reached.await(10, TimeUnit.SECONDS)).isTrue()
+        coordinator.cancel()
+        release.countDown()
+        delay(500)
+
+        assertThat(gate.heldBy).isNull()
     }
 }

--- a/data/download/src/test/kotlin/com/stash/data/download/files/SwapCoordinatorTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/files/SwapCoordinatorTest.kt
@@ -100,7 +100,7 @@ class SwapCoordinatorTest {
             downloadExecutor.download(any(), any(), any(), any(), any())
         } returns DownloadResult.Success(newTemp)
         coEvery {
-            fileOrganizer.commitDownload(any(), any(), any(), any(), any())
+            fileOrganizer.commitDownload(any(), any(), any(), any(), any(), any())
         } returns FileOrganizer.CommittedTrack(committedPath, 123L)
 
         coordinator.performSwap(

--- a/data/download/src/test/kotlin/com/stash/data/download/shared/TrackFinalizerTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/shared/TrackFinalizerTest.kt
@@ -50,7 +50,7 @@ class TrackFinalizerTest {
             firstArg()
         }
         coEvery {
-            fileOrganizer.commitDownload(any(), any(), any(), any(), any())
+            fileOrganizer.commitDownload(any(), any(), any(), any(), any(), any())
         } returns FileOrganizer.CommittedTrack("/library/Drake/x.flac", 100)
         coEvery { audioExtractor.extract(any()) } returns null
 
@@ -76,7 +76,7 @@ class TrackFinalizerTest {
             firstArg()
         }
         coEvery {
-            fileOrganizer.commitDownload(any(), any(), any(), any(), any())
+            fileOrganizer.commitDownload(any(), any(), any(), any(), any(), any())
         } returns FileOrganizer.CommittedTrack("/library/Drake/x.flac", 100)
         coEvery { audioExtractor.extract(any()) } returns null
 
@@ -93,7 +93,7 @@ class TrackFinalizerTest {
 
     @Test fun `finalizeFile propagates cancellation from commit`() = runTest {
         coEvery {
-            fileOrganizer.commitDownload(any(), any(), any(), any(), any())
+            fileOrganizer.commitDownload(any(), any(), any(), any(), any(), any())
         } throws CancellationException("cancelled")
 
         var cancellationPropagated = false

--- a/data/lyrics/src/main/kotlin/com/stash/data/lyrics/sidecar/LyricsSidecarWriter.kt
+++ b/data/lyrics/src/main/kotlin/com/stash/data/lyrics/sidecar/LyricsSidecarWriter.kt
@@ -7,8 +7,9 @@ import androidx.documentfile.provider.DocumentFile
 import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.db.entity.LyricsEntity
 import com.stash.core.data.db.entity.TrackEntity
+import com.stash.core.data.prefs.LibraryLayout
 import com.stash.core.data.prefs.StoragePreference
-import com.stash.data.download.files.FileOrganizerSlugs
+import com.stash.data.download.files.LibraryLayoutResolver
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
 import java.io.File
@@ -25,16 +26,16 @@ import javax.inject.Singleton
  * integration. Two storage targets are supported:
  *
  *  - **Internal storage** — `track.filePath` is an absolute filesystem
- *    path; the sidecar is written via plain `java.io.File`.
+ *    path; the sidecar is written via plain `java.io.File` next to the
+ *    audio (correct under every folder structure).
  *  - **SAF tree** — `track.filePath` starts with `content://`; the
  *    sidecar location is derived from the user's persisted external
  *    tree URI (from [StoragePreference], NOT from the audio URI —
  *    DocumentFile.fromTreeUri requires the tree ROOT, not a child),
- *    and the slug-walked DocumentFile mirror of the download layout
- *    (`<artistSlug>/<albumSlug>/<titleSlug>.lrc`) is created on
- *    demand. Slug semantics come from
- *    [FileOrganizerSlugs.slugify] so the sidecar always lands in the
- *    same directory the download created.
+ *    walked down through the SAME [LibraryLayoutResolver] location the
+ *    download pipeline used (#198/#104: Artist/Album, Single folder,
+ *    Per playlist), so the `.lrc` always lands in the directory the
+ *    download created.
  *
  * Write failure is non-fatal for the Room state: [LyricsRepository]
  * wraps the throwing `write()` API in `runCatching`; only that path is best-effort
@@ -117,19 +118,33 @@ class LyricsSidecarWriter @Inject constructor(
             Log.w(TAG, "DocumentFile.fromTreeUri returned null for $treeUri; sidecar skipped")
             throw IOException("Invalid SAF tree $treeUri")
         }
-        val artistName = track.albumArtist.ifBlank { track.artist }
-        val artistDir = findOrCreateDir(tree, FileOrganizerSlugs.slugify(artistName))
-            ?: fail("Could not create artist directory")
-        val albumSlug = if (track.album.isNotBlank()) {
-            FileOrganizerSlugs.slugify(track.album)
-        } else {
-            "singles"
+        // Resolve the sidecar location through the SAME layout resolver the
+        // download pipeline used — Artist/Album, Single folder, or Per
+        // playlist (#198/#104). track.artist (not albumArtist) matches what
+        // commitDownload slugged into the directory names.
+        val layout = runCatching { storagePreference.libraryLayout.first() }
+            .getOrDefault(LibraryLayout.DEFAULT)
+        val playlistName =
+            if (layout == LibraryLayout.PLAYLIST) {
+                runCatching { trackDao.getFirstPlaylistNameForTrack(track.id) }.getOrNull()
+            } else {
+                null
+            }
+        val location = LibraryLayoutResolver.resolve(
+            layout,
+            artist = track.artist,
+            album = track.album.takeIf { it.isNotBlank() },
+            title = track.title,
+            playlistName = playlistName,
+        )
+        var cursor = tree
+        for (segment in location.segments) {
+            cursor = findOrCreateDir(cursor, segment) ?: fail("Could not create directory '$segment'")
         }
-        val albumDir = findOrCreateDir(artistDir, albumSlug) ?: fail("Could not create album directory")
-        val filename = "${FileOrganizerSlugs.slugify(track.title)}.lrc"
-        val existing = albumDir.findFile(filename)
-        val target = existing ?: albumDir.createFile(LRC_MIME, filename) ?: run {
-            Log.w(TAG, "Could not create SAF sidecar '$filename' under ${albumDir.uri}")
+        val filename = "${location.baseName}.lrc"
+        val existing = cursor.findFile(filename)
+        val target = existing ?: cursor.createFile(LRC_MIME, filename) ?: run {
+            Log.w(TAG, "Could not create SAF sidecar '$filename' under ${cursor.uri}")
             throw IOException("Could not create SAF sidecar $filename")
         }
         context.contentResolver.openOutputStream(target.uri, "wt")?.use { out ->

--- a/data/lyrics/src/main/kotlin/com/stash/data/lyrics/sidecar/LyricsSidecarWriter.kt
+++ b/data/lyrics/src/main/kotlin/com/stash/data/lyrics/sidecar/LyricsSidecarWriter.kt
@@ -2,6 +2,7 @@ package com.stash.data.lyrics.sidecar
 
 import android.content.Context
 import android.net.Uri
+import android.provider.DocumentsContract
 import android.util.Log
 import androidx.documentfile.provider.DocumentFile
 import com.stash.core.data.db.dao.TrackDao
@@ -118,30 +119,45 @@ class LyricsSidecarWriter @Inject constructor(
             Log.w(TAG, "DocumentFile.fromTreeUri returned null for $treeUri; sidecar skipped")
             throw IOException("Invalid SAF tree $treeUri")
         }
-        // Resolve the sidecar location through the SAME layout resolver the
-        // download pipeline used — Artist/Album, Single folder, or Per
-        // playlist (#198/#104). track.artist (not albumArtist) matches what
-        // commitDownload slugged into the directory names.
-        val layout = runCatching { storagePreference.libraryLayout.first() }
-            .getOrDefault(LibraryLayout.DEFAULT)
-        val playlistName =
-            if (layout == LibraryLayout.PLAYLIST) {
-                runCatching { trackDao.getFirstPlaylistNameForTrack(track.id) }.getOrNull()
-            } else {
-                null
-            }
-        val location = LibraryLayoutResolver.resolve(
-            layout,
-            artist = track.artist,
-            album = track.album.takeIf { it.isNotBlank() },
-            title = track.title,
-            playlistName = playlistName,
-        )
+        // The sidecar contract is "next to the audio", so the audio's OWN
+        // directory wins over anything re-derived. A track downloaded under
+        // one layout stays put until Reorganize runs, and re-deriving from
+        // the CURRENT preference would drop the .lrc in an empty folder while
+        // the audio sat elsewhere — invisible to every external player.
+        // Falls back to the layout resolver when the provider's document ids
+        // don't follow the `<volume>:<path>` convention we can decode.
+        val beside = safLocationBesideAudio(treeUri, track.filePath)
+        val segments: List<String>
+        val baseName: String
+        if (beside != null) {
+            segments = beside.first
+            baseName = beside.second
+        } else {
+            // track.artist (not albumArtist) matches what commitDownload
+            // slugged into the directory names (#198/#104).
+            val layout = runCatching { storagePreference.libraryLayout.first() }
+                .getOrDefault(LibraryLayout.DEFAULT)
+            val playlistName =
+                if (layout == LibraryLayout.PLAYLIST) {
+                    runCatching { trackDao.getFirstPlaylistNameForTrack(track.id) }.getOrNull()
+                } else {
+                    null
+                }
+            val location = LibraryLayoutResolver.resolve(
+                layout,
+                artist = track.artist,
+                album = track.album.takeIf { it.isNotBlank() },
+                title = track.title,
+                playlistName = playlistName,
+            )
+            segments = location.segments
+            baseName = location.baseName
+        }
         var cursor = tree
-        for (segment in location.segments) {
+        for (segment in segments) {
             cursor = findOrCreateDir(cursor, segment) ?: fail("Could not create directory '$segment'")
         }
-        val filename = "${location.baseName}.lrc"
+        val filename = "$baseName.lrc"
         val existing = cursor.findFile(filename)
         val target = existing ?: cursor.createFile(LRC_MIME, filename) ?: run {
             Log.w(TAG, "Could not create SAF sidecar '$filename' under ${cursor.uri}")
@@ -150,6 +166,31 @@ class LyricsSidecarWriter @Inject constructor(
         context.contentResolver.openOutputStream(target.uri, "wt")?.use { out ->
             out.write(body.toByteArray(Charsets.UTF_8))
         } ?: fail("Could not open SAF output stream for sidecar ${target.uri}")
+    }
+
+
+    /**
+     * Decode a SAF audio document uri into (directory segments relative to
+     * the picked tree, filename without extension) so the sidecar can be
+     * written in the audio's ACTUAL directory.
+     *
+     * Mirrors the `<volume>:<path>` decode used by the reorganize pass.
+     * Returns null whenever the ids don't parse or the document doesn't sit
+     * under the tree — the caller then falls back to the layout resolver.
+     */
+    private fun safLocationBesideAudio(treeUri: Uri, docUriString: String?): Pair<List<String>, String>? {
+        if (docUriString.isNullOrBlank() || !docUriString.startsWith("content://")) return null
+        return try {
+            val baseRel = DocumentsContract.getTreeDocumentId(treeUri).substringAfter(':', "")
+            val docRel = DocumentsContract.getDocumentId(Uri.parse(docUriString)).substringAfter(':', "")
+            if (!docRel.startsWith(baseRel, ignoreCase = true)) return null
+            val parts = docRel.substring(baseRel.length).split('/').filter { it.isNotBlank() }
+            if (parts.isEmpty()) null
+            else parts.dropLast(1) to parts.last().substringBeforeLast('.')
+        } catch (t: Throwable) {
+            Log.d(TAG, "Sidecar location undecodable for $docUriString: ${t.message}")
+            null
+        }
     }
 
     /**

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsLibraryStorageScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsLibraryStorageScreen.kt
@@ -460,6 +460,51 @@ fun SettingsLibraryStorageScreen(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
 
+                // Folder structure (#198 / #104) ---------------------------
+                // Applies to new downloads immediately; existing files move
+                // only when the user runs the Reorganize action below.
+                Spacer(modifier = Modifier.height(12.dp))
+                HorizontalDivider(color = extendedColors.glassBorder)
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = "Folder structure",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Column(modifier = Modifier.selectableGroup()) {
+                    com.stash.core.data.prefs.LibraryLayout.entries.forEach { layout ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .selectable(
+                                    selected = uiState.libraryLayout == layout,
+                                    role = Role.RadioButton,
+                                    onClick = { viewModel.setLibraryLayout(layout) },
+                                )
+                                .padding(vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            RadioButton(
+                                selected = uiState.libraryLayout == layout,
+                                onClick = null,
+                            )
+                            Column(modifier = Modifier.padding(start = 8.dp)) {
+                                Text(
+                                    text = layout.label,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                                Text(
+                                    text = layout.description,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+
                 // Move library — rendered only when there's work to do. We
                 // refresh the count reactively after each move (state
                 // transition to Idle) and when the user picks a new folder.
@@ -498,6 +543,39 @@ fun SettingsLibraryStorageScreen(
                         },
                         onCancel = viewModel::cancelMoveLibrary,
                         onDismiss = viewModel::dismissMoveLibrary,
+                    )
+                }
+
+                // Reorganize library (#198/#104) — relocate already-downloaded
+                // tracks into the chosen Folder structure, within whichever
+                // destination they're in. Hidden when everything already
+                // matches and no pass is running.
+                var misplacedCount by remember { mutableStateOf<Int?>(null) }
+                LaunchedEffect(uiState.libraryLayout, uiState.reorganizeLibraryState) {
+                    if (uiState.reorganizeLibraryState !is com.stash.data.download.files.ReorganizeLibraryState.Running) {
+                        misplacedCount = runCatching { viewModel.countMisplacedTracks() }.getOrNull()
+                    }
+                }
+
+                val showReorganizeSection = when (uiState.reorganizeLibraryState) {
+                    com.stash.data.download.files.ReorganizeLibraryState.Idle ->
+                        (misplacedCount ?: 0) > 0
+                    is com.stash.data.download.files.ReorganizeLibraryState.Done -> true
+                    is com.stash.data.download.files.ReorganizeLibraryState.Error -> true
+                    is com.stash.data.download.files.ReorganizeLibraryState.Running -> true
+                }
+
+                if (showReorganizeSection) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    HorizontalDivider(color = extendedColors.glassBorder)
+                    Spacer(modifier = Modifier.height(12.dp))
+                    LibStorageReorganizeSection(
+                        state = uiState.reorganizeLibraryState,
+                        misplacedCount = misplacedCount ?: 0,
+                        layoutLabel = uiState.libraryLayout.label,
+                        onStart = viewModel::startReorganize,
+                        onCancel = viewModel::cancelReorganize,
+                        onDismiss = viewModel::dismissReorganize,
                     )
                 }
             }
@@ -625,6 +703,125 @@ private fun LibStorageMoveLibrarySection(
         is com.stash.data.download.files.MoveLibraryState.Error -> {
             Text(
                 text = "Couldn't move library",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = state.message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            androidx.compose.material3.TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Dismiss")
+            }
+        }
+    }
+}
+
+/**
+ * Renders the "Reorganize existing library" action inside the Storage card
+ * (issue #198 / #104). Relocates already-downloaded tracks into the chosen
+ * folder structure without changing their storage destination.
+ *
+ * Four visual states driven by [ReorganizeLibraryState]:
+ * - **Idle** — prompt + start button (shown only when [misplacedCount] > 0).
+ * - **Running(c, t)** — live progress + linear bar + Cancel.
+ * - **Done(moved, skipped, failed)** — result summary + Dismiss.
+ * - **Error(msg)** — error text + Dismiss.
+ */
+@Composable
+private fun LibStorageReorganizeSection(
+    state: com.stash.data.download.files.ReorganizeLibraryState,
+    misplacedCount: Int,
+    layoutLabel: String,
+    onStart: () -> Unit,
+    onCancel: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    when (state) {
+        com.stash.data.download.files.ReorganizeLibraryState.Idle -> {
+            Text(
+                text = "Reorganize existing tracks",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "$misplacedCount downloaded track${if (misplacedCount == 1) "" else "s"} " +
+                    "don't follow the \"$layoutLabel\" structure yet. Move them now? New downloads " +
+                    "already use it.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            androidx.compose.material3.OutlinedButton(
+                onClick = onStart,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.primary,
+                ),
+            ) {
+                Text("Move $misplacedCount track${if (misplacedCount == 1) "" else "s"} into \"$layoutLabel\"")
+            }
+        }
+        is com.stash.data.download.files.ReorganizeLibraryState.Running -> {
+            Text(
+                text = "Moving ${state.current} of ${state.total}...",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            androidx.compose.material3.LinearProgressIndicator(
+                progress = {
+                    if (state.total == 0) 0f
+                    else state.current.toFloat() / state.total.toFloat()
+                },
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            androidx.compose.material3.TextButton(
+                onClick = onCancel,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Cancel")
+            }
+        }
+        is com.stash.data.download.files.ReorganizeLibraryState.Done -> {
+            Text(
+                text = buildString {
+                    append("Moved ${state.moved} track")
+                    if (state.moved != 1) append("s")
+                    if (state.skipped > 0) append(" • ${state.skipped} already organized")
+                    if (state.failed > 0) append(" • ${state.failed} failed")
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            if (state.failed > 0) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Failed tracks keep their old location. Try again later.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            androidx.compose.material3.TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Dismiss")
+            }
+        }
+        is com.stash.data.download.files.ReorganizeLibraryState.Error -> {
+            Text(
+                text = "Couldn't reorganize library",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.error,
             )

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsUiState.kt
@@ -153,6 +153,19 @@ data class SettingsUiState(
      */
     val moveLibraryState: com.stash.data.download.files.MoveLibraryState =
         com.stash.data.download.files.MoveLibraryState.Idle,
+    /**
+     * Folder structure new downloads are filed under (#198/#104). Changing
+     * it does not move files; see [reorganizeLibraryState] for the explicit
+     * relocation pass.
+     */
+    val libraryLayout: com.stash.core.data.prefs.LibraryLayout =
+        com.stash.core.data.prefs.LibraryLayout.DEFAULT,
+    /**
+     * Live state of the one-shot "Reorganize library" pass that relocates
+     * already-downloaded tracks into [libraryLayout]'s structure.
+     */
+    val reorganizeLibraryState: com.stash.data.download.files.ReorganizeLibraryState =
+        com.stash.data.download.files.ReorganizeLibraryState.Idle,
     /** Last.fm connection state — drives the Settings → Last.fm section. */
     val lastFmState: LastFmAuthState = LastFmAuthState.NotConfigured,
     /** True while a manual scrobble-drain is in-flight. */

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -35,6 +35,8 @@ import com.stash.data.download.files.LibrarySizeBreakdown
 import com.stash.data.download.files.LibrarySizeHolder
 import com.stash.data.download.files.MoveLibraryCoordinator
 import com.stash.data.download.files.MoveLibraryState
+import com.stash.data.download.files.ReorganizeLibraryCoordinator
+import com.stash.data.download.files.ReorganizeLibraryState
 import com.stash.data.download.lossless.AggregatorRateLimiter
 import com.stash.data.download.lossless.LosslessAvailability
 import com.stash.data.download.lossless.LosslessQualityTier
@@ -90,6 +92,7 @@ class SettingsViewModel @Inject constructor(
     private val storagePreference: StoragePreference,
     private val downloadNetworkPreference: DownloadNetworkPreference,
     private val moveLibraryCoordinator: MoveLibraryCoordinator,
+    private val reorganizeLibraryCoordinator: ReorganizeLibraryCoordinator,
     private val youTubeCookieHelper: YouTubeCookieHelper,
     private val lastFmApiClient: LastFmApiClient,
     private val lastFmSessionPreference: LastFmSessionPreference,
@@ -592,6 +595,8 @@ class SettingsViewModel @Inject constructor(
         homeSectionsPreference.order,
         homeSectionsPreference.hidden,
         homeSectionsPreference.showLikedOnHome,
+        storagePreference.libraryLayout,
+        reorganizeLibraryCoordinator.state,
     ) { values ->
         // Read strictly in the order the flows are declared above. See [Values]:
         // there are no positional indices to renumber, and requireExhausted()
@@ -639,6 +644,8 @@ class SettingsViewModel @Inject constructor(
         @Suppress("UNCHECKED_CAST")
         val homeSectionsHidden = v.next<Set<com.stash.core.data.prefs.HomeSection>>()
         val showLikedOnHome = v.next<Boolean>()
+        val libraryLayout = v.next<com.stash.core.data.prefs.LibraryLayout>()
+        val reorganizeState = v.next<ReorganizeLibraryState>()
         v.requireExhausted()
 
         val lastFmState: LastFmAuthState = local.lastFmAuthOverride
@@ -671,6 +678,8 @@ class SettingsViewModel @Inject constructor(
             youTubeError = local.youTubeError,
             externalTreeUri = externalTree,
             moveLibraryState = moveState,
+            libraryLayout = libraryLayout,
+            reorganizeLibraryState = reorganizeState,
             lastFmState = lastFmState,
             isScrobbleDraining = local.isScrobbleDraining,
             scrobbleDrainResult = local.lastScrobbleDrainResult,
@@ -752,6 +761,41 @@ class SettingsViewModel @Inject constructor(
     fun dismissMoveLibrary() {
         moveLibraryCoordinator.dismiss()
     }
+
+    // -- Folder structure (#198 / #104) ---------------------------------------
+
+    /**
+     * Persists the folder structure new downloads are filed under. Does not
+     * move existing files — the user opts into that with [startReorganize].
+     */
+    fun setLibraryLayout(layout: com.stash.core.data.prefs.LibraryLayout) {
+        viewModelScope.launch {
+            storagePreference.setLibraryLayout(layout)
+        }
+    }
+
+    /** Starts the reorganize job on the coordinator's app-scoped job. */
+    fun startReorganize() {
+        reorganizeLibraryCoordinator.start()
+    }
+
+    /** Cancels an in-progress reorganize. State reverts to Idle. */
+    fun cancelReorganize() {
+        reorganizeLibraryCoordinator.cancel()
+    }
+
+    /** Dismisses a terminal Done/Error state, returning to Idle. */
+    fun dismissReorganize() {
+        reorganizeLibraryCoordinator.dismiss()
+    }
+
+    /**
+     * Counts downloaded tracks whose on-disk location doesn't already match
+     * the chosen structure — used by the Settings UI to gate and label the
+     * "Reorganize" action.
+     */
+    suspend fun countMisplacedTracks(): Int =
+        runCatching { reorganizeLibraryCoordinator.countMisplacedTracks() }.getOrDefault(0)
 
     /**
      * Triggers a database export to the chosen URI.

--- a/feature/settings/src/test/kotlin/com/stash/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/stash/feature/settings/SettingsViewModelTest.kt
@@ -53,6 +53,7 @@ class SettingsViewModelTest {
         storagePreference = mockk(relaxed = true),
         downloadNetworkPreference = mockk(relaxed = true),
         moveLibraryCoordinator = mockk(relaxed = true),
+        reorganizeLibraryCoordinator = mockk(relaxed = true),
         youTubeCookieHelper = mockk(relaxed = true),
         lastFmApiClient = mockk(relaxed = true),
         lastFmSessionPreference = mockk(relaxed = true),

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/FailedMatchesViewModel.kt
@@ -492,6 +492,7 @@ class FailedMatchesViewModel @Inject constructor(
                             album = null,
                             title = title,
                             format = result.file.extension,
+                            trackId = trackId,
                         )
                         // Reject a too-small "successful" download (failed
                         // yt-dlp run leaving a tiny error body): delete it +


### PR DESCRIPTION
Closes #198. Closes #104.

Downloads were always filed as `<Artist>/<Album>/<title>`. This makes the structure selectable and adds a one-shot pass to move already-downloaded tracks into the chosen shape.

## Layouts

| Layout | Shape |
|---|---|
| `ARTIST_ALBUM` (default) | `<artist>/<album>/<title>.<ext>` — unchanged historical behavior |
| `SINGLE_FOLDER` | `<artist>-<title>.<ext>` directly in the root (**#104**) |
| `PLAYLIST` | `<playlist>/<artist>-<title>.<ext>` (**#198**) |

`LibraryLayoutResolver` is the single source of truth for both writes (`resolve`) and lookups (`lookupCandidates`) — the layout was previously re-derived by hand in four places. The flat layouts prefix the artist because the directory no longer separates artists; two songs both called "Intro" would otherwise overwrite each other. Blank album → `singles/`; `PLAYLIST` with no sync-enabled owner falls back to Artist/Album.

Changing the setting never moves files. "Reorganize existing tracks" does that explicitly, and only appears when something is actually misplaced.

## Verified on device

Samsung Tab (SM-T570), debug build, internal storage:

- All three layouts listed, Artist/Album default, selection **persists across a full app restart**.
- With layout set to Single folder, a real download landed flat as `daft-punk-one-more-time-radio-edit.opus` with its `.lrc` beside it — new downloads follow the layout.
- Reorganize section stayed **hidden** while the file matched the layout and **appeared** the moment the layout changed and made it misplaced.

Not exercised on device: the reorganize pass itself against a real SAF/SD-card tree.

## Review fixes

Four defects found in review, all fixed here:

- **Wrong-song adoption.** The tree-wide filename fallback matched a bare `<title>.<ext>`. Outside its own `<artist>/<album>` directory that isn't an identity — a different artist's same-titled song could be adopted and this track's `file_path` healed onto the wrong audio. Only artist-qualified names match tree-wide now. Covered by two new tests.
- **SAF reorganize was broken entirely.** `moveWithinSaf` resolved the source with `DocumentFile.fromTreeUri`, but `file_path` holds the audio **document** URI — `fromTreeUri` rebuilds the tree root, so copy+delete ran against the wrong document for every SAF track. Uses `fromSingleUri`.
- **Cancel didn't cancel.** The per-entry `runCatching` swallowed `CancellationException`, so the pass kept moving files and then overwrote Idle with Done.
- **Disabled playlists claimed tracks.** `getFirstPlaylistNameForTrack` only *ordered* by `sync_enabled`, so a track whose memberships were all disabled was filed under a switched-off playlist. It now filters. Deliberately not the same rule as `DownloadQueueDao`'s "from &lt;playlist&gt;" label — showing *some* name is right for a label and wrong for a directory, and the KDoc no longer claims parity.

Lyrics sidecars also now follow the audio through a reorganize on **both** internal and SAF paths, and the SAF writer places the `.lrc` beside the audio's actual directory rather than re-deriving it from the current layout preference.

## Known gap

`ReorganizeLibraryCoordinator` has no dedicated unit test. Its resolver and matcher are covered, and the internal path was exercised on device, but the coordinator's own move logic is not under test — worth adding before this is relied on for large libraries.

## Tests

`core:data` 713, `feature:settings` 38, `data:lyrics` 40, `feature:sync` 45, `data:download` 36 — 0 failures; `:app:compileDebugKotlin` clean.
