### PR TITLE
feat(lossless): sign relay mints with a config-delivered key (Plan B client half)

### DIFF
--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/relay/LosslessConfigFetcher.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/relay/LosslessConfigFetcher.kt
@@ -17,6 +17,7 @@ import java.security.KeyFactory
 import java.security.Signature
 import java.security.spec.X509EncodedKeySpec
 import java.util.Base64
+import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CancellationException
@@ -44,6 +45,13 @@ data class LosslessConfig(
     val v: Int = 1,
     val relays: List<RelayEntry> = emptyList(),
     @SerialName("updated_at") val updatedAt: Long = 0,
+    /**
+     * Relay access key (spec §5.4). When present, [LosslessRelayClient] signs every
+     * mint with it. Delivered here — inside the signed, cached, every-cold-start
+     * config — rather than baked into the APK, so it rotates by publishing a new
+     * config and is dead on every device within one cold start. Null → unsigned.
+     */
+    @SerialName("relay_key") val relayKey: String? = null,
 )
 
 private val Context.losslessRelayConfigDataStore: DataStore<Preferences> by preferencesDataStore(
@@ -78,6 +86,24 @@ class LosslessConfigFetcher @Inject constructor(
     private val _relays = MutableStateFlow<List<RelayEntry>>(emptyList())
     val relays: StateFlow<List<RelayEntry>> = _relays.asStateFlow()
 
+    private val _relayKey = MutableStateFlow<String?>(null)
+    /** The current relay access key from the applied config; null when unsigned. */
+    val relayKey: StateFlow<String?> = _relayKey.asStateFlow()
+
+    private val installIdKey = stringPreferencesKey("install_id")
+
+    /**
+     * A random id created once per install and persisted beside the config cache.
+     * Sent with every signed mint so the relay can rate-limit per install. It is a
+     * cooperative bucket, not an identity: random, no PII, never leaves the relay
+     * request. Created inside a single `edit` so two first-callers can't race two
+     * different ids into existence.
+     */
+    suspend fun installId(): String =
+        context.losslessRelayConfigDataStore.edit { p ->
+            if (p[installIdKey] == null) p[installIdKey] = UUID.randomUUID().toString()
+        }[installIdKey]!!
+
     val enabled: Boolean get() = configUrl.isNotBlank() && publicKeyB64.isNotBlank()
 
     /**
@@ -87,7 +113,7 @@ class LosslessConfigFetcher @Inject constructor(
      */
     suspend fun loadCached() {
         val cached = readCache() ?: return
-        parse(cached)?.let { _relays.value = it.relays }
+        parse(cached)?.let { _relays.value = it.relays; _relayKey.value = it.relayKey }
     }
 
     /** Fetch + verify + apply. Returns true only when a fresh, valid config was applied. Never throws. */
@@ -111,6 +137,7 @@ class LosslessConfigFetcher @Inject constructor(
             return@withContext false
         }
         _relays.value = fresh.relays
+        _relayKey.value = fresh.relayKey
         ioCatching("cache write") { context.losslessRelayConfigDataStore.edit { it[jsonKey] = text } }
         Log.i(TAG, "lossless config applied: ${fresh.relays.size} relay(s)")
         true
@@ -181,6 +208,7 @@ class LosslessConfigFetcher @Inject constructor(
 
     internal suspend fun clearForTest() {
         _relays.value = emptyList()
+        _relayKey.value = null
         context.losslessRelayConfigDataStore.edit { it.clear() }
     }
 

--- a/data/download/src/main/kotlin/com/stash/data/download/lossless/relay/LosslessRelayClient.kt
+++ b/data/download/src/main/kotlin/com/stash/data/download/lossless/relay/LosslessRelayClient.kt
@@ -2,8 +2,11 @@ package com.stash.data.download.lossless.relay
 
 import android.util.Log
 import java.io.IOException
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
@@ -57,7 +60,10 @@ internal data class RelayFileResponse(
  * survive a junk value, not sanitise one.
  */
 @Singleton
-class LosslessRelayClient @Inject constructor(sharedClient: OkHttpClient) {
+class LosslessRelayClient @Inject constructor(
+    sharedClient: OkHttpClient,
+    private val config: LosslessConfigFetcher,
+) {
     /**
      * Derived client so the relay's short timeouts don't leak onto the shared
      * one — a relay that hangs must fail over fast, not stall a download.
@@ -99,6 +105,7 @@ class LosslessRelayClient @Inject constructor(sharedClient: OkHttpClient) {
         val req = Request.Builder().url(url)
             .header("X-Stash-Version", PROTOCOL_VERSION)
             .header("Accept", "application/json")
+            .also { signIfKeyed(it, trackId, formatId) }
             .get().build()
         // The body read stays INSIDE the try: a relay that returns 200 headers and then
         // stalls throws out of string(), and that must cool this base — not escape into
@@ -165,6 +172,34 @@ class LosslessRelayClient @Inject constructor(sharedClient: OkHttpClient) {
             Log.i(TAG, "probe of ${host(base)} failed (${e.javaClass.simpleName})")
             false
         }
+    }
+
+    /**
+     * Relay access control (spec §5.4). When the signed config carries a
+     * `relay_key`, the mint is signed: `X-Stash-Auth` = hex HMAC-SHA256 over
+     * `"<install_id>:<track_id>:<format_id>:<unix_ts>"`, with `X-Stash-Install` and
+     * `X-Stash-Ts` alongside. The install id sits INSIDE the MAC so a captured
+     * header cannot be replayed under another install's allowance; the timestamp
+     * lets the relay reject anything outside its ±5 min window.
+     *
+     * No key → no headers. A user-run custom endpoint built to the public contract
+     * needs none, and a relay that wants auth answers an unsigned mint with a
+     * non-2xx that [mint] already cools for 5 min.
+     *
+     * A DataStore failure fetching the install id falls back to a transient id
+     * rather than throwing: this runs BEFORE the HTTP try, and an exception here
+     * would escape into QbdlxQobuzSource's breaker and trip qbdlx wholesale.
+     *
+     * ponytail: the ±5 min window assumes an NTP-synced clock; add Date-header
+     * skew correction if relay 401s show up in the field.
+     */
+    private suspend fun signIfKeyed(b: Request.Builder, trackId: Long, formatId: Int) {
+        val key = config.relayKey.value ?: return
+        val install = runCatching { config.installId() }.getOrElse { UUID.randomUUID().toString() }
+        val ts = clock() / 1000
+        val mac = Mac.getInstance("HmacSHA256").apply { init(SecretKeySpec(key.toByteArray(), "HmacSHA256")) }
+        val sig = mac.doFinal("$install:$trackId:$formatId:$ts".toByteArray()).joinToString("") { "%02x".format(it) }
+        b.header("X-Stash-Install", install).header("X-Stash-Ts", ts.toString()).header("X-Stash-Auth", sig)
     }
 
     private fun cool(base: String, ms: Long) {

--- a/data/download/src/test/kotlin/com/stash/data/download/lossless/relay/LosslessConfigFetcherTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/lossless/relay/LosslessConfigFetcherTest.kt
@@ -51,6 +51,37 @@ class LosslessConfigFetcherTest {
         assertThat(cold.relays.value.map { it.base }).containsExactly("https://a.example", "https://b.example").inOrder()
     }
 
+    @Test fun `relay_key rides the signed config, survives the cache, and rotates with it`() = runTest {
+        val keyed = """{"v":1,"relays":[{"base":"https://a.example","priority":1}],"updated_at":5,"relay_key":"k-one"}"""
+        server.enqueue(MockResponse().setBody(keyed))
+        server.enqueue(MockResponse().setBody(sign(keyed.toByteArray())))
+        val f = fetcher()
+        assertThat(f.refresh()).isTrue()
+        assertThat(f.relayKey.value).isEqualTo("k-one")
+
+        // Cold start reads the key back from the cache, not the network.
+        val cold = fetcher()
+        cold.loadCached()
+        assertThat(cold.relayKey.value).isEqualTo("k-one")
+
+        // Rotation = a newer config with a different key; and a config that DROPS
+        // the key must clear it, not leave the old one armed.
+        val unkeyed = """{"v":1,"relays":[{"base":"https://a.example","priority":1}],"updated_at":6}"""
+        server.enqueue(MockResponse().setBody(unkeyed))
+        server.enqueue(MockResponse().setBody(sign(unkeyed.toByteArray())))
+        assertThat(cold.refresh()).isTrue()
+        assertThat(cold.relayKey.value).isNull()
+    }
+
+    @Test fun `install id is created once and is stable across instances`() = runTest {
+        val a = fetcher().installId()
+        val b = fetcher().installId()
+        assertThat(a).isNotEmpty()
+        assertThat(b).isEqualTo(a)
+        // Random, not derived from anything: a UUID shape, no PII.
+        assertThat(a).matches("[0-9a-f-]{36}")
+    }
+
     @Test fun `tampered body is ignored and the cached copy kept`() = runTest {
         server.enqueue(MockResponse().setBody(body)); server.enqueue(MockResponse().setBody(sign(body.toByteArray())))
         val f = fetcher(); f.refresh()

--- a/data/download/src/test/kotlin/com/stash/data/download/lossless/relay/LosslessRelayClientTest.kt
+++ b/data/download/src/test/kotlin/com/stash/data/download/lossless/relay/LosslessRelayClientTest.kt
@@ -1,6 +1,12 @@
 package com.stash.data.download.lossless.relay
 
 import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlinx.coroutines.flow.MutableStateFlow
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
@@ -13,12 +19,18 @@ import org.junit.Test
 class LosslessRelayClientTest {
     private lateinit var server: MockWebServer
     private lateinit var client: LosslessRelayClient
+    private lateinit var config: LosslessConfigFetcher
+    /** Null by default: the existing tests exercise the unsigned path. */
+    private val relayKey = MutableStateFlow<String?>(null)
     private var now = 1_000_000L
     private val base get() = server.url("/").toString().trimEnd('/')
 
     @Before fun setUp() {
         server = MockWebServer(); server.start()
-        client = LosslessRelayClient(OkHttpClient()).also { it.clock = { now } }
+        config = mockk()
+        every { config.relayKey } returns relayKey
+        coEvery { config.installId() } returns INSTALL_ID
+        client = LosslessRelayClient(OkHttpClient(), config).also { it.clock = { now } }
     }
     @After fun tearDown() { server.shutdown() }
 
@@ -138,4 +150,47 @@ class LosslessRelayClientTest {
         assertThat(client.probe("relay.example")).isFalse()
         assertThat(server.requestCount).isEqualTo(0)
     }
+
+    // --- request signing (spec §5.4) --------------------------------------
+
+    @Test fun `no relay key means no auth headers at all`() = runTest {
+        server.enqueue(MockResponse().setBody("""{"url":"https://cdn.example/f.flac?etsp=1"}"""))
+        client.mint(base, 42, 27)
+        val req = server.takeRequest()
+        assertThat(req.getHeader("X-Stash-Auth")).isNull()
+        assertThat(req.getHeader("X-Stash-Install")).isNull()
+        assertThat(req.getHeader("X-Stash-Ts")).isNull()
+    }
+
+    @Test fun `with a relay key the mint carries install id, timestamp, and a verifiable HMAC`() = runTest {
+        relayKey.value = "k-secret"
+        now = 1_700_000_000_123L // ts is unix SECONDS — the millis must be truncated, not rounded
+        server.enqueue(MockResponse().setBody("""{"url":"https://cdn.example/f.flac?etsp=1"}"""))
+        client.mint(base, 42, 27)
+        val req = server.takeRequest()
+        assertThat(req.getHeader("X-Stash-Install")).isEqualTo(INSTALL_ID)
+        assertThat(req.getHeader("X-Stash-Ts")).isEqualTo("1700000000")
+        // Recompute independently: the relay will do exactly this.
+        val mac = Mac.getInstance("HmacSHA256").apply { init(SecretKeySpec("k-secret".toByteArray(), "HmacSHA256")) }
+        val expected = mac.doFinal("$INSTALL_ID:42:27:1700000000".toByteArray()).joinToString("") { "%02x".format(it) }
+        assertThat(req.getHeader("X-Stash-Auth")).isEqualTo(expected)
+        // The custom-endpoint / unsigned contract header is unchanged by signing.
+        assertThat(req.getHeader("X-Stash-Version")).isEqualTo("1")
+    }
+
+    @Test fun `a failing install-id store falls back to a transient id instead of throwing`() = runTest {
+        // This runs BEFORE the HTTP try in mint(): a throw here would escape into
+        // QbdlxQobuzSource's breaker and trip qbdlx wholesale.
+        relayKey.value = "k-secret"
+        coEvery { config.installId() } throws java.io.IOException("datastore unavailable")
+        server.enqueue(MockResponse().setBody("""{"url":"https://cdn.example/f.flac?etsp=1"}"""))
+        val r = client.mint(base, 42, 27)
+        assertThat(r).isInstanceOf(RelayMint.Ok::class.java)
+        assertThat(server.takeRequest().getHeader("X-Stash-Install")).isNotEmpty()
+    }
+
+    private companion object {
+        const val INSTALL_ID = "0f7c3a2e-install"
+    }
+
 }


### PR DESCRIPTION
## Why now

Plan B's relay gates access with an HMAC over each mint. That's a **client** change — and the client ships on the release cycle, while the relay can be deployed any afternoon. So it lands first and sits dormant until a config carries a key.

## What

- `lossless.json` gains an optional `relay_key`. The fetcher exposes it beside `relays`, restores it from cache on cold start, and **clears it when a newer config omits it**. Delivering the key inside the already-signed config — not baked into the APK — is the point: it rotates by publishing a new config and is dead on every device within one cold start. The APK still carries no relay hostname and no key.
- `LosslessRelayClient` signs a mint only when a key is present: `X-Stash-Auth` = hex HMAC-SHA256 over `"<install_id>:<track_id>:<format_id>:<unix_ts>"`, plus `X-Stash-Install` (random per-install UUID, created once) and `X-Stash-Ts`. No key → no headers, so a user-run custom endpoint built to the public contract keeps working unsigned.
- Install-id storage failure falls back to a transient id instead of throwing — signing runs before `mint()`'s HTTP try, and an exception there would escape into qbdlx's breaker.

## Verification

- `LosslessRelayClientTest` 17/17 (3 new — the HMAC is recomputed independently in the test against a fixed clock, including that `ts` is truncated seconds). `LosslessConfigFetcherTest` 12/12 (2 new). Router tests green.
- `:app:compileDebugKotlin` succeeds — the Hilt graph resolves the new constructor.

Spec: `docs/superpowers/specs/2026-08-31-lossless-relay-plan-b-contract.md` §5.4 (on `docs/plan-b-decisions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRM34E479iwx8WSjiGdbg1
