### PR TITLE
Fix "View Album" routing resolved YT albums into the local library screen

### DIFF
--- a/app/src/main/kotlin/com/stash/app/navigation/StashNavHost.kt
+++ b/app/src/main/kotlin/com/stash/app/navigation/StashNavHost.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import com.stash.data.ytmusic.model.AlbumSource
 import com.stash.feature.home.HomeScreen
 import com.stash.feature.home.MixBrowseScreen
 import com.stash.feature.home.MixRail
@@ -148,6 +149,18 @@ fun StashNavHost(
                 },
                 onNavigateToAlbum = { _, name, _, artistName ->
                     navController.navigate(AlbumDetailRoute(name, artistName))
+                },
+                onNavigateToRemoteAlbum = { albumId, name, artUrl, artistName ->
+                    navController.navigate(
+                        SearchAlbumRoute(
+                            browseId = albumId,
+                            title = name,
+                            artist = artistName,
+                            thumbnailUrl = artUrl,
+                            year = null,
+                            source = com.stash.data.ytmusic.model.AlbumSource.YOUTUBE,
+                        ),
+                    )
                 },
                 onSelectionModeChanged = onSelectionModeChanged,
             )
@@ -440,8 +453,17 @@ fun StashNavHost(
                 onNavigateToArtist = { id, name, avatar, focusAlbum ->
                     navController.navigate(SearchArtistRoute(id, name, avatar, focusAlbum))
                 },
-                onNavigateToAlbum = { _, name, _, artistName ->
-                    navController.navigate(AlbumDetailRoute(name, artistName))
+                onNavigateToAlbum = { albumId, name, artUrl, artistName ->
+                    navController.navigate(
+                        SearchAlbumRoute(
+                            browseId = albumId,
+                            title = name,
+                            artist = artistName,
+                            thumbnailUrl = artUrl,
+                            year = null,
+                            source = AlbumSource.YOUTUBE,
+                        ),
+                    )
                 },
             )
         }

--- a/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/kotlin/com/stash/feature/library/LibraryScreen.kt
@@ -135,6 +135,7 @@ fun LibraryScreen(
     onNavigateToPlaylist: (Long) -> Unit = {},
     onNavigateToArtist: (String) -> Unit = {},
     onNavigateToAlbum: (albumId: String, name: String, artUrl: String?, artistName: String) -> Unit = { _, _, _, _ -> },
+    onNavigateToRemoteAlbum: (albumId: String, name: String, artUrl: String?, artistName: String) -> Unit = { _, _, _, _ -> },
     onSelectionModeChanged: (Boolean) -> Unit = {},
     viewModel: LibraryViewModel = hiltViewModel(),
 ) {
@@ -185,7 +186,7 @@ fun LibraryScreen(
 
     LaunchedEffect(Unit) {
         viewModel.albumNavEvents.collect { a ->
-            onNavigateToAlbum(a.albumId, a.name, a.artUrl, a.artistName)
+            onNavigateToRemoteAlbum(a.albumId, a.name, a.artUrl, a.artistName)
         }
     }
     


### PR DESCRIPTION
## Summary
`NowPlayingViewModel.onViewAlbumTapped()` and `LibraryViewModel.onViewAlbumTapped()`
both correctly resolve the tapped track's album via
`ytMusicApiClient.resolveAlbum(...)` and emit a real YT Music browseId in
`AlbumNavTarget.albumId`. But `StashNavHost`'s `NowPlayingRoute` wiring
discarded that `albumId` (and `artUrl`) entirely:

```kotlin
onNavigateToAlbum = { _, name, _, artistName ->
    navController.navigate(AlbumDetailRoute(name, artistName))
},
```

`AlbumDetailRoute` backs `AlbumDetailScreen`/`AlbumDetailViewModel`, which
filters `musicRepository.getAllTracks()` by matching `album`/`artist`
strings against the LOCAL, downloaded library — it has no notion of a
remote browseId. So a real remote album resolve was funneled into a
local-only lookup, which almost always finds nothing ("0 tracks / No songs
in your library yet") and, when it did coincidentally match a local album
by name, showed the wrong one. Every other remote-album entry point in the
nav graph (Home discovery rows, Search, ArtistProfileScreen) already
navigates to `SearchAlbumRoute(browseId = ..., source = AlbumSource.YOUTUBE)`,
which resolves the actual remote-aware `AlbumDiscoveryScreen` — that's the
destination "View Album" needed too.

`LibraryScreen`'s Albums-grid tap (`onOpenAlbum`) intentionally reuses this
same local `AlbumDetailRoute` path, passing the local album name in place
of a real `albumId` — that path is correct as-is and needed to stay
untouched. Since `LibraryScreen` only exposed one `onNavigateToAlbum`
callback shared by both the grid tap and the track-sheet "View Album" tap
(`viewModel.albumNavEvents`), the two intents couldn't be routed
differently without splitting the callback.

## Changes
* `StashNavHost.kt`
  * `NowPlayingRoute`: `onNavigateToAlbum` now navigates to
    `SearchAlbumRoute(browseId = albumId, title = name, artist = artistName,
    thumbnailUrl = artUrl, year = null, source = AlbumSource.YOUTUBE)`
    instead of `AlbumDetailRoute(name, artistName)`. This callback is fed
    exclusively by `NowPlayingViewModel`'s remote resolve, so no local-album
    case needed preserving here.
  * `LibraryRoute`: wired the new `onNavigateToRemoteAlbum` callback to the
    same `SearchAlbumRoute` navigation; left the existing `onNavigateToAlbum`
    → `AlbumDetailRoute` wiring untouched for the Albums-grid tap.
* `LibraryScreen.kt`
  * Added a new `onNavigateToRemoteAlbum: (albumId, name, artUrl, artistName) -> Unit`
    parameter, distinct from the existing `onNavigateToAlbum`.
  * `viewModel.albumNavEvents`'s `LaunchedEffect` now calls
    `onNavigateToRemoteAlbum` instead of `onNavigateToAlbum`.
  * `onOpenAlbum`'s existing wiring to `onNavigateToAlbum` (the Albums-grid
    tap, local-library path) is unchanged.

## Test plan
* [x] From Now Playing, tap the track title → artist page → tap the
      highlighted album → confirms real tracklist and correct name (existing
      working path, used as the reference).
* [x] From Now Playing, tap ⋮ → View Album → lands directly on the same
      real album (no artist-page hop), correct name, correct tracklist.
* [x] From Library → a track's ⋮ → View Album → same remote album screen,
      not the local "0 tracks" screen.
* [x] Library → Albums tab → tap an album card → still opens the local
      `AlbumDetailScreen` unaffected (regression check for the shared
      callback split).
* [x] Device / Android version tested: S26u/Android 16

Closes https://github.com/ParaliyzedEvo/Stash/issues/191