### PR TITLE
fix(arcod): discriminate a daily-quota 429 on "daily", not "quota"

### DIFF
--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/arcod/ArcodClient.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/arcod/ArcodClient.kt
@@ -289,7 +289,11 @@ class ArcodClient @Inject constructor(
     private fun note429(response: okhttp3.Response) {
         if (response.code != 429) return
         val body = runCatching { response.body?.string().orEmpty() }.getOrDefault("")
-        val daily = body.contains("quota", ignoreCase = true)
+        // Discriminate on the RESET PERIOD, not the kind of limit: the observed
+        // body is {"error":"Daily quota reached","resetAt":"midnight UTC"}. Matching
+        // "quota" would also catch a burst body like "rate quota exceeded, retry in
+        // 60s" and lock arcod out until midnight over a momentary throttle.
+        val daily = body.contains("daily", ignoreCase = true)
         // Epoch millis are already UTC, so the next day boundary is plain arithmetic
         // — no java.time desugaring needed for one ceiling division.
         blockedUntilMs = if (daily) {

--- a/data/download/src/test/kotlin/com/stash/data/download/lossless/arcod/ArcodClientTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/lossless/arcod/ArcodClientTest.kt
@@ -303,6 +303,21 @@ class ArcodClientTest {
         assertEquals(2, server.requestCount)
     }
 
+    @Test fun `a 429 that says quota but not daily is a burst, not a day-long lockout`() = runTest {
+        // The discriminator is the reset PERIOD ("daily"), not the kind of limit
+        // ("quota"): a momentary throttle worded like this must not cost the rest
+        // of the day.
+        server.enqueue(MockResponse().setResponseCode(429).setBody("""{"error":"rate quota exceeded, retry in 60s"}"""))
+        var now = FIXED_NOW
+        client.nowMs = { now }
+        try { client.search("first") } catch (e: ArcodRateLimitedException) { /* expected */ }
+
+        now = FIXED_NOW + 61_000L
+        server.enqueue(MockResponse().setResponseCode(200).setBody(SEARCH_BODY))
+        assertTrue(client.search("after cooldown").isNotEmpty())
+        assertEquals(2, server.requestCount)
+    }
+
     @Test fun `non-quota 429 backs off only briefly`() = runTest {
         server.enqueue(MockResponse().setResponseCode(429).setBody("""{"error":"slow down"}"""))
         var now = FIXED_NOW


### PR DESCRIPTION
## What

One word. The arcod quota gate merged in #463 decides "block until midnight UTC" vs "60s burst cooldown" by whether the 429 body contains `quota`. That names the *kind* of limit, not the *reset period*. A burst body worded "rate quota exceeded, retry in 60s" would lock arcod out for the rest of the day over a momentary throttle. The word that actually says "resets at midnight" in the observed body — `{"error":"Daily quota reached","resetAt":"midnight UTC"}` — is `daily`.

## Verification

- `ArcodClientTest` 19/19 (one new regression test).
- The new test was confirmed to **fail** against the old discriminator before being trusted: swapped the word back, ran it, watched it fail, restored.

Found on a second review pass of this session's work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRM34E479iwx8WSjiGdbg1
