### PR TITLE
Fix update-check notification never posting on API 30+

### DIFF
--- a/core/data/src/main/kotlin/com/stash/core/data/sync/workers/UpdateCheckWorker.kt
+++ b/core/data/src/main/kotlin/com/stash/core/data/sync/workers/UpdateCheckWorker.kt
@@ -311,11 +311,10 @@ class UpdateCheckWorker(
             PackageManager.MATCH_ALL,
         ).mapNotNull { it.activityInfo?.packageName }.toSet()
 
-        val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(DOWNLOAD_URL))
-        val resolved = packageManager.queryIntentActivities(
-            browserIntent,
-            PackageManager.MATCH_DEFAULT_ONLY,
-        )
+        val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(DOWNLOAD_URL)).apply {
+            addCategory(Intent.CATEGORY_BROWSABLE)
+        }
+        val resolved = packageManager.queryIntentActivities(browserIntent, PackageManager.MATCH_DEFAULT_ONLY)
 
         // Prefer a resolver that's a genuine browser; otherwise fall back to
         // whatever the system resolved. Then make the launch explicit by


### PR DESCRIPTION
## Summary
`UpdateCheckWorker.showUpdateNotification` resolves a launch target for the
GitHub releases URL via `packageManager.queryIntentActivities(browserIntent, ...)`,
but `browserIntent` was built without `CATEGORY_BROWSABLE`. On API 30+,
the automatic package-visibility exemption for `ACTION_VIEW` with an
`http`/`https` URI only applies when that category is set on the intent
being queried — without it (and with no `<queries>` override in the
manifest), `queryIntentActivities` returns an empty list on any device
that doesn't otherwise expose browser packages to us. `preferredActivity`
then resolves to null, hitting the existing
`"No browser activity resolved for update URL; skipping notification"`
log path, and `showUpdateNotification` returns `false` — so the update
notification silently never posts, regardless of installed version. The
sibling `genericBrowserIntent` used just above (for building
`browserPackages`) already sets this category correctly, which is why
that half of the resolution logic wasn't affected.

## Changes
* `UpdateCheckWorker.kt`
  * Added `.addCategory(Intent.CATEGORY_BROWSABLE)` to `browserIntent`
    before querying `packageManager.queryIntentActivities`, matching
    `genericBrowserIntent`'s existing category handling.

## Test plan
* [x] `./gradlew testDebugUnitTest` — `UpdateCheckWorkerTest`
* [x] Device / Android version tested: S26u/Android 16

Closes https://github.com/ParaliyzedEvo/Stash/issues/218