### PR TITLE
Add translate/contributor menus to Home issue button and Settings donate button

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ That isn't a workaround. It's a principled choice: open-source tools that give u
 
 Bug reports and feature requests through [GitHub Issues](https://github.com/rawnaldclark/Stash/issues). For everything else — questions, requests, "is this thing on" — the [Stash Discord](https://discord.gg/vcbjEby5PC) is the place. Active dev there, fast answers.
 
+Want to help translate Stash into your language? Join the [Crowdin project](https://crowdin.com/project/stash-music-player) and [request translator access here](https://docs.google.com/forms/d/e/1FAIpQLSexDpqAvK82QlYYpC8J0ukwVXkzOQSjC8V10SPVbj1ug0ojow/viewform?usp=sharing&ouid=101376898883134592146).
+
 ---
 
 ## Contributing
@@ -234,7 +236,11 @@ Stash is GPL-3.0. You can use, copy, modify, and redistribute it freely. If you 
 
 Stash is free, open source, and has no ads or telemetry. If it replaced a subscription for you and you want to throw a few bucks at the project:
 
+**rawnaldclark (rawn)** — Owner, main dev
 <a href="https://ko-fi.com/rawnald"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Support on Ko-fi" height="36"></a>
+
+**Paraliyzed_evo** — Co-dev, makes the beta builds
+<a href="https://www.paypal.com/paypalme/Paraliyzedevo"><img src="https://img.shields.io/badge/PayPal-Donate-00457C?logo=paypal&logoColor=white" alt="Support on PayPal" height="36"></a>
 
 You can also [sponsor on GitHub](https://github.com/sponsors/rawnaldclark) for recurring support.
 

--- a/README.md
+++ b/README.md
@@ -236,10 +236,10 @@ Stash is GPL-3.0. You can use, copy, modify, and redistribute it freely. If you 
 
 Stash is free, open source, and has no ads or telemetry. If it replaced a subscription for you and you want to throw a few bucks at the project:
 
-**rawnaldclark (rawn)** — Owner, main dev
+**rawnaldclark (rawn)** — Owner, main dev<br>
 <a href="https://ko-fi.com/rawnald"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Support on Ko-fi" height="36"></a>
 
-**Paraliyzed_evo** — Co-dev, makes the beta builds
+**Paraliyzed_evo** — Co-dev, makes the beta builds<br>
 <a href="https://www.paypal.com/paypalme/Paraliyzedevo"><img src="https://img.shields.io/badge/PayPal-Donate-00457C?logo=paypal&logoColor=white" alt="Support on PayPal" height="36"></a>
 
 You can also [sponsor on GitHub](https://github.com/sponsors/rawnaldclark) for recurring support.

--- a/app/src/main/kotlin/com/stash/app/navigation/StashNavHost.kt
+++ b/app/src/main/kotlin/com/stash/app/navigation/StashNavHost.kt
@@ -222,6 +222,7 @@ fun StashNavHost(
                 onOpenAppearance = { navController.navigate(SettingsAppearanceRoute) },
                 onOpenAbout = { navController.navigate(SettingsAboutRoute) },
                 onDonate = { runCatching { uriHandler.openUri("https://ko-fi.com/rawnald") } },
+                onDonateCoDev = { runCatching { uriHandler.openUri("https://www.paypal.com/paypalme/Paraliyzedevo") } },
                 onStar = { runCatching { uriHandler.openUri("https://github.com/rawnaldclark/Stash") } },
             )
         }

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
@@ -68,7 +68,11 @@ import androidx.compose.material.icons.filled.RemoveCircleOutline
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -267,16 +271,101 @@ fun HomeScreen(
                     )
                 }
 
-                androidx.compose.material3.IconButton(
-                    onClick = { socialUriHandler.openUri(STASH_ISSUE_URL) },
-                    modifier = Modifier.size(40.dp),
-                ) {
-                    androidx.compose.material3.Icon(
-                        imageVector = Icons.Filled.Build,
-                        contentDescription = "Report an issue on GitHub",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(20.dp),
-                    )
+                var showHelpMenu by remember { mutableStateOf(false) }
+                Box {
+                    androidx.compose.material3.IconButton(
+                        onClick = { showHelpMenu = true },
+                        modifier = Modifier.size(40.dp),
+                    ) {
+                        androidx.compose.material3.Icon(
+                            imageVector = Icons.Filled.Build,
+                            contentDescription = "Get involved with Stash",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = showHelpMenu,
+                        onDismissRequest = { showHelpMenu = false },
+                        modifier = Modifier.background(MaterialTheme.colorScheme.surface),
+                    ) {
+                        DropdownMenuItem(
+                            text = {
+                                Column {
+                                    Text(
+                                        text = "Report an issue",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                    )
+                                    Text(
+                                        text = "Open a bug or feature request on GitHub",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Filled.Build,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            },
+                            onClick = {
+                                showHelpMenu = false
+                                socialUriHandler.openUri(STASH_ISSUE_URL)
+                            },
+                        )
+                        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                        DropdownMenuItem(
+                            text = {
+                                Column {
+                                    Text(
+                                        text = "Help us translate",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                    )
+                                    Text(
+                                        text = "Join on Crowdin, then request access",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Filled.Language,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            },
+                            trailingIcon = {
+                                // Secondary tap target: opens the access-request form directly,
+                                // separate from the row's main click (Crowdin project page).
+                                Box(
+                                    modifier = Modifier
+                                        .size(28.dp)
+                                        .clip(CircleShape)
+                                        .clickable {
+                                            showHelpMenu = false
+                                            socialUriHandler.openUri(STASH_TRANSLATE_ACCESS_FORM_URL)
+                                        },
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Filled.OpenInNew,
+                                        contentDescription = "Request translator access",
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier.size(16.dp),
+                                    )
+                                }
+                            },
+                            onClick = {
+                                showHelpMenu = false
+                                socialUriHandler.openUri(STASH_CROWDIN_URL)
+                            },
+                        )
+                    }
                 }
             }
         }
@@ -1029,6 +1118,10 @@ private const val STASH_ISSUE_URL = "https://github.com/rawnaldclark/Stash/issue
 // to the left of the wrench. Tap → opens the invite in the default
 // browser. Edit when the invite rotates.
 private const val STASH_DISCORD_URL = "https://discord.gg/vcbjEby5PC"
+
+private const val STASH_CROWDIN_URL = "https://crowdin.com/project/stash-music-player"
+private const val STASH_TRANSLATE_ACCESS_FORM_URL =
+    "https://docs.google.com/forms/d/e/1FAIpQLSexDpqAvK82QlYYpC8J0ukwVXkzOQSjC8V10SPVbj1ug0ojow/viewform?usp=sharing&ouid=101376898883134592146"
 
 private val LEGACY_SUPPORTERS = listOf(
     Supporter(

--- a/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt
@@ -279,7 +279,7 @@ fun HomeScreen(
                     ) {
                         androidx.compose.material3.Icon(
                             imageVector = Icons.Filled.Build,
-                            contentDescription = "Get involved with Stash",
+                            contentDescription = "Report an issue or help translate",
                             tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.size(20.dp),
                         )
@@ -287,7 +287,6 @@ fun HomeScreen(
                     DropdownMenu(
                         expanded = showHelpMenu,
                         onDismissRequest = { showHelpMenu = false },
-                        modifier = Modifier.background(MaterialTheme.colorScheme.surface),
                     ) {
                         DropdownMenuItem(
                             text = {
@@ -313,7 +312,7 @@ fun HomeScreen(
                             },
                             onClick = {
                                 showHelpMenu = false
-                                socialUriHandler.openUri(STASH_ISSUE_URL)
+                                runCatching { socialUriHandler.openUri(STASH_ISSUE_URL) }
                             },
                         )
                         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
@@ -339,30 +338,29 @@ fun HomeScreen(
                                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                             },
-                            trailingIcon = {
-                                // Secondary tap target: opens the access-request form directly,
-                                // separate from the row's main click (Crowdin project page).
-                                Box(
-                                    modifier = Modifier
-                                        .size(28.dp)
-                                        .clip(CircleShape)
-                                        .clickable {
-                                            showHelpMenu = false
-                                            socialUriHandler.openUri(STASH_TRANSLATE_ACCESS_FORM_URL)
-                                        },
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Filled.OpenInNew,
-                                        contentDescription = "Request translator access",
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        modifier = Modifier.size(16.dp),
-                                    )
-                                }
+                            onClick = {
+                                showHelpMenu = false
+                                runCatching { socialUriHandler.openUri(STASH_CROWDIN_URL) }
+                            },
+                        )
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    text = "Request translator access",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Filled.OpenInNew,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
                             },
                             onClick = {
                                 showHelpMenu = false
-                                socialUriHandler.openUri(STASH_CROWDIN_URL)
+                                runCatching { socialUriHandler.openUri(STASH_TRANSLATE_ACCESS_FORM_URL) }
                             },
                         )
                     }
@@ -1119,9 +1117,12 @@ private const val STASH_ISSUE_URL = "https://github.com/rawnaldclark/Stash/issue
 // browser. Edit when the invite rotates.
 private const val STASH_DISCORD_URL = "https://discord.gg/vcbjEby5PC"
 
+// Translation project on Crowdin. Tap → Crowdin project page.
 private const val STASH_CROWDIN_URL = "https://crowdin.com/project/stash-music-player"
+
+// Form to request translator access on Crowdin.
 private const val STASH_TRANSLATE_ACCESS_FORM_URL =
-    "https://docs.google.com/forms/d/e/1FAIpQLSexDpqAvK82QlYYpC8J0ukwVXkzOQSjC8V10SPVbj1ug0ojow/viewform?usp=sharing&ouid=101376898883134592146"
+    "https://docs.google.com/forms/d/e/1FAIpQLSexDpqAvK82QlYYpC8J0ukwVXkzOQSjC8V10SPVbj1ug0ojow/viewform"
 
 private val LEGACY_SUPPORTERS = listOf(
     Supporter(

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsHubScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsHubScreen.kt
@@ -158,7 +158,7 @@ fun SettingsHubScreen(
             style = MaterialTheme.typography.headlineSmall,
             color = MaterialTheme.colorScheme.onSurface,
         )
-        SupportBanner(onDonate = onDonate, onStar = onStar)
+        SupportBanner(onDonate = onDonate, onDonateCoDev = onDonateCoDev, onStar = onStar)
         SettingsSearchField(
             value = searchQuery,
             onValueChange = { searchQuery = it },

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsHubScreen.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/SettingsHubScreen.kt
@@ -41,7 +41,7 @@ import com.stash.feature.settings.components.SupportBanner
  * "spoke" screens (built in later tasks) via the `onOpen*` callbacks.
  *
  * Pure host: it owns no navigation itself — the caller wires every `onOpen*`,
- * [onDonate], and [onStar]. It shares the existing [SettingsViewModel] so the
+ * [onDonate], [onDonateCoDev], and [onStar]. It shares the existing [SettingsViewModel] so the
  * subtitles reflect live playback/quality/account/library/appearance/version
  * state.
  */
@@ -54,6 +54,7 @@ fun SettingsHubScreen(
     onOpenAppearance: () -> Unit,
     onOpenAbout: () -> Unit,
     onDonate: () -> Unit,
+    onDonateCoDev: () -> Unit,
     onStar: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SettingsViewModel = hiltViewModel(),

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SupportBanner.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SupportBanner.kt
@@ -27,6 +27,10 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SupportBanner.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SupportBanner.kt
@@ -3,6 +3,8 @@ package com.stash.feature.settings.components
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,10 +19,13 @@ import androidx.compose.material.icons.rounded.FavoriteBorder
 import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -29,6 +34,8 @@ import androidx.compose.ui.unit.dp
 import com.stash.core.ui.theme.StashCyan
 import com.stash.core.ui.theme.StashPurple
 import com.stash.core.ui.theme.StashPurpleLight
+
+private const val STASH_PAYPAL_URL = "https://www.paypal.com/paypalme/Paraliyzedevo"
 
 /**
  * A premium gradient Support card for the Settings hub. Renders a one-line pitch
@@ -74,20 +81,71 @@ fun SupportBanner(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
-            Button(
-                onClick = onDonate,
-                modifier = Modifier.weight(1f),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                ),
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.FavoriteBorder,
-                    contentDescription = null,
-                    modifier = Modifier.size(16.dp),
-                )
-                Spacer(modifier = Modifier.width(6.dp))
-                Text(text = "Donate", style = MaterialTheme.typography.labelMedium)
+            var showDonateMenu by remember { mutableStateOf(false) }
+            val uriHandler = LocalUriHandler.current
+
+            Box(modifier = Modifier.weight(1f)) {
+                Button(
+                    onClick = { showDonateMenu = true },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                    ),
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.FavoriteBorder,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(text = "Donate", style = MaterialTheme.typography.labelMedium)
+                }
+                DropdownMenu(
+                    expanded = showDonateMenu,
+                    onDismissRequest = { showDonateMenu = false },
+                    modifier = Modifier.background(MaterialTheme.colorScheme.surface),
+                ) {
+                    DropdownMenuItem(
+                        text = {
+                            Column {
+                                Text(
+                                    text = "rawnaldclark (rawn)",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                                Text(
+                                    text = "Owner, main dev",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        },
+                        onClick = {
+                            showDonateMenu = false
+                            onDonate()
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = {
+                            Column {
+                                Text(
+                                    text = "Paraliyzed_evo",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                                Text(
+                                    text = "Co-dev — makes the beta builds",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        },
+                        onClick = {
+                            showDonateMenu = false
+                            uriHandler.openUri(STASH_PAYPAL_URL)
+                        },
+                    )
+                }
             }
             OutlinedButton(
                 onClick = onStar,

--- a/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SupportBanner.kt
+++ b/feature/settings/src/main/kotlin/com/stash/feature/settings/components/SupportBanner.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -25,7 +24,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -39,8 +37,6 @@ import com.stash.core.ui.theme.StashCyan
 import com.stash.core.ui.theme.StashPurple
 import com.stash.core.ui.theme.StashPurpleLight
 
-private const val STASH_PAYPAL_URL = "https://www.paypal.com/paypalme/Paraliyzedevo"
-
 /**
  * A premium gradient Support card for the Settings hub. Renders a one-line pitch
  * and two actions (Donate / Star). Pure presentation — the hub screen wires the
@@ -49,6 +45,7 @@ private const val STASH_PAYPAL_URL = "https://www.paypal.com/paypalme/Paraliyzed
 @Composable
 fun SupportBanner(
     onDonate: () -> Unit,
+    onDonateCoDev: () -> Unit,
     onStar: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -86,7 +83,6 @@ fun SupportBanner(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             var showDonateMenu by remember { mutableStateOf(false) }
-            val uriHandler = LocalUriHandler.current
 
             Box(modifier = Modifier.weight(1f)) {
                 Button(
@@ -107,21 +103,12 @@ fun SupportBanner(
                 DropdownMenu(
                     expanded = showDonateMenu,
                     onDismissRequest = { showDonateMenu = false },
-                    modifier = Modifier.background(MaterialTheme.colorScheme.surface),
                 ) {
                     DropdownMenuItem(
                         text = {
                             Column {
-                                Text(
-                                    text = "rawnaldclark (rawn)",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurface,
-                                )
-                                Text(
-                                    text = "Owner, main dev",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
+                                Text(text = "rawnaldclark (rawn)", style = MaterialTheme.typography.bodyMedium)
+                                Text(text = "Owner, main dev", style = MaterialTheme.typography.bodySmall)
                             }
                         },
                         onClick = {
@@ -132,21 +119,16 @@ fun SupportBanner(
                     DropdownMenuItem(
                         text = {
                             Column {
-                                Text(
-                                    text = "Paraliyzed_evo",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurface,
-                                )
+                                Text(text = "Paraliyzed_evo", style = MaterialTheme.typography.bodyMedium)
                                 Text(
                                     text = "Co-dev — makes the beta builds",
                                     style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                             }
                         },
                         onClick = {
                             showDonateMenu = false
-                            uriHandler.openUri(STASH_PAYPAL_URL)
+                            onDonateCoDev()
                         },
                     )
                 }


### PR DESCRIPTION
## Summary
Two entry points needed more than a single link: the Home wrench icon only
opened GitHub Issues, and the Settings Donate button only pointed at rawn's
Ko-fi — neither surfaced Stash's translation effort or Paraliyzed_evo's
PayPal, and there was nowhere in-app to attribute either contributor's role.

Both buttons now open a small anchored `DropdownMenu` instead of firing a
single URI directly. This keeps each button a single tap target (no new
rows competing for space on Home or Settings) while giving each destination
its own labeled entry.

Reused `DropdownMenu`/`DropdownMenuItem` rather than a `ModalBottomSheet`
(as `HomeScreen`'s other long-press action sheets use) since both of these
are anchored to a small icon/button rather than a long-press on a full-width
card — a bottom sheet felt heavier than the two-item choice warranted.

## Changes
* `feature/home/src/main/kotlin/com/stash/feature/home/HomeScreen.kt`
  * Wrench `IconButton` no longer opens `STASH_ISSUE_URL` directly — it now
    toggles `showHelpMenu`, anchoring a `DropdownMenu` with two items:
    "Report an issue" (unchanged GitHub URL) and "Help us translate."
  * Added `STASH_CROWDIN_URL` and `STASH_TRANSLATE_ACCESS_FORM_URL`.
  * "Help us translate" row's main click opens the Crowdin project page; a
    separate trailing `OpenInNew` tap target opens the translator-access
    request form, so both links are reachable without a second full row.
* `feature/settings/src/main/kotlin/com/stash/feature/settings/components/SupportBanner.kt`
  * Donate `Button` no longer calls `onDonate` directly — it now toggles
    `showDonateMenu`, anchoring a `DropdownMenu` with two items:
    "rawnaldclark (rawn)" → Owner, main dev (still routed through the
    existing `onDonate` callback, so the hub screen keeps owning that URL)
    and "Paraliyzed_evo" → Co-dev, makes the beta builds (opens the new
    hardcoded `STASH_PAYPAL_URL`).
  * Added missing `androidx.compose.runtime` imports (`remember`,
    `mutableStateOf`, `getValue`, `setValue`) required for the new
    `by remember { mutableStateOf(false) }` menu-visibility state.
* `README.md`
  * "Community" section: added a one-line pointer to the Crowdin project
    and the translator-access-request form, matching the existing
    per-channel sentence style.
  * "Support Stash" section: added a PayPal badge for Paraliyzed_evo next
    to rawn's existing Ko-fi badge, each labeled with name and role.

## Test plan
* [x] Tap the Home wrench icon — menu opens anchored below it; "Report an
      issue" still opens GitHub Issues; "Help us translate" opens Crowdin;
      the trailing icon opens the access-request form; tapping outside
      dismisses the menu.
* [x] Tap Settings Donate — menu opens anchored below it; rawn's row still
      fires the existing `onDonate` callback; Paraliyzed_evo's row opens
      the PayPal.me link.
* [x] Device / Android version tested: S26u/Android 16
Closes https://github.com/ParaliyzedEvo/Stash/issues/201, Closes https://github.com/ParaliyzedEvo/Stash/issues/202

**NOTE:** Would recommend changing the design of the popups if you wish