### PR TITLE
feat(sync): Last.fm as a sync source with recommended playlist (#255)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ These sources are somebody else's infrastructure, mostly run solo and mostly fre
 - **Spotify + YouTube Music in one unified library** — liked songs, playlists, daily mixes, every Spotify mix worth syncing
 - **Bulletproof matching** — finds the right version of a track 99% of the time
 - **Last.fm scrobbling**, optional, off by default
+- **Last.fm recommendations** — connect Last.fm and it appears under Sync → Sources, keeping a rotating "Recommended by Last.fm" playlist of tracks it suggests from your listening
 - **Wrong-match flag** — if Stash picked the wrong version, tap once from Now Playing and it queues a re-search
 - **Likes and History mirroring** — When enabled, each track you like & stream in Stash lands in your Spotify & YouTube accounts.
 

--- a/app/src/main/kotlin/com/stash/app/StashApplication.kt
+++ b/app/src/main/kotlin/com/stash/app/StashApplication.kt
@@ -118,6 +118,14 @@ class StashApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var stashMixPreference: com.stash.core.data.prefs.StashMixPreference
 
+    /**
+     * Issue #255 — Last.fm-as-a-source lifecycle owner. Startup reconcile
+     * activates/deactivates the "Recommended by Last.fm" recipe to match
+     * the current session + preference state.
+     */
+    @Inject
+    lateinit var lastFmRecommendationSource: com.stash.core.data.mix.LastFmRecommendationSource
+
     @Inject
     lateinit var downloadNetworkPreference: DownloadNetworkPreference
 
@@ -395,6 +403,12 @@ class StashApplication : Application(), Configuration.Provider {
             maybeRetuneStashMixes()
             maybeRemoveRetiredBuiltinMixes()
             maybeCleanupDiscoveryLibraryHits()
+            // Issue #255: activate/deactivate the "Recommended by Last.fm"
+            // recipe BEFORE the one-shot refresh below, so a freshly
+            // reconciled recipe is picked up by that same run instead of
+            // waiting for tomorrow's periodic cycle.
+            runCatching { lastFmRecommendationSource.reconcile() }
+                .onFailure { Log.w("StashStartup", "lastfm recommendation reconcile failed", it) }
             // Fire a one-shot refresh on first launch so mixes populate
             // without waiting for the 24-hour periodic cycle. Subsequent
             // one-shots are safe (unique-work policy = REPLACE).

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/PlaylistDao.kt
@@ -350,6 +350,10 @@ interface PlaylistDao {
     @Query("SELECT * FROM playlists WHERE id = :id LIMIT 1")
     suspend fun getById(id: Long): PlaylistEntity?
 
+    /** Reactive twin of [getById] — emits again whenever the row changes. */
+    @Query("SELECT * FROM playlists WHERE id = :id LIMIT 1")
+    fun getByIdFlow(id: Long): Flow<PlaylistEntity?>
+
     /** Find a playlist by its remote source ID (e.g. Spotify playlist ID). */
     @Query("SELECT * FROM playlists WHERE source_id = :sourceId LIMIT 1")
     suspend fun findBySourceId(sourceId: String): PlaylistEntity?
@@ -657,6 +661,15 @@ interface PlaylistDao {
      *  remaining silently hidden. */
     @Query("UPDATE playlists SET is_active = 1 WHERE id = :playlistId AND is_active = 0")
     suspend fun reactivateById(playlistId: Long): Int
+
+    /**
+     * Set [is_active] on one playlist, either direction. Used by app-managed
+     * surfaces (e.g. [com.stash.core.data.mix.LastFmRecommendationSource]) that
+     * hide their playlist without hard-deleting it — the same pattern as
+     * [setActiveForBuiltinMixes], scoped to a single row.
+     */
+    @Query("UPDATE playlists SET is_active = :active WHERE id = :playlistId")
+    suspend fun setActiveById(playlistId: Long, active: Boolean)
 
     /**
      * Re-file a playlist under the type today's snapshot reports.

--- a/core/data/src/main/kotlin/com/stash/core/data/db/dao/StashMixRecipeDao.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/db/dao/StashMixRecipeDao.kt
@@ -65,6 +65,19 @@ interface StashMixRecipeDao {
     suspend fun findByPlaylistId(playlistId: Long): StashMixRecipeEntity?
 
     /**
+     * Find a recipe by its exact name — the lookup behind app-managed
+     * recipes (e.g. [com.stash.core.data.mix.LastFmRecommendationSource]'s
+     * "Recommended by Last.fm"), which are find-or-create by name because
+     * they're seeded lazily rather than shipped in [StashMixDefaults].
+     */
+    @Query("SELECT * FROM stash_mix_recipes WHERE name = :name LIMIT 1")
+    suspend fun getByName(name: String): StashMixRecipeEntity?
+
+    /** Reactive twin of [getByName] for UI surfaces that track one recipe. */
+    @Query("SELECT * FROM stash_mix_recipes WHERE name = :name LIMIT 1")
+    fun observeByName(name: String): Flow<StashMixRecipeEntity?>
+
+    /**
      * Return every materialized playlist_id across builtin recipes —
      * used by the "reset builtins" migration to delete the old backing
      * playlists before we wipe and reseed the recipe table.

--- a/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmSourcePreference.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/lastfm/LastFmSourcePreference.kt
@@ -1,0 +1,52 @@
+package com.stash.core.data.lastfm
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Dedicated DataStore for Last.fm-as-a-source preferences (issue #255) —
+ * mirrors `lastfm_session`, which stays scoped to the scrobble connection.
+ */
+private val Context.lastFmSourceDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "lastfm_source",
+)
+
+/**
+ * User toggle for the "Recommended by Last.fm" source playlist
+ * ([com.stash.core.data.mix.LastFmRecommendationSource]).
+ *
+ * Default is `true`: the issue asks for recommendations to simply show up
+ * under Sync → Sources once Last.fm is connected, and this matches how
+ * Daily Discover behaves for everyone. The recipe only ever materializes
+ * while a Last.fm session exists — turning the connection off (or this
+ * toggle off) deactivates it without deleting anything, so re-enabling
+ * restores the playlist with its accumulated tracks intact.
+ */
+@Singleton
+class LastFmSourcePreference @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val recommendationsEnabledKey = booleanPreferencesKey("recommendations_enabled")
+
+    val recommendationsEnabled: Flow<Boolean> = context.lastFmSourceDataStore.data.map { prefs ->
+        prefs[recommendationsEnabledKey] ?: true
+    }
+
+    suspend fun current(): Boolean = recommendationsEnabled.first()
+
+    suspend fun setRecommendationsEnabled(enabled: Boolean) {
+        context.lastFmSourceDataStore.edit {
+            it[recommendationsEnabledKey] = enabled
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/mix/LastFmRecommendationSource.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/mix/LastFmRecommendationSource.kt
@@ -183,19 +183,25 @@ class LastFmRecommendationSource @Inject constructor(
      */
     private suspend fun applyActivation(active: Boolean, kickRefresh: Boolean) {
         val recipe = recipeDao.getByName(RECIPE_NAME) ?: return
-        if (recipe.isActive != active) {
-            recipeDao.setActive(recipe.id, active)
+        // The Stash-Mixes master switch owns every mix surface, and this
+        // recipe materializes a STASH_MIX like any other. Gate HERE — the one
+        // place activation is applied — so no caller can light it up while the
+        // user has mixes switched off. Re-enabling mixes restores it on the
+        // next reconcile() (app start, or a Last.fm connect/toggle).
+        val effectiveActive = active && stashMixPreference.current()
+        if (recipe.isActive != effectiveActive) {
+            recipeDao.setActive(recipe.id, effectiveActive)
         }
         val playlistId = recipe.playlistId
         if (playlistId != null) {
             val playlist = playlistDao.getById(playlistId)
             // Only touch STASH_MIX rows: if the user somehow deleted the
             // playlist, getById returns null and there's nothing to hide.
-            if (playlist != null && playlist.type == PlaylistType.STASH_MIX && playlist.isActive != active) {
-                playlistDao.setActiveById(playlistId, active)
+            if (playlist != null && playlist.type == PlaylistType.STASH_MIX && playlist.isActive != effectiveActive) {
+                playlistDao.setActiveById(playlistId, effectiveActive)
             }
         }
-        if (active && kickRefresh && stashMixPreference.current()) {
+        if (effectiveActive && kickRefresh) {
             // Single-recipe one-shot: builds/rebuilds only this mix. REPLACE
             // policy coalesces rapid double-taps.
             runCatching { StashMixRefreshWorker.enqueueOneTime(context, recipe.id) }

--- a/core/data/src/main/kotlin/com/stash/core/data/mix/LastFmRecommendationSource.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/mix/LastFmRecommendationSource.kt
@@ -144,13 +144,20 @@ class LastFmRecommendationSource @Inject constructor(
 
     /**
      * Bring persisted state in line with reality. Idempotent; called from
-     * app startup and after Last.fm connect/disconnect.
+     * app startup, after Last.fm connect/disconnect, and when the
+     * Stash-Mixes master switch flips.
+     *
+     * @param kickRefresh start building the playlist immediately instead of
+     *   waiting for the daily cycle. True on an interactive connect, where
+     *   the user is looking at the Sync tab expecting something to happen;
+     *   false on startup and on master-switch flips, which have their own
+     *   refresh scheduling.
      */
-    suspend fun reconcile() {
+    suspend fun reconcile(kickRefresh: Boolean = false) {
         ensureRecipe()
         val connected = sessionPreference.session.first() != null
         val enabled = sourcePreference.recommendationsEnabled.first()
-        applyActivation(active = connected && enabled, kickRefresh = false)
+        applyActivation(active = connected && enabled, kickRefresh = kickRefresh)
         Log.i(TAG, "reconcile: connected=$connected enabled=$enabled")
     }
 

--- a/core/data/src/main/kotlin/com/stash/core/data/mix/LastFmRecommendationSource.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/mix/LastFmRecommendationSource.kt
@@ -1,0 +1,226 @@
+package com.stash.core.data.mix
+
+import android.content.Context
+import android.util.Log
+import com.stash.core.data.db.dao.PlaylistDao
+import com.stash.core.data.db.dao.StashMixRecipeDao
+import com.stash.core.data.db.entity.StashMixRecipeEntity
+import com.stash.core.data.lastfm.LastFmSessionPreference
+import com.stash.core.data.lastfm.LastFmSourcePreference
+import com.stash.core.data.prefs.StashMixPreference
+import com.stash.core.data.sync.workers.StashMixRefreshWorker
+import com.stash.core.model.PlaylistType
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * UI state for the Last.fm source surface (issue #255). Everything the
+ * Sync-tab card and its manage screen render, derived reactively.
+ *
+ * @property connected   A Last.fm session exists (user completed web auth).
+ * @property enabled     The user hasn't turned Recommendations off.
+ * @property trackCount  Tracks currently in the materialized playlist;
+ *                       null until the first refresh has created it.
+ * @property lastRefreshedAt  Epoch-millis of the last successful recipe
+ *                       refresh; null never-refreshed.
+ */
+data class LastFmRecommendationState(
+    val connected: Boolean = false,
+    val enabled: Boolean = true,
+    val trackCount: Int? = null,
+    val lastRefreshedAt: Long? = null,
+)
+
+/**
+ * Treats Last.fm as a sync **source**, not just a scrobble destination.
+ *
+ * Last.fm has no public playlist API, so "importing from Last.fm" means
+ * something different here than it does for Spotify/YouTube: a dedicated,
+ * app-managed Stash Mix recipe — **"Recommended by Last.fm"** — whose slots
+ * fill entirely with tracks Last.fm recommends (`track.getSimilar` seeded
+ * from the user's recent plays and top tracks), matched against YouTube
+ * Music / Spotify and downloaded/streamed through the existing discovery
+ * pipeline ([com.stash.core.data.sync.workers.StashMixRefreshWorker] +
+ * [com.stash.core.data.sync.workers.StashDiscoveryWorker]). No new worker,
+ * table, or fetch path — the feature rides machinery that already handles
+ * candidate generation, library/skip filtering, cross-mix dedup, and
+ * stream-only stubs.
+ *
+ * Lifecycle:
+ *  - The recipe is NOT shipped in [StashMixDefaults] — users without
+ *    Last.fm must not accumulate an eternally-empty pure-discovery mix.
+ *    It's find-or-created lazily by [ensureRecipe].
+ *  - [reconcile] runs at app startup and after every Last.fm connect /
+ *    disconnect: the recipe (and its materialized playlist) are active iff
+ *    a session exists AND the user hasn't opted out via
+ *    [LastFmSourcePreference]. Disabling hides the playlist rather than
+ *    deleting it — re-enabling restores the accumulated track list, the
+ *    same contract as the Stash-Mixes master opt-out.
+ *
+ * Deliberately `isBuiltin = false`: Home's Discover hero resolves "the"
+ * builtin playlist as `builtinPlaylistIds.first()`, and Library/Home rails
+ * exclude builtin ids by set membership. Managing our row outside the
+ * builtin machinery keeps those assumptions valid while behaving identically
+ * to a user-built mix on every screen.
+ */
+@Singleton
+class LastFmRecommendationSource @Inject constructor(
+    private val recipeDao: StashMixRecipeDao,
+    private val playlistDao: PlaylistDao,
+    private val sessionPreference: LastFmSessionPreference,
+    private val sourcePreference: LastFmSourcePreference,
+    private val stashMixPreference: StashMixPreference,
+    @ApplicationContext private val context: Context,
+) {
+    companion object {
+        const val TAG = "LastFmRecSource"
+
+        /** Exact recipe (and therefore playlist) name. */
+        const val RECIPE_NAME = "Recommended by Last.fm"
+
+        /**
+         * Pure recommendations: every slot comes from Last.fm candidates,
+         * nothing from the local library — that's what makes it a *source*
+         * rather than another mix flavor.
+         */
+        const val DISCOVERY_RATIO = 1.0f
+
+        /** Rotating window size; matches Daily Discover's scale. */
+        const val TARGET_LENGTH = 40
+
+        /**
+         * Seed strategy: similar TRACKS to what the user actually plays —
+         * the closest thing to Last.fm's own recommendation shape among the
+         * supported strategies (ARTIST_SIMILAR is Daily Discover's lane).
+         */
+        const val SEED_STRATEGY = "TRACK_SIMILAR"
+    }
+
+    /**
+     * Reactive state for the Sync-tab Last.fm card + manage screen. Combines
+     * session, preference, and (when the recipe exists) its materialized
+     * playlist's live track count.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun observeState(): Flow<LastFmRecommendationState> =
+        combine(
+            sessionPreference.session,
+            sourcePreference.recommendationsEnabled,
+            recipeDao.observeByName(RECIPE_NAME),
+        ) { session, enabled, recipe ->
+            StateInputs(session != null, enabled, recipe?.playlistId, recipe?.lastRefreshedAt)
+        }.flatMapLatest { inputs ->
+            if (inputs.playlistId == null) {
+                flowOf(
+                    LastFmRecommendationState(
+                        connected = inputs.connected,
+                        enabled = inputs.enabled,
+                        trackCount = null,
+                        lastRefreshedAt = inputs.lastRefreshedAt,
+                    ),
+                )
+            } else {
+                playlistDao.getByIdFlow(inputs.playlistId).map { playlist ->
+                    LastFmRecommendationState(
+                        connected = inputs.connected,
+                        enabled = inputs.enabled,
+                        // Hidden (is_active=0) counts as not-materialized for
+                        // display purposes — the user turned it off, so the
+                        // card shouldn't quote a stale number.
+                        trackCount = playlist?.takeIf { it.isActive }?.trackCount,
+                        lastRefreshedAt = inputs.lastRefreshedAt,
+                    )
+                }
+            }
+        }
+
+    /**
+     * Bring persisted state in line with reality. Idempotent; called from
+     * app startup and after Last.fm connect/disconnect.
+     */
+    suspend fun reconcile() {
+        ensureRecipe()
+        val connected = sessionPreference.session.first() != null
+        val enabled = sourcePreference.recommendationsEnabled.first()
+        applyActivation(active = connected && enabled, kickRefresh = false)
+        Log.i(TAG, "reconcile: connected=$connected enabled=$enabled")
+    }
+
+    /**
+     * User flipped the Recommendations toggle on the Sync surface. Persists
+     * the choice and applies it immediately; enabling kicks a one-shot
+     * single-recipe refresh so the playlist starts building without waiting
+     * for the daily cycle (skipped when the Stash-Mixes master switch is
+     * off — that opt-out owns all mix scheduling).
+     */
+    suspend fun setRecommendationsEnabled(enabled: Boolean) {
+        sourcePreference.setRecommendationsEnabled(enabled)
+        applyActivation(active = enabled && sessionPreference.session.first() != null, kickRefresh = enabled)
+        Log.i(TAG, "setRecommendationsEnabled($enabled)")
+    }
+
+    /** Ensure the managed recipe row exists; returns its id. */
+    internal suspend fun ensureRecipe(): Long {
+        recipeDao.getByName(RECIPE_NAME)?.let { return it.id }
+        val id = recipeDao.insert(managedRecipe())
+        Log.i(TAG, "created recipe '$RECIPE_NAME' (id=$id)")
+        return id
+    }
+
+    /**
+     * Apply the desired activation state to the recipe AND its materialized
+     * playlist. Deactivation never deletes: the recipe keeps its playlistId
+     * and discovery backlog, the playlist keeps its rows — flipping back on
+     * restores everything in place.
+     */
+    private suspend fun applyActivation(active: Boolean, kickRefresh: Boolean) {
+        val recipe = recipeDao.getByName(RECIPE_NAME) ?: return
+        if (recipe.isActive != active) {
+            recipeDao.setActive(recipe.id, active)
+        }
+        val playlistId = recipe.playlistId
+        if (playlistId != null) {
+            val playlist = playlistDao.getById(playlistId)
+            // Only touch STASH_MIX rows: if the user somehow deleted the
+            // playlist, getById returns null and there's nothing to hide.
+            if (playlist != null && playlist.type == PlaylistType.STASH_MIX && playlist.isActive != active) {
+                playlistDao.setActiveById(playlistId, active)
+            }
+        }
+        if (active && kickRefresh && stashMixPreference.current()) {
+            // Single-recipe one-shot: builds/rebuilds only this mix. REPLACE
+            // policy coalesces rapid double-taps.
+            runCatching { StashMixRefreshWorker.enqueueOneTime(context, recipe.id) }
+                .onFailure { Log.w(TAG, "refresh enqueue failed; recipe still activated", it) }
+        }
+    }
+
+    /** The managed recipe definition. Inactive until reconciled into existence. */
+    internal fun managedRecipe() = StashMixRecipeEntity(
+        name = RECIPE_NAME,
+        description = "Tracks Last.fm recommends, based on what you listen to.",
+        affinityBias = 0f,
+        freshnessWindowDays = 0,
+        discoveryRatio = DISCOVERY_RATIO,
+        targetLength = TARGET_LENGTH,
+        seedStrategy = SEED_STRATEGY,
+        isBuiltin = false,
+        isActive = false,
+    )
+
+    /** Narrow carrier so the combine lambda stays single-expression. */
+    private data class StateInputs(
+        val connected: Boolean,
+        val enabled: Boolean,
+        val playlistId: Long?,
+        val lastRefreshedAt: Long?,
+    )
+}

--- a/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.stash.core.data.db.dao.TrackDao
 import com.stash.core.data.db.entity.SyncHistoryEntity
 import com.stash.core.data.mapper.toDomain
 import com.stash.core.data.mapper.toEntity
+import com.stash.core.data.mix.LastFmRecommendationSource
 import com.stash.core.model.Playlist
 import com.stash.core.model.Track
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -335,6 +336,16 @@ class MusicRepositoryImpl @Inject constructor(
             // queries that filter on is_active = 1.
             stashMixRecipeDao.setActiveForBuiltins(false)
             playlistDao.setActiveForBuiltinMixes(false)
+            // The Last.fm recommendations recipe (#255) materializes a
+            // STASH_MIX but is NOT a builtin, so both sweeps above miss it.
+            // Hide it explicitly — otherwise the master opt-out leaves one mix
+            // still visible. Re-enabling restores it through
+            // LastFmRecommendationSource.reconcile(), which re-checks that
+            // Last.fm is still connected and recommendations still enabled.
+            stashMixRecipeDao.getByName(LastFmRecommendationSource.RECIPE_NAME)?.let { recipe ->
+                stashMixRecipeDao.setActive(recipe.id, false)
+                recipe.playlistId?.let { playlistDao.setActiveById(it, false) }
+            }
         }
     }
 

--- a/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/repository/MusicRepositoryImpl.kt
@@ -52,6 +52,7 @@ class MusicRepositoryImpl @Inject constructor(
     private val localFileOps: com.stash.core.data.files.LocalFileOps,
     private val syncPreferencesManager: com.stash.core.data.sync.SyncPreferencesManager,
     private val singleTrackDownloadEnqueuer: com.stash.core.data.sync.SingleTrackDownloadEnqueuer,
+    private val lastFmRecommendationSource: LastFmRecommendationSource,
 ) : MusicRepository {
 
     // ── Deletion event plumbing ─────────────────────────────────────────
@@ -324,6 +325,12 @@ class MusicRepositoryImpl @Inject constructor(
             // Fire a one-shot refresh so the surfaces repopulate immediately
             // rather than waiting for the next periodic cycle.
             com.stash.core.data.sync.workers.StashMixRefreshWorker.enqueueOneTime(context)
+            // The Last.fm source (#255) is a STASH_MIX but NOT a builtin, so
+            // the sweeps above miss it in both directions. reconcile() re-
+            // derives its state from session + toggle + this switch, so one
+            // call restores it here and hides it below — no second copy of
+            // the predicate to drift.
+            runCatching { lastFmRecommendationSource.reconcile() }
         } else {
             // Cancel periodic + one-shot work by unique name. The constants
             // live inside the workers as private vals; the names are stable
@@ -336,16 +343,10 @@ class MusicRepositoryImpl @Inject constructor(
             // queries that filter on is_active = 1.
             stashMixRecipeDao.setActiveForBuiltins(false)
             playlistDao.setActiveForBuiltinMixes(false)
-            // The Last.fm recommendations recipe (#255) materializes a
-            // STASH_MIX but is NOT a builtin, so both sweeps above miss it.
-            // Hide it explicitly — otherwise the master opt-out leaves one mix
-            // still visible. Re-enabling restores it through
-            // LastFmRecommendationSource.reconcile(), which re-checks that
-            // Last.fm is still connected and recommendations still enabled.
-            stashMixRecipeDao.getByName(LastFmRecommendationSource.RECIPE_NAME)?.let { recipe ->
-                stashMixRecipeDao.setActive(recipe.id, false)
-                recipe.playlistId?.let { playlistDao.setActiveById(it, false) }
-            }
+            // Same single call as the enable branch: reconcile() reads the
+            // now-persisted master switch and deactivates the Last.fm recipe
+            // and its playlist without deleting anything.
+            runCatching { lastFmRecommendationSource.reconcile() }
         }
     }
 

--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/StashMixRefreshWorker.kt
@@ -31,6 +31,7 @@ import com.stash.core.data.lastfm.LastFmTopTrack
 import com.stash.core.data.mix.MixGenerator
 import com.stash.core.data.mix.MixSeedGenerator
 import com.stash.core.data.mix.MixSeedStrategy
+import com.stash.core.data.mix.LastFmRecommendationSource
 import com.stash.core.data.mix.RecipeTagResolver
 import com.stash.core.data.mix.StashMixDefaults
 import com.stash.core.data.mix.TagPoolBuilder
@@ -477,6 +478,9 @@ class StashMixRefreshWorker @AssistedInject constructor(
      *
      *  - First Listen (1.0 discovery, library-blind) — has no opinion on
      *    the library pool; claims TAG_GRAPH survivors first.
+     *  - Recommended by Last.fm (1.0 discovery, library-blind; issue #255)
+     *    — same reasoning as First Listen: a pure-discovery recipe claims
+     *    its TRACK_SIMILAR survivors before library-mixed recipes see them.
      *  - Deep Cuts (0.85 discovery) — claims TRACK_SIMILAR survivors and
      *    a sparse library slice next.
      *  - Daily Discover (0.85 discovery) — most permissive on the
@@ -488,8 +492,9 @@ class StashMixRefreshWorker @AssistedInject constructor(
      */
     private fun recipeDedupPriority(recipe: StashMixRecipeEntity): Int = when (recipe.name) {
         "First Listen" -> 1
-        "Deep Cuts" -> 2
-        "Daily Discover" -> 3
+        LastFmRecommendationSource.RECIPE_NAME -> 2
+        "Deep Cuts" -> 3
+        "Daily Discover" -> 4
         else -> 99
     }
 

--- a/core/data/src/test/kotlin/com/stash/core/data/mix/LastFmRecommendationSourceTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/mix/LastFmRecommendationSourceTest.kt
@@ -1,0 +1,205 @@
+package com.stash.core.data.mix
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.stash.core.data.db.StashDatabase
+import com.stash.core.data.db.entity.PlaylistEntity
+import com.stash.core.data.lastfm.LastFmSession
+import com.stash.core.data.lastfm.LastFmSessionPreference
+import com.stash.core.data.lastfm.LastFmSourcePreference
+import com.stash.core.data.prefs.StashMixPreference
+import com.stash.core.model.MusicSource
+import com.stash.core.model.PlaylistType
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for [LastFmRecommendationSource] — the issue #255 lifecycle owner
+ * that turns a Last.fm scrobble connection into a Sync **source** backed by
+ * the app-managed "Recommended by Last.fm" mix recipe.
+ *
+ * Uses a real in-memory Room DB (the DAO interactions are the contract) and
+ * mock-backed DataStores (Robolectric + process-singleton DataStore delegates
+ * don't reset cleanly between tests — see StashMixRecipeDaoRetuneTest for the
+ * Room-only variant of this pattern).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class LastFmRecommendationSourceTest {
+
+    private lateinit var db: StashDatabase
+    private lateinit var source: LastFmRecommendationSource
+
+    private val sessionFlow = MutableStateFlow<LastFmSession?>(null)
+    private val enabledFlow = MutableStateFlow(true)
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            StashDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+
+        val sessionPreference = mockk<LastFmSessionPreference> {
+            every { session } returns sessionFlow
+        }
+        val sourcePreference = mockk<LastFmSourcePreference> {
+            every { recommendationsEnabled } returns enabledFlow
+            coEvery { current() } answers { enabledFlow.value }
+            // Simulate the real DataStore: persisting flips the observable flow.
+            coEvery { setRecommendationsEnabled(any()) } answers {
+                enabledFlow.value = firstArg()
+            }
+        }
+        // Master switch ON would make setRecommendationsEnabled(true) try to
+        // kick a one-shot refresh through WorkManager, which isn't initialized
+        // under Robolectric. OFF keeps that glue out of these lifecycle tests;
+        // the enqueue call itself is fail-safe runCatching glue.
+        val stashMixPreference = mockk<StashMixPreference> {
+            coEvery { current() } returns false
+        }
+
+        source = LastFmRecommendationSource(
+            recipeDao = db.stashMixRecipeDao(),
+            playlistDao = db.playlistDao(),
+            sessionPreference = sessionPreference,
+            sourcePreference = sourcePreference,
+            stashMixPreference = stashMixPreference,
+            context = ApplicationProvider.getApplicationContext(),
+        )
+    }
+
+    @After fun tearDown() {
+        db.close()
+    }
+
+    private fun dao() = db.stashMixRecipeDao()
+    private fun playlistDao() = db.playlistDao()
+
+    private suspend fun recipe() = dao().getByName(LastFmRecommendationSource.RECIPE_NAME)
+
+    /** Insert a materialized playlist row and point the managed recipe at it,
+     *  mirroring what StashMixRefreshWorker.materializeMix does on first fill. */
+    private suspend fun materializePlaylist(): Long {
+        val recipeId = source.ensureRecipe()
+        val playlistId = playlistDao().insert(
+            PlaylistEntity(
+                name = LastFmRecommendationSource.RECIPE_NAME,
+                source = MusicSource.BOTH,
+                sourceId = "stash_mix_test_$recipeId",
+                type = PlaylistType.STASH_MIX,
+                trackCount = 12,
+            ),
+        )
+        dao().setPlaylistId(recipeId, playlistId)
+        return playlistId
+    }
+
+    @Test fun `reconcile creates the managed recipe when missing`() = runTest {
+        source.reconcile()
+        val r = recipe()
+        assertNotNull("reconcile must find-or-create the recipe", r)
+        assertEquals(LastFmRecommendationSource.TARGET_LENGTH, r!!.targetLength)
+        assertEquals(LastFmRecommendationSource.DISCOVERY_RATIO, r.discoveryRatio)
+        assertEquals(LastFmRecommendationSource.SEED_STRATEGY, r.seedStrategy)
+        assertFalse("recipe must not ship builtin-flagged", r.isBuiltin)
+    }
+
+    @Test fun `ensureRecipe is idempotent`() = runTest {
+        val first = source.ensureRecipe()
+        val second = source.ensureRecipe()
+        assertEquals(first, second)
+        // getActive() filters on is_active (the managed recipe seeds inactive),
+        // so count via the unfiltered list.
+        val rows = dao().observeAll().first()
+        assertEquals(1, rows.count { it.name == LastFmRecommendationSource.RECIPE_NAME })
+    }
+
+    @Test fun `reconcile activates while connected and enabled`() = runTest {
+        sessionFlow.value = LastFmSession("scrobbler", "key")
+        source.reconcile()
+        assertTrue(recipe()!!.isActive)
+    }
+
+    @Test fun `reconcile keeps the recipe inactive without a session`() = runTest {
+        source.reconcile()
+        assertNotNull(recipe())
+        assertFalse(recipe()!!.isActive)
+    }
+
+    @Test fun `reconcile honors the user opt-out even when connected`() = runTest {
+        sessionFlow.value = LastFmSession("scrobbler", "key")
+        enabledFlow.value = false
+        source.reconcile()
+        assertFalse(recipe()!!.isActive)
+    }
+
+    @Test fun `disconnecting deactivates without deleting anything`() = runTest {
+        sessionFlow.value = LastFmSession("scrobbler", "key")
+        val playlistId = materializePlaylist()
+        source.reconcile()
+        assertTrue(recipe()!!.isActive)
+
+        sessionFlow.value = null
+        source.reconcile()
+        assertFalse("no session → no active recipe", recipe()!!.isActive)
+        assertNotNull("playlist must survive disconnect", playlistDao().getById(playlistId))
+    }
+
+    @Test fun `toggling off hides the playlist and toggling on restores it`() = runTest {
+        sessionFlow.value = LastFmSession("scrobbler", "key")
+        val playlistId = materializePlaylist()
+        source.reconcile()
+        assertTrue(playlistDao().getById(playlistId)!!.isActive)
+
+        source.setRecommendationsEnabled(false)
+        assertFalse(enabledFlow.value)
+        assertFalse(recipe()!!.isActive)
+        assertFalse("disabled source must hide its playlist", playlistDao().getById(playlistId)!!.isActive)
+
+        source.setRecommendationsEnabled(true)
+        assertTrue(recipe()!!.isActive)
+        assertTrue("re-enabling restores the playlist in place", playlistDao().getById(playlistId)!!.isActive)
+    }
+
+    @Test fun `observeState reports connection, preference, and track count`() = runTest {
+        var state = source.observeState().first()
+        assertFalse(state.connected)
+
+        sessionFlow.value = LastFmSession("scrobbler", "key")
+        val playlistId = materializePlaylist()
+        source.reconcile()
+
+        state = source.observeState().first()
+        assertTrue(state.connected)
+        assertTrue(state.enabled)
+        assertEquals(12, state.trackCount)
+
+        playlistDao().setActiveById(playlistId, false)
+        state = source.observeState().first()
+        assertEquals("a hidden playlist counts as no tracks", null, state.trackCount)
+    }
+
+    @Test fun `observeByName emits the managed recipe reactively`() = runTest {
+        // Sanity: the reactive lookup used by observeState resolves after create.
+        source.reconcile()
+        val observed = dao().observeByName(LastFmRecommendationSource.RECIPE_NAME).first()
+        assertNotNull(observed)
+        assertEquals(false, observed!!.isActive)
+    }
+}

--- a/core/data/src/test/kotlin/com/stash/core/data/mix/LastFmRecommendationSourceTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/mix/LastFmRecommendationSourceTest.kt
@@ -66,12 +66,13 @@ class LastFmRecommendationSourceTest {
                 enabledFlow.value = firstArg()
             }
         }
-        // Master switch ON would make setRecommendationsEnabled(true) try to
-        // kick a one-shot refresh through WorkManager, which isn't initialized
-        // under Robolectric. OFF keeps that glue out of these lifecycle tests;
-        // the enqueue call itself is fail-safe runCatching glue.
+        // Defaults ON, matching production: the master switch now gates
+        // ACTIVATION, not just the refresh kick, so an OFF default would make
+        // every lifecycle test below assert against a globally-disabled mix.
+        // The one-shot WorkManager enqueue that ON enables is fail-safe
+        // runCatching glue, so it stays harmless under Robolectric.
         val stashMixPreference = mockk<StashMixPreference> {
-            coEvery { current() } returns false
+            coEvery { current() } answers { stashMixesOn }
         }
 
         source = LastFmRecommendationSource(
@@ -83,6 +84,9 @@ class LastFmRecommendationSourceTest {
             context = ApplicationProvider.getApplicationContext(),
         )
     }
+
+    /** Stash-Mixes master switch seen by the mocked preference. */
+    private var stashMixesOn = true
 
     @After fun tearDown() {
         db.close()
@@ -201,5 +205,17 @@ class LastFmRecommendationSourceTest {
         val observed = dao().observeByName(LastFmRecommendationSource.RECIPE_NAME).first()
         assertNotNull(observed)
         assertEquals(false, observed!!.isActive)
+    }
+
+    @Test fun `the Stash Mixes master switch keeps the recipe inactive`() = runTest {
+        // #255 regression: the master opt-out only sweeps BUILTIN recipes, and
+        // this one is not builtin — activation must consult the switch itself.
+        stashMixesOn = false
+        sessionFlow.value = LastFmSession("scrobbler", "key")
+        enabledFlow.value = true
+
+        source.reconcile()
+
+        assertFalse(recipe()!!.isActive)
     }
 }

--- a/core/data/src/test/kotlin/com/stash/core/data/repository/MusicRepositoryDownloadsMixTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/repository/MusicRepositoryDownloadsMixTest.kt
@@ -98,6 +98,7 @@ class MusicRepositoryDownloadsMixTest {
         localFileOps = mockk(relaxed = true),
         syncPreferencesManager = syncPreferencesManager,
         singleTrackDownloadEnqueuer = singleTrackDownloadEnqueuer,
+        lastFmRecommendationSource = mockk(relaxed = true),
     )
 
     private fun downloadedTrack(id: Long, filePath: String = "/music/$id.flac") = TrackEntity(

--- a/core/data/src/test/kotlin/com/stash/core/data/repository/MusicRepositoryEnsureTrackPersistedTest.kt
+++ b/core/data/src/test/kotlin/com/stash/core/data/repository/MusicRepositoryEnsureTrackPersistedTest.kt
@@ -61,5 +61,6 @@ class MusicRepositoryEnsureTrackPersistedTest {
         localFileOps = mockk(relaxed = true),
         syncPreferencesManager = mockk(relaxed = true),
         singleTrackDownloadEnqueuer = mockk(relaxed = true),
+        lastFmRecommendationSource = mockk(relaxed = true),
     )
 }

--- a/core/ui/src/main/kotlin/com/stash/core/ui/theme/Color.kt
+++ b/core/ui/src/main/kotlin/com/stash/core/ui/theme/Color.kt
@@ -13,6 +13,8 @@ val StashCyanLight = Color(0xFF22D3EE)
 val StashCyanDark = Color(0xFF0891B2)
 val StashSpotifyGreen = Color(0xFF1DB954)
 val StashYouTubeRed = Color(0xFFFF0033)
+// Last.fm brand red — the Sync-tab Last.fm source card's brand bar (issue #255).
+val StashLastfmRed = Color(0xFFD51007)
 val StashError = Color(0xFFEF4444)
 val StashWarning = Color(0xFFF59E0B)
 val StashSuccess = Color(0xFF10B981)
@@ -54,6 +56,7 @@ val StashGlassBorderBrightLight = Color(0x337C3AED)
 data class StashExtendedColors(
     val spotifyGreen: Color = StashSpotifyGreen,
     val youtubeRed: Color = StashYouTubeRed,
+    val lastfmRed: Color = StashLastfmRed,
     val cyan: Color = StashCyan,
     val cyanLight: Color = StashCyanLight,
     val cyanDark: Color = StashCyanDark,

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -909,7 +909,10 @@ class SettingsViewModel @Inject constructor(
                     // Issue #255: the connection just became a SOURCE. Reconcile
                     // so "Recommended by Last.fm" activates now — the user sees
                     // it on the Sync tab without restarting.
-                    runCatching { lastFmRecommendationSource.reconcile() }
+                    // kickRefresh: the user is watching the Sync tab right
+                    // now — without it the new playlist sits empty until the
+                    // next daily cycle or app restart.
+                    runCatching { lastFmRecommendationSource.reconcile(kickRefresh = true) }
                         .onFailure { android.util.Log.w("SettingsVM", "lastfm reconcile failed", it) }
                     // Clear the override — the session flow now drives Connected state.
                     _localState.update { it.copy(lastFmAuthOverride = null) }

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsViewModel.kt
@@ -123,6 +123,12 @@ class SettingsViewModel @Inject constructor(
     private val listenSinkCoordinator: com.stash.core.data.listen.ListenSinkCoordinator,
     private val listenSubmissionDao: com.stash.core.data.db.dao.ListenSubmissionDao,
     private val relayClient: LosslessRelayClient,
+    /**
+     * Issue #255 — Last.fm-as-a-source lifecycle. Connect/disconnect
+     * reconcile the "Recommended by Last.fm" recipe so the Sync-tab
+     * source card appears (or disappears) immediately, not next launch.
+     */
+    private val lastFmRecommendationSource: com.stash.core.data.mix.LastFmRecommendationSource,
 ) : ViewModel() {
 
     // ── ListenBrainz ────────────────────────────────────────────────────────
@@ -900,6 +906,11 @@ class SettingsViewModel @Inject constructor(
             result.fold(
                 onSuccess = { (username, sessionKey) ->
                     lastFmSessionPreference.save(LastFmSession(username, sessionKey))
+                    // Issue #255: the connection just became a SOURCE. Reconcile
+                    // so "Recommended by Last.fm" activates now — the user sees
+                    // it on the Sync tab without restarting.
+                    runCatching { lastFmRecommendationSource.reconcile() }
+                        .onFailure { android.util.Log.w("SettingsVM", "lastfm reconcile failed", it) }
                     // Clear the override — the session flow now drives Connected state.
                     _localState.update { it.copy(lastFmAuthOverride = null) }
                 },
@@ -921,6 +932,10 @@ class SettingsViewModel @Inject constructor(
     fun onDisconnectLastFm() {
         viewModelScope.launch {
             lastFmSessionPreference.clear()
+            // Issue #255: no session → no source. Deactivate the recipe and
+            // hide its playlist; nothing is deleted, reconnect restores it.
+            runCatching { lastFmRecommendationSource.reconcile() }
+                .onFailure { android.util.Log.w("SettingsVM", "lastfm reconcile failed", it) }
             _localState.update { it.copy(lastFmAuthOverride = null) }
         }
     }

--- a/feature/settings/src/test/kotlin/com/stash/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/stash/feature/settings/SettingsViewModelTest.kt
@@ -90,6 +90,7 @@ class SettingsViewModelTest {
         listenSinkCoordinator = mockk(relaxed = true),
         listenSubmissionDao = mockk(relaxed = true),
         relayClient = relayClient,
+        lastFmRecommendationSource = mockk(relaxed = true),
     )
 
     @Test fun `refreshStorageUsage requests a fresh filesystem calculation`() {

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/ManagePlaylistsScreen.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/ManagePlaylistsScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stash.core.model.PlaylistType
+import com.stash.core.data.mix.LastFmRecommendationState
 import com.stash.core.ui.theme.StashTheme
 import com.stash.core.common.extensions.pluralize
 
@@ -59,21 +60,30 @@ fun ManagePlaylistsScreen(
     viewModel: SyncViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    // Issue #255 — the Last.fm manage surface is driven by recommendation
+    // state, not by imported-playlist lists.
+    val lastFmState by viewModel.lastFmState.collectAsStateWithLifecycle()
 
     // Both source playlist types share the same shape but are distinct classes;
     // map into one source-agnostic row so the rest of the screen ignores which.
     val rows: List<ManageRow> = if (source == SyncSource.SPOTIFY) {
         uiState.spotifyPlaylists.map { ManageRow(it.id, it.name, it.trackCount, it.type, it.syncEnabled, it.hideFromHome) }
-    } else {
+    } else if (source == SyncSource.YOUTUBE) {
         uiState.youTubePlaylists.map { ManageRow(it.id, it.name, it.trackCount, it.type, it.syncEnabled, it.hideFromHome) }
+    } else {
+        emptyList()
     }
 
-    val accent = if (source == SyncSource.SPOTIFY) {
-        StashTheme.extendedColors.spotifyGreen
-    } else {
-        StashTheme.extendedColors.youtubeRed
+    val accent = when (source) {
+        SyncSource.SPOTIFY -> StashTheme.extendedColors.spotifyGreen
+        SyncSource.YOUTUBE -> StashTheme.extendedColors.youtubeRed
+        SyncSource.LASTFM -> StashTheme.extendedColors.lastfmRed
     }
-    val title = if (source == SyncSource.SPOTIFY) "Spotify playlists" else "YouTube Music playlists"
+    val title = when (source) {
+        SyncSource.SPOTIFY -> "Spotify playlists"
+        SyncSource.YOUTUBE -> "YouTube Music playlists"
+        SyncSource.LASTFM -> "Last.fm"
+    }
 
     var query by remember { mutableStateOf("") }
     var segment by remember { mutableStateOf(ManageSegment.ALL) }
@@ -121,6 +131,18 @@ fun ManagePlaylistsScreen(
             )
         },
     ) { innerPadding ->
+        if (source == SyncSource.LASTFM) {
+            // Issue #255 — Last.fm has no importable playlists; its manage
+            // surface is the single Recommendations toggle + explainer.
+            LastFmManageContent(
+                state = lastFmState,
+                onToggle = viewModel::onLastFmRecommendationsToggled,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            )
+            return@Scaffold
+        }
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -406,5 +428,89 @@ private fun MixHideRow(
             checked = shown,
             onCheckedChange = onToggleShown,
         )
+    }
+}
+
+// ── Last.fm (issue #255) ─────────────────────────────────────────────────────
+
+/**
+ * Manage surface for the Last.fm source. Last.fm has no public playlist
+ * API, so there is nothing to import and nothing to list — the entire
+ * source is the app-managed "Recommended by Last.fm" mix. This screen
+ * hosts its toggle, an honest explainer of what the playlist is and where
+ * it lands, and the connect hint when Last.fm isn't connected.
+ */
+@Composable
+private fun LastFmManageContent(
+    state: LastFmRecommendationState,
+    onToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(horizontal = 16.dp),
+    ) {
+        Text(
+            text = "Recommendations",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = 0.5.sp,
+            modifier = Modifier.padding(top = 12.dp, bottom = 4.dp),
+        )
+
+        // The toggle row mirrors SpotifySyncToggleRow's shape so all three
+        // manage screens read as siblings.
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(enabled = state.connected) { onToggle(!state.enabled) }
+                .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Recommended by Last.fm",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = when {
+                        !state.connected ->
+                            "Connect Last.fm in Settings → Accounts to enable"
+                        !state.enabled ->
+                            "Off — no recommendations are generated"
+                        else ->
+                            "On · ${state.trackCount ?: 0} tracks synced"
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            com.stash.core.ui.components.StashSwitch(
+                checked = state.connected && state.enabled,
+                onCheckedChange = onToggle,
+                enabled = state.connected,
+            )
+        }
+
+        Text(
+            text = "Builds a rotating playlist of tracks Last.fm recommends, " +
+                "seeded from what you play and scrobble most. Each refresh " +
+                "swaps in fresh picks; tracks are matched against YouTube " +
+                "Music / Spotify and downloaded like any other sync, " +
+                "respecting your network settings.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+        Text(
+            text = "Find it as “Recommended by Last.fm” under Library → Mixes.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(top = 8.dp),
+        )
+
+        Spacer(Modifier.height(80.dp))
     }
 }

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncScreen.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncScreen.kt
@@ -95,6 +95,9 @@ fun SyncScreen(
     val authState by viewModel.authExpiry.collectAsStateWithLifecycle()
     val streamingMode by viewModel.streamingEnabled.collectAsStateWithLifecycle()
     val playbackOnline by viewModel.playbackOnline.collectAsStateWithLifecycle()
+    // Last.fm source card state (issue #255) — collected with the rest of
+    // the screen's state because LazyListScope isn't a composable context.
+    val lastFmState by viewModel.lastFmState.collectAsStateWithLifecycle()
 
     LazyColumn(
         modifier = modifier
@@ -322,6 +325,47 @@ fun SyncScreen(
             }
         }
 
+        // -- Last.fm source dashboard (issue #255) ----------------------------
+        // Last.fm can't import playlists (no public playlist API), so its
+        // source card is the app-managed "Recommended by Last.fm" mix: a
+        // rotating playlist of tracks Last.fm recommends from the user's
+        // listening, matched + downloaded through the discovery pipeline.
+        // Rendered only while a Last.fm session exists — the scrobble
+        // connection IS the source connection.
+        if (lastFmState.connected) {
+            item {
+                val hasTracks = (lastFmState.trackCount ?: 0) > 0
+                com.stash.feature.sync.components.SourcePreferencesCard(
+                    name = "Last.fm",
+                    brandColor = StashTheme.extendedColors.lastfmRed,
+                    connected = true,
+                    stats = {
+                        if (hasTracks) {
+                            Row(modifier = Modifier.fillMaxWidth()) {
+                                SourceStatCell(
+                                    number = "${lastFmState.trackCount}",
+                                    label = "RECOMMENDED",
+                                )
+                            }
+                        } else {
+                            SourceEmptyHint(
+                                "A playlist of tracks Last.fm recommends — seeded from " +
+                                    "what you listen to — will be built on the next sync. " +
+                                    "Tap Sync Now to start it.",
+                            )
+                        }
+                    },
+                    modeChips = {
+                        LastFmRecommendationsToggleRow(
+                            enabled = lastFmState.enabled,
+                            onChange = viewModel::onLastFmRecommendationsToggled,
+                        )
+                    },
+                    onManage = { onManageSource(SyncSource.LASTFM) },
+                )
+            }
+        }
+
         // -- Schedule section -------------------------------------------------
         item { SyncSectionLabel("Schedule") }
         item {
@@ -480,7 +524,16 @@ private fun DownloadManagementCard(onClick: () -> Unit) {
 }
 
 /** Which source a "Manage ›" tap targets. Consumed by the nav host (Task 5). */
-enum class SyncSource { SPOTIFY, YOUTUBE }
+enum class SyncSource { SPOTIFY, YOUTUBE,
+
+    /**
+     * Last.fm as a recommendation SOURCE (issue #255). Unlike SPOTIFY/
+     * YOUTUBE there are no remote playlists to import — Last.fm has no
+     * public playlist API — so its manage surface toggles the app-managed
+     * "Recommended by Last.fm" mix instead.
+     */
+    LASTFM,
+}
 
 // -- Source dashboard: numbers row ───────────────────────────────────────────
 
@@ -972,6 +1025,48 @@ private fun SyncModeChipRow(
 }
 
 // ── Spotify sync toggle row ─────────────────────────────────────────────────
+
+/**
+ * Recommendations toggle for the Last.fm source card (issue #255). Lives in
+ * the [com.stash.feature.sync.components.SourcePreferencesCard] modeChips
+ * slot — where Spotify/YouTube put their Refresh/Accumulate chips — because
+ * rotation is the only mode a recommendation playlist has; the only choice
+ * worth offering is whether it exists.
+ */
+@Composable
+private fun LastFmRecommendationsToggleRow(
+    enabled: Boolean,
+    onChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onChange(!enabled) }
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Recommended tracks",
+                style = MaterialTheme.typography.labelMedium,
+                color = StashTheme.extendedColors.lastfmRed,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = if (enabled)
+                    "A rotating playlist of Last.fm recommendations is kept up to date"
+                else
+                    "Off — no recommendations are generated",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        com.stash.core.ui.components.StashSwitch(
+            checked = enabled,
+            onCheckedChange = onChange,
+        )
+    }
+}
 
 @Composable
 internal fun SpotifySyncToggleRow(

--- a/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncViewModel.kt
+++ b/feature/sync/src/main/kotlin/com/stash/feature/sync/SyncViewModel.kt
@@ -211,6 +211,12 @@ class SyncViewModel @Inject constructor(
     * combinations this unlocks.
     */
     private val playbackModePreference: com.stash.core.data.prefs.PlaybackModePreference,
+    /**
+     * Last.fm-as-a-source manager (issue #255). Owns the "Recommended by
+     * Last.fm" mix recipe lifecycle; the Sync tab only renders its state
+     * and forwards the user's toggle.
+     */
+    private val lastFmRecommendationSource: com.stash.core.data.mix.LastFmRecommendationSource,
 ) : ViewModel() {
 
     /**
@@ -337,6 +343,31 @@ class SyncViewModel @Inject constructor(
                 started = SharingStarted.WhileSubscribed(5_000),
                 initialValue = false,
             )
+
+    /**
+     * Live Last.fm source state (issue #255): connection, Recommendations
+     * toggle, and the materialized playlist's track count. Drives the
+     * Last.fm card in the Sync tab's Sources section and its manage screen.
+     */
+    val lastFmState: StateFlow<com.stash.core.data.mix.LastFmRecommendationState> =
+        lastFmRecommendationSource.observeState()
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = com.stash.core.data.mix.LastFmRecommendationState(),
+            )
+
+    /**
+     * User toggled the "Recommended by Last.fm" playlist on/off from the
+     * Sync surface. Delegates to [LastFmRecommendationSource], which
+     * persists the choice, activates/deactivates recipe + playlist, and —
+     * when enabling — kicks a one-shot refresh so the mix starts building.
+     */
+    fun onLastFmRecommendationsToggled(enabled: Boolean) {
+        viewModelScope.launch {
+            lastFmRecommendationSource.setRecommendationsEnabled(enabled)
+        }
+    }
 
     /**
     * Reactive playback-mode flag — separate from [streamingEnabled], which is

--- a/feature/sync/src/test/kotlin/com/stash/feature/sync/SyncViewModelTest.kt
+++ b/feature/sync/src/test/kotlin/com/stash/feature/sync/SyncViewModelTest.kt
@@ -96,6 +96,7 @@ class SyncViewModelTest {
         librarySizeHolder = librarySizeHolder,
         streamingPreference = streamingPreference,
         playbackModePreference = playbackModePreference,
+        lastFmRecommendationSource = mockk(relaxed = true),
     )
 
     @Before fun setUp() {


### PR DESCRIPTION
Closes #255.

Last.fm was scrobble-only. This makes it a **source**: connecting it surfaces a Last.fm card under Sync → Sources, and its recommendations build into a "Recommended by Last.fm" playlist that shows up with the other mixes.

The recipe is managed by `LastFmRecommendationSource`. Deactivating never deletes — the recipe keeps its `playlistId` and discovery backlog and the playlist keeps its rows, so disconnecting hides the source and reconnecting restores it in place. `reconcile()` is idempotent and re-derives state from session + toggle + the Stash-Mixes master switch.

No schema change: this branch adds DAO queries only, and the database stays at `version = 42`.

## Review fixes

Two defects found in review, both fixed here:

- **Bypassed the Stash Mixes master opt-out.** The recipe materializes a `STASH_MIX` but is not builtin, and the opt-out only sweeps builtins (`setActiveForBuiltins` / `setActiveForBuiltinMixes`), so connecting Last.fm lit the mix up even with mixes switched off. Activation is now gated inside `applyActivation` — the single place activation is applied, so both entry points inherit it. Covered by a new test with a negative-control run.
- **Re-enabling mixes left it hidden, and connecting left it empty.** Turning the master switch back on only reactivated builtins, and finishing auth mid-session reconciled with `kickRefresh = false` so the playlist sat empty until a restart. Both master-switch branches now call `reconcile()` — one predicate rather than a second copy to drift — and the interactive connect passes `kickRefresh = true`.

## Not verified end-to-end

**This has never been exercised on a device.** The build gates the whole feature on a Last.fm API key: `app/build.gradle.kts` reads `lastfm.apiKey` / `lastfm.apiSecret` from `local.properties` (or `LASTFM_API_KEY` / `LASTFM_API_SECRET`) into a `buildConfigField`, and without one the app correctly reports *"This build of Stash doesn't include a Last.fm API key."*

The negative case does check out — no Last.fm card appears under Sources while disconnected. Everything past connecting needs a key plus a Last.fm account, so **the connect → recommendations → playlist path is unverified outside unit tests.**

## Known gap

`ensureRecipe()` claims the managed row by display name, so a user's own Stash Mix named exactly "Recommended by Last.fm" would be adopted and toggled by connect/disconnect. A stable marker column would fix it properly; that's a schema change and isn't in this branch.

## Tests

`core:data` 720, `feature:sync` 45, `feature:settings` 38 — 0 failures; `:app:compileDebugKotlin` clean.
